### PR TITLE
[MOIC-79] - Get Staff details

### DIFF
--- a/app/services/nomis/custody/api.rb
+++ b/app/services/nomis/custody/api.rb
@@ -1,0 +1,21 @@
+module Nomis
+  module Custody
+    class Api
+      include Singleton
+
+      class << self
+        delegate :fetch_nomis_staff_details, to: :instance
+      end
+
+      def initialize
+        host = Rails.configuration.nomis_oauth_host
+        @custodyapi_client = Nomis::Custody::Client.new(host)
+      end
+
+      def fetch_nomis_staff_details(username)
+        route = "/custodyapi/api/nomis-staff-users/#{username}"
+        @custodyapi_client.get(route)
+      end
+    end
+  end
+end

--- a/app/services/nomis/custody/client.rb
+++ b/app/services/nomis/custody/client.rb
@@ -1,0 +1,31 @@
+require 'faraday'
+
+module Nomis
+  module Custody
+    class Client
+      def initialize(host)
+        @host = host
+        @connection = Faraday.new
+      end
+
+      def get(route)
+        request(:get, route)
+      end
+
+    private
+
+      def request(method, route)
+        response = @connection.send(method) { |req|
+          req.url(@host + route)
+          req.headers['Authorization'] = "Bearer #{token.access_token}"
+        }
+
+        JSON.parse(response.body)
+      end
+
+      def token
+        Nomis::Oauth::TokenService.valid_token
+      end
+    end
+  end
+end

--- a/app/services/nomis/oauth/client.rb
+++ b/app/services/nomis/oauth/client.rb
@@ -1,8 +1,8 @@
-require 'base64'
-
 module Nomis
   module Oauth
     class Client
+      include ClientHelper
+
       def initialize(host)
         @host = host
         @connection = Faraday.new
@@ -17,20 +17,11 @@ module Nomis
       def request(method, route)
         response = @connection.send(method) { |req|
           req.url(@host + route)
-          req.headers['Authorization'] =
-            'Basic ' + authorisation
+          req.headers['Authorization'] = authorisation
         }
 
         JSON.parse(response.body)
       end
-
-      # rubocop:disable Metrics/LineLength
-      def authorisation
-        Base64.urlsafe_encode64(
-          "#{Rails.configuration.nomis_oauth_client_id}:#{Rails.configuration.nomis_oauth_client_secret}"
-        )
-      end
-      # rubocop:enable Metrics/LineLength
     end
   end
 end

--- a/app/services/nomis/oauth/client_helper.rb
+++ b/app/services/nomis/oauth/client_helper.rb
@@ -1,0 +1,17 @@
+require 'base64'
+
+#:nocov:
+module Nomis
+  module Oauth
+    module ClientHelper
+      # rubocop:disable Metrics/LineLength
+      def authorisation
+        'Basic ' + Base64.urlsafe_encode64(
+          "#{Rails.configuration.nomis_oauth_client_id}:#{Rails.configuration.nomis_oauth_client_secret}"
+        )
+      end
+      # rubocop:enable Metrics/LineLength
+    end
+  end
+end
+#:nocov:

--- a/lib/hmpps_sso.rb
+++ b/lib/hmpps_sso.rb
@@ -1,6 +1,5 @@
 require 'omniauth-oauth2'
 require 'base64'
-require 'byebug'
 
 module OmniAuth
   module Strategies

--- a/spec/fixtures/vcr_cassettes/custodyapi_client_auth_header.yml
+++ b/spec/fixtures/vcr_cassettes/custodyapi_client_auth_header.yml
@@ -1,0 +1,108 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://gateway.t3.nomis-api.hmpps.dsd.io/auth/oauth/token?grant_type=client_credentials
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - authorisation_header
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;charset=UTF-8
+      Server:
+      - nginx/1.15.3
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - DENY
+      Date:
+      - Sun, 09 Dec 2018 19:08:58 GMT
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbnRlcm5hbFVzZXIiOmZhbHNlLCJzY29wZSI6WyJyZWFkIiwid3JpdGUiXSwiZXhwIjoxNTQ0MzgzNzM4LCJhdXRob3JpdGllcyI6WyJST0xFX1NZU1RFTV9SRUFEX09OTFkiXSwianRpIjoiMjI3NGQ3ZDctM2QzYi00NmRhLTg0NGMtM2Y3Yzc2YmVkNDJiIiwiY2xpZW50X2lkIjoib2ZmZW5kZXItbWFuYWdlbWVudC1hbGxvY2F0aW9uLW1hbmFnZXIifQ.BKYcKggL1JE1vFbrF0-absKolbfzXRmQwy_k3wIPntCVaTWGlVVUk_0r9FS9Okrle26mTfZ-DPD_vus5m6Jto7mj2On6j_zqhx1Eae7pbcgji1yU_e5cO-Oo0JcoqDZZPzcbiypZ-AMbh9iBFBcYYbg0UsfQnknTob48i9-p_PDTWX4sdRWEwSRn71xAewfaSWEvg4tMdZW0js6gti9K4iEEbEdAktM1eUT4woqbvOFURjOVXaD4F-qTF1Fb5adgoWdp63KbSkz4lWzQN5l6Qka1XekZoi0jgw1WLE-DnHU_v888Ft736BQQo9Wa4egHf4ERMagsxkyCen2OCcbCAg","token_type":"bearer","expires_in":1199,"scope":"read
+        write","internalUser":false,"jti":"2274d7d7-3d3b-46da-844c-3f7c76bed42b"}'
+    http_version: 
+  recorded_at: Sun, 09 Dec 2018 00:00:00 GMT
+- request:
+    method: get
+    uri: https://gateway.t3.nomis-api.hmpps.dsd.io/custodyapi/api/nomis-staff-users/PK000223
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - authorisation_header
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;charset=UTF-8
+      Expires:
+      - '0'
+      Server:
+      - nginx/1.15.3
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Application-Context:
+      - application:logstash,oracle
+      Date:
+      - Sun, 09 Dec 2018 19:08:59 GMT
+    body:
+      encoding: UTF-8
+      string: '{"username":"PK000223","staffId":485637,"firstName":"KATH","lastName":"POBEE-NORRIS","status":"ACTIVE","activeNomisCaseload":"LEI","nomisCaseloads":{"LEI":{"id":"LEI","name":"LEEDS
+        (HMP)","type":"INST","currentActive":true,"agencies":[{"agencyLocationId":"LEI","description":"LEEDS
+        (HMP)","longDescription":"HMP LEEDS","agencyLocationType":"INST","districtCode":"YORK","bailOffice":false,"housingLev1Code":"WING","housingLev2Code":"LAND","housingLev3Code":"CELL","housingLev4Code":"NULL","serviceRequired":false,"active":true,"areaCode":"YORK","nomsRegionCode":"YOHUM","geographicRegionCode":"YORK","cjitCode":"E00LE00"},{"agencyLocationId":"OUT","description":"OUTSIDE","longDescription":"OUTSIDE
+        JURISDICTION","agencyLocationType":"INST","districtCode":"FD","deactivationDate":"2008-05-29","jurisdictionCode":"CC","bailOffice":true,"listSeq":2,"housingLev1Code":"BED","propertyLev1Code":"BOX","serviceRequired":false,"active":false,"disabilityAccessCode":"WHEEL","cjitCode":"TEST"},{"agencyLocationId":"TRN","description":"TRANSFER","agencyLocationType":"INST","districtCode":"FD","bailOffice":true,"housingLev1Code":"CB","serviceRequired":false,"active":true}]},"NWEB":{"id":"NWEB","name":"Nomis-Web
+        Application","type":"APP","currentActive":false,"agencies":[]},"PVI":{"id":"PVI","name":"PENTONVILLE
+        (HMP)","type":"INST","currentActive":false,"agencies":[{"agencyLocationId":"OUT","description":"OUTSIDE","longDescription":"OUTSIDE
+        JURISDICTION","agencyLocationType":"INST","districtCode":"FD","deactivationDate":"2008-05-29","jurisdictionCode":"CC","bailOffice":true,"listSeq":2,"housingLev1Code":"BED","propertyLev1Code":"BOX","serviceRequired":false,"active":false,"disabilityAccessCode":"WHEEL","cjitCode":"TEST"},{"agencyLocationId":"PVI","description":"PENTONVILLE
+        (HMP)","longDescription":"HMP PENTONVILLE","agencyLocationType":"INST","districtCode":"LONDON","bailOffice":false,"housingLev1Code":"WING","housingLev2Code":"LAND","housingLev3Code":"CELL","housingLev4Code":"NULL","serviceRequired":false,"active":true,"areaCode":"LONDON","nomsRegionCode":"LON","geographicRegionCode":"LONDON","cjitCode":"E00PV00"},{"agencyLocationId":"TRN","description":"TRANSFER","agencyLocationType":"INST","districtCode":"FD","bailOffice":true,"housingLev1Code":"CB","serviceRequired":false,"active":true}]},"WEI":{"id":"WEI","name":"WEALSTUN
+        (HMP)","type":"INST","currentActive":false,"agencies":[{"agencyLocationId":"OUT","description":"OUTSIDE","longDescription":"OUTSIDE
+        JURISDICTION","agencyLocationType":"INST","districtCode":"FD","deactivationDate":"2008-05-29","jurisdictionCode":"CC","bailOffice":true,"listSeq":2,"housingLev1Code":"BED","propertyLev1Code":"BOX","serviceRequired":false,"active":false,"disabilityAccessCode":"WHEEL","cjitCode":"TEST"},{"agencyLocationId":"TRN","description":"TRANSFER","agencyLocationType":"INST","districtCode":"FD","bailOffice":true,"housingLev1Code":"CB","serviceRequired":false,"active":true},{"agencyLocationId":"WEI","description":"WEALSTUN
+        (HMP)","longDescription":"HMP WEALSTUN","agencyLocationType":"INST","districtCode":"YORK","bailOffice":false,"housingLev1Code":"WING","housingLev2Code":"LAND","housingLev3Code":"CELL","housingLev4Code":"NULL","serviceRequired":false,"active":true,"areaCode":"YORK","nomsRegionCode":"YOHUM","geographicRegionCode":"YORK","cjitCode":"E00WE00"}]}}}'
+    http_version: 
+  recorded_at: Sun, 09 Dec 2018 00:00:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/hmpps_sso_spec.rb
+++ b/spec/lib/hmpps_sso_spec.rb
@@ -13,22 +13,20 @@ describe OmniAuth::Strategies::HmppsSso do
   end
 
   context 'when methods' do
-    let(:user_name) { double('user_name') }
+    context 'when #info' do
+      it 'returns a hash with the user name and caseload' do
+        leeds_prison = 'LEI'
+        username = 'Fred'
+        staff_details = {
+          'activeNomisCaseload' => leeds_prison,
+          'username' => username
+        }
 
-    let(:token_info) do
-      {
-        'user_name' => user_name
-      }
-    end
+        allow(Nomis::Custody::Api).to receive(:fetch_nomis_staff_details).and_return(staff_details)
+        allow(strategy).to receive(:username).and_return(username)
 
-    context 'when #token_info' do
-      before do
-        allow(strategy).to receive(:token_info).and_return(token_info)
-      end
-
-      it 'returns a hash with the user name' do
-        expect(strategy.info).to eq(
-          username: user_name)
+        expect(strategy.info[:username]).to eq(leeds_prison)
+        expect(strategy.info[:caseload]).to eq(username)
       end
     end
   end

--- a/spec/services/nomis/custody/api_spec.rb
+++ b/spec/services/nomis/custody/api_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Nomis::Custody::Api do
+  # Ensure that we have a new instance to prevent other specs interfering
+  around do |ex|
+    Singleton.__init__(described_class)
+    ex.run
+    Singleton.__init__(described_class)
+  end
+
+  it 'fetches the staff\'s details' do
+    allow_any_instance_of(Nomis::Custody::Client).to receive(:get).and_return(
+      activenomiscaseload: 'LEI'
+    )
+
+    username = 'Fred'
+
+    response = described_class.fetch_nomis_staff_details(username)
+
+    expect(response[:activenomiscaseload]).to eq "LEI"
+  end
+end

--- a/spec/services/nomis/custody/client_spec.rb
+++ b/spec/services/nomis/custody/client_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Nomis::Custody::Client do
+  describe 'with a valid request' do
+    around do |example|
+      travel_to Date.new(2018, 12, 9, 17) do
+        example.run
+      end
+    end
+
+    it 'sets the Authorization header', vcr: { cassette_name: 'custodyapi_client_auth_header' } do
+      api_host = Rails.configuration.nomis_oauth_host
+      username = 'PK000223'
+      route = "/custodyapi/api/nomis-staff-users/#{username}"
+      client = described_class.new(api_host)
+      token_service = Nomis::Oauth::TokenService
+      access_token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbnRlcm5hbFVzZXIiOmZhbHNlLCJzY29wZSI6WyJyZWFkIiwid3JpdGUiXSwiZXhwIjoxNTQ0MzgzNzM4LCJhdXRob3JpdGllcyI6WyJST0xFX1NZU1RFTV9SRUFEX09OTFkiXSwianRpIjoiMjI3NGQ3ZDctM2QzYi00NmRhLTg0NGMtM2Y3Yzc2YmVkNDJiIiwiY2xpZW50X2lkIjoib2ZmZW5kZXItbWFuYWdlbWVudC1hbGxvY2F0aW9uLW1hbmFnZXIifQ.BKYcKggL1JE1vFbrF0-absKolbfzXRmQwy_k3wIPntCVaTWGlVVUk_0r9FS9Okrle26mTfZ-DPD_vus5m6Jto7mj2On6j_zqhx1Eae7pbcgji1yU_e5cO-Oo0JcoqDZZPzcbiypZ-AMbh9iBFBcYYbg0UsfQnknTob48i9-p_PDTWX4sdRWEwSRn71xAewfaSWEvg4tMdZW0js6gti9K4iEEbEdAktM1eUT4woqbvOFURjOVXaD4F-qTF1Fb5adgoWdp63KbSkz4lWzQN5l6Qka1XekZoi0jgw1WLE-DnHU_v888Ft736BQQo9Wa4egHf4ERMagsxkyCen2OCcbCAg"
+      valid_token = Nomis::Oauth::Token.new(access_token)
+
+      allow(token_service).to receive(:valid_token).and_return(valid_token)
+
+      client.get(route)
+
+      expect(WebMock).to have_requested(:get, /\w/).
+        with(
+          headers: {
+            'Authorization': "Bearer #{access_token}"
+          }
+      )
+    end
+  end
+end


### PR DESCRIPTION
When a user has authenticated with Nomis Oauth, a call is made to the Custody API to fetch their caseload (i.e. the prison for which they are 'active'). This will then determine what offenders are viewed within the application.

This PR makes the call to the Custody API to fetch the case load and adds it to the Oauth2 Strategy response