### PR TITLE
[MOICM_94] - Adds a basic dashboard page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,28 @@
  *= require_tree .
  *= require_self
  */
+
+
+ .no-bottom-margin {
+     margin-bottom: 0;
+ }
+
+ .dashboard-row {
+     margin-top: 20px;
+     
+     .wrapper {
+        min-height: 130px;
+        background-color: #f9f9f9;
+    }
+    .govuk-heading-s {
+        background-color: #eaeaea;
+        padding: 8px;
+        margin-bottom: 0;
+    }
+    .govuk-body {
+        padding: 8px;
+    }
+ }
+
+
+

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,5 @@
+class DashboardController < ApplicationController
+  before_action :authenticate_user
+
+  def index; end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,74 @@
+<h1 class="govuk-heading-xl">Dashboard</h1>
+
+<h2 class="govuk-heading-m no-bottom-margin">Allocations</h2>
+<hr class="govuk-section-break govuk-section-break--visible">
+<div class="govuk-grid-row dashboard-row">
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "Allocated prisoners", allocations_path(), class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">All prisoners who have been allocated a Prison Offender Manager.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "Awaiting allocation", allocations_path(anchor: "awaiting-allocation"), class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">Prisoners who need to be allocated a Prison Offender Manager.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "Missing information", allocations_path(anchor: "awaiting-tiering"), class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">Prisoners who have not yet had their risk tiering completed</p>
+    </div>
+  </div>
+</div>
+
+<h2 class="govuk-heading-m no-bottom-margin">Caseload</h2>
+<hr class="govuk-section-break govuk-section-break--visible">
+<div class="govuk-grid-row dashboard-row">
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "My caseload", "/", class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">All cases allocated to you.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "New allocations", "/", class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">Cases allocated to you in the last 7 days.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "Approaching handover", "/" %>
+      </h1>
+      <p class="govuk-body">Cases that are 10 months or less from the release date.</p>
+    </div>
+  </div>
+</div>
+
+<h2 class="govuk-heading-m no-bottom-margin">Staff</h2>
+<hr class="govuk-section-break govuk-section-break--visible">
+<div class="govuk-grid-row dashboard-row">
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "Active POMs", "/", class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">Active and inactive Prison Offender Managers at this prison.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third"></div>
+  <div class="govuk-grid-column-one-third"></div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  root to: 'status#index'
+  root to: 'dashboard#index'
 
+  get '/status', to: 'status#index'
   get '/auth/:provider/callback', to: 'sessions#create'
 
   get('health' => 'health#index')

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature 'get dashboard' do
+  around do |example|
+    travel_to Date.new(2018, 11, 3, 16) do
+      example.run
+    end
+  end
+
+  it 'shows the status page', vcr: { cassette_name: :get_status_feature } do
+    signin_user
+
+    visit '/'
+
+    expect(page).to have_css('.dashboard-row', count: 3)
+    expect(page).to have_link('Allocated prisoners', href: allocations_path)
+    expect(page).to have_link('Awaiting allocation', href: allocations_path(anchor: "awaiting-allocation"))
+    expect(page).to have_link('Missing information', href: allocations_path(anchor: "awaiting-tiering"))
+  end
+end

--- a/spec/features/status_feature_spec.rb
+++ b/spec/features/status_feature_spec.rb
@@ -10,7 +10,7 @@ feature 'get status' do
   it 'returns a status message', vcr: { cassette_name: :get_status_feature } do
     signin_user
 
-    visit '/'
+    visit '/status'
 
     expect(page).to have_css('.status', text: 'ok')
     expect(page).to have_css('.postgres_version', text: 'PostgreSQL 10.5')


### PR DESCRIPTION
Adds the basic dashboard (with links but no search or prison selection) to allow users to navigate through the system as new pages are added. Currently only the allocation links work, the others will just reload the same page.

As part of this PR, the application.css file was renamed to application.scss to make the CSS more usable and minimal changes added for the formatting/display of the dashboard rows.

Moves the status endpoint to /status in case it is still useful.

It is expected that as more pages are available, this page will also be changed as part of those PRs to ensure the link works.