### PR TITLE
[MOIC-83] - Sign out a user

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,4 +9,21 @@ class SessionsController < ApplicationController
       redirect_to root_url
     end
   end
+
+  def destroy
+    session.delete(:sso_data)
+    redirect_to signout_url
+  end
+
+  private
+
+  def signout_url
+    url = URI.parse(Rails.configuration.nomis_oauth_host)
+    url.query = {
+      redirect_uri: Rails.configuration.offender_manager_host,
+      client_id: Rails.configuration.nomis_oauth_client_id
+    }.to_query
+
+    url.to_s
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     redirect_to signout_url
   end
 
-  private
+private
 
   def signout_url
     url = URI.parse(Rails.configuration.nomis_oauth_host)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,7 +18,7 @@ class SessionsController < ApplicationController
 private
 
   def signout_url
-    url = URI.parse(Rails.configuration.nomis_oauth_host)
+    url = URI.parse("#{Rails.configuration.nomis_oauth_host}/auth/logout")
     url.query = {
       redirect_uri: Rails.configuration.offender_manager_host,
       client_id: Rails.configuration.nomis_oauth_client_id

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,6 +12,9 @@
         <span class='govuk-body hmpss-header__prison-identifier govuk-!-font-size-16'>HMP Cardiff  |</span>
         <a href='#' class='govuk-header__link govuk-!-font-size-16'><%= current_user %></a>
       </li>
+      <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+        <%= link_to 'Sign out', signout_path  %>
+      </li>
     </ul>
   </div>
 </header>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module OffenderManagementAllocationClient
     config.nomis_oauth_client_id = ENV['NOMIS_OAUTH_CLIENT_ID']
     config.nomis_oauth_client_secret = ENV['NOMIS_OAUTH_CLIENT_SECRET']
     config.nomis_oauth_public_key = ENV['NOMIS_OAUTH_PUBLIC_KEY']
+    config.offender_manager_host = ENV.fetch('OFFENDER_MANAGER_HOST', 'http://localhost:3000')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,11 +20,14 @@ module OffenderManagementAllocationClient
       'OFFENDER_MANAGEMENT_ALLOCATION_API',
       'http://localhost:8000'
     )
+    config.offender_manager_host = ENV.fetch(
+      'OFFENDER_MANAGER_HOST',
+      'http://localhost:3000'
+    )
     config.sentry_dsn = ENV['SENTRY_DSN']
     config.nomis_oauth_host = ENV['NOMIS_OAUTH_HOST']
     config.nomis_oauth_client_id = ENV['NOMIS_OAUTH_CLIENT_ID']
     config.nomis_oauth_client_secret = ENV['NOMIS_OAUTH_CLIENT_SECRET']
     config.nomis_oauth_public_key = ENV['NOMIS_OAUTH_PUBLIC_KEY']
-    config.offender_manager_host = ENV.fetch('OFFENDER_MANAGER_HOST', 'http://localhost:3000')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'status#index'
 
   get '/auth/:provider/callback', to: 'sessions#create'
+  get '/signout', to: 'sessions#destroy'
 
   get('health' => 'health#index')
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SessionsController, type: :controller do
 
   describe '#create' do
     let(:auth_hash) { { 'info' => 'anything' } }
+
     subject(:create) { get :create, params: { provider: 'hmpps_sso' } }
 
     before do
@@ -24,7 +25,6 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context 'when the user can be signed in' do
-
       before do
         allow(SignonIdentity).to receive(:from_omniauth).and_return(signon_identity)
       end
@@ -72,7 +72,7 @@ RSpec.describe SessionsController, type: :controller do
       allow(Rails.configuration).to receive(:nomis_oauth_client_id).and_return(client_id)
       allow(Rails.configuration).to receive(:offender_manager_host).and_return(offender_manager_host)
 
-      expect(delete :destroy).to  redirect_to(nomis_oauth_sign_out_path)
+      expect(delete :destroy).to redirect_to(nomis_oauth_sign_out_path)
       expect(session[:sso_data]).to be_nil
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -62,17 +62,17 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     it 'deletes the session and redirects to Nomis Single Sign On' do
-      signout_url = 'http://nomis_sso/auth/logout'
+      nomis_oauth_host = 'http://nomis_sso'
       client_id = 'Bob'
       offender_manager_host = 'http://test:3000'
-      nomis_oauth_sign_out_path =
-        "#{signout_url}?client_id=#{client_id}&redirect_uri=#{CGI.escape(offender_manager_host)}"
+      nomis_oauth_sign_out_url =
+        "#{nomis_oauth_host}/auth/logout?client_id=#{client_id}&redirect_uri=#{CGI.escape(offender_manager_host)}"
 
-      allow(Rails.configuration).to receive(:nomis_oauth_host).and_return(signout_url)
+      allow(Rails.configuration).to receive(:nomis_oauth_host).and_return(nomis_oauth_host)
       allow(Rails.configuration).to receive(:nomis_oauth_client_id).and_return(client_id)
       allow(Rails.configuration).to receive(:offender_manager_host).and_return(offender_manager_host)
 
-      expect(delete :destroy).to redirect_to(nomis_oauth_sign_out_path)
+      expect(delete :destroy).to redirect_to(nomis_oauth_sign_out_url)
       expect(session[:sso_data]).to be_nil
     end
   end


### PR DESCRIPTION
- Add 'sign out' link to navigation
- When a user clicks 'sign out', their application session is destroyed and they are signed out of Nomis OAuth2 SSO
- The user will then be redirected to the Nomis OAuth2 SSO sign in page. Upon successful authentication the user will be redirected back to the root path