### PR TITLE
[MOIC-52] Add Allocate Prison Offender Manager

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
  *= require_self
  */
 
+@import "tables";
 
  .no-bottom-margin {
      margin-bottom: 0;
@@ -21,7 +22,7 @@
 
  .dashboard-row {
      margin-top: 20px;
-     
+
      .wrapper {
         min-height: 130px;
         background-color: #f9f9f9;
@@ -35,6 +36,3 @@
         padding: 8px;
     }
  }
-
-
-

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -1,0 +1,32 @@
+@media screen and (max-width: 768px) {
+  table.responsive thead {
+    display: none;
+  }
+  
+  table.responsive tr {
+    border-bottom: 2px solid govuk-colour("grey-2");
+    display: block;
+  }
+
+  table.responsive td {
+    border-bottom: 1px solid govuk-colour("grey-2");
+    display: block;
+    text-align: right;
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+  table.responsive td:before {
+    content: attr(aria-label);
+    float: left;
+    font-weight: bold;
+  }
+}
+
+.table_cell__right_align {
+  text-align: right;
+}
+
+.hmpps-table-cell__key {
+  width: 50%;
+}

--- a/app/controllers/allocate_prison_offender_managers_controller.rb
+++ b/app/controllers/allocate_prison_offender_managers_controller.rb
@@ -1,0 +1,7 @@
+class AllocatePrisonOffenderManagersController < ApplicationController
+  before_action :authenticate_user
+
+  def show; end
+
+  def update; end
+end

--- a/app/views/allocate_prison_offender_managers/_basic_prisoner_info.html.erb
+++ b/app/views/allocate_prison_offender_managers/_basic_prisoner_info.html.erb
@@ -1,0 +1,40 @@
+<div class="govuk-!-margin-top-1">
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header" scope="row">Prisoner</td>
+      <td class="govuk-table__cell table_cell__right_align"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell hmpps-table-cell__key">Name</td>
+      <td class="govuk-table__cell table_cell__right_align"><a
+          href="#">Michael Scarn</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell hmpps-table-cell__key">Number</td>
+      <td class="govuk-table__cell table_cell__right_align">AB1234C</td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell hmpps-table-cell__key">Nationality</td>
+        <td class="govuk-table__cell table_cell__right_align">British</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header" scope="row">Offence</td>
+      <td class="govuk-table__cell table_cell__right_align"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell hmpps-table-cell__key">Main Offence</td>
+      <td class="govuk-table__cell table_cell__right_align">Fraud</td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell hmpps-table-cell__key">Nationality</td>
+        <td class="govuk-table__cell table_cell__right_align">British</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/allocate_prison_offender_managers/_case_information.html.erb
+++ b/app/views/allocate_prison_offender_managers/_case_information.html.erb
@@ -1,0 +1,23 @@
+<table class="govuk-table govuk-!-margin-top-3">
+  <tbody class="govuk-table__body">
+  <tr class="govuk-table__row">
+    <td class="govuk-table__header" scope="row">Case information</td>
+    <td class="govuk-table__cell table_cell__right_align"></td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell hmpps-table-cell__key">Current responsibility</td>
+    <td class="govuk-table__cell table_cell__right_align">Prison</td>
+  </tr>
+
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell hmpps-table-cell__key">Case allocation</td>
+    <td class="govuk-table__cell table_cell__right_align">National Probation Service (NPS)
+    </td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell hmpps-table-cell__key">Tiering calculation</td>
+    <td class="govuk-table__cell table_cell__right_align">
+      <a href="#">Tier A</a></td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/allocate_prison_offender_managers/_current_pom_info.html.erb
+++ b/app/views/allocate_prison_offender_managers/_current_pom_info.html.erb
@@ -1,0 +1,16 @@
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header" scope="row">Current POM</td>
+      <td class="govuk-table__cell table_cell__right_align"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell hmpps-table-cell__key">Name</td>
+      <td class="govuk-table__cell table_cell__right_align">Green, Samantha</td>
+    </tr>
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell hmpps-table-cell__key">Grade</td>
+        <td class="govuk-table__cell table_cell__right_align">Probation POM</td>
+      </tr>
+    </tbody>
+  </table>

--- a/app/views/allocate_prison_offender_managers/_pom_tables.html.erb
+++ b/app/views/allocate_prison_offender_managers/_pom_tables.html.erb
@@ -1,0 +1,92 @@
+<h4 class="govuk-heading-m">
+Recommendation:
+</h4>
+
+<p>Based on the prisoner's tiering calculation.</p>
+
+<table class="govuk-table responsive">
+  <thead class="govuk-table__head">
+    <h2 class="govuk-heading-s">One type of POM</h2>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Name</th>
+      <th class="govuk-table__header" scope="col">Previous allocation</th>
+      <th class="govuk-table__header" scope="col">Tier A cases</th>
+      <th class="govuk-table__header" scope="col">Tier B cases</th>
+      <th class="govuk-table__header" scope="col">Tier C cases</th>
+      <th class="govuk-table__header" scope="col">Tier D cases</th>
+      <th class="govuk-table__header" scope="col">Total</th>
+      <th class="govuk-table__header" scope="col">Working pattern</th>
+      <th class="govuk-table__header" scope="col">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td aria-label="POM name" class="govuk-table__cell ">Green, Samantha</td>
+        <td aria-label="Type" class="govuk-table__cell"></td>
+        <td aria-label="Tier A cases" class="govuk-table__cell table_cell__right_align">11</td>
+        <td aria-label="Tier B cases" class="govuk-table__cell table_cell__right_align">10</td>
+        <td aria-label="Tier C cases" class="govuk-table__cell table_cell__right_align">2</td>
+        <td aria-label="Tier D cases" class="govuk-table__cell table_cell__right_align">1</td>
+        <td aria-label="Total" class="govuk-table__cell table_cell__right_align">24</td>
+        <td aria-label="Working pattern" class="govuk-table__cell table_cell__right_align">Full time</td>
+        <% if current_page?(action: 'show') %>
+          <td aria-label="Action" class="govuk-table__cell table_cell__right_align"><a
+                                href="#">Allocate</a></td>
+        <% else %>
+          <td aria-label="Action" class="govuk-table__cell table_cell__right_align"><a
+                              href="#">Reallocate</a></td>
+        <% end %>
+      </tr>
+  </tbody>
+</table>
+
+<!-- Spacer -->
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-top-4"></div>
+</div>
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Show other type of POMs
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <table class="govuk-table responsive">
+        <h2 class="govuk-heading-m">
+        </h2>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Name</th>
+          <th class="govuk-table__header" scope="col">Previous allocation</th>
+          <th class="govuk-table__header" scope="col">Tier A cases</th>
+          <th class="govuk-table__header" scope="col">Tier B cases</th>
+          <th class="govuk-table__header" scope="col">Tier C cases</th>
+          <th class="govuk-table__header" scope="col">Tier D cases</th>
+          <th class="govuk-table__header" scope="col">Total</th>
+          <th class="govuk-table__header" scope="col">Working pattern</th>
+          <th class="govuk-table__header" scope="col">Action</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td aria-label="POM name" class="govuk-table__cell table_cell__right_align">Penge, Frank</td>
+            <td aria-label="Type" class="govuk-table__cell"></td>
+            <td aria-label="Tier A cases" class="govuk-table__cell table_cell__right_align">0</td>
+            <td aria-label="Tier B cases" class="govuk-table__cell table_cell__right_align">0</td>
+            <td aria-label="Tier C cases" class="govuk-table__cell table_cell__right_align">13</td>
+            <td aria-label="Tier D cases" class="govuk-table__cell table_cell__right_align">15</td>
+            <td aria-label="Total" class="govuk-table__cell table_cell__right_align">28</td>
+            <td aria-label="Working pattern" class="govuk-table__cell table_cell__right_align">Full time</td>
+            <% if current_page?(action: 'show') %>
+              <td aria-label="Action" class="govuk-table__cell table_cell__right_align"><a
+                                    href="#">Allocate</a></td>
+            <% else %>
+              <td aria-label="Action" class="govuk-table__cell table_cell__right_align"><a
+                                  href="#">Reallocate</a></td>
+            <% end %>
+          </tr>
+      </tbody>
+    </table>
+  </div>
+</details>

--- a/app/views/allocate_prison_offender_managers/edit.html.erb
+++ b/app/views/allocate_prison_offender_managers/edit.html.erb
@@ -1,0 +1,13 @@
+<a href="#" class="govuk-back-link govuk-!-margin-bottom-6">Back</a>
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
+
+<%= render 'allocate_prison_offender_managers/basic_prisoner_info' %>
+
+<%= render 'allocate_prison_offender_managers/current_pom_info' %>
+
+<%= render 'allocate_prison_offender_managers/case_information' %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible"></hr>
+
+<%= render 'allocate_prison_offender_managers/pom_tables' %>

--- a/app/views/allocate_prison_offender_managers/show.html.erb
+++ b/app/views/allocate_prison_offender_managers/show.html.erb
@@ -1,0 +1,11 @@
+<a href="#" class="govuk-back-link govuk-!-margin-bottom-6">Back</a>
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
+
+<%= render 'allocate_prison_offender_managers/basic_prisoner_info' %>
+
+<%= render 'allocate_prison_offender_managers/case_information' %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible"></hr>
+
+<%= render 'allocate_prison_offender_managers/pom_tables' %>

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-phase-banner govuk-width-container app-site-
 width-container">
   <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag hmpps-tag__alpha govuk-phase-banner__content__tag ">alpha</strong>
+    <strong class="govuk-tag hmpps-tag__beta govuk-phase-banner__content__tag ">beta</strong>
     <span class="govuk-phase-banner__text">
       This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
     </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   get('/poms' => 'poms#index')
   get('/poms/:id' => 'poms#show', as: 'poms_show')
   get('/poms/:id/edit' => 'poms#edit', as: 'poms_edit')
+  resource :allocate_prison_offender_managers, only: %i[show edit]
 end

--- a/spec/features/offender_allocations_spec.rb
+++ b/spec/features/offender_allocations_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+feature 'allocate a POM' do
+  it 'shows the allocate a POM page' do
+    signin_user
+
+    visit '/allocate_prison_offender_managers'
+
+    expect(page).to have_css('h1', text: 'Allocate a Prison Offender Manager')
+  end
+end


### PR DESCRIPTION
Adds a basic show and edit page for allocating a Prison Offender
Manager.  These pages contain no data and the links do not work; the page
will be updated as work progresses on the backend.

Updated phase banner to "beta" from "alpha".