### PR TITLE
Adds breadcrumbs to relevant pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'sentry-raven'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
+gem 'loaf'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    loaf (0.8.0)
+      rails (>= 3.2)
     lograge (0.10.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -278,6 +280,7 @@ DEPENDENCIES
   jbuilder (~> 2.8)
   jwt
   listen (>= 3.0.5, < 3.2)
+  loaf
   lograge
   logstash-event
   omniauth-oauth2
@@ -303,4 +306,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,5 +1,6 @@
 class AllocationsController < ApplicationController
   before_action :authenticate_user
+  breadcrumb 'Allocations', :allocations_path
 
   def index
     @prisoners = Nomis::Custody::Api.get_offenders(caseload)

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -1,6 +1,9 @@
 class PomsController < ApplicationController
   before_action :authenticate_user
 
+  breadcrumb 'Prison Offender Managers', :poms_path, only: [:index, :show]
+  breadcrumb -> { 'Surname, Forename' }, -> {  poms_show_path(1) }, only: [:show]
+
   def index; end
 
   def show; end

--- a/app/views/allocate_prison_offender_managers/edit.html.erb
+++ b/app/views/allocate_prison_offender_managers/edit.html.erb
@@ -1,4 +1,4 @@
-<a href="<%= allocations_path() %>" class="govuk-back-link govuk-!-margin-bottom-6">Back</a>
+<%= render :partial => "/shared/backlink", :locals => { :page => allocations_path() } %>
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
 

--- a/app/views/allocate_prison_offender_managers/show.html.erb
+++ b/app/views/allocate_prison_offender_managers/show.html.erb
@@ -1,4 +1,4 @@
-<a href="<%= allocations_path(anchor: "awaiting-allocation") %>" class="govuk-back-link govuk-!-margin-bottom-6">Back</a>
+<%= render :partial => "/shared/backlink", :locals => { :page => allocations_path(anchor: "awaiting-allocation") } %>
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,9 @@
 
     <div class='govuk-width-container'>
       <main class='govuk-main-wrapper' id='main-content' role='main'>
+
+        <%= render '/shared/breadcrumbs' %>
+
         <%= yield %>
       </main>
     </div>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,4 +1,6 @@
-<a href="<%= poms_show_path(id: 1) %>" class="govuk-back-link">Back</a>
+
+
+<%= render :partial => "/shared/backlink", :locals => { :page => poms_show_path(id: 1) } %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Edit profile</h1>
 <h2 class="govuk-heading-l">Surname, Forename</h2>

--- a/app/views/shared/_backlink.html.erb
+++ b/app/views/shared/_backlink.html.erb
@@ -1,0 +1,1 @@
+<a href="<%= page %>" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6">Back</a>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,14 @@
+<% if breadcrumb_trail.count > 0 %>
+    <div class="govuk-breadcrumbs govuk-!-margin-top-0 govuk-!-margin-bottom-6">
+    <ol class="govuk-breadcrumbs__list">
+        <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/">Home</a>
+        </li>
+        <% breadcrumb_trail do |crumb| %>
+        <li class="govuk-breadcrumbs__list-item" <%= crumb.current? ? 'aria-current="page"' : '' %> >
+            <a class="govuk-breadcrumbs__link" href="<%= crumb.url %>"><%= crumb.name %></a>
+        </li>
+        <% end %>
+    </ol>
+    </div>
+<% end %>

--- a/config/locales/loaf.en.yml
+++ b/config/locales/loaf.en.yml
@@ -1,0 +1,6 @@
+en:
+  loaf:
+    errors:
+      invalid_options: "Invalid option :%{invalid}. Valid options are: %{valid}, make sure these are the ones you are using."
+    breadcrumbs:
+      home: 'Home'

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -14,6 +14,8 @@ feature 'allcations summary feature' do
       visit 'allocations/#awaiting_tiering'
 
       expect(page).to have_css('.govuk-tabs__tab', text: 'Awaiting tiering')
+      expect(page).to have_css('.govuk-breadcrumbs')
+      expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
     end
   end
 end

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -16,5 +16,6 @@ feature 'get dashboard' do
     expect(page).to have_link('Allocated prisoners', href: allocations_path)
     expect(page).to have_link('Awaiting allocation', href: allocations_path(anchor: "awaiting-allocation"))
     expect(page).to have_link('Missing information', href: allocations_path(anchor: "awaiting-tiering"))
+    expect(page).not_to have_css('.govuk-breadcrumbs')
   end
 end

--- a/spec/features/offender_allocations_spec.rb
+++ b/spec/features/offender_allocations_spec.rb
@@ -7,5 +7,6 @@ feature 'allocate a POM' do
     visit '/allocate_prison_offender_managers'
 
     expect(page).to have_css('h1', text: 'Allocate a Prison Offender Manager')
+    expect(page).not_to have_css('.govuk-breadcrumbs')
   end
 end

--- a/spec/features/poms_controller_spec.rb
+++ b/spec/features/poms_controller_spec.rb
@@ -10,6 +10,9 @@ feature "get poms list" do
     expect(page).to have_content("Prison Offender Managers")
     expect(page).to have_content("Prison POM")
     expect(page).to have_content("Probation POM")
+
+    expect(page).to have_css('.govuk-breadcrumbs')
+    expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
   end
 
   it "allows viewing a POM", vcr: { cassette_name: :get_token } do
@@ -20,6 +23,8 @@ feature "get poms list" do
     expect(page).to have_css(".govuk-button", count: 1)
     expect(page).to have_content("Surname, Forename")
     expect(page).to have_content("Caseload")
+    expect(page).to have_css('.govuk-breadcrumbs')
+    expect(page).to have_css('.govuk-breadcrumbs__link', count: 3)
   end
 
   it "allows editing a POM", vcr: { cassette_name: :get_token } do
@@ -32,5 +37,6 @@ feature "get poms list" do
     expect(page).to have_content("Edit profile")
     expect(page).to have_content("Working pattern")
     expect(page).to have_content("Working status")
+    expect(page).not_to have_css('.govuk-breadcrumbs')
   end
 end


### PR DESCRIPTION
Adds a new dependency (loaf - https://github.com/piotrmurach/loaf) to
make using breadcrumbs easier. Have reviewed, looks okay. You will need
to `bundle` after pulling this PR.

Breadcrumbs can be added to a particular controller as follows (taken
from allocations_controller):

```
breadcrumb 'Allocations', :allocations_path
```

If a controller adds no breadcrumbs, then none are shown.

More complex use of the breadcrumbs is possible using only: and expect:
for example in the POMS Controller we have the following where a proc
can be used for the title or the URL (which will be needed when an ID of
come sort is involved).

```
  breadcrumb 'Prison Offender Managers', :poms_path, only: [:index,
:show]
  breadcrumb -> { 'Surname, Forename' }, -> {  poms_show_path(1) },
only: [:show]
```

This will show the relevant breadcrumb items for show and index, but not
edit which is expected to have a back link instead.

Have also added a new backlink partial to make the styling easier, it
can be used in an erb in the following way:

```
<%= render :partial => "/shared/backlink", :locals => { :page =>
poms_show_path(id: 1) } %>
```