### PR TITLE
Changes to the reference to the crest image for staging

### DIFF
--- a/app/assets/stylesheets/hmpps_header.scss
+++ b/app/assets/stylesheets/hmpps_header.scss
@@ -6,7 +6,7 @@
 .hmpps__logotype-crest {
   display: inline-block;
   content: "";
-  background: url('Crest@2x.png') no-repeat;
+  background: asset-url('Crest@2x.png') no-repeat;
   background-size: contain;
   width: 36px;
   height: 30px;


### PR DESCRIPTION
Currently on staging the hmpps header css references Crest-2x.png but
because of the pipeline, this doesn't exist.  However it is fine in
development.

This PR just replaces the url() in the CSS with asset-url() which
ensures that the versioned image url is used.