### PR TITLE
Rename expect_exception to raven_intercept_exception

### DIFF
--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -8,7 +8,7 @@ feature 'allocations summary feature' do
   end
 
   describe 'awaiting allocations table' do
-    it 'displays offenders awaiting tiering', :expect_exception, vcr: { cassette_name: :awaiting_tiering_feature } do
+    it 'displays offenders awaiting tiering', :raven_intercept_exception, vcr: { cassette_name: :awaiting_tiering_feature } do
       signin_user
 
       visit 'allocations/missing-information'
@@ -18,7 +18,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
     end
 
-    it 'renders allocation offenders at index', :expect_exception, vcr: { cassette_name: :allocated_offenders } do
+    it 'renders allocation offenders at index', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders } do
       signin_user
       visit 'allocations'
 
@@ -27,7 +27,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
     end
 
-    it 'displays offenders already allocated', :expect_exception, vcr: { cassette_name: :allocated_offenders } do
+    it 'displays offenders already allocated', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders } do
       signin_user
 
       visit 'allocations/allocated'
@@ -37,7 +37,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
     end
 
-    it 'displays offenders pending allocation', :expect_exception, vcr: { cassette_name: :awaiting_allocation_offenders } do
+    it 'displays offenders pending allocation', :raven_intercept_exception, vcr: { cassette_name: :awaiting_allocation_offenders } do
       signin_user
 
       visit 'allocations/awaiting'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
-  config.before(:each, :expect_exception) do
+  config.before(:each, :raven_intercept_exception) do
     Rails.configuration.sentry_dsn = 'https://test.com'
     allow(Raven).to receive(:capture_exception)
   end
@@ -25,7 +25,7 @@ RSpec.configure do |config|
   config.include JWTHelper
   config.include FeaturesHelper
 
-  config.after(:each, :expect_exception) do
+  config.after(:each, :raven_intercept_exception) do
     Rails.configuration.sentry_dsn = nil
   end
 end

--- a/spec/services/nomis/custody/api_deserialiser_spec.rb
+++ b/spec/services/nomis/custody/api_deserialiser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Nomis::Custody::ApiDeserialiser do
 
   subject { model.new(payload) }
 
-  it 'will serialise a payload with unknown attributes', :expect_exception do
+  it 'will serialise a payload with unknown attributes', :raven_intercept_exception do
     expect(described_class.new.deserialise(memory_model_class, payload)).to have_attributes foo: 'bar'
   end
 

--- a/spec/services/nomis/custody/api_spec.rb
+++ b/spec/services/nomis/custody/api_spec.rb
@@ -45,7 +45,7 @@ describe Nomis::Custody::Api do
       expect(response.release_date).to eq('2017-04-09')
     end
 
-  it 'returns a NullReleaseDetails if there are no release details for a prisoner', :expect_exception,
+  it 'returns a NullReleaseDetails if there are no release details for a prisoner', :raven_intercept_exception,
     vcr: { cassette_name: :handle_null_release_details } do
       offender_id = '1027417'
       booking_id = '1142296'

--- a/spec/services/nomis/custody/client_spec.rb
+++ b/spec/services/nomis/custody/client_spec.rb
@@ -44,7 +44,7 @@ describe Nomis::Custody::Client do
       WebMock.stub_request(:get, /\w/).to_raise(error)
     end
 
-    it 'raises an APIError', :expect_exception do
+    it 'raises an APIError', :raven_intercept_exception do
       expect { client.get(path) }.
         to raise_error(Nomis::Custody::Client::APIError, 'Unexpected status 401')
     end


### PR DESCRIPTION
Renames expect_exception so that it is clearer that the test expects
raven to intercept the exception.