### PR TITLE
Handles 500 errors in the custody API

### DIFF
--- a/app/services/nomis/custody/client.rb
+++ b/app/services/nomis/custody/client.rb
@@ -31,7 +31,7 @@ module Nomis
         }
 
         JSON.parse(response.body)
-      rescue Faraday::ResourceNotFound => e
+      rescue Faraday::ResourceNotFound, Faraday::ClientError => e
         AllocationManager::ExceptionHandler.capture_exception(e)
         raise APIError, "Unexpected status #{e.response[:status]}"
       end


### PR DESCRIPTION
Currently the custody client only handles ResourceNotFound (404) errors,
which means that 500 errors will crash the current request if the
custody client raises one.

This PR handles 500 errors, in much the same way as 404 errors (logs to
sentry and raises a local APIError) but for some reason Faraday thinks a
500 is a ClientError, which might just be a case of bad naming (it's
actually a server error).

Hopefully this will handle the cases when the custody API has database
connectivity issues in staging (although APIError is only currently
handled safely in getting release details).