### PR TITLE
If there is no page metadata, don't show the pagination

### DIFF
--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,33 +1,35 @@
-<div class="govuk-grid-row pagination">
-  <div class="govuk-grid-column-one-half">
-    <ul class="links">
-      <li>
-        <% if @page_data.previous? %>
-          <a href="<%= replace_param('page', @page_data.current_page - 1) %>">&laquo; Previous</a>
-        <% else %>
-          &laquo; Previous
-        <% end %>
-      </li>
-      <% for page_num in @page_data.page_numbers %>
+<% if @page_data %>
+  <div class="govuk-grid-row pagination">
+    <div class="govuk-grid-column-one-half">
+      <ul class="links">
         <li>
-          <% if page_num == @page_data.current_page %>
-            <%= page_num %>
+          <% if @page_data.previous? %>
+            <a href="<%= replace_param('page', @page_data.current_page - 1) %>">&laquo; Previous</a>
           <% else %>
-            <a href="<%= replace_param('page', page_num) %>"><%= page_num %></a>
+            &laquo; Previous
           <% end %>
         </li>
-      <% end %>
-      <li>
-        <% if @page_data.next? %>
-          <a href="<%= replace_param('page', @page_data.current_page + 1) %>">Next &raquo;</a>
-        <% else %>
-          Next &raquo;
+        <% for page_num in @page_data.page_numbers %>
+          <li>
+            <% if page_num == @page_data.current_page %>
+              <%= page_num %>
+            <% else %>
+              <a href="<%= replace_param('page', page_num) %>"><%= page_num %></a>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-    </ul>
+        <li>
+          <% if @page_data.next? %>
+            <a href="<%= replace_param('page', @page_data.current_page + 1) %>">Next &raquo;</a>
+          <% else %>
+            Next &raquo;
+          <% end %>
+        </li>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-one-half result-count">
+      Showing <%= @page_data.record_range %> of <%= @page_data.total_elements %> results
+    </div>
   </div>
-  <div class="govuk-grid-column-one-half result-count">
-    Showing <%= @page_data.record_range %> of <%= @page_data.total_elements %> results
-  </div>
-</div>
-</section>
+  </section>
+<% end %>


### PR DESCRIPTION
There is little point showing pagination elements if there is no
metadata for the available pages.