### PR TITLE
Create Fake NDelius Server

### DIFF
--- a/app/services/ndelius/api.rb
+++ b/app/services/ndelius/api.rb
@@ -1,0 +1,13 @@
+module Ndelius
+  class Api
+    include Singleton
+
+    class << self
+      delegate :get_record, to: :instance
+    end
+
+    def get_record(nomis_id)
+      FakeRecord.generate(nomis_id)
+    end
+  end
+end

--- a/app/services/ndelius/fake_record.rb
+++ b/app/services/ndelius/fake_record.rb
@@ -1,0 +1,50 @@
+module Ndelius
+  class FakeRecord
+    TIER_A = 'A'
+    TIER_B = 'B'
+    TIER_C = 'C'
+    TIER_D = 'D'
+
+    NPS_CASE_ALLOCATION = 'NPS'
+    CRC_CASE_ALLOCATION = 'CRC'
+
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
+    def self.generate(nomis_id)
+      last_letter = nomis_id.split('').last
+
+      case last_letter
+      when 'A', 'B', 'C', 'D'
+        new(TIER_A, NPS_CASE_ALLOCATION, nomis_id)
+      when 'E', 'F', 'G', 'H'
+        new(TIER_B, NPS_CASE_ALLOCATION, nomis_id)
+      when 'I', 'J', 'K', 'L'
+        new(TIER_C, CRC_CASE_ALLOCATION, nomis_id)
+      when 'M', 'N', 'O', 'P'
+        new(TIER_D, CRC_CASE_ALLOCATION, nomis_id)
+      when 'Q', 'R', 'S', 'T'
+        raise NoTierException
+      when 'U', 'V', 'W', 'X'
+        raise MultipleRecordException
+      when 'Y', 'Z'
+        raise NoRecordException
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength
+
+    attr_reader :tier, :case_allocation, :nomis_id
+
+    def initialize(tier, case_allocation, nomis_id)
+      @tier = tier
+      @case_allocation = case_allocation
+      @nomis_id = nomis_id
+    end
+  end
+
+  class NoTierException < StandardError; end
+
+  class MultipleRecordException < StandardError; end
+
+  class NoRecordException < StandardError; end
+end

--- a/spec/services/ndelius/api_spec.rb
+++ b/spec/services/ndelius/api_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Ndelius::Api do
+  # Ensure that we have a new instance to prevent other specs interfering
+  around do |ex|
+    Singleton.__init__(described_class)
+    ex.run
+    Singleton.__init__(described_class)
+  end
+
+  it 'gets an NDelius record' do
+    nomis_id = 'A1234BA'
+    expect(described_class.get_record(nomis_id)).
+      to be_kind_of(Ndelius::FakeRecord)
+  end
+end

--- a/spec/services/ndelius/fake_record_spec.rb
+++ b/spec/services/ndelius/fake_record_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Ndelius::FakeRecord do
+  describe 'Generating a fake record' do
+    let(:subject) { described_class }
+
+    context 'when the Nomis id ends with A, B, C, D' do
+      it 'returns a FakeRecord with tier A' do
+        %w[A1234BA A1234BB A1234BC A1234BD].each do |nomis_id|
+          record = subject.generate(nomis_id)
+
+          expect(record.tier).to eq('A')
+          expect(record.nomis_id).to eq(nomis_id)
+          expect(record.case_allocation).to eq('NPS')
+        end
+      end
+    end
+
+    context 'when the Nomis id ends with E, F, G, H' do
+      it 'returns a FakeRecord with tier B' do
+        %w[A1234BE A1234BF A1234BG A1234BH].each do |nomis_id|
+          record = subject.generate(nomis_id)
+
+          expect(record.tier).to eq('B')
+          expect(record.nomis_id).to eq(nomis_id)
+          expect(record.case_allocation).to eq('NPS')
+        end
+      end
+    end
+
+    context 'when the Nomis id ends with I, J, K, L' do
+      it 'returns a FakeRecord with tier C' do
+        %w[A1234BI A1234BJ A1234BK A1234BL].each do |nomis_id|
+          record = subject.generate(nomis_id)
+
+          expect(record.tier).to eq('C')
+          expect(record.nomis_id).to eq(nomis_id)
+          expect(record.case_allocation).to eq('CRC')
+        end
+      end
+    end
+
+    context 'when the Nomis id ends with M, N, O, P' do
+      it 'returns a FakeRecord with tier D' do
+        %w[A1234BM A1234BN A1234BO A1234BP].each do |nomis_id|
+          record = subject.generate(nomis_id)
+
+          expect(record.tier).to eq('D')
+          expect(record.nomis_id).to eq(nomis_id)
+          expect(record.case_allocation).to eq('CRC')
+        end
+      end
+    end
+
+    context 'when the Nomis id ends with Q, R, S, T' do
+      it 'raises a NoTier exception' do
+        %w[A1234BQ A1234BR A1234BS A1234BT].each do |nomis_id|
+          expect { subject.generate(nomis_id) }.to raise_error(Ndelius::NoTierException)
+        end
+      end
+    end
+
+    context 'when the Nomis id ends with U, V, W, X' do
+      it 'raises a MultipleRecordException' do
+        %w[A1234BU A1234BV A1234BW A1234BX].each do |nomis_id|
+          expect { subject.generate(nomis_id) }.to raise_error(Ndelius::MultipleRecordException)
+        end
+      end
+    end
+
+    context 'when the Nomis id ends with Y, Z' do
+      it 'returns a NoRecordException' do
+        %w[A1234BY A1234BZ].each do |nomis_id|
+          expect { subject.generate(nomis_id) }.to raise_error(Ndelius::NoRecordException)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Create NDelius API wrapper that returns responses from a fake NDelius server
- Different types of records are returned by the fake server depending on the last character of the Nomis Id.
- Scenarios where there are missing records or multiple records will raise an exception. If a fake record has no tier than an exception will also be raised