### PR TITLE
Adds an OffenderService class

### DIFF
--- a/app/controllers/allocate_prison_offender_managers_controller.rb
+++ b/app/controllers/allocate_prison_offender_managers_controller.rb
@@ -4,7 +4,7 @@ class AllocatePrisonOffenderManagersController < ApplicationController
   def show; end
 
   def new
-    response = Nomis::Custody::Api.get_offender(noms_id)
+    response = OffenderService.new.get_offender(noms_id)
     @prisoner = response.data
   end
 

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -9,7 +9,10 @@ class AllocationsController < ApplicationController
   def allocated
     breadcrumb 'Allocated', :allocations_allocated_path
 
-    response = Nomis::Elite2::Api.get_offender_list(caseload, page_number)
+    response = OffenderService.new.get_offenders_for_prison(
+      caseload,
+      page_number: page_number
+    )
     @prisoners = response.data
     @page_data = response.meta
   end
@@ -17,7 +20,10 @@ class AllocationsController < ApplicationController
   def awaiting
     breadcrumb 'Awaiting allocation', :allocations_awaiting_path
 
-    response = Nomis::Elite2::Api.get_offender_list(caseload, page_number)
+    response = OffenderService.new.get_offenders_for_prison(
+      caseload,
+      page_number: page_number
+    )
     @prisoners = response.data
     @page_data = response.meta
   end
@@ -25,7 +31,10 @@ class AllocationsController < ApplicationController
   def missing_information
     breadcrumb 'Awaiting tiering', :allocations_missing_information_path
 
-    response = Nomis::Elite2::Api.get_offender_list(caseload, page_number)
+    response = OffenderService.new.get_offenders_for_prison(
+      caseload,
+      page_number: page_number
+    )
     @prisoners = response.data
     @page_data = response.meta
   end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -1,0 +1,9 @@
+class OffenderService
+  def get_offender(noms_id)
+    Nomis::Custody::Api.get_offender(noms_id)
+  end
+
+  def get_offenders_for_prison(prison, page_number: 0)
+    Nomis::Elite2::Api.get_offender_list(prison, page_number)
+  end
+end

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_prison } do
+  it "get first page of offenders for a specific prison" do
+    offenders = OffenderService.new.get_offenders_for_prison('LEI')
+    expect(offenders.meta).to be_kind_of(PageMeta)
+    expect(offenders.data).to be_kind_of(Array)
+    expect(offenders.data.length).to eq(10)
+    expect(offenders.data.first).to be_kind_of(Nomis::OffenderShort)
+  end
+
+  it "get last page of offenders for a specific prison", vcr: { cassette_name: :get_offenders_for_specific_prison_last_page } do
+    offenders = OffenderService.new.get_offenders_for_prison('LEI', page_number: 116)
+    expect(offenders.meta).to be_kind_of(PageMeta)
+    expect(offenders.data).to be_kind_of(Array)
+    expect(offenders.data.length).to eq(7)
+    expect(offenders.data.first).to be_kind_of(Nomis::OffenderShort)
+  end
+
+  it "gets a single offender", vcr: { cassette_name: :get_single_offender } do
+    offender = OffenderService.new.get_offender('G4273GI')
+    expect(offender.data).to be_kind_of(Nomis::OffenderDetails)
+  end
+end


### PR DESCRIPTION
Currently the controllers call the APIs directly, and this is likely to
lead to much complexity being added to handle calls to different
endpoints.

This PR abstracts the actions into a separate service so we can isolate
the complexity in one place away from the controllers.