### PR TITLE
Switch our HTTP client to use typhoeus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'sentry-raven'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 gem 'loaf'
+gem 'typhoeus'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.8.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -247,6 +249,8 @@ GEM
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -298,6 +302,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
+  typhoeus
   tzinfo-data
   uglifier (>= 1.3.0)
   vcr

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'typhoeus/adapters/faraday'
 
 module Nomis
   class Client
@@ -13,7 +14,7 @@ module Nomis
 
         faraday.options.params_encoder = Faraday::FlatParamsEncoder
         faraday.use Faraday::Response::RaiseError
-        faraday.adapter Faraday.default_adapter
+        faraday.adapter :typhoeus
       end
     end
 

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -5,7 +5,6 @@ class OffenderService
 
   def get_offenders_for_prison(prison, page_number: 0)
     offenders = Nomis::Elite2::Api.get_offender_list(prison, page_number)
-
     offender_ids = offenders.data.map(&:offender_no)
 
     tier_map = Ndelius::Api.get_records(offender_ids)


### PR DESCRIPTION
Currently the app uses net:http in faraday for making HTTP request, and
this PR switches it out to use typhoeus (which is libcurl based)
instead.