### PR TITLE
Adds main offence text to single offender view

### DIFF
--- a/app/services/nomis/elite2/api.rb
+++ b/app/services/nomis/elite2/api.rb
@@ -7,9 +7,10 @@ module Nomis
       include Singleton
 
       class << self
+        delegate :get_offender, to: :instance
         delegate :get_offender_list, to: :instance
         delegate :get_bulk_release_dates, to: :instance
-        delegate :get_offender, to: :instance
+        delegate :get_offence, to: :instance
       end
 
       def initialize
@@ -57,6 +58,12 @@ module Nomis
         ApiResponse.new(NullOffender.new)
       end
       # rubocop:enable Metrics/MethodLength
+
+      def get_offence(booking_id)
+        route = "/elite2api/api/bookings/#{booking_id}/mainOffence"
+        data = @e2_client.get(route)
+        ApiResponse.new(data.first['offenceDescription'])
+      end
 
       def get_bulk_release_dates(offender_ids)
         route = '/elite2api/api/offender-sentences'

--- a/app/services/nomis/offender.rb
+++ b/app/services/nomis/offender.rb
@@ -27,6 +27,7 @@ module Nomis
     attribute :reception_date, :date
     attribute :marital_status, :string
 
+    attr_accessor :main_offence
     attr_accessor :release_date
     attr_accessor :tier
 

--- a/app/services/nomis/offender.rb
+++ b/app/services/nomis/offender.rb
@@ -26,7 +26,7 @@ module Nomis
     attribute :imprisonment_status, :string
     attribute :reception_date, :date
     attribute :marital_status, :string
-    attribute :main_offence, :date
+    attribute :main_offence, :string
     attribute :release_date, :date
     attribute :tier, :string
     attribute :case_allocation, :string

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -5,6 +5,8 @@ class OffenderService
 
       release = Nomis::Elite2::Api.get_bulk_release_dates([offender_no])
       o.data.release_date = release.data[offender_no]
+
+      o.data.main_offence = Nomis::Elite2::Api.get_offence(o.data.latest_booking_id).data
     }
   end
 

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <tr class="govuk-table__row">
     <td class="govuk-table__cell hmpps-table-cell__key">Main Offence</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key">Need to get from somewhere!</td>
+    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= @prisoner.main_offence %></td>
   </tr>
   <tr class="govuk-table__row">
       <td class="govuk-table__cell hmpps-table-cell__key">Release date / parole eligibility</td>

--- a/spec/services/nomis/elite2/api_spec.rb
+++ b/spec/services/nomis/elite2/api_spec.rb
@@ -21,6 +21,13 @@ describe Nomis::Elite2::Api do
     expect(response.data).to be_instance_of(Nomis::Offender)
   end
 
+  it "can get an offence description for a booking id", vcr: { cassette_name: :get_offence_ok }  do
+    booking_id = '1153753'
+    response = described_class.get_offence(booking_id)
+    expect(response.data).to be_instance_of(String)
+    expect(response.data).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
+  end
+
   it 'returns null if unable to find prisoner', :raven_intercept_exception,
     vcr: { cassette_name: :elite2_api_fail_get_offender_details } do
       noms_id = 'AAA22D'

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -23,5 +23,6 @@ describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_pris
     expect(offender.data).to be_kind_of(Nomis::Offender)
     expect(offender.data.release_date).to eq '2020-02-07'
     expect(offender.data.tier).to eq 'C'
+    expect(offender.data.main_offence).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
   end
 end


### PR DESCRIPTION
This PR adds an API call to get the main offence for a given booking,
and then calls it in the OffenderService so that the main offence
description is available in the main prisoner allocation view.