### PR TITLE
Adds the case allocation field to the single offender

### DIFF
--- a/app/services/nomis/offender.rb
+++ b/app/services/nomis/offender.rb
@@ -29,6 +29,7 @@ module Nomis
 
     attr_accessor :release_date
     attr_accessor :tier
+    attr_accessor :case_allocation
 
     def full_name
       "#{last_name}, #{first_name}".titleize

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -1,7 +1,9 @@
 class OffenderService
   def get_offender(offender_no)
     Nomis::Elite2::Api.get_offender(offender_no).tap { |o|
-      o.data.tier = Ndelius::Api.get_record(offender_no).tier
+      record = Ndelius::Api.get_record(offender_no)
+      o.data.tier = record.tier
+      o.data.case_allocation = record.case_allocation
 
       release = Nomis::Elite2::Api.get_bulk_release_dates([offender_no])
       o.data.release_date = release.data[offender_no]

--- a/app/views/allocate_prison_offender_managers/_case_information.html.erb
+++ b/app/views/allocate_prison_offender_managers/_case_information.html.erb
@@ -11,7 +11,7 @@
 
   <tr class="govuk-table__row">
     <td class="govuk-table__cell hmpps-table-cell__key">Case allocation</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key">Need to get from somewhere!
+    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= @prisoner.case_allocation %>
     </td>
   </tr>
   <tr class="govuk-table__row">

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -23,5 +23,6 @@ describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_pris
     expect(offender.data).to be_kind_of(Nomis::Offender)
     expect(offender.data.release_date).to eq '2020-02-07'
     expect(offender.data.tier).to eq 'C'
+    expect(offender.data.case_allocation).to eq 'CRC'
   end
 end


### PR DESCRIPTION
When using the Delius API to fetch the tier, we also fetch the case
allcoation (if any) and this PR adds it to the model and adds to the
prisoner allocation screen.