### PR TITLE
Store release_date as a date rather than a string

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,9 +9,9 @@ module ApplicationHelper
     uri.to_s
   end
 
-  def string_to_date(str)
-    return str if str.blank?
+  def format_date(date_obj)
+    return '' if date_obj.nil?
 
-    Date.parse(str).strftime('%d/%m/%Y')
+    date_obj.strftime('%d/%m/%Y')
   end
 end

--- a/app/services/nomis/elite2/api.rb
+++ b/app/services/nomis/elite2/api.rb
@@ -70,7 +70,8 @@ module Nomis
 
         results = data.each_with_object({}) { |record, hash|
           oid = record['offenderNo']
-          hash[oid] = record['sentenceDetail'].fetch('releaseDate', '')
+          datestring = record['sentenceDetail'].fetch('releaseDate', '')
+          hash[oid] = datestring.present? ? Date.parse(datestring) : nil
         }
 
         ApiResponse.new(results)

--- a/app/services/nomis/offender.rb
+++ b/app/services/nomis/offender.rb
@@ -26,9 +26,8 @@ module Nomis
     attribute :imprisonment_status, :string
     attribute :reception_date, :date
     attribute :marital_status, :string
-
-    attr_accessor :release_date
-    attr_accessor :tier
+    attribute :release_date, :date
+    attribute :tier, :string
 
     def full_name
       "#{last_name}, #{first_name}".titleize

--- a/app/views/allocations/allocated.html.erb
+++ b/app/views/allocations/allocated.html.erb
@@ -26,7 +26,7 @@
         <td aria-label="Prisoner number" class="govuk-table__cell"><%= prisoner.offender_no %></td>
         <td aria-label="Arrival date" class="govuk-table__cell
               ">N/A</td>
-        <td aria-label="Release date" class="govuk-table__cell"><%= string_to_date(prisoner.release_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell"><%= format_date(prisoner.release_date) %></td>
         <td aria-label="Tier" class="govuk-table__cell"><%= prisoner.tier %></td>
         <td aria-label="POM" class="govuk-table__cell">NA</td>
         <td aria-label="Allocation date" class="govuk-table__cell">NA</td>

--- a/app/views/allocations/awaiting.html.erb
+++ b/app/views/allocations/awaiting.html.erb
@@ -21,7 +21,7 @@
         <td aria-label="Action" class="govuk-table__cell "><%= prisoner.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= prisoner.offender_no %></td>
         <td aria-label="Arrival date" class="govuk-table__cell ">N/A</td>
-        <td aria-label="Release date" class="govuk-table__cell "><%= string_to_date(prisoner.release_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(prisoner.release_date) %></td>
         <td aria-label="Tier" class="govuk-table__cell "><%= prisoner.tier %></td>
         <td aria-label="Action" class="govuk-table__cell "><a href="<%= allocate_prison_offender_managers_new_path(prisoner.offender_no) %>">Allocate</a></td>
       </tr>

--- a/app/views/allocations/missing_information.html.erb
+++ b/app/views/allocations/missing_information.html.erb
@@ -21,7 +21,7 @@
         <td aria-label="Action" class="govuk-table__cell "><%= prisoner.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= prisoner.offender_no %></td>
         <td aria-label="Arrival date" class="govuk-table__cell ">NA</td>
-        <td aria-label="Release date" class="govuk-table__cell "><%= string_to_date(prisoner.release_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(prisoner.release_date) %></td>
         <td aria-label="Action" class="govuk-table__cell "><a
           href="#">View</a></td>
       </tr>

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <tr class="govuk-table__row">
       <td class="govuk-table__cell hmpps-table-cell__key">Release date / parole eligibility</td>
-      <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= string_to_date(@prisoner.release_date) %></td>
+      <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= format_date(@prisoner.release_date) %></td>
     </tr>
   </tbody>
 </table>

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -21,7 +21,7 @@ describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_pris
     noms_id = 'G4273GI'
     offender = OffenderService.new.get_offender(noms_id)
     expect(offender.data).to be_kind_of(Nomis::Offender)
-    expect(offender.data.release_date).to eq '2020-02-07'
+    expect(offender.data.release_date).to eq Date.new(2020, 2, 7)
     expect(offender.data.tier).to eq 'C'
   end
 end


### PR DESCRIPTION
Currently we store the release_date as a string, but this means we parse
it into a date in many places on every use, and will also make the
calculation of the 'Current Responsiblity' more complicated.

This PR changes the API to return a hash of offender_no=>Date rather
than offender_no=>string