### PR TITLE
Fetch user details from Elite2 API

### DIFF
--- a/app/services/nomis/elite2/api.rb
+++ b/app/services/nomis/elite2/api.rb
@@ -11,11 +11,21 @@ module Nomis
         delegate :get_offender_list, to: :instance
         delegate :get_bulk_release_dates, to: :instance
         delegate :get_offence, to: :instance
+        delegate :get_offender, to: :instance
+        delegate :fetch_nomis_user_details, to: :instance
       end
 
       def initialize
         host = Rails.configuration.nomis_oauth_host
         @e2_client = Nomis::Client.new(host)
+      end
+
+      def fetch_nomis_user_details(username)
+        route = "/elite2api/api/users/#{username}"
+        response = @e2_client.get(route)
+
+        ApiResponse.new(api_deserialiser.
+          deserialise(Nomis::Elite2::UserDetails, response))
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/app/services/nomis/elite2/user_details.rb
+++ b/app/services/nomis/elite2/user_details.rb
@@ -1,0 +1,15 @@
+module Nomis
+  module Elite2
+    class UserDetails
+      include MemoryModel
+
+      attribute :staff_id, :integer
+      attribute :username, :string
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :active_case_load_id, :string
+      attribute :locked_flag, :string
+      attribute :expired_flag, :string
+    end
+  end
+end

--- a/spec/services/nomis/elite2/api_spec.rb
+++ b/spec/services/nomis/elite2/api_spec.rb
@@ -36,4 +36,14 @@ describe Nomis::Elite2::Api do
 
       expect(response.data).to be_instance_of(Nomis::NullOffender)
     end
+
+  it "gets staff details",
+    vcr: { cassette_name: :elite2_api_get_nomis_user_details } do
+    username = 'PK000223'
+
+    response = described_class.fetch_nomis_user_details(username)
+
+    expect(response.data).to be_kind_of(Nomis::Elite2::UserDetails)
+    expect(response.data.active_case_load_id).to eq('LEI')
+  end
 end


### PR DESCRIPTION
At present we are getting the details for a member of staff logging into
our service from the Custody API, but are switching over to using Elite2
and this PR covers that switch.  A subsequent PR will be raised to
remove the Custody API as will no longer be required.