### PR TITLE
Only build and push an image on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,9 @@ workflows:
             - test
             - security-static-analysis
             - rubocop
+          filters:
+            branches:
+              only: master
       - deploy_staging:
           requires:
             - build_push_docker


### PR DESCRIPTION
We don't need to do this on every commit that's pushed (when the tests pass)
- we only need an image in the ECR repo for builds that we want to be able to
  deploy to staging/production. This will also speed up build times and free
up build containers.