### PR TITLE
Rename VCR cassettes so they can be clearly matched to the correct test

### DIFF
--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -13,7 +13,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.pagination ul.links li', count: 7)
     end
 
-    it 'renders allocation offenders at index', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders } do
+    it 'renders allocation offenders at index', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_feature } do
       signin_user
       visit 'allocations'
 
@@ -24,7 +24,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.pagination ul.links li', count: 7)
     end
 
-    it 'displays offenders already allocated', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders } do
+    it 'displays offenders already allocated', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_feature } do
       signin_user
 
       visit 'allocations/allocated'
@@ -35,7 +35,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.pagination ul.links li', count: 7)
     end
 
-    it 'displays offenders pending allocation', :raven_intercept_exception, vcr: { cassette_name: :awaiting_allocation_offenders } do
+    it 'displays offenders pending allocation', :raven_intercept_exception, vcr: { cassette_name: :awaiting_allocation_feature } do
       signin_user
 
       visit 'allocations/awaiting'
@@ -48,7 +48,7 @@ feature 'allocations summary feature' do
   end
 
   describe 'paging' do
-    it 'shows pages for allocation', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_paged, match_requests_on: [:query] } do
+    it 'shows pages for allocation', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_paged_feature, match_requests_on: [:query] } do
       signin_user
 
       visit allocations_allocated_path

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'get dashboard' do
-  it 'shows the status page', vcr: { cassette_name: :get_status_feature } do
+  it 'shows the status page', vcr: { cassette_name: :dashboard_feature } do
     signin_user
 
     visit '/'

--- a/spec/features/pom_allocation_feature_spec.rb
+++ b/spec/features/pom_allocation_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'allocate a POM' do
-  it 'shows the allocate a POM page', vcr: { cassette_name: :get_offender_details, match_requests_on: [:query] } do
+  it 'shows the allocate a POM page', vcr: { cassette_name: :pom_allocation_feature, match_requests_on: [:query] } do
     signin_user
     noms_id = 'G4273GI'
 

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "get poms list" do
-  it "shows the page", vcr: { cassette_name: :get_token } do
+  it "shows the page", vcr: { cassette_name: :show_poms_feature } do
     signin_user
 
     visit "/poms"
@@ -15,7 +15,7 @@ feature "get poms list" do
     expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
   end
 
-  it "allows viewing a POM", vcr: { cassette_name: :get_token } do
+  it "allows viewing a POM", vcr: { cassette_name: :show_poms_feature } do
     signin_user
 
     visit "/poms/1"
@@ -27,7 +27,7 @@ feature "get poms list" do
     expect(page).to have_css('.govuk-breadcrumbs__link', count: 3)
   end
 
-  it "allows editing a POM", vcr: { cassette_name: :get_token } do
+  it "allows editing a POM", vcr: { cassette_name: :show_poms_feature } do
     signin_user
 
     visit "/poms/1/edit"

--- a/spec/features/status_feature_spec.rb
+++ b/spec/features/status_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'get status' do
-  it 'returns a status message', vcr: { cassette_name: :get_status_feature } do
+  it 'returns a status message', vcr: { cassette_name: :status_feature } do
     signin_user
 
     visit '/status'

--- a/spec/services/allocation/client_spec.rb
+++ b/spec/services/allocation/client_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Allocation::Client do
   describe 'with a valid request' do
-    it 'sets the Authorization header', vcr: { cassette_name: 'allocation_client_auth_header' } do
+    it 'sets the Authorization header', vcr: { cassette_name: :allocation_client_spec } do
       api_host = Rails.configuration.allocation_api_host
       route = '/status'
       client = described_class.new(api_host)

--- a/spec/services/nomis/elite2/api_spec.rb
+++ b/spec/services/nomis/elite2/api_spec.rb
@@ -28,7 +28,8 @@ describe Nomis::Elite2::Api do
   end
 
   describe 'Single offender' do
-    it "can get a single offender's details", vcr: { cassette_name: :full_single_offender } do
+    it "can get a single offender's details",
+       vcr: { cassette_name: :elite2_api_single_offender_spec } do
       noms_id = 'G2911GD'
 
       response = described_class.get_offender(noms_id)
@@ -37,7 +38,7 @@ describe Nomis::Elite2::Api do
     end
 
     it 'returns null if unable to find prisoner', :raven_intercept_exception,
-      vcr: { cassette_name: :elite2_api_fail_get_offender_details } do
+      vcr: { cassette_name: :elite2_api_null_offender_spec  } do
       noms_id = 'AAA22D'
 
       response = described_class.get_offender(noms_id)
@@ -49,7 +50,7 @@ describe Nomis::Elite2::Api do
   describe 'Staff' do
     # Note we are temporarily getting POMs from keyworker
     it 'can get a of Prison Offender Managers (POMs)',
-      vcr: { cassette_name: :get_elite2_keyworkers } do
+      vcr: { cassette_name: :elite2_api_keyworkers_spec  } do
       response = described_class.prisoner_offender_manager_list('LEI')
 
       expect(response.data).to be_instance_of(Array)
@@ -57,7 +58,7 @@ describe Nomis::Elite2::Api do
     end
 
     it "gets staff details",
-      vcr: { cassette_name: :elite2_api_get_nomis_user_details } do
+      vcr: { cassette_name: :elite2_api_staff_details_spec  } do
       username = 'PK000223'
 
       response = described_class.fetch_nomis_user_details(username)

--- a/spec/services/nomis/elite2/api_spec.rb
+++ b/spec/services/nomis/elite2/api_spec.rb
@@ -29,7 +29,7 @@ describe Nomis::Elite2::Api do
 
   describe 'Single offender' do
     it "can get a single offender's details",
-       vcr: { cassette_name: :elite2_api_single_offender_spec } do
+      vcr: { cassette_name: :elite2_api_single_offender_spec } do
       noms_id = 'G2911GD'
 
       response = described_class.get_offender(noms_id)

--- a/spec/services/nomis/oauth/api_spec.rb
+++ b/spec/services/nomis/oauth/api_spec.rb
@@ -8,7 +8,7 @@ describe Nomis::Oauth::Api do
     Singleton.__init__(described_class)
   end
 
-  it 'fetches an auth token', vcr: { cassette_name: :get_token } do
+  it 'fetches an auth token', vcr: { cassette_name: :nomis_oauth_api_auth_token_spec } do
     token = described_class.fetch_new_auth_token
 
     expect(token).to be_kind_of(Nomis::Oauth::Token)

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_prison } do
+describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_prison_spec } do
   it "get first page of offenders for a specific prison" do
     offenders = OffenderService.new.get_offenders_for_prison('LEI')
     expect(offenders.meta).to be_kind_of(PageMeta)
@@ -9,7 +9,7 @@ describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_pris
     expect(offenders.data.first).to be_kind_of(Nomis::Elite2::OffenderShort)
   end
 
-  it "get last page of offenders for a specific prison", vcr: { cassette_name: :get_offenders_for_specific_prison_last_page } do
+  it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
     offenders = OffenderService.new.get_offenders_for_prison('LEI', page_number: 116)
     expect(offenders.meta).to be_kind_of(PageMeta)
     expect(offenders.data).to be_kind_of(Array)
@@ -17,7 +17,7 @@ describe OffenderService, vcr: { cassette_name: :get_offenders_for_specific_pris
     expect(offenders.data.first).to be_kind_of(Nomis::Elite2::OffenderShort)
   end
 
-  it "gets a single offender", vcr: { cassette_name: :get_single_offender } do
+  it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     noms_id = 'G4273GI'
     offender = OffenderService.new.get_offender(noms_id)
     expect(offender.data).to be_kind_of(Nomis::Elite2::Offender)


### PR DESCRIPTION
- VCR cassettes are renamed to close match the spec that it is associated to
- This is to prevent any confusion arising from using the same cassette across multiple specs