### PR TITLE
Annotate deployments with CircleCI build URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ jobs:
           name: Deploy to staging
           command: |
             kubectl set image -f deploy/deployment.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
+            | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local --o yaml \
             | kubectl apply -f -
             kubectl apply \
               -f ./deploy/ingress.yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,14 +198,13 @@ jobs:
           command: |
             kubectl set image -f deploy/deployment.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
             | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local --o yaml \
-            | kubectl apply -f -
-            kubectl apply \
+            | kubectl apply \
+              -f - \
               -f ./deploy/ingress.yaml \
               -f ./deploy/service.yaml \
               -f ./deploy/service-monitor.yaml \
               -f ./deploy/network-policy.yaml \
               -f ./deploy/allocation-manager-secrets.yaml \
-              -f ./deploy/deployment.yaml
           environment:
             <<: *github_team_name_slug
 

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: RAILS_SERVE_STATIC_FILES
               value: "true"
             - name: WEB_CONCURRENCY
-              valueFrom: 
+              valueFrom:
                 secretKeyRef:
                   name: allocation-manager-secrets
                   key: rails_web_concurrency

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: allocation-manager
   labels:
     app: allocation-manager
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy job command>"
 spec:
   replicas: 3
   revisionHistoryLimit: 1


### PR DESCRIPTION
This should make it easier to identify which job triggered a particular
deployment so that we can roll back to it if we need to.

Borrowed from [ministryofjustice/cla_public#797](https://github.com/ministryofjustice/cla_public/pull/797)