### PR TITLE
Don't overwrite build URL annotation on kubectl apply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           command: |
             kubectl set image -f deploy/deployment.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
             | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local -o yaml \
-            | kubectl apply \
+            | kubectl apply --record=false \
               -f - \
               -f ./deploy/ingress.yaml \
               -f ./deploy/service.yaml \


### PR DESCRIPTION
CLA used this option in the PR I was borrowing from, so I considered
including this in the initial PR adding the annotation, but decided not to
because `--record` defaults to `false` for `apply`. However I should have read the
[CLA commit] message more carefully - it says:

    When a `kubernetes.io/change-cause` annotation is set, the default
    behaviour for further commands is to overwrite the value with the
    command executed.

    Setting `--record=false` will prevent it from being overwritten.

At the moment the annotation looks like this instead of having the build URL:

```
$ kubectl rollout history deployment.v1.apps/allocation-manager --namespace offender-management-staging
deployments "allocation-manager"
REVISION  CHANGE-CAUSE
75        <none>
76        <none>
77        kubectl apply --filename=- --filename=./deploy/ingress.yaml --filename=./deploy/service.yaml --filename=./deploy/service-monitor.yaml --filename=./deploy/network-policy.yaml --filename=./deploy/allocation-manager-secrets.yaml
```

[CLA commit]:
https://github.com/ministryofjustice/cla_public/commit/cbeaeac2b41f64e92a3a84b58357b6ce9c28ad79