### PR TITLE
Add rubocop to the precommit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Install the git pre-commit hook before you start working on this repository so
 that we're all using some checks to help us avoid committing unencrypted
-secrets. From the root of the repo:
+secrets or unlinted code. From the root of the repo:
 
 ```
 ln -s ../../config/git-hooks/pre-commit.sh .git/hooks/pre-commit

--- a/config/git-hooks/pre-commit.sh
+++ b/config/git-hooks/pre-commit.sh
@@ -4,6 +4,17 @@
 #    $> cd /path/to/repository
 #    $> ln -s ../../config/git-hooks/pre-commit.sh .git/hooks/pre-commit
 #
+
+################################################################################
+# Check that any changes to be committed do not upset rubocop
+#
+FILES="$(git diff --cached --name-only --diff-filter=AMC | grep "\.rb$" | tr '\n' ' ')"
+bundle exec rubocop ${FILES}
+if [ $? -ne 0 ]; then
+  echo "Rubocop failed! You must appease the linter!"
+  exit 1
+fi
+
 ################################################################################
 # https://github.com/AGWA/git-crypt/issues/45#issuecomment-151985431
 # Pre-commit hook to avoid accidentally adding unencrypted files which are


### PR DESCRIPTION
As per https://trello.com/c/W6e1lTUg/362-add-rubocop-pre-commit-hook
this will stop us committing code that rubocop doesn't like.