### PR TITLE
Implements get_active_allocations in the allocation api client

### DIFF
--- a/app/services/allocation/api.rb
+++ b/app/services/allocation/api.rb
@@ -5,6 +5,7 @@ module Allocation
     class << self
       delegate :status, to: :instance
       delegate :get_allocation_data, to: :instance
+      delegate :get_active_allocations, to: :instance
       delegate :allocate, to: :instance
     end
 
@@ -22,6 +23,11 @@ module Allocation
       staff_ids.each_with_object({}) do |id, hash|
         hash[id] = FakeAllocationRecord.generate(id)
       end
+    end
+
+    def get_active_allocations(offender_ids)
+      route = '/allocation/active'
+      @allocation_api_client.post(route, offender_ids)
     end
 
     def allocate(body)

--- a/app/services/allocation/client.rb
+++ b/app/services/allocation/client.rb
@@ -23,17 +23,17 @@ module Allocation
     end
 
     def post(route, body)
-      request(:post, route, body)
+      request(:post, route, body: body)
     end
 
   private
 
-    def request(method, route, body: {})
+    def request(method, route, body: nil)
       response = @connection.send(method) { |req|
         req.url(@host + route)
         req.headers['Authorization'] = "Bearer #{token.access_token}"
         req.headers['Content-Type'] = 'application/json'
-        req.body = body
+        req.body = body.to_json if body.present? && method == :post
       }
 
       JSON.parse(response.body)

--- a/app/services/nomis/elite2/api.rb
+++ b/app/services/nomis/elite2/api.rb
@@ -53,9 +53,9 @@ module Nomis
         page_meta = nil
 
         hdrs = paging_headers(page_size, page_offset)
+
         data = @e2_client.get(route, extra_headers: hdrs) { |json, response|
           total_records = response.headers['Total-Records'].to_i
-
           records_shown = json.length
           page_meta = make_page_meta(
             page, page_size, total_records, records_shown
@@ -97,7 +97,6 @@ module Nomis
         # last item. This appears to be a bug in faraday because the Elite2 API works
         # fine with the same URL when called via Postman.
         parameters = { 'offenderNo' => offender_ids + [''] }
-
         data = @e2_client.get(route, queryparams: parameters)
 
         results = data.each_with_object({}) { |record, hash|
@@ -113,7 +112,7 @@ module Nomis
 
       def paging_headers(page_size, page_offset)
         {
-          'Page-Size' => page_size.to_s,
+          'Page-Limit' => page_size.to_s,
           'Page-Offset' => page_offset.to_s
         }
       end

--- a/spec/services/allocation/api_spec.rb
+++ b/spec/services/allocation/api_spec.rb
@@ -51,7 +51,7 @@ describe Allocation::Api do
         'offender_no' => 'A1234AB',
         'offender_id' => '65677888',
         'prison' => 'Leeds',
-        'reason' => 'Why not?',
+        'override_reason' => 'Why not?',
         'notes' => 'Blah',
         'email' => 'pom@pompom.com'
       }
@@ -59,6 +59,15 @@ describe Allocation::Api do
       response = described_class.allocate(body)
 
       expect(response[:status][:code]).to eq(200)
+    end
+
+    it 'fetches active allocations for offenders', vcr: { cassette_name: :allocation_api_spec } do
+      # TODO: - Test output of API when we have seed data
+      body = ['A1A']
+      response = described_class.get_active_allocations(body)
+
+      expect(response['status']).to eq('ok')
+      expect(response['data']).to eq({})
     end
   end
 end

--- a/spec/services/allocation/client_spec.rb
+++ b/spec/services/allocation/client_spec.rb
@@ -41,7 +41,7 @@ describe Allocation::Client do
         'offender_no' => 'A1234AB',
         'offender_id' => '65677888',
         'prison' => 'Leeds',
-        'reason' => 'Why not?',
+        'override_reason' => 'Why not?',
         'notes' => 'Blah',
         'email' => 'pom@pompom.com'
       }


### PR DESCRIPTION
Will post a list of IDs to the correct endpoint and return the data to
the client.

A test exists but should be filled out once we have some seed data.