### PR TITLE
Fetch POMs via Elite2 API

### DIFF
--- a/app/services/nomis/elite2/api.rb
+++ b/app/services/nomis/elite2/api.rb
@@ -30,8 +30,7 @@ module Nomis
       end
 
       def prisoner_offender_manager_list(prison)
-        # Temporarily using keyworker endpoint for now
-        route = "/elite2api/api/key-worker/#{prison}/available"
+        route = "/elite2api/api/staff/roles/#{prison}/role/POM"
 
         response = @e2_client.get(route) { |data|
           raise Nomis::Client::APIError, 'No data was returned' if data.empty?

--- a/app/services/nomis/elite2/prison_offender_manager.rb
+++ b/app/services/nomis/elite2/prison_offender_manager.rb
@@ -1,4 +1,3 @@
-# Note this is currently deserializing a Nomis Keyworker
 module Nomis
   module Elite2
     class PrisonOffenderManager
@@ -7,7 +6,17 @@ module Nomis
       attribute :staff_id, :string
       attribute :first_name, :string
       attribute :last_name, :string
-      attribute :number_allocated, :string
+      attribute :agency_id, :string
+      attribute :agency_description, :string
+      attribute :from_date, :date
+      attribute :position, :string
+      attribute :position_description, :string
+      attribute :role, :string
+      attribute :role_description, :string
+      attribute :schedule_type, :string
+      attribute :schedule_type_description, :string
+      attribute :hours_per_week, :integer
+      attribute :thumbnail_id, :string
 
       attribute :tier_a, :integer
       attribute :tier_b, :integer

--- a/app/views/allocate_prison_offender_managers/_pom_tables.html.erb
+++ b/app/views/allocate_prison_offender_managers/_pom_tables.html.erb
@@ -6,7 +6,7 @@ Recommendation:
 
 <table class="govuk-table responsive">
   <thead class="govuk-table__head">
-    <h2 class="govuk-heading-s">One type of POM</h2>
+    <h2 class="govuk-heading-s">Probation POMs</h2>
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Name</th>
       <th class="govuk-table__header" scope="col">Previous allocation</th>
@@ -20,7 +20,7 @@ Recommendation:
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @poms.each do |pom| %>
+  <% @poms.select{ |pom| pom.position_description.include?('Probation Officer')}.each do |pom| %>
     <tr class="govuk-table__row">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Previous allocation" class="govuk-table__cell">-</td>
@@ -30,7 +30,7 @@ Recommendation:
       <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
-      <% if current_page?(action: 'show') %>
+      <% if current_page?(action: 'new') %>
         <td aria-label="Action" class="govuk-table__cell table_cell__left_align"><a
           href="#">Allocate</a></td>
       <% else %>
@@ -50,7 +50,7 @@ Recommendation:
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      Show other type of POMs
+      Prison POMs
     </span>
   </summary>
   <div class="govuk-details__text">
@@ -71,22 +71,25 @@ Recommendation:
         </tr>
       </thead>
       <tbody class="govuk-table__body">
+        <% @poms.select{ |pom| pom.position_description.include?('Prison Officer')}.each do |pom| %>
           <tr class="govuk-table__row">
-            <td aria-label="POM name" class="govuk-table__cell table_cell__left_align poms-table-cell__key">Penge, Frank</td>
+            <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
             <td aria-label="Previous allocation" class="govuk-table__cell">-</td>
-            <td aria-label="Tier A cases" class="govuk-table__cell table_cell__left_align">0</td>
-            <td aria-label="Tier B cases" class="govuk-table__cell table_cell__left_align">0</td>
-            <td aria-label="Tier C cases" class="govuk-table__cell table_cell__left_align">13</td>
-            <td aria-label="Tier D cases" class="govuk-table__cell table_cell__left_align">15</td>
-            <td aria-label="Total" class="govuk-table__cell table_cell__left_align">28</td>
-            <td aria-label="Working pattern" class="govuk-table__cell">Full time</td>
-            <% if current_page?(action: 'show') %>
-              <td aria-label="Action" class="govuk-table__cell table_cell__right_align"><a
-                                    href="#">Allocate</a></td>
+            <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>
+            <td aria-label="Tier B cases" class="govuk-table__cell "><%= pom.tier_b %></td>
+            <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
+            <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
+            <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
+            <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
+            <% if current_page?(action: 'new') %>
+              <td aria-label="Action" class="govuk-table__cell table_cell__left_align"><a
+                href="#">Allocate</a></td>
             <% else %>
               <td aria-label="Action" class="govuk-table__cell table_cell__right_align"><a
-                                  href="#">Reallocate</a></td>
+                href="#">Reallocate</a></td>
             <% end %>
+          </tr>
+        <% end %>
           </tr>
       </tbody>
     </table>

--- a/app/views/poms/_active.html.erb
+++ b/app/views/poms/_active.html.erb
@@ -1,8 +1,8 @@
 <section class="govuk-tabs__panel" id="active">
   <h2 class="govuk-heading-m">Probation POM</h2>
-  <%= render 'poms_table' %>
+  <%= render 'probation_poms_table' %>
 
   <h2 class="govuk-heading-m">Prison POM</h2>
-  <%= render 'poms_table' %>
+  <%= render 'prison_poms_table' %>
 
 </section>

--- a/app/views/poms/_inactive.html.erb
+++ b/app/views/poms/_inactive.html.erb
@@ -1,9 +1,9 @@
 <section class="govuk-tabs__panel" id="inactive">
   <h2 class="govuk-heading-m">Probation POM</h2>
-  <%= render 'poms_table' %>
+  <%= render 'probation_poms_table' %>
 
   <h2 class="govuk-heading-m">Prison POM</h2>
-  <%= render 'poms_table' %>
+  <%= render 'prison_poms_table' %>
 
 
 </section>

--- a/app/views/poms/_prison_poms_table.html.erb
+++ b/app/views/poms/_prison_poms_table.html.erb
@@ -22,7 +22,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @poms.each do |pom| %>
+  <% @poms.select{ |pom| pom.position_description.include?('Prison Officer')}.each do |pom| %>
     <tr class="govuk-table__row">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>

--- a/app/views/poms/_probation_poms_table.html.erb
+++ b/app/views/poms/_probation_poms_table.html.erb
@@ -1,0 +1,40 @@
+<table class="govuk-table responsive tablesorter">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col"><a
+      class='table-sorter__link' href='#'>POM name</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Tier A cases</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Tier B cases</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Tier C cases</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Tier D cases</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Total</a></th>
+    <th class="govuk-table__header header-width__8" scope="col">
+      <a
+        class='table-sorter__link' href='#'>Working pattern</a></th>
+    <th class="govuk-table__header" scope="col"><a
+      class='table-sorter__link' href='#'>Status</a></th>
+    <th class="govuk-table__header sorter-false" scope="col">Action</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @poms.select{ |pom| pom.position_description.include?('Probation Officer')}.each do |pom| %>
+    <tr class="govuk-table__row">
+      <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
+      <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>
+      <td aria-label="Tier B cases" class="govuk-table__cell "><%= pom.tier_b %></td>
+      <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
+      <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
+      <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
+      <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
+      <td aria-label="Status" class="govuk-table__cell "><%= pom.status %></td>
+      <td aria-label="Action" class="govuk-table__cell "><a
+        href="<%= poms_show_path(id: 1) %>">View</a></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
Up until this point we have been using the Elite2 API to fetch
keyworkers, but a new POM role has been added to T3 and this PR updates
the views, models and Api to make use of this.