### PR TITLE
Filter out offenders with no release date

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -7,9 +7,11 @@ class AllocationsController < ApplicationController
       page_number: page_number
     )
 
-    @offenders_allocated = response.data
-    @offenders_awaiting_allocation = response.data
-    @offenders_awaiting_tiering = response.data
+    offenders = response.data
+
+    @offenders_allocated = offenders
+    @offenders_awaiting_allocation = offenders
+    @offenders_awaiting_tiering = offenders
 
     @page_data = response.meta
   end

--- a/app/services/nomis/elite2/api.rb
+++ b/app/services/nomis/elite2/api.rb
@@ -44,10 +44,9 @@ module Nomis
       end
 
       # rubocop:disable Metrics/MethodLength
-      def get_offender_list(prison, page = 0)
+      def get_offender_list(prison, page = 0, page_size: 10)
         route = "/elite2api/api/locations/description/#{prison}/inmates"
 
-        page_size = 10
         page_offset = page * page_size
         page_meta = nil
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -5,7 +5,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
     offenders = OffenderService.new.get_offenders_for_prison('LEI')
     expect(offenders.meta).to be_kind_of(PageMeta)
     expect(offenders.data).to be_kind_of(Array)
-    expect(offenders.data.length).to eq(10)
+    expect(offenders.data.length).to eq(5)
     expect(offenders.data.first).to be_kind_of(Nomis::Elite2::OffenderShort)
   end
 
@@ -13,7 +13,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
     offenders = OffenderService.new.get_offenders_for_prison('LEI', page_number: 116)
     expect(offenders.meta).to be_kind_of(PageMeta)
     expect(offenders.data).to be_kind_of(Array)
-    expect(offenders.data.length).to eq(7)
+    expect(offenders.data.length).to eq(5)
     expect(offenders.data.first).to be_kind_of(Nomis::Elite2::OffenderShort)
   end
 


### PR DESCRIPTION
If an offender has no release date, are they really on remand?  For
now we will filter them out of the list as it is one of the criteria for
determining that a prisoner is on remand (along with lack of booking
info which is not yet checked).

This may mean we will see less than 10 items per tab in the allocation summary 