### PR TITLE
Fixes for 'create_allocation_spec'

### DIFF
--- a/spec/features/create_allocation_spec.rb
+++ b/spec/features/create_allocation_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
+
 feature 'Allocation' do
-  let(:pom) { Nomis::Elite2::PrisonOffenderManager.new(staff_id: 485_752) }
-  let(:prisoner) { Nomis::Elite2::Offender.new(offender_no: 'G4273GI', tier: 'C', latest_booking_id: '1153753') }
+  let(:nomis_staff_id) { 485752 }
+  let(:nomis_offender_id) { 'G4273GI' }
 
   scenario 'creating an allocation', vcr: { cassette_name: :create_allocation_feature } do
     signin_user
 
-    visit new_allocates_path(prisoner.offender_no, pom.staff_id)
+    visit new_allocates_path(nomis_offender_id, nomis_staff_id)
 
     expect(page).to have_css('h1', text: 'Confirm allocation')
     expect(page).to have_css('p', text: 'You are allocating Abbella, Ozullirn to Jones, Ross')
@@ -17,20 +18,27 @@ feature 'Allocation' do
   end
 
   scenario 'overriding an allocation', vcr: { cassette_name: :override_allocation_feature } do
+    override_nomis_staff_id = 485636
+
     signin_user
 
-    visit allocates_show_path(prisoner.offender_no)
+    visit allocates_show_path(nomis_offender_id)
 
     within('.not_recommended_pom_row_0') do
       click_link 'Allocate'
     end
 
     expect(page).to have_css('h1', text: 'Choose reason for changing recommended grade')
-    check('override-1')
 
+    check('override-1')
     click_button('Continue')
 
-    expect(page).to have_css('h1', text: 'Confirm allocation')
-    expect(page).to have_css('p', text: 'You are allocating Abbella, Ozullirn to Duckett, Jenny')
+    expect(Override.count).to eq(1)
+    expect(page).to have_current_path new_allocates_path(nomis_offender_id, override_nomis_staff_id)
+
+    click_button 'Complete allocation'
+
+    expect(page).to have_current_path allocations_path
+    expect(Override.count).to eq(0)
   end
 end

--- a/spec/features/create_allocation_spec.rb
+++ b/spec/features/create_allocation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Allocation' do
-  let(:nomis_staff_id) { 485752 }
+  let(:nomis_staff_id) { 485_752 }
   let(:nomis_offender_id) { 'G4273GI' }
 
   scenario 'creating an allocation', vcr: { cassette_name: :create_allocation_feature } do
@@ -18,7 +18,7 @@ feature 'Allocation' do
   end
 
   scenario 'overriding an allocation', vcr: { cassette_name: :override_allocation_feature } do
-    override_nomis_staff_id = 485636
+    override_nomis_staff_id = 485_636
 
     signin_user
 


### PR DESCRIPTION
- Don't create in-memory models
- Check that an Override is created and deleted when overriding an
allocation