### PR TITLE
Override functionality updated

### DIFF
--- a/app/controllers/allocates_controller.rb
+++ b/app/controllers/allocates_controller.rb
@@ -25,7 +25,7 @@ class AllocatesController < ApplicationController
       data
     @override = Override.where(
       nomis_offender_id: allocation_params[:nomis_offender_id]).
-      where(nomis_staff_id: allocation_params[:nomis_staff_id])
+      where(nomis_staff_id: allocation_params[:nomis_staff_id]).last
 
     AllocationService.create_allocation(
       nomis_staff_id: allocation_params[:nomis_staff_id].to_i,
@@ -37,8 +37,6 @@ class AllocatesController < ApplicationController
       override_reason: override_reason,
       override_detail: override_detail
     )
-
-    delete_override
 
     redirect_to allocations_path
   end
@@ -59,16 +57,10 @@ private
   end
 
   def override_reason
-    @override.first[:override_reason] if @override.present?
+    @override[:override_reason] if @override.present?
   end
 
   def override_detail
-    @override.first[:override_detail] if @override.present?
-  end
-
-  def delete_override
-    if @override.present?
-      @override.first.destroy
-    end
+    @override[:more_detail] if @override.present?
   end
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,4 +1,5 @@
 class AllocationService
+  # rubocop:disable Metrics/MethodLength
   def self.create_allocation(params)
     Allocation.transaction do
       Allocation.where(nomis_offender_id: params[:nomis_offender_id]).
@@ -12,7 +13,9 @@ class AllocationService
         alloc.save!
       end
     end
+    delete_overrides(params)
   end
+  # rubocop:enable Metrics/MethodLength
 
   def self.active_allocations(nomis_offender_ids)
     Allocation.where(nomis_offender_id: nomis_offender_ids, active: true).map { |a|
@@ -24,10 +27,22 @@ class AllocationService
   end
 
   def self.create_override(params)
-    Override.create!(params)
+    o = Override.find_or_create_by(
+      nomis_staff_id: params[:nomis_staff_id],
+      nomis_offender_id: params[:nomis_offender_id]
+    )
+    o.override_reason = params[:override_reason]
+    o.more_detail = params[:more_detail]
+    o.save!
+    o
   end
 
-  def self.override_instance
-    Override.new
+private
+
+  def self.delete_overrides(params)
+    Override.where(
+      nomis_staff_id: params[:nomis_staff_id],
+      nomis_offender_id: params[:nomis_offender_id]).
+        destroy_all
   end
 end

--- a/app/views/allocates/_pom_tables.html.erb
+++ b/app/views/allocates/_pom_tables.html.erb
@@ -51,9 +51,9 @@ Recommendation: <%= @recommended_pom %> POMs
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       <% if @prisoner.current_responsibility == 'Probation' %>
-        Prison POMs
+        Show prison officer POMs
       <% else %>
-        Probation POMs
+        Show probation officer POMs
       <% end %>
     </span>
   </summary>

--- a/app/views/allocates/new.html.erb
+++ b/app/views/allocates/new.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => "/shared/backlink", :locals => { :page => allocates_show_path() } %>
+
 <div>
     <%= form_tag(allocates_path, method: :post) do %>
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">Confirm allocation</h1>

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -1,4 +1,6 @@
-  <div>
+<%= render :partial => "/shared/backlink", :locals => { :page => allocates_show_path() } %>
+
+<div>
     <%= form_tag(overrides_path, method: :post)  do %>
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">Choose reason for changing recommended grade</h1>
 
@@ -25,14 +27,17 @@
                 <%= label_tag "override[override_reason]", "Maintain continuity of previous POM", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reason]", "other", false, id: "override-4", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reason]", "Other", class: 'govuk-label govuk-checkboxes__label' %>
+                <input class="govuk-checkboxes__input" id="override-conditional-4" name="override[override_reason]" type="checkbox" value="other" data-aria-controls="override-4">
+                <label class="govuk-label govuk-checkboxes__label"
+                       for="override-conditional-4">Other</label>
               </div>
-              <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden">
+              <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="override-4">
                 <div class="govuk-form-group">
-                  <%= text_area_tag "override[more_detail]", nil, rows: 3, class: "govuk-input govuk-!-width-one-third" %>
-                  <%= label_tag "override[more_detail]", 'Please provide detail here', class: 'govuk-label govuk-checkboxes__label' %>
+                  <label class="govuk-label" for="provide-detail">Please provide detail
+                    here</label>
+                  <textarea class="govuk-textarea" id="more-detail" name="override[more_detail]" rows="3" aria-describedby="more-detail-hint"></textarea>
                 </div>
+              </div>
               </div>
             </div>
           </fieldset>


### PR DESCRIPTION
The override view had an 'other' option that wasn't working properly, but now reveals the text box for 
staff to add details about why they have changed from the recommended POM.

We are now also deleting all overrides related to a particular POM and offender as there could be multiple records in the database if someone bailed out before completing the allocation process.

A couple of 'back' links were missing and some content has been updated too.

