### PR TITLE
Change override_reason to be an array

### DIFF
--- a/app/controllers/allocates_controller.rb
+++ b/app/controllers/allocates_controller.rb
@@ -34,7 +34,7 @@ class AllocatesController < ApplicationController
       nomis_booking_id: prisoner.latest_booking_id,
       allocated_at_tier: prisoner.tier,
       prison: caseload,
-      override_reason: override_reason,
+      override_reasons: override_reasons,
       override_detail: override_detail
     )
 
@@ -56,8 +56,8 @@ private
     params.require(:allocate).permit(:nomis_staff_id, :nomis_offender_id)
   end
 
-  def override_reason
-    @override[:override_reason] if @override.present?
+  def override_reasons
+    @override[:override_reasons] if @override.present?
   end
 
   def override_detail

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -9,7 +9,7 @@ class OverridesController < ApplicationController
     AllocationService.create_override(
       nomis_staff_id: override_params[:nomis_staff_id],
       nomis_offender_id: override_params[:nomis_offender_id],
-      override_reason: override_params[:override_reason],
+      override_reasons: override_params[:override_reasons],
       more_detail: override_params[:more_detail]
       )
 
@@ -28,7 +28,7 @@ private
 
   def override_params
     params.require(:override).permit(
-      :nomis_offender_id, :nomis_staff_id, :override_reason, :more_detail
+      :nomis_offender_id, :nomis_staff_id, :more_detail, override_reasons: []
     )
   end
 end

--- a/app/models/override.rb
+++ b/app/models/override.rb
@@ -1,3 +1,3 @@
 class Override < ApplicationRecord
-  validates :nomis_staff_id, :nomis_offender_id, :override_reason, presence: true
+  validates :nomis_staff_id, :nomis_offender_id, :override_reasons, presence: true
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -31,7 +31,7 @@ class AllocationService
       nomis_staff_id: params[:nomis_staff_id],
       nomis_offender_id: params[:nomis_offender_id]
     )
-    o.override_reason = params[:override_reason]
+    o.override_reasons = params[:override_reasons]
     o.more_detail = params[:more_detail]
     o.save!
     o

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -15,19 +15,19 @@
               <%= hidden_field_tag("override[nomis_offender_id]", @prisoner.offender_no) %>
               <%= hidden_field_tag("override[nomis_staff_id]", @pom.staff_id) %>
               <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reason]", "complex",  false, id: "override-1", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reason]", "Prisoner assessed as too complex for #{@recommended_pom} officer POM", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= check_box_tag("override[override_reasons][]", "complex",  false, id: "override-1", class: "govuk-checkboxes__input") %>
+                <%= label_tag "override[override_reasons][]", "Prisoner assessed as too complex for #{@recommended_pom} officer POM", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reason]", "no-staff", false, id: "override-2", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reason]", "No avaliable staff at recommended grade", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= check_box_tag("override[override_reasons][]", "no-staff", false, id: "override-2", class: "govuk-checkboxes__input") %>
+                <%= label_tag "override[override_reasons][]", "No avaliable staff at recommended grade", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reason]", "continuity", false, id: "override-3", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reason]", "Maintain continuity of previous POM", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= check_box_tag("override[override_reasons][]", "continuity", false, id: "override-3", class: "govuk-checkboxes__input") %>
+                <%= label_tag "override[override_reasons][]", "Maintain continuity of previous POM", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="override-conditional-4" name="override[override_reason]" type="checkbox" value="other" data-aria-controls="override-4">
+                <input class="govuk-checkboxes__input" id="override-conditional-4" name="override[override_reasons][]" type="checkbox" value="other" data-aria-controls="override-4">
                 <label class="govuk-label govuk-checkboxes__label"
                        for="override-conditional-4">Other</label>
               </div>

--- a/db/migrate/20190210105233_add_overrides_table.rb
+++ b/db/migrate/20190210105233_add_overrides_table.rb
@@ -2,7 +2,7 @@ class AddOverridesTable < ActiveRecord::Migration[5.2]
   create_table "overrides", force: :cascade do |t|
     t.integer "nomis_staff_id"
     t.string "nomis_offender_id"
-    t.string "override_reason"
+    t.string "override_reasons"
     t.string "more_detail"
   end
 end

--- a/db/migrate/20190210132134_rename_column_allocations_table.rb
+++ b/db/migrate/20190210132134_rename_column_allocations_table.rb
@@ -1,11 +1,11 @@
 class RenameColumnAllocationsTable < ActiveRecord::Migration[5.2]
   def up
-    rename_column :allocations, :reason, :override_reason
+    rename_column :allocations, :reason, :override_reasons
     rename_column :allocations, :note, :override_detail
   end
 
   def down
     rename_column :allocations, :override_detail, :note
-    rename_column :allocations, :override_reason, :reason
+    rename_column :allocations, :override_reasons, :reason
   end
 end

--- a/db/migrate/20190212160351_update_overrides_column_type.rb
+++ b/db/migrate/20190212160351_update_overrides_column_type.rb
@@ -1,0 +1,13 @@
+class UpdateOverridesColumnType < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :overrides, :override_reason, :override_reasons
+    rename_column :allocations, :override_reason, :override_reasons
+    change_column :overrides, :override_reasons, :string, using: "override_reasons::character varying[]"
+  end
+
+  def down
+    change_coloumn :overrides, :override_reasons, :string
+    rename_column :allocations, :override_reasons, :override_reason
+    rename_column :overrides, :override_reasons, :override_reason
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_10_132134) do
+ActiveRecord::Schema.define(version: 2019_02_12_160351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2019_02_10_132134) do
     t.string "nomis_offender_id"
     t.string "prison"
     t.string "allocated_at_tier"
-    t.string "override_reason"
+    t.string "override_reasons"
     t.string "override_detail"
     t.string "created_by"
     t.boolean "active"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2019_02_10_132134) do
   create_table "overrides", force: :cascade do |t|
     t.integer "nomis_staff_id"
     t.string "nomis_offender_id"
-    t.string "override_reason"
+    t.string "override_reasons"
     t.string "more_detail"
   end
 

--- a/spec/features/create_allocation_spec.rb
+++ b/spec/features/create_allocation_spec.rb
@@ -31,6 +31,7 @@ feature 'Allocation' do
     expect(page).to have_css('h1', text: 'Choose reason for changing recommended grade')
 
     check('override-1')
+    check('override-2')
     click_button('Continue')
 
     expect(Override.count).to eq(1)

--- a/spec/models/override_spec.rb
+++ b/spec/models/override_spec.rb
@@ -3,5 +3,5 @@ require 'rails_helper'
 RSpec.describe Override, type: :model do
   it { is_expected.to validate_presence_of(:nomis_offender_id) }
   it { is_expected.to validate_presence_of(:nomis_staff_id) }
-  it { is_expected.to validate_presence_of(:override_reason) }
+  it { is_expected.to validate_presence_of(:override_reasons) }
 end


### PR DESCRIPTION
It is possible for staff to choose more than one reason when overriding
the recommended POM type and so we needed to change the override table
from a string to an array.

It also made sense to change the column names in the override and
allocation table from 'override_reason' to 'override_reasons'.