### PR TITLE
Implements view list of poms and view a single POM.

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -2,13 +2,27 @@ class PomsController < ApplicationController
   before_action :authenticate_user
 
   breadcrumb 'Prison Offender Managers', :poms_path, only: [:index, :show]
-  breadcrumb -> { 'Surname, Forename' }, -> {  poms_show_path(1) }, only: [:show]
+  breadcrumb -> { pom.full_name }, -> {  poms_show_path(params[:id]) }, only: [:show]
 
   def index
-    @poms = PrisonOffenderManagerService.get_poms(caseload)
+    poms = PrisonOffenderManagerService.get_poms(caseload)
+    @active_poms, @inactive_poms = poms.partition { |pom|
+      pom.status == 'active'
+    }
   end
 
-  def show; end
+  def show
+    @pom = pom
+
+    @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
+  end
 
   def edit; end
+
+private
+
+  def pom
+    poms_list = PrisonOffenderManagerService.get_poms(caseload)
+    @pom = poms_list.select { |p| p.staff_id.to_i == params['id'].to_i }.first
+  end
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -1,7 +1,7 @@
 class AllocationService
   # rubocop:disable Metrics/MethodLength
   def self.create_allocation(params)
-    Allocation.transaction do
+    allocation = Allocation.transaction {
       Allocation.where(nomis_offender_id: params[:nomis_offender_id]).
         update_all(active: false)
 
@@ -12,8 +12,11 @@ class AllocationService
         alloc.active = true
         alloc.save!
       end
-    end
+    }
+
     delete_overrides(params)
+
+    allocation
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/services/nomis/elite2/sentence_detail.rb
+++ b/app/services/nomis/elite2/sentence_detail.rb
@@ -1,0 +1,26 @@
+module Nomis
+  module Elite2
+    class SentenceDetail
+      include MemoryModel
+
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :booking_id, :integer
+      attribute :offender_no
+      attribute :agency_location_id
+      attribute :sentence_detail
+      attribute :date_of_birth
+      attribute :agency_location_desc
+      attribute :facial_image_id
+      attribute :internal_location_desc
+
+      def release_date
+        sentence_detail['releaseDate']
+      end
+
+      def full_name
+        "#{last_name}, #{first_name}".titleize
+      end
+    end
+  end
+end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -37,4 +37,8 @@ class OffenderService
     offenders
   end
   # rubocop:enable Metrics/MethodLength
+
+  def self.get_sentence_details(offender_id_list)
+    Nomis::Elite2::Api.get_bulk_sentence_details(offender_id_list).data
+  end
 end

--- a/app/views/poms/_active.html.erb
+++ b/app/views/poms/_active.html.erb
@@ -1,8 +1,7 @@
 <section class="govuk-tabs__panel" id="active">
   <h2 class="govuk-heading-m">Probation POM</h2>
-  <%= render 'probation_poms_table' %>
+  <%= render :partial => "probation_poms_table", locals: { poms: @active_poms } %>
 
   <h2 class="govuk-heading-m">Prison POM</h2>
-  <%= render 'prison_poms_table' %>
-
+  <%= render :partial => "prison_poms_table", locals: { poms: @active_poms } %>
 </section>

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -13,19 +13,18 @@
         <a class="table-sorter__link" href="#">Allocation date</a></th>
       <th class="govuk-table__header" scope="col">
         <a class="table-sorter__link" href="#">Role</a></th>
-      <th class="govuk-table__header sorter-false" scope="col">Action</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
+    <% @allocations.each do |allocation, sentence| %>
     <tr class="govuk-table__row">
-      <td aria-label="Prisoner name" class="govuk-table__cell ">N/A</td>
-      <td aria-label="Prisoner number" class="govuk-table__cell ">N/A</td>
-      <td aria-label="Release date" class="govuk-table__cell ">N/A</td>
-      <td aria-label="Tier" class="govuk-table__cell ">N/A</td>
-      <td aria-label="Allocation date" class="govuk-table__cell ">N/A</td>
+      <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
+      <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
+      <td aria-label="Release date" class="govuk-table__cell "><%= sentence.release_date %></td>
+      <td aria-label="Tier" class="govuk-table__cell "><%= allocation.allocated_at_tier %></td>
+      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
       <td aria-label="Role" class="govuk-table__cell ">N/A</td>
-      <td aria-label="Action" class="govuk-table__cell "><a
-          href="">View</a></td>
     </tr>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/poms/_inactive.html.erb
+++ b/app/views/poms/_inactive.html.erb
@@ -1,9 +1,7 @@
 <section class="govuk-tabs__panel" id="inactive">
   <h2 class="govuk-heading-m">Probation POM</h2>
-  <%= render 'probation_poms_table' %>
+  <%= render :partial => "probation_poms_table", locals: { :poms => @inactive_poms } %>
 
   <h2 class="govuk-heading-m">Prison POM</h2>
-  <%= render 'prison_poms_table' %>
-
-
+  <%= render :partial => "prison_poms_table", locals: { :poms => @inactive_poms } %>
 </section>

--- a/app/views/poms/_prison_poms_table.html.erb
+++ b/app/views/poms/_prison_poms_table.html.erb
@@ -22,7 +22,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @poms.select{ |pom| pom.position_description.include?('Prison Officer')}.each_with_index do |pom, i| %>
+  <% poms.select{ |pom| pom.position_description.include?('Prison Officer')}.each_with_index do |pom, i| %>
     <tr class="govuk-table__row prison_pom_row_<%= i %>">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>
@@ -31,9 +31,9 @@
       <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
-      <td aria-label="Status" class="govuk-table__cell "><%= pom.status %></td>
+      <td aria-label="Status" class="govuk-table__cell "><%= pom.status.capitalize %></td>
       <td aria-label="Action" class="govuk-table__cell "><a
-        href="<%= poms_show_path(id: 1) %>">View</a></td>
+        href="<%= poms_show_path(id: pom.staff_id ) %>">View</a></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/poms/_probation_poms_table.html.erb
+++ b/app/views/poms/_probation_poms_table.html.erb
@@ -22,7 +22,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @poms.select{ |pom| pom.position_description.include?('Probation Officer')}.each_with_index do |pom, i| %>
+  <% poms.select{ |pom| pom.position_description.include?('Probation Officer')}.each_with_index do |pom, i| %>
     <tr class="govuk-table__row probation_pom_row_<%= i %>">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>
@@ -31,9 +31,9 @@
       <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
-      <td aria-label="Status" class="govuk-table__cell "><%= pom.status %></td>
+      <td aria-label="Status" class="govuk-table__cell "><%= pom.status.capitalize %></td>
       <td aria-label="Action" class="govuk-table__cell "><a
-        href="<%= poms_show_path(id: 1) %>">View</a></td>
+        href="<%= poms_show_path(id: pom.staff_id) %>">View</a></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -7,12 +7,12 @@
   <ul class="govuk-tabs__list" role='tablist'>
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#active">
-        Active (N)
+        Active (<%= @active_poms.count %>)
       </a>
     </li>
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#inactive">
-        Inactive (N)
+        Inactive (<%= @inactive_poms.count %>)
       </a>
     </li>
   </ul>

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -1,5 +1,5 @@
 
-<h1 class="govuk-heading-xl">Surname, Forename</h1>
+<h1 class="govuk-heading-xl"><%= @pom.full_name %></h1>
 <h2 class="govuk-heading-m">email@example.com</h2>
 
 <div class="govuk-grid-row">
@@ -9,37 +9,25 @@
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">POM level</div>
-    <div class="govuk-body govuk-!-font-weight-bold">LEVEL</div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.position %></div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">Working pattern</div>
-    <div class="govuk-body govuk-!-font-weight-bold">PATTERN</div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.working_pattern %></div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">Status</div>
-    <div class="govuk-body govuk-!-font-weight-bold">STATUS</div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.status.capitalize %></div>
   </div>
 </div>
 
-<%= link_to("Edit profile", poms_edit_path(id: 1), class: "govuk-button") %>
+<%= link_to("Edit profile", poms_edit_path(id: @pom.staff_id), class: "govuk-button") %>
 
-<div class="govuk-tabs" data-module="tabs">
-  <ul class="govuk-tabs__list" role='tablist'>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#caseload">
-        Caseload
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#notes">
-        Notes
-      </a>
-    </li>
-  </ul>
-  <section class="govuk-tabs__panel" id="caseload">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <h2 class="govuk-heading-l">Caseload</h2>
+  </div>
+  <div class="govuk-grid-column-full">
     <%= render 'caseload' %>
-  </section>
-  <section class="govuk-tabs__panel" id="notes">
-    <%= render 'notes' %>
-  </section>
+  </div>
 </div>

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -18,10 +18,10 @@ feature "get poms list" do
   it "allows viewing a POM", vcr: { cassette_name: :show_poms_feature } do
     signin_user
 
-    visit "/poms/1"
+    visit "/poms/485752"
 
     expect(page).to have_css(".govuk-button", count: 1)
-    expect(page).to have_content("Surname, Forename")
+    expect(page).to have_content("Jones, Ross")
     expect(page).to have_content("Caseload")
     expect(page).to have_css('.govuk-breadcrumbs')
     expect(page).to have_css('.govuk-breadcrumbs__link', count: 3)

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe AllocationService do
+  let(:allocation) {
+    described_class.create_allocation(
+      nomis_staff_id: 485_595,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 0,
+      allocated_at_tier: 'A',
+      prison: 'LEI'
+    )
+  }
+
+  it "Can get the active allocations" do
+    alloc = described_class.active_allocations([allocation.nomis_offender_id])
+    expect(alloc).to be_instance_of(Hash)
+  end
+end

--- a/spec/services/nomis/elite2/api_spec.rb
+++ b/spec/services/nomis/elite2/api_spec.rb
@@ -27,6 +27,35 @@ describe Nomis::Elite2::Api do
     end
   end
 
+  describe 'Bulk operations' do
+    it 'can get bulk sentence details',
+      vcr: { cassette_name: :elite2_api_bulk_sentence_details } do
+      noms_ids = ['G2911GD']
+
+      response = described_class.get_bulk_sentence_details(noms_ids)
+
+      expect(response.data).to be_instance_of(Hash)
+
+      records = response.data.values
+      expect(records.first).to be_instance_of(Nomis::Elite2::SentenceDetail)
+      expect(records.first.release_date).to eq('2019-05-17')
+      expect(records.first.full_name).to eq('Ahmonis, Imanjah')
+    end
+
+    it 'can get bulk release dates',
+      vcr: { cassette_name: :elite2_api_bulk_sentence_details } do
+      noms_ids = ['G2911GD']
+
+      response = described_class.get_bulk_release_dates(noms_ids)
+
+      expect(response.data).to be_instance_of(Hash)
+
+      records = response.data.values
+      expect(records.first).to be_instance_of(Date)
+      expect(records.first.to_s).to eq('2019-05-17')
+    end
+  end
+
   describe 'Single offender' do
     it "can get a single offender's details",
       vcr: { cassette_name: :elite2_api_single_offender_spec } do

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require_relative '../../app/services/nomis/elite2/sentence_detail'
+
+describe PrisonOffenderManagerService do
+  let(:pom_detail) {
+    described_class.get_pom_detail(485_595)
+  }
+  let(:allocation) {
+    AllocationService.create_allocation(
+      nomis_staff_id: pom_detail.nomis_staff_id,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 0,
+      allocated_at_tier: 'A',
+      prison: 'LEI'
+    )
+  }
+
+  it "can get allocated offenders for a POM",
+    vcr: { cassette_name: :pom_service_allocated_offenders } do
+    allocated_offenders = described_class.get_allocated_offenders(allocation.nomis_staff_id)
+
+    alloc, sentence_detail = allocated_offenders.first
+    expect(alloc).to be_kind_of(Allocation)
+    expect(sentence_detail).to be_kind_of(Nomis::Elite2::SentenceDetail)
+  end
+
+  it "can get a list of POMs",
+    vcr: { cassette_name: :pom_service_get_poms } do
+    poms = described_class.get_poms('LEI')
+    expect(poms).to be_kind_of(Array)
+    expect(poms.count).to eq(5)
+  end
+end


### PR DESCRIPTION
The List of POMs is shown and grouped according to their status
(active/inactive).

The Single POM is shown w/o gender/email as we don't currently know
where to get these.  Functionality is added to the
PrisonOffenderManagerService which allows for the retrieval of a list of
[allocation,offender] but unfortunately in this case the offender is a
SentenceDetail as we are currently unable to get the Offender model from
/locations/description/LEI/inmates due to it not accepting a list of
IDs.