### PR TITLE
Allocation tab cleanup

### DIFF
--- a/app/controllers/allocates_controller.rb
+++ b/app/controllers/allocates_controller.rb
@@ -15,7 +15,7 @@ class AllocatesController < ApplicationController
     @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url).data
 
     poms_list = PrisonOffenderManagerService.get_poms(caseload)
-    @pom = poms_list.select { |p| p.staff_id == nomis_staff_id_from_url }.first
+    @pom = poms_list.select { |p| p.staff_id == nomis_staff_id_from_url.to_i }.first
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/controllers/allocates_controller.rb
+++ b/app/controllers/allocates_controller.rb
@@ -38,7 +38,7 @@ class AllocatesController < ApplicationController
       override_detail: override_detail
     )
 
-    redirect_to allocations_path
+    redirect_to allocations_path(anchor: 'awaiting-allocation')
   end
 # rubocop:enable Metrics/MethodLength
 

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -23,7 +23,7 @@ private
 
   def pom
     @poms_list ||= PrisonOffenderManagerService.get_poms(caseload)
-    @poms_list.select { |p| p.staff_id == params.require(:nomis_staff_id) }.first
+    @poms_list.select { |p| p.staff_id == params.require(:nomis_staff_id).to_i }.first
   end
 
   def override_params

--- a/app/services/allocation_summary_service.rb
+++ b/app/services/allocation_summary_service.rb
@@ -56,10 +56,17 @@ class AllocationSummaryService
       @counts[:missing_count].digits[0]
     )
 
+    # For the allocated offenders, we need to provide the allocated POM's
+    # name
+    allocated_offenders = OffenderService.set_allocated_pom_name(
+      @allocated_bucket.last(allocated_wanted),
+      prison
+    )
+
     # Return the last (N) records from each bucket, in case
     # the capacity was higher than 10 (we need more than one page worth).
     AllocationSummary.new.tap { |summary|
-      summary.allocated_offenders = @allocated_bucket.last(allocated_wanted)
+      summary.allocated_offenders = allocated_offenders
       summary.unallocated_offenders = @unallocated_bucket.last(unallocated_wanted)
       summary.missing_info_offenders = @missing_info_bucket.last(missing_wanted)
 

--- a/app/services/nomis/elite2/offender_short.rb
+++ b/app/services/nomis/elite2/offender_short.rb
@@ -24,6 +24,7 @@ module Nomis
       attribute :rnum, :integer
       attribute :release_date, :date
       attribute :tier, :string
+      attribute :allocated_pom_name, :string
 
       def full_name
         "#{last_name}, #{first_name}".titleize

--- a/app/services/nomis/elite2/prison_offender_manager.rb
+++ b/app/services/nomis/elite2/prison_offender_manager.rb
@@ -3,7 +3,7 @@ module Nomis
     class PrisonOffenderManager
       include MemoryModel
 
-      attribute :staff_id, :string
+      attribute :staff_id, :integer
       attribute :first_name, :string
       attribute :last_name, :string
       attribute :agency_id, :string

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -15,6 +15,13 @@ class PrisonOffenderManagerService
     }
   end
 
+  def self.get_pom_names(prison)
+    poms_list = PrisonOffenderManagerService.get_poms(prison)
+    poms_list.each_with_object({}) { |p, hsh|
+      hsh[p.staff_id] = p.full_name
+    }
+  end
+
   def self.get_allocations_for_pom(nomis_staff_id)
     detail = PrisonOffenderManagerService.get_pom_detail(nomis_staff_id)
     detail.allocations.where(active: true)

--- a/app/views/allocations/_allocated.html.erb
+++ b/app/views/allocations/_allocated.html.erb
@@ -6,9 +6,7 @@
         class='table-sorter__link' href='#'>Prisoner name</a></th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
       <th class="govuk-table__header sorter-false" scope="col">Arrival date</th>
-      <th class="govuk-table__header sorter-false" scope="col">Release date</th>
-      <th class="govuk-table__header header-width__8" scope="col"><a
-        class='table-sorter__link' href='#'>Tier</a></th>
+      <th class="govuk-table__header sorter-false" scope="col">Release date/Parole eligibility</th>
       <th class="govuk-table__header" scope="col"><a
         class='table-sorter__link' href='#'>POM</a></th>
       <th class="govuk-table__header" scope="col"><a
@@ -24,8 +22,7 @@
         <td aria-label="Arrival date" class="govuk-table__cell
               ">N/A</td>
         <td aria-label="Release date" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
-        <td aria-label="Tier" class="govuk-table__cell"><%= offender.tier %></td>
-        <td aria-label="POM" class="govuk-table__cell">NA</td>
+        <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name %></td>
         <td aria-label="Allocation date" class="govuk-table__cell">NA</td>
         <td aria-label="Action" class="govuk-table__cell "><a
           href="">Reallocate</a></td>

--- a/app/views/allocations/_awaiting.html.erb
+++ b/app/views/allocations/_awaiting.html.erb
@@ -7,7 +7,7 @@
         class='table-sorter__link' href='#'>Prisoner name</th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
       <th class="govuk-table__header sorter-false" scope="col">Arrival date</th>
-      <th class="govuk-table__header sorter-false" scope="col">Release date</th>
+      <th class="govuk-table__header sorter-false" scope="col">Release date/Parole eligibility</th>
       <th class="govuk-table__header header-width__8" scope="col"><a href='#'
                                                                      class='table-sorter__link'>Tier</th>
       <th class="govuk-table__header" scope="col">Action</th>

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -11,7 +11,7 @@ feature 'allocations summary feature' do
       expect(page).to have_css('.pagination ul.links li', count: 16)
     end
 
-    it 'renders allocation offenders at index', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_feature } do
+    it 'renders allocated offenders at index', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_feature } do
       signin_user
       visit 'allocations#allocated'
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -26,4 +26,27 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
     expect(offender.data.main_offence).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
     expect(offender.data.case_allocation).to eq 'CRC'
   end
+
+  it "gets the POM names for allocated offenders",
+    vcr: { cassette_name: :offender_service_pom_names_spec } do
+
+    offenders = OffenderService.new.get_offenders_for_prison('LEI', page_size: 3).data
+
+    PomDetail.create!(nomis_staff_id: 485_752, working_pattern: 1.0, status: 'active')
+
+    AllocationService.create_allocation(
+      nomis_offender_id: offenders.first.offender_no,
+      nomis_booking_id: 1_153_753,
+      prison: 'LEI',
+      allocated_at_tier: 'C',
+      created_by: 'user@username.com',
+      nomis_staff_id: 485_752
+    )
+
+    updated_offenders = OffenderService.set_allocated_pom_name(offenders, 'LEI')
+    expect(updated_offenders).to be_kind_of(Array)
+    expect(updated_offenders.first).to be_kind_of(Nomis::Elite2::OffenderShort)
+    expect(updated_offenders.count).to eq(offenders.count)
+    expect(updated_offenders.first.allocated_pom_name).to eq('Jones, Ross')
+  end
 end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -31,4 +31,11 @@ describe PrisonOffenderManagerService do
     expect(poms).to be_kind_of(Array)
     expect(poms.count).to eq(5)
   end
+
+  it "can get the names for POMs when given IDs",
+    vcr: { cassette_name: :pom_service_get_poms } do
+    names = described_class.get_pom_names('LEI')
+    expect(names).to be_kind_of(Hash)
+    expect(names.count).to eq(5)
+  end
 end


### PR DESCRIPTION
This PR shows the name of the allocated POM when the user is looking at
the allocated tab in the summary screen.  The tier column has also been
removed and the release date column renamed.

As it was included in the cleanup ticket, once an allocation is complete the user is redirected to the awaiting allocation tab rather than the allocated tab.