### PR TITLE
Fix migrations

### DIFF
--- a/db/migrate/20190210105233_add_overrides_table.rb
+++ b/db/migrate/20190210105233_add_overrides_table.rb
@@ -2,7 +2,7 @@ class AddOverridesTable < ActiveRecord::Migration[5.2]
   create_table "overrides", force: :cascade do |t|
     t.integer "nomis_staff_id"
     t.string "nomis_offender_id"
-    t.string "override_reasons"
+    t.string "override_reason"
     t.string "more_detail"
   end
 end

--- a/db/migrate/20190212160351_update_overrides_column_type.rb
+++ b/db/migrate/20190212160351_update_overrides_column_type.rb
@@ -1,13 +1,11 @@
 class UpdateOverridesColumnType < ActiveRecord::Migration[5.2]
   def up
     rename_column :overrides, :override_reason, :override_reasons
-    rename_column :allocations, :override_reason, :override_reasons
     change_column :overrides, :override_reasons, :string, using: "override_reasons::character varying[]"
   end
 
   def down
     change_coloumn :overrides, :override_reasons, :string
-    rename_column :allocations, :override_reasons, :override_reason
     rename_column :overrides, :override_reasons, :override_reason
   end
 end


### PR DESCRIPTION
update_overrides_column_type was trying to rename a field in the
allocations table that was already renamed in

```
db/migrate/20190210132134_rename_column_allocations_table.rb
  3,33:     rename_column :allocations, :reason, :override_reasons
  9,52:     rename_column :allocations, :override_reasons, :reason
```