### PR TITLE
Remove pagination text when only 1 page

### DIFF
--- a/app/models/page_meta.rb
+++ b/app/models/page_meta.rb
@@ -18,6 +18,10 @@ class PageMeta
     number
   end
 
+  def page_count
+    total_pages
+  end
+
   def page_numbers
     page = current_page
 

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,6 +1,7 @@
 <% if page_data %>
 <div class="govuk-grid-row pagination">
   <div class="govuk-grid-column-one-half">
+    <% if page_data.page_count > 1 %>
     <ul class="links">
       <li>
         <% if page_data.previous? %>
@@ -26,6 +27,9 @@
         <% end %>
       </li>
     </ul>
+    <% else %>
+      &nbsp;
+    <% end %>
   </div>
   <div class="govuk-grid-column-one-half result-count">
     Showing <%= page_data.record_range %> of <%= page_data.total_elements %> results

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -20,7 +20,7 @@ feature 'allocations summary feature' do
 
       expect(page).to have_css('.govuk-tabs__tab', text: 'Awaiting allocation')
       within('#awaiting-allocation') do
-        expect(page).to have_css('.pagination ul.links li', count: 2)
+        expect(page).to have_css('.pagination ul.links li', count: 0)
       end
     end
 
@@ -31,7 +31,7 @@ feature 'allocations summary feature' do
 
       expect(page).to have_css('.govuk-tabs__tab', text: 'Allocated')
       within('#allocated') do
-        expect(page).to have_css('.pagination ul.links li', count: 2)
+        expect(page).to have_css('.pagination ul.links li', count: 0)
       end
     end
   end


### PR DESCRIPTION
When there is only one page of results in the allocation summary, there
is little point in showing the Next/Previous and page number.  This PR
removes them.