### PR TITLE
Fix case information

### DIFF
--- a/app/views/case_information/new.html.erb
+++ b/app/views/case_information/new.html.erb
@@ -19,8 +19,8 @@
           <%= label_tag "case_information[case_allocation]", "National Probation Service (NPS)", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[allocation]", "CRC", false, class: "govuk-radios__input") %>
-          <%= label_tag "case_information[allocation]", "Community Rehabilitation Company (CRC)", class: "govuk-label govuk-radios__label" %>
+          <%= radio_button_tag("case_information[case_allocation]", "CRC", false, class: "govuk-radios__input") %>
+          <%= label_tag "case_information[case_allocation]", "Community Rehabilitation Company (CRC)", class: "govuk-label govuk-radios__label" %>
         </div>
       </div>
     </fieldset>

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -5,7 +5,8 @@ feature 'case information feature' do
     nomis_offender_id = 'G4273GI'
 
     signin_user
-    visit 'allocations#awaiting_information'
+    visit allocations_path
+
     within('#awaiting-information') do
       within('.offender_row_0') do
         click_link 'Edit'
@@ -23,5 +24,9 @@ feature 'case information feature' do
     expect(CaseInformation.first.tier).to eq('A')
     expect(CaseInformation.first.case_allocation).to eq('NPS')
     expect(page).to have_current_path allocations_path
+
+    within('#awaiting-allocation') do
+      expect(page).to have_css('.offender_row_0', count: 1)
+    end
   end
 end


### PR DESCRIPTION
- CRC form field now submitting correctly
- Increased test coverage - assert a prisoner with case information appears in the 'awaiting allocation' tab