### PR TITLE
POM view of own caseload

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,9 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user
 
-  def index; end
+  def index
+    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
+    poms_list = PrisonOffenderManagerService.get_poms(caseload)
+    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,8 +2,6 @@ class DashboardController < ApplicationController
   before_action :authenticate_user
 
   def index
-    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
-    poms_list = PrisonOffenderManagerService.get_poms(caseload)
-    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
+    @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
   end
 end

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -3,9 +3,9 @@ class PomsController < ApplicationController
 
   breadcrumb 'Prison Offender Managers', :poms_path, only: [:index, :show]
   breadcrumb -> { pom.full_name }, -> {  poms_show_path(params[:id]) }, only: [:show]
-  breadcrumb 'My caseload', :my_caseload_path, only: [ :new_cases]
+  breadcrumb 'My caseload', :my_caseload_path, only: [:new_allocations]
   breadcrumb -> { 'My caseload' }, -> { my_caseload_path(1) }, only: [:my_caseload]
-  breadcrumb -> { 'New cases' }, -> { new_cases_path(1) }, only: [:new_cases]
+  breadcrumb -> { 'New cases' }, -> { new_allocations_path(1) }, only: [:new_allocations]
 
   def index
     poms = PrisonOffenderManagerService.get_poms(caseload)
@@ -23,18 +23,26 @@ class PomsController < ApplicationController
   def edit; end
 
   def my_caseload
-    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
-    poms_list = PrisonOffenderManagerService.get_poms(caseload)
-    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
+    signed_in_pom_details
     @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
-    @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id)
+    @new_allocations = PrisonOffenderManagerService.get_new_allocations(@pom.staff_id)
   end
 
-  def new_cases; end
+  def new_allocations
+    signed_in_pom_details
+    @new_allocations = PrisonOffenderManagerService.get_new_allocations(@pom.staff_id)
+  end
+
 private
 
   def pom
     poms_list = PrisonOffenderManagerService.get_poms(caseload)
     @pom = poms_list.select { |p| p.staff_id.to_i == params['id'].to_i }.first
+  end
+
+  def signed_in_pom_details
+    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
+    poms_list = PrisonOffenderManagerService.get_poms(caseload)
+    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
   end
 end

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -23,13 +23,13 @@ class PomsController < ApplicationController
   def edit; end
 
   def my_caseload
-    signed_in_pom_details
+    @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
     @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
     @new_allocations = PrisonOffenderManagerService.get_new_allocations(@pom.staff_id)
   end
 
   def new_allocations
-    signed_in_pom_details
+    @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
     @new_allocations = PrisonOffenderManagerService.get_new_allocations(@pom.staff_id)
   end
 
@@ -38,11 +38,5 @@ private
   def pom
     poms_list = PrisonOffenderManagerService.get_poms(caseload)
     @pom = poms_list.select { |p| p.staff_id.to_i == params['id'].to_i }.first
-  end
-
-  def signed_in_pom_details
-    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
-    poms_list = PrisonOffenderManagerService.get_poms(caseload)
-    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
   end
 end

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -3,6 +3,9 @@ class PomsController < ApplicationController
 
   breadcrumb 'Prison Offender Managers', :poms_path, only: [:index, :show]
   breadcrumb -> { pom.full_name }, -> {  poms_show_path(params[:id]) }, only: [:show]
+  breadcrumb 'My caseload', :my_caseload_path, only: [ :new_cases]
+  breadcrumb -> { 'My caseload' }, -> { my_caseload_path(1) }, only: [:my_caseload]
+  breadcrumb -> { 'New cases' }, -> { new_cases_path(1) }, only: [:new_cases]
 
   def index
     poms = PrisonOffenderManagerService.get_poms(caseload)
@@ -19,6 +22,15 @@ class PomsController < ApplicationController
 
   def edit; end
 
+  def my_caseload
+    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
+    poms_list = PrisonOffenderManagerService.get_poms(caseload)
+    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
+    @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
+    @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id)
+  end
+
+  def new_cases; end
 private
 
   def pom

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -39,4 +39,10 @@ class PrisonOffenderManagerService
     end
     allocations_and_offender
   end
+
+  def self.get_new_cases(nomis_staff_id)
+    today = DateTime.now
+    week_ago = 7.days.ago
+    Allocation.where(nomis_staff_id: nomis_staff_id).where(created_at: week_ago..today)
+    end
 end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -44,4 +44,10 @@ class PrisonOffenderManagerService
     allocations = PrisonOffenderManagerService.get_allocated_offenders(nomis_staff_id)
     allocations.select { |allocation, _offender| allocation.created_at >= 7.days.ago }
   end
+
+  def self.get_signed_in_pom_details(current_user)
+    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
+    poms_list = PrisonOffenderManagerService.get_poms(user.active_case_load_id)
+    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
+  end
 end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -40,9 +40,8 @@ class PrisonOffenderManagerService
     allocations_and_offender
   end
 
-  def self.get_new_cases(nomis_staff_id)
-    today = DateTime.now
-    week_ago = 7.days.ago
-    Allocation.where(nomis_staff_id: nomis_staff_id).where(created_at: week_ago..today)
-    end
+  def self.get_new_allocations(nomis_staff_id)
+    allocations = PrisonOffenderManagerService.get_allocated_offenders(nomis_staff_id)
+    allocations.select { |allocation, _offender| allocation.created_at >= 7.days.ago }
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -35,7 +35,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "My caseload", my_caseload_path("1"), class:"govuk-link" %>
+        <%= link_to "My caseload", my_caseload_path(@pom.staff_id), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">All cases allocated to you.</p>
     </div>
@@ -43,7 +43,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "New allocations", new_cases_path("1"), class:"govuk-link" %>
+        <%= link_to "New allocations", new_allocations_path(@pom.staff_id), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">Cases allocated to you in the last 7 days.</p>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -35,7 +35,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "My caseload", "/", class:"govuk-link" %>
+        <%= link_to "My caseload", my_caseload_path("1"), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">All cases allocated to you.</p>
     </div>
@@ -43,7 +43,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "New allocations", "/", class:"govuk-link" %>
+        <%= link_to "New allocations", new_cases_path("1"), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">Cases allocated to you in the last 7 days.</p>
     </div>

--- a/app/views/poms/my_caseload.html.erb
+++ b/app/views/poms/my_caseload.html.erb
@@ -1,0 +1,43 @@
+<h2 class="govuk-heading-l">My caseload (<%= @allocations.count  %>)</h2>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-body">New cases</div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= link_to "#{@new_cases.count}", new_cases_path(@pom.staff_id), class:"govuk-link"%></a></div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-body">Working pattern</div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.working_pattern %></div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="govuk-body">Status</div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.status.capitalize  %></div>
+  </div>
+</div>
+
+<table class="govuk-table responsive tablesorter">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col"><a
+      class='table-sorter__link' href='#'>Prisoner name</a></th>
+    <th class="govuk-table__header" scope="col">Prisoner number</th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Release date/parole eligibility</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Allocation date</a></th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Role</a></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @allocations.each do |allocation, sentence| %>
+    <tr class="govuk-table__row">
+      <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
+      <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
+      <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
+      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
+      <td aria-label="Role" class="govuk-table__cell ">N/A</td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/poms/new_allocations.html.erb
+++ b/app/views/poms/new_allocations.html.erb
@@ -1,19 +1,4 @@
-<h2 class="govuk-heading-l">My caseload (<%= @allocations.count  %>)</h2>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
-    <div class="govuk-body">New cases</div>
-    <div class="govuk-body govuk-!-font-weight-bold"><%= link_to "#{@new_allocations.count}", new_allocations_path(@pom.staff_id), class:"govuk-link"%></a></div>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <div class="govuk-body">Working pattern</div>
-    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.working_pattern %></div>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <div class="govuk-body">Status</div>
-    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.status.capitalize  %></div>
-  </div>
-</div>
+<h2 class="govuk-heading-l">New allocations</h2>
 
 <table class="govuk-table responsive tablesorter">
   <thead class="govuk-table__head">
@@ -21,6 +6,8 @@
     <th class="govuk-table__header" scope="col"><a
       class='table-sorter__link' href='#'>Prisoner name</a></th>
     <th class="govuk-table__header" scope="col">Prisoner number</th>
+    <th class="govuk-table__header" scope="col">
+      <a class="table-sorter__link" href="#">Arrival date</a></th>
     <th class="govuk-table__header" scope="col">
       <a class="table-sorter__link" href="#">Release date/parole eligibility</a></th>
     <th class="govuk-table__header" scope="col">
@@ -30,13 +17,14 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @allocations.each do |allocation, sentence| %>
+  <% @new_allocations.each do |allocation, sentence| %>
     <tr class="govuk-table__row">
       <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
+      <td aria-label="Arrival date" class="govuk-table__cell ">ARRIVAL DATE</td>
       <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
       <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
-      <td aria-label="Role" class="govuk-table__cell ">N/A</td>
+      <td aria-label="Role" class="govuk-table__cell ">ROLE</td>
     </tr>
   <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   get('/poms' => 'poms#index')
   get('/poms/:id' => 'poms#show', as: 'poms_show')
   get('/poms/:id/edit' => 'poms#edit', as: 'poms_edit')
+  get('/poms/:id/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
+  get('/poms/:id/new_cases' => 'poms#new_cases', as: 'new_cases')
 
   get('/prisoners/:id' => 'prisoners#show', as: 'prisoners_show')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   get('/poms' => 'poms#index')
   get('/poms/:id' => 'poms#show', as: 'poms_show')
   get('/poms/:id/edit' => 'poms#edit', as: 'poms_edit')
-  get('/poms/:id/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
-  get('/poms/:id/new_cases' => 'poms#new_cases', as: 'new_cases')
+  get('/poms/:staff_id/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
+  get('/poms/:staff_id/new_allocations' => 'poms#new_allocations', as: 'new_allocations')
 
   get('/prisoners/:id' => 'prisoners#show', as: 'prisoners_show')
 

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'get dashboard' do
   it 'shows the status page', vcr: { cassette_name: :dashboard_feature } do
-    signin_user
+    signin_user('PK000223')
 
     visit '/'
 

--- a/spec/features/view_allocations_spec.rb
+++ b/spec/features/view_allocations_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+feature "view POM's caseload" do
+  let(:nomis_staff_id) { 485_637 }
+  let(:nomis_offender_id) { 'G4273GI' }
+
+  it 'displays all cases for a specific POM',  vcr: { cassette_name: :show_poms_caseload } do
+    signin_user('PK000223')
+
+    visit new_allocates_path(nomis_offender_id, nomis_staff_id)
+
+    click_button 'Complete allocation'
+
+    visit "/poms/485637/my_caseload"
+
+    expect(page).to have_content("My caseload")
+    expect(page).to have_content("Abbella, Ozullirn")
+  end
+
+  it 'displays all cases that have been allocated to a specific POM in the last week', vcr: { cassette_name: :show_new_allocations } do
+    signin_user('PK000223')
+
+    visit new_allocates_path(nomis_offender_id, nomis_staff_id)
+    click_button 'Complete allocation'
+
+    visit "/poms/485637/my_caseload"
+    click_link('1')
+
+    expect(page).to have_content("New allocations")
+    expect(page).to have_content("Abbella, Ozullirn")
+  end
+end

--- a/spec/features/view_allocations_spec.rb
+++ b/spec/features/view_allocations_spec.rb
@@ -4,6 +4,10 @@ feature "view POM's caseload" do
   let(:nomis_staff_id) { 485_637 }
   let(:nomis_offender_id) { 'G4273GI' }
 
+  before do
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC')
+  end
+
   it 'displays all cases for a specific POM',  vcr: { cassette_name: :show_poms_caseload } do
     signin_user('PK000223')
 


### PR DESCRIPTION
This feature allows signed in POMs to view all their allocated cases, and specifically those newly allocated cases from the past 7 days.