### PR TITLE
Remove the ApiResponse struct

### DIFF
--- a/app/controllers/allocates_controller.rb
+++ b/app/controllers/allocates_controller.rb
@@ -2,7 +2,7 @@ class AllocatesController < ApplicationController
   before_action :authenticate_user
 
   def show
-    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url).data
+    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url)
     @recommended_pom = @prisoner.current_responsibility
 
     pom_response = PrisonOffenderManagerService.get_poms(caseload)
@@ -12,7 +12,7 @@ class AllocatesController < ApplicationController
   end
 
   def new
-    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url).data
+    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url)
 
     poms_list = PrisonOffenderManagerService.get_poms(caseload)
     @pom = poms_list.select { |p| p.staff_id == nomis_staff_id_from_url.to_i }.first
@@ -21,8 +21,7 @@ class AllocatesController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def create
     prisoner  = OffenderService.new.
-      get_offender(allocation_params[:nomis_offender_id]).
-      data
+      get_offender(allocation_params[:nomis_offender_id])
     @override = Override.where(
       nomis_offender_id: allocation_params[:nomis_offender_id]).
       where(nomis_staff_id: allocation_params[:nomis_staff_id]).last

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -2,7 +2,7 @@ class CaseInformationController < ApplicationController
   before_action :authenticate_user
 
   def new
-    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url).data
+    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url)
   end
 
   def create

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -1,6 +1,6 @@
 class OverridesController < ApplicationController
   def new
-    @prisoner = OffenderService.new.get_offender(params.require(:nomis_offender_id)).data
+    @prisoner = OffenderService.new.get_offender(params.require(:nomis_offender_id))
     @recommended_pom = @prisoner.current_responsibility
     @pom = pom
   end

--- a/app/services/allocation_summary_service.rb
+++ b/app/services/allocation_summary_service.rb
@@ -95,11 +95,7 @@ private
   def max_requests_count(prison)
     # Fetch the first 1 prisoners just for the total number of pages so that we
     # can send batched queries.
-    info_request = OffenderService.new.get_offenders_for_prison(
-      prison,
-      page_number: 0,
-      page_size: 1
-    )
+    info_request = Nomis::Elite2::Api.get_offender_list(prison, 1, page_size: 1)
 
     # The maximum number of pages we need to fetch before we have all of
     # the offenders
@@ -107,12 +103,11 @@ private
   end
 
   def get_page_of_offenders(prison, page_number)
-    response = OffenderService.new.get_offenders_for_prison(
+    OffenderService.new.get_offenders_for_prison(
       prison,
       page_number: page_number,
       page_size: FETCH_SIZE
     )
-    response.data
   end
 
   def get_tiered_offenders(offender_list)

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -8,7 +8,7 @@ class PrisonOffenderManagerService
 
   def self.get_poms(prison)
     poms = Nomis::Elite2::Api.prisoner_offender_manager_list(prison)
-    poms.data.map { |pom|
+    poms.map { |pom|
       detail = get_pom_detail(pom.staff_id)
       pom.add_detail(detail)
       pom
@@ -46,7 +46,7 @@ class PrisonOffenderManagerService
   end
 
   def self.get_signed_in_pom_details(current_user)
-    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user).data
+    user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user)
     poms_list = PrisonOffenderManagerService.get_poms(user.active_case_load_id)
     @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
   end

--- a/lib/hmpps_sso.rb
+++ b/lib/hmpps_sso.rb
@@ -41,7 +41,7 @@ module OmniAuth
     private
 
       def staff_details
-        @staff_details ||= Nomis::Elite2::Api.fetch_nomis_user_details(username).data
+        @staff_details ||= Nomis::Elite2::Api.fetch_nomis_user_details(username)
       end
 
       #:nocov:

--- a/spec/lib/hmpps_sso_spec.rb
+++ b/spec/lib/hmpps_sso_spec.rb
@@ -17,12 +17,10 @@ describe OmniAuth::Strategies::HmppsSso do
       it 'returns a hash with the user name and caseload' do
         leeds_prison = 'LEI'
         username = 'Fred'
-        response = Nomis::Elite2::ApiResponse.new(
-          double('staff_details',
-            active_case_load_id: leeds_prison,
-            username: username
-          )
-        )
+        response = double('staff_details',
+          active_case_load_id: leeds_prison,
+          username: username
+                   )
 
         allow(Nomis::Elite2::Api).to receive(:fetch_nomis_user_details).and_return(response)
         allow(strategy).to receive(:username).and_return(username)

--- a/spec/services/nomis/elite2/api_spec.rb
+++ b/spec/services/nomis/elite2/api_spec.rb
@@ -13,7 +13,7 @@ describe Nomis::Elite2::Api do
       vcr: { cassette_name: :get_elite2_offender_list } do
       response = described_class.get_offender_list('LEI')
 
-      expect(response).not_to be_nil
+      expect(response.data).not_to be_nil
       expect(response.data).to be_instance_of(Array)
       expect(response.data).to all(be_an Nomis::Elite2::OffenderShort)
     end
@@ -22,8 +22,8 @@ describe Nomis::Elite2::Api do
       vcr: { cassette_name: :get_offence_ok } do
       booking_id = '1153753'
       response = described_class.get_offence(booking_id)
-      expect(response.data).to be_instance_of(String)
-      expect(response.data).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
+      expect(response).to be_instance_of(String)
+      expect(response).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
     end
   end
 
@@ -34,9 +34,9 @@ describe Nomis::Elite2::Api do
 
       response = described_class.get_bulk_sentence_details(noms_ids)
 
-      expect(response.data).to be_instance_of(Hash)
+      expect(response).to be_instance_of(Hash)
 
-      records = response.data.values
+      records = response.values
       expect(records.first).to be_instance_of(Nomis::Elite2::SentenceDetail)
       expect(records.first.release_date).to eq('2019-05-17')
       expect(records.first.full_name).to eq('Ahmonis, Imanjah')
@@ -50,7 +50,7 @@ describe Nomis::Elite2::Api do
 
       response = described_class.get_offender(noms_id)
 
-      expect(response.data).to be_instance_of(Nomis::Elite2::Offender)
+      expect(response).to be_instance_of(Nomis::Elite2::Offender)
     end
 
     it 'returns null if unable to find prisoner', :raven_intercept_exception,
@@ -59,7 +59,7 @@ describe Nomis::Elite2::Api do
 
       response = described_class.get_offender(noms_id)
 
-      expect(response.data).to be_instance_of(Nomis::Elite2::NullOffender)
+      expect(response).to be_instance_of(Nomis::Elite2::NullOffender)
     end
   end
 
@@ -69,8 +69,8 @@ describe Nomis::Elite2::Api do
       vcr: { cassette_name: :elite2_api_keyworkers_spec  } do
       response = described_class.prisoner_offender_manager_list('LEI')
 
-      expect(response.data).to be_instance_of(Array)
-      expect(response.data).to all(be_an Nomis::Elite2::PrisonOffenderManager)
+      expect(response).to be_instance_of(Array)
+      expect(response).to all(be_an Nomis::Elite2::PrisonOffenderManager)
     end
 
     it "gets staff details",
@@ -79,8 +79,8 @@ describe Nomis::Elite2::Api do
 
       response = described_class.fetch_nomis_user_details(username)
 
-      expect(response.data).to be_kind_of(Nomis::Elite2::UserDetails)
-      expect(response.data.active_case_load_id).to eq('LEI')
+      expect(response).to be_kind_of(Nomis::Elite2::UserDetails)
+      expect(response.active_case_load_id).to eq('LEI')
     end
   end
 end

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -3,18 +3,16 @@ require 'rails_helper'
 describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_prison_spec } do
   it "get first page of offenders for a specific prison" do
     offenders = OffenderService.new.get_offenders_for_prison('LEI')
-    expect(offenders.meta).to be_kind_of(PageMeta)
-    expect(offenders.data).to be_kind_of(Array)
-    expect(offenders.data.length).to eq(5)
-    expect(offenders.data.first).to be_kind_of(Nomis::Elite2::OffenderShort)
+    expect(offenders).to be_kind_of(Array)
+    expect(offenders.length).to eq(5)
+    expect(offenders.first).to be_kind_of(Nomis::Elite2::OffenderShort)
   end
 
   it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
     offenders = OffenderService.new.get_offenders_for_prison('LEI', page_number: 116)
-    expect(offenders.meta).to be_kind_of(PageMeta)
-    expect(offenders.data).to be_kind_of(Array)
-    expect(offenders.data.length).to eq(5)
-    expect(offenders.data.first).to be_kind_of(Nomis::Elite2::OffenderShort)
+    expect(offenders).to be_kind_of(Array)
+    expect(offenders.length).to eq(5)
+    expect(offenders.first).to be_kind_of(Nomis::Elite2::OffenderShort)
   end
 
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
@@ -23,17 +21,17 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
     CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC')
     offender = OffenderService.new.get_offender(nomis_offender_id)
 
-    expect(offender.data).to be_kind_of(Nomis::Elite2::Offender)
-    expect(offender.data.release_date).to eq Date.new(2020, 2, 7)
-    expect(offender.data.tier).to eq 'C'
-    expect(offender.data.main_offence).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
-    expect(offender.data.case_allocation).to eq 'CRC'
+    expect(offender).to be_kind_of(Nomis::Elite2::Offender)
+    expect(offender.release_date).to eq Date.new(2020, 2, 7)
+    expect(offender.tier).to eq 'C'
+    expect(offender.main_offence).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
+    expect(offender.case_allocation).to eq 'CRC'
   end
 
   it "gets the POM names for allocated offenders",
     vcr: { cassette_name: :offender_service_pom_names_spec } do
 
-    offenders = OffenderService.new.get_offenders_for_prison('LEI', page_size: 3).data
+    offenders = OffenderService.new.get_offenders_for_prison('LEI', page_size: 3)
 
     PomDetail.create!(nomis_staff_id: 485_752, working_pattern: 1.0, status: 'active')
 


### PR DESCRIPTION
In the Nomis::Elite2::Api we were returning the result wrapped in a
struct which had a single field.  This was because we _did_ need a paged
response that would contain the data and the page metadata.

This PR removes the ApiResponse (but leaves the ApiPaginatedResponse for
the one call that needs it) so that we no longer need to keep tacking
.data onto the end of API calls.