### PR TITLE
Show POM: Remove gender, set POM level

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,11 @@ module ApplicationHelper
 
     date_obj.strftime('%d/%m/%Y')
   end
+
+  def pom_level(level)
+    {
+      'PO' => 'Prison POM',
+      'PRO'=> 'Probation POM'
+    }[level]
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   def pom_level(level)
     {
       'PO' => 'Prison POM',
-      'PRO'=> 'Probation POM'
+      'PRO' => 'Probation POM'
     }[level]
   end
 end

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -4,12 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
-    <div class="govuk-body">Gender</div>
-    <div class="govuk-body govuk-!-font-weight-bold">GENDER</div>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">POM level</div>
-    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.position %></div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= pom_level(@pom.position) %></div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">Working pattern</div>


### PR DESCRIPTION
We decided to remove the POM gender until we find out how to get it from
Elite2.

Also uses a simple helper to change the display string for POM level.