### PR TITLE
Do not show inactive POMs on allocation page

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -5,7 +5,9 @@ class AllocationsController < ApplicationController
     @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url)
     @recommended_pom = @prisoner.current_responsibility
 
-    pom_response = PrisonOffenderManagerService.get_poms(caseload)
+    pom_response = PrisonOffenderManagerService.get_poms(caseload) { |pom|
+      pom.status == 'active'
+    }
     @recommended_poms, @not_recommended_poms = pom_response.partition { |pom|
       pom.position_description.include?(@recommended_pom)
     }

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -2,17 +2,24 @@ class PrisonOffenderManagerService
   def self.get_pom_detail(nomis_staff_id)
     PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id.to_i) { |s|
       s.working_pattern = s.working_pattern || 0.0
-      s.status = s.status || 'inactive'
+      s.status = s.status || 'active'
     }
   end
 
-  def self.get_poms(prison)
+  def self.get_poms(prison, &filter)
     poms = Nomis::Elite2::Api.prisoner_offender_manager_list(prison)
-    poms.map { |pom|
+
+    poms = poms.map { |pom|
       detail = get_pom_detail(pom.staff_id)
       pom.add_detail(detail)
       pom
-    }
+    }.compact
+
+    if filter
+      poms = poms.select { |pom| yield pom }
+    end
+
+    poms
   end
 
   def self.get_pom(caseload, nomis_staff_id)

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -6,7 +6,7 @@ class PrisonOffenderManagerService
     }
   end
 
-  def self.get_poms(prison, &filter)
+  def self.get_poms(prison)
     poms = Nomis::Elite2::Api.prisoner_offender_manager_list(prison)
 
     poms = poms.map { |pom|
@@ -15,9 +15,7 @@ class PrisonOffenderManagerService
       pom
     }.compact
 
-    if filter
-      poms = poms.select { |pom| yield pom }
-    end
+    poms = poms.select { |pom| yield pom } if block_given?
 
     poms
   end

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => summary_path() } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => summary_path(anchor: 'awaiting-allocation') } %>
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -3,12 +3,11 @@ require_relative '../../app/services/nomis/elite2/sentence_detail'
 require_relative '../../app/services/nomis/elite2/offender'
 
 describe PrisonOffenderManagerService do
-  let(:pom_detail) {
-    described_class.get_pom_detail(485_595)
-  }
+  let(:staff_id) { 485_737 }
+
   let(:allocation_one) {
     AllocationService.create_allocation(
-      nomis_staff_id: pom_detail.nomis_staff_id,
+      nomis_staff_id: staff_id,
       nomis_offender_id: 'G2911GD',
       created_by: 'Test User',
       nomis_booking_id: 0,
@@ -19,13 +18,17 @@ describe PrisonOffenderManagerService do
 
   let(:allocation_two) {
     AllocationService.create_allocation(
-      nomis_staff_id: pom_detail.nomis_staff_id,
+      nomis_staff_id: staff_id,
       nomis_offender_id: 'G8060UF',
       created_by: 'Test User',
       nomis_booking_id: 1,
       allocated_at_tier: 'A',
       prison: 'LEI'
     )
+  }
+
+  before(:each) {
+    PomDetail.create(nomis_staff_id: 485_637, working_pattern: 1.0, status: 'inactive')
   }
 
   it "can get allocated offenders for a POM",
@@ -52,6 +55,15 @@ describe PrisonOffenderManagerService do
     poms = described_class.get_poms('LEI')
     expect(poms).to be_kind_of(Array)
     expect(poms.count).to eq(7)
+  end
+
+  it "can get a filtered list of POMs",
+    vcr: { cassette_name: :pom_service_get_poms } do
+    poms = described_class.get_poms('LEI') { |pom|
+      pom.status == 'active'
+    }
+    expect(poms).to be_kind_of(Array)
+    expect(poms.count).to eq(6)
   end
 
   it "can get the names for POMs when given IDs",


### PR DESCRIPTION
When allocating a prisoner to a POM, we currently show all POMs
regardless of status. This means it is possible to allocate a prisoner
to a POM who is not available.

This PR changes the allocations_controller to only show active POMs.  To
achieve this the `get_poms` call can now take a filtering block that
will allow for get_poms to return just the POMs that caller is
interested in.  In this case, we filter with

```ruby
get_poms('LEI') { |pom|
   pom.status == 'active'
}
```

Currently when we get_pom_detail, we find or create a PomDetail and set
the status to 'inactive' if we create a POM.  This is a stopgap, for
development purposes and will eventually be removed to not create a
PomDetail when not found.  In the meantime, we've changed the default status
to 'active' rather than 'inactive'