### PR TITLE
Show validation errors when creating case information

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -2,20 +2,31 @@ class CaseInformationController < ApplicationController
   before_action :authenticate_user
 
   def new
-    @prisoner = OffenderService.new.get_offender(nomis_offender_id_from_url)
+    @case_info = CaseInformation.new(
+      nomis_offender_id: nomis_offender_id_from_url
+    )
+
+    @prisoner = prisoner(nomis_offender_id_from_url)
   end
 
   def create
-    CaseInformation.create!(
+    @case_info = CaseInformation.create(
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
       case_allocation: case_information_params[:case_allocation]
     )
 
-    redirect_to summary_path(anchor: 'awaiting-information')
+    return redirect_to summary_path(anchor: 'awaiting-information') if @case_info.valid?
+
+    @prisoner = prisoner(case_information_params[:nomis_offender_id])
+    render :new
   end
 
 private
+
+  def prisoner(nomis_id)
+    @prisoner ||= OffenderService.new.get_offender(nomis_id)
+  end
 
   def nomis_offender_id_from_url
     params.require(:nomis_offender_id)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -1,4 +1,6 @@
 class CaseInformation < ApplicationRecord
   self.table_name = 'case_information'
-  validates :nomis_offender_id, :tier, :case_allocation, presence: true
+  validates :nomis_offender_id, presence: true
+  validates :tier, presence: { message: 'must be provided' }
+  validates :case_allocation, presence: { message: 'must be provided' }
 end

--- a/app/views/case_information/new.html.erb
+++ b/app/views/case_information/new.html.erb
@@ -1,55 +1,78 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => summary_path } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => summary_path(anchor: 'awaiting-information') } %>
+
+
+<% if @case_info.errors.count > 0 %>
+  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>
+<% end %>
 
 <%= form_tag(case_information_path, method: :post) do %>
   <h1 class="govuk-heading-l govuk-!-margin-top-4">Case information</h1>
   <h2 class="govuk-heading-m">Prisoner name and number</h2>
   <p>Please provide information on:</p>
 
-  <div class="govuk-form-group">
+  <div class="govuk-form-group <% if @case_info.errors[:case_allocation].present? %>govuk-form-group--error<% end %>">
     <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend">
+        <% if @case_info.errors[:case_allocation].present? %>
+          <span class="govuk-error-message">
+            Case allocation <%= @case_info.errors[:case_allocation].first %>
+          </span>
+        <% end %>
+
         <p class="govuk-fieldset__heading">
         Case allocation decision
         </p>
       </legend>
+
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[case_allocation]", "NPS", false, class: "govuk-radios__input") %>
+          <%= radio_button_tag("case_information[case_allocation]", "NPS", @case_info.case_allocation == 'NPS', class: "govuk-radios__input") %>
           <%= label_tag "case_information[case_allocation]", "National Probation Service (NPS)", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[case_allocation]", "CRC", false, class: "govuk-radios__input") %>
+          <%= radio_button_tag("case_information[case_allocation]", "CRC", @case_info.case_allocation == 'CRC', class: "govuk-radios__input") %>
           <%= label_tag "case_information[case_allocation]", "Community Rehabilitation Company (CRC)", class: "govuk-label govuk-radios__label" %>
         </div>
       </div>
     </fieldset>
+  </div>
 
+  <div class="govuk-form-group <% if @case_info.errors[:tier].present? %>govuk-form-group--error<% end %>">
     <fieldset class="govuk-fieldset govuk-!-margin-top-6">
       <legend class="govuk-fieldset__legend">
+        <% if @case_info.errors[:tier].present? %>
+          <span class="govuk-error-message">
+            Tier <%= @case_info.errors[:tier].first %>
+          </span>
+        <% end %>
+
         <p class="govuk-fieldset__heading">
         Prisoner's tiering decision
         </p>
       </legend>
+
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "A", false, class: "govuk-radios__input") %>
+          <%= radio_button_tag("case_information[tier]", "A", @case_info[:tier] == 'A', class: "govuk-radios__input") %>
           <%= label_tag "case_information[tier]", "Tier A", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "B", false, class: "govuk-radios__input") %>
+          <%= radio_button_tag("case_information[tier]", "B", @case_info[:tier] == 'B', class: "govuk-radios__input") %>
           <%= label_tag "case_information[tier]", "Tier B", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "C", false, class: "govuk-radios__input") %>
+          <%= radio_button_tag("case_information[tier]", "C", @case_info[:tier] == 'C', class: "govuk-radios__input") %>
           <%= label_tag "case_information[tier]", "Tier C", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "D", false, class: "govuk-radios__input") %>
+          <%= radio_button_tag("case_information[tier]", "D", @case_info[:tier] == 'D', class: "govuk-radios__input") %>
           <%= label_tag "case_information[tier]", "Tier D", class: "govuk-label govuk-radios__label" %>
         </div>
       </div>
     </fieldset>
-    <%= submit_tag "Save", role: "button", draggable: "false", class: "govuk-button govuk govuk-!-margin-top-4" %>
   </div>
+
+  <%= submit_tag "Save", role: "button", draggable: "false", class: "govuk-button govuk govuk-!-margin-top-4" %>
+
 <% end %>

--- a/app/views/shared/_validation_errors.html.erb
+++ b/app/views/shared/_validation_errors.html.erb
@@ -1,0 +1,15 @@
+
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    There is a problem
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <% errors.full_messages.each do |message| %>
+      <li>
+          <%= message %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -29,4 +29,67 @@ feature 'case information feature' do
       expect(page).to have_css('.offender_row_0', count: 1)
     end
   end
+
+  it 'complains if allocation data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_case_feature } do
+    nomis_offender_id = 'G4273GI'
+
+    signin_user
+    visit summary_path
+
+    within('#awaiting-information') do
+      within('.offender_row_0') do
+        click_link 'Edit'
+      end
+    end
+
+    expect(page).to have_current_path new_case_information_path(nomis_offender_id)
+
+    choose('case_information_tier_A')
+    click_button 'Save'
+
+    expect(CaseInformation.count).to eq(0)
+    expect(page).to have_content("Case allocation must be provided")
+  end
+
+  it 'complains if all data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_all_feature } do
+    nomis_offender_id = 'G4273GI'
+
+    signin_user
+    visit summary_path
+
+    within('#awaiting-information') do
+      within('.offender_row_0') do
+        click_link 'Edit'
+      end
+    end
+
+    expect(page).to have_current_path new_case_information_path(nomis_offender_id)
+
+    click_button 'Save'
+
+    expect(CaseInformation.count).to eq(0)
+    expect(page).to have_content("Case allocation must be provided")
+    expect(page).to have_content("Tier must be provided")
+  end
+
+  it 'complains if tier data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_tier_feature } do
+    nomis_offender_id = 'G4273GI'
+
+    signin_user
+    visit summary_path
+
+    within('#awaiting-information') do
+      within('.offender_row_0') do
+        click_link 'Edit'
+      end
+    end
+
+    expect(page).to have_current_path new_case_information_path(nomis_offender_id)
+
+    choose('case_information_case_allocation_NPS')
+    click_button 'Save'
+
+    expect(CaseInformation.count).to eq(0)
+    expect(page).to have_content("Tier must be provided")
+  end
 end


### PR DESCRIPTION
When creating a new case information this PR will perform validation. If
validation fails then the :new action if performed and validation errors
are shown on the form.

Unfortunately because the :create call goes to /case_information/ it is
not possible to reload that form (it will instead raise a 404 because it
is looking for :index).

The messages in the error summary at the top of the page cannot link to
the relevant part of the page as a new request is made which fails with
a 404 because of the issue described above.