### PR TITLE
Edit a POM's working pattern/status

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -22,7 +22,19 @@ class PomsController < ApplicationController
     @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
   end
 
-  def edit; end
+  def edit
+    @pom = PrisonOffenderManagerService.get_pom(caseload, params[:id])
+  end
+
+  def update
+    @pom = PrisonOffenderManagerService.get_pom_detail(params[:nomis_staff_id])
+    PrisonOffenderManagerService.edit_a_pom(
+      nomis_staff_id: params[:nomis_staff_id].to_i,
+      working_pattern: edit_pom_params[:working_pattern],
+      status: edit_pom_params[:status]
+    )
+    redirect_to poms_show_path(id: @pom.nomis_staff_id)
+  end
 
   def my_caseload
     @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
@@ -39,5 +51,9 @@ private
 
   def pom
     PrisonOffenderManagerService.get_pom(caseload, params[:nomis_staff_id])
+  end
+
+  def edit_pom_params
+    params.require(:edit_pom).permit(:working_pattern, :status)
   end
 end

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -28,7 +28,7 @@ class PomsController < ApplicationController
 
   def update
     @pom = PrisonOffenderManagerService.get_pom_detail(params[:nomis_staff_id])
-    PrisonOffenderManagerService.edit_a_pom(
+    PrisonOffenderManagerService.update_pom(
       nomis_staff_id: params[:nomis_staff_id].to_i,
       working_pattern: edit_pom_params[:working_pattern],
       status: edit_pom_params[:status]

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -23,7 +23,7 @@ class PomsController < ApplicationController
   end
 
   def edit
-    @pom = PrisonOffenderManagerService.get_pom(caseload, params[:id])
+    @pom = PrisonOffenderManagerService.get_pom(caseload, params[:nomis_staff_id])
   end
 
   def update
@@ -33,7 +33,7 @@ class PomsController < ApplicationController
       working_pattern: edit_pom_params[:working_pattern],
       status: edit_pom_params[:status]
     )
-    redirect_to poms_show_path(id: @pom.nomis_staff_id)
+    redirect_to poms_path(id: @pom.nomis_staff_id)
   end
 
   def my_caseload

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -1,0 +1,9 @@
+module PomHelper
+  def format_working_pattern(pattern)
+    if pattern == '1.0'
+      'Full time'
+    else
+      "Part time - #{pattern}"
+    end
+  end
+end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -61,7 +61,7 @@ class PrisonOffenderManagerService
     @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
   end
 
-  def self.edit_a_pom(params)
+  def self.update_pom(params)
     pom = PomDetail.where(nomis_staff_id: params[:nomis_staff_id]).first
     pom.working_pattern = params[:working_pattern] || pom.working_pattern
     pom.status = params[:status] || pom.status

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -60,4 +60,19 @@ class PrisonOffenderManagerService
     poms_list = PrisonOffenderManagerService.get_poms(user.active_case_load_id)
     @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
   end
+
+  def self.edit_a_pom(params)
+    pom = PomDetail.where(nomis_staff_id: params[:nomis_staff_id]).first
+    pom.working_pattern = params[:working_pattern] || pom.working_pattern
+    pom.status = params[:status] || pom.status
+    pom.save!
+    deallocate(params[:nomis_staff_id]) if pom.status == 'inactive'
+    pom
+  end
+
+private
+
+  def self.deallocate(nomis_staff_id)
+    Allocation.where(nomis_staff_id: nomis_staff_id).update_all(active: false)
+  end
 end

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -16,8 +16,8 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @allocations.each do |allocation, sentence| %>
-    <tr class="govuk-table__row">
+    <% @allocations.each_with_index do |(allocation, sentence), i| %>
+    <tr class="govuk-table__row pom_cases_row_<%= i %>">
       <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
       <td aria-label="Release date" class="govuk-table__cell "><%= sentence.release_date %></td>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => {:page => poms_show_path(id: @pom.staff_id)} %>
+<%= render :partial => "/shared/backlink", :locals => {:page => poms_path(id: @pom.staff_id)} %>
 
 <div>
   <%= form_tag poms_update_path(@pom.staff_id), method: :put do %>
@@ -79,7 +79,7 @@
 
     <div class="govuk-form-group">
       <button type="submit" class="govuk-button">Save</button>
-      <a href="<%= poms_show_path(id: @pom.staff_id) %> class=" govuk-link">Cancel</a>
+      <a href="<%= poms_path(id: @pom.staff_id) %> class=" govuk-link">Cancel</a>
     </div>
 
     </form>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,96 +1,87 @@
+<%= render :partial => "/shared/backlink", :locals => {:page => poms_show_path(id: @pom.staff_id)} %>
 
+<div>
+  <%= form_tag poms_update_path(@pom.staff_id), method: :put do %>
+    <h1 class="govuk-heading-xl govuk-!-margin-top-4">Edit profile</h1>
+    <h2 class="govuk-heading-l"><%= @pom.full_name %></h2>
 
-<%= render :partial => "/shared/backlink", :locals => { :page => edit_pom_path(nomis_staff_id: 1) } %>
-
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Edit profile</h1>
-<h2 class="govuk-heading-l">Surname, Forename</h2>
-
-<form method="POST">
-  <fieldset class="govuk-fieldset">
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="working-pattern">
-        Working pattern
-      </label>
-
-      <div class="govuk-radios">
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-pattern-1" name="working-pattern" type="radio" value="1.0">
-          <label class="govuk-label govuk-radios__label" for="working-pattern-1">
-            Full-time
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-pattern-2" name="working-pattern" type="radio" value="0.8">
-          <label class="govuk-label govuk-radios__label" for="working-pattern-2">
-            Part time - 0.8
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-pattern-3" name="working-pattern" type="radio" value="0.6">
-          <label class="govuk-label govuk-radios__label" for="working-pattern-3">
-            Part time - 0.6
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-pattern-4" name="working-pattern" type="radio" value="0.4">
-          <label class="govuk-label govuk-radios__label" for="working-pattern-4">
-            Part time - 0.4
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-pattern-5" name="working-pattern" type="radio" value="0.2">
-          <label class="govuk-label govuk-radios__label" for="working-pattern-5">
-            Part time - 0.2
-          </label>
-        </div>
+    <div class='govuk-!-margin-top-6'>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            <h1 class="govuk-fieldset__heading">Working pattern</h1>
+          </legend>
+          <div class="govuk-radios" data-module="radios">
+            <div class="govuk-radios__item">
+              <%= radio_button_tag("edit_pom[working_pattern]", "1.0", @pom.working_pattern == '1.0', id: "working_pattern-1", class: "govuk-radios__input") %>
+              <%= label_tag "edit_pom[working_pattern]", "Full time", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= radio_button_tag("edit_pom[working_pattern]", "0.8", @pom.working_pattern == '0.8', id: "working_pattern-2", class: "govuk-radios__input") %>
+              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.8", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= radio_button_tag("edit_pom[working_pattern]", "0.6", @pom.working_pattern == '0.6', id: "working_pattern-3", class: "govuk-radios__input") %>
+              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.6", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= radio_button_tag("edit_pom[working_pattern]", "0.4", @pom.working_pattern == '0.4', id: "working_pattern-4", class: "govuk-radios__input") %>
+              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.4", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= radio_button_tag("edit_pom[working_pattern]", "0.2", @pom.working_pattern == '0.2', id: "working_pattern-5", class: "govuk-radios__input") %>
+              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.2", class: "govuk-label govuk-radios__label" %>
+            </div>
+          </div>
+        </fieldset>
       </div>
     </div>
 
-
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="working-status">
-        Working status
-      </label>
-
-      <div class="govuk-radios">
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-status-1" name="working-status" type="radio" value="active">
-          <label class="govuk-label govuk-radios__label" for="working-pattern-1">
-            Active
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-status-2" name="working-status" type="radio" value="capacity">
-          <label class="govuk-label govuk-radios__label" for="working-status-2">
-            Active - At capacity (no new cases)
-          </label>
-        </div>
-        <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="working-status-3" name="working-status" type="radio" value="inactive">
-          <label class="govuk-label govuk-radios__label" for="working-status-3">
-            Inactive (remove and and reallocate all cases)
-          </label>
-        </div>
+    <div class='govuk-!-margin-top-6'>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            <h3 class="govuk-fieldset__heading">Status</h3>
+          </legend>
+          <div class="govuk-radios" data-module="radios">
+            <div class="govuk-radios__item">
+              <%= radio_button_tag("edit_pom[status]", "active", @pom.status == 'active', id: "status-1", class: "govuk-radios__input") %>
+              <%= label_tag "edit_pom[status]", "Active", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-conditional-2" name="edit_pom[status]" type="radio" value="active-at-capacity" data-aria-controls="status-2" <%= 'checked' if @pom.status == 'active-at-capacity'%>>
+              <label class="govuk-label govuk-radios__label"
+                     for="status-conditional-2">Active - at capacity (no new cases)</label>
+            </div>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="status-2">
+              <h4 class="govuk-heading-s">You will not be able to allocate new cases to this POM. To allocate new cases
+                again, set their status to active</h4>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-conditional-3" name="edit_pom[status]" type="radio" value="inactive" data-aria-controls="status-3"  <%= 'checked' if @pom.status == 'inactive'%>>
+              <label class="govuk-label govuk-radios__label"
+                     for="status-conditional-3">Inactive</label>
+            </div>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="status-3">
+              <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                  <span class="govuk-warning-text__assistive">Warning</span>
+                  This will remove the pom from their current cases.<br/>
+                  Their cases will need to be reallocated.
+                </strong>
+              </div>
+            </div>
+          </div>
+        </fieldset>
       </div>
     </div>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        This will remove the POM from their current cases.<br/>
-        Their cases will need to be reallocated.
-      </strong>
-    </div>
-
     <div class="govuk-form-group">
-        <button type="submit" class="govuk-button">
-          Save
-        </button>
-        <br/>
-        <a href="#" class="govuk-link">Cancel</a>
+      <button type="submit" class="govuk-button">Save</button>
+      <a href="<%= poms_show_path(id: @pom.staff_id) %> class=" govuk-link">Cancel</a>
     </div>
 
-
-  </fieldset>
-</form>
+    </form>
+  <% end %>
+</div>

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">Working pattern</div>
-    <div class="govuk-body govuk-!-font-weight-bold"><%= @pom.working_pattern %></div>
+    <div class="govuk-body govuk-!-font-weight-bold"><%= format_working_pattern(@pom.working_pattern) %></div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="govuk-body">Status</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,18 +10,19 @@ Rails.application.routes.draw do
   get('/summary' => 'summary#index')
   get('/prisoners/:id' => 'prisoners#show', as: 'prisoners_show')
   get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocations')
+  put('/poms/:nomis_staff_id' => 'poms#update', as: 'poms_update')
   get('/poms/:nomis_staff_id/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
   get('/poms/:nomis_staff_id/new_cases' => 'poms#new_cases', as: 'new_cases')
 
   resource :allocations, only: %i[ new create ], path_names: {
-    new: 'new/:nomis_offender_id',
-    confirm: 'confirm/:nomis_offender_id/:nomis_staff_id'
+      new: 'new/:nomis_offender_id',
+      confirm: 'confirm/:nomis_offender_id/:nomis_staff_id'
   }
   resources :poms, only: %i[ index show edit ], param: :nomis_staff_id
   resource :summary, only: %i[ index ], controller: 'summary'
   resource :overrides,  only: %i[ new create ], path_names: { new: 'new/:nomis_offender_id/:nomis_staff_id'}
   resource :case_information, only: %i[new create edit update], controller: 'case_information', path_names: {
-    new: 'new/:nomis_offender_id',
-    edit: 'edit/:nomis_offender_id'
+      new: 'new/:nomis_offender_id',
+      edit: 'edit/:nomis_offender_id'
   }
 end

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+feature "edit a POM's details" do
+  let(:nomis_staff_id) { 485_637 }
+  let(:nomis_offender_id) { 'G4273GI' }
+
+  before do
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC')
+  end
+
+  it "makes an inactive POM active", vcr: { cassette_name: :edit_poms_activate_pom_feature } do
+    signin_user
+
+    visit "/poms#inactive"
+    within('.probation_pom_row_0') do
+      click_link 'View'
+    end
+
+    click_link "Edit profile"
+
+    expect(page).to have_css('h1', text: 'Edit profile')
+
+    choose('working_pattern-2')
+    choose('Active')
+
+    expect(page).to have_content('Part time - 0.8')
+    expect(page).to have_content('Active')
+  end
+
+  it "de-allocates all a POM's cases when made inactive", vcr: { cassette_name: :edit_poms_deactivate_pom_feature } do
+    signin_user('PK000223')
+    visit new_allocations_path(nomis_offender_id, nomis_staff_id)
+    click_button 'Complete allocation'
+
+    visit "/poms/485637"
+    click_link "Edit profile"
+
+    expect(page).to have_content("Pobee Norris, Kath")
+    expect(Allocation.count).to eq 1
+
+    choose('working_pattern-2')
+    choose('Inactive')
+    click_button('Save')
+
+    expect(page).to have_content("Pobee Norris, Kath")
+    expect(page).to have_css('.pom_cases_row_0', count: 0)
+  end
+end

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -29,7 +29,7 @@ feature "edit a POM's details" do
 
   it "de-allocates all a POM's cases when made inactive", vcr: { cassette_name: :edit_poms_deactivate_pom_feature } do
     signin_user('PK000223')
-    visit new_allocations_path(nomis_offender_id, nomis_staff_id)
+    visit "allocations/confirm/G4273GI/485637"
     click_button 'Complete allocation'
 
     visit "/poms/485637"

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -30,13 +30,13 @@ feature "get poms list" do
   it "allows editing a POM", vcr: { cassette_name: :show_poms_feature } do
     signin_user
 
-    visit "/poms/1/edit"
+    visit "/poms/485752/edit"
 
     expect(page).to have_css(".govuk-button", count: 1)
     expect(page).to have_css(".govuk-radios__item", count: 8)
     expect(page).to have_content("Edit profile")
     expect(page).to have_content("Working pattern")
-    expect(page).to have_content("Working status")
+    expect(page).to have_content("Status")
     expect(page).not_to have_css('.govuk-breadcrumbs')
   end
 end

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe PomHelper do
+  describe 'format_working_pattern' do
+    it "formats a POM's working pattern" do
+      expect(format_working_pattern('1.0')).to eq('Full time')
+    end
+  end
+end


### PR DESCRIPTION
This feature allows a staff to update a POM's working pattern and status.  This involves an edit form with radio buttons, and these buttons are pre-selected with the POM's current details.

There is an option to make a POM inactive, and if selected this de-allocates all the POM's cases so they can be allocated to another POM.  A warning is displayed to avoid this option being chosen without the person understanding this behaviour.