### PR TITLE
Dynamically change link label depending on whether user is allocating or reallocating

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -4,20 +4,20 @@ class AllocationsController < ApplicationController
   alias_action :new, :edit
 
   def new
-    @prisoner = get_prisoner(nomis_offender_id_from_url)
+    @prisoner = prisoner(nomis_offender_id_from_url)
     @recommended_pom = @prisoner.current_responsibility
-    @recommended_poms, @not_recommended_poms = get_recommended_and_nonrecommended_poms
+    @recommended_poms, @not_recommended_poms = recommended_and_nonrecommended_poms
   end
 
   def confirm
-    @prisoner = get_prisoner(nomis_offender_id_from_url)
+    @prisoner = prisoner(nomis_offender_id_from_url)
     @pom = PrisonOffenderManagerService.get_pom(caseload, nomis_staff_id_from_url)
   end
 
   # rubocop:disable Metrics/MethodLength
   def create
-    prisoner  = get_prisoner(allocation_params[:nomis_offender_id])
-    @override = get_override
+    prisoner  = prisoner(allocation_params[:nomis_offender_id])
+    @override = override
 
     AllocationService.create_allocation(
       nomis_staff_id: allocation_params[:nomis_staff_id].to_i,
@@ -36,17 +36,17 @@ class AllocationsController < ApplicationController
 
 private
 
-  def get_prisoner(nomis_offender_id)
+  def prisoner(nomis_offender_id)
     OffenderService.new.get_offender(nomis_offender_id)
   end
 
-  def get_override
+  def override
     Override.where(
       nomis_offender_id: allocation_params[:nomis_offender_id]).
       where(nomis_staff_id: allocation_params[:nomis_staff_id]).last
   end
 
-  def get_recommended_and_nonrecommended_poms
+  def recommended_and_nonrecommended_poms
     pom_response = PrisonOffenderManagerService.get_poms(caseload) { |pom|
       pom.status == 'active'
     }

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -3,12 +3,14 @@ class AllocationsController < ApplicationController
 
   def new
     @prisoner = prisoner(nomis_offender_id_from_url)
-    @recommended_poms, @not_recommended_poms = recommended_and_nonrecommended_poms_for(@prisoner)
+    @recommended_poms, @not_recommended_poms =
+      recommended_and_nonrecommended_poms_for(@prisoner)
   end
 
   def edit
     @prisoner = prisoner(nomis_offender_id_from_url)
-    @recommended_poms, @not_recommended_poms = recommended_and_nonrecommended_poms_for(@prisoner)
+    @recommended_poms, @not_recommended_poms =
+      recommended_and_nonrecommended_poms_for(@prisoner)
     @current_pom = current_pom_for(nomis_offender_id_from_url)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,11 +21,11 @@ class ApplicationController < ActionController::Base
   def self.alias_action(existing, aliased)
     define_method(aliased) do
       send(existing)
-      render :action => existing
+      render action: existing
     end
   end
 
-  private
+private
 
   def session_expired?
     Time.current > Time.zone.at(sso_identity['expiry'])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,13 +18,6 @@ class ApplicationController < ActionController::Base
     sso_identity['caseload']
   end
 
-  def self.alias_action(existing, aliased)
-    define_method(aliased) do
-      send(existing)
-      render action: existing
-    end
-  end
-
 private
 
   def session_expired?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,14 @@ class ApplicationController < ActionController::Base
     sso_identity['caseload']
   end
 
-private
+  def self.alias_action(existing, aliased)
+    define_method(aliased) do
+      send(existing)
+      render :action => existing
+    end
+  end
+
+  private
 
   def session_expired?
     Time.current > Time.zone.at(sso_identity['expiry'])

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,6 +1,6 @@
 class Allocation < ApplicationRecord
   belongs_to :pom_detail
 
-  validates :nomis_offender_id, :nomis_booking_id, :prison, :allocated_at_tier,
+  validates :nomis_offender_id, :nomis_staff_id, :nomis_booking_id, :prison, :allocated_at_tier,
     :created_by, presence: true
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,6 +1,10 @@
 class Allocation < ApplicationRecord
   belongs_to :pom_detail
 
-  validates :nomis_offender_id, :nomis_staff_id, :nomis_booking_id, :prison, :allocated_at_tier,
+  validates :nomis_offender_id,
+    :nomis_staff_id,
+    :nomis_booking_id,
+    :prison,
+    :allocated_at_tier,
     :created_by, presence: true
 end

--- a/app/services/nomis/elite2/prison_offender_manager.rb
+++ b/app/services/nomis/elite2/prison_offender_manager.rb
@@ -30,6 +30,10 @@ module Nomis
         "#{last_name}, #{first_name}".titleize
       end
 
+      def grade
+        "#{ position_description.split(" ").first } POM"
+      end
+
       def add_detail(pom_detail)
         allocations = pom_detail.allocations.where(active: true)
         allocation_counts = allocations.group_by(&:allocated_at_tier)

--- a/app/services/nomis/elite2/prison_offender_manager.rb
+++ b/app/services/nomis/elite2/prison_offender_manager.rb
@@ -31,7 +31,7 @@ module Nomis
       end
 
       def grade
-        "#{ position_description.split(" ").first } POM"
+        "#{position_description.split(' ').first} POM"
       end
 
       def add_detail(pom_detail)

--- a/app/views/allocations/_pom_info.html.erb
+++ b/app/views/allocations/_pom_info.html.erb
@@ -6,11 +6,11 @@
   </tr>
   <tr class="govuk-table__row">
     <td class="govuk-table__cell hmpps-table-cell__key">Name</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"></td>
+    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key current_pom_full_name"><%= @current_pom.full_name %></td>
   </tr>
   <tr class="govuk-table__row">
     <td class="govuk-table__cell hmpps-table-cell__key">Grade</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"></td>
+    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key current_pom_grade"><%= @current_pom.grade %></td>
   </tr>
   </tbody>
 </table>

--- a/app/views/allocations/_pom_info.html.erb
+++ b/app/views/allocations/_pom_info.html.erb
@@ -1,0 +1,16 @@
+<table class="govuk-table">
+  <tbody class="govuk-table__body">
+  <tr class="govuk-table__row">
+    <td class="govuk-table__header" scope="row">Current POM</td>
+    <td class="govuk-table__cell"></td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell hmpps-table-cell__key">Name</td>
+    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"></td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell hmpps-table-cell__key">Grade</td>
+    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"></td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -1,12 +1,12 @@
 <h4 class="govuk-heading-m">
-  Recommendation: <%= @recommended_pom %> POMs
+  Recommendation: <%= @prisoner.current_responsibility %> POMs
 </h4>
 
 <p>Based on the prisoner's tiering calculation.</p>
 
 <table class="govuk-table responsive">
   <thead class="govuk-table__head">
-  <h2 class="govuk-heading-s"><%= @recommended_pom %> POMs</h2>
+  <h2 class="govuk-heading-s"><%= @prisoner.current_responsibility %> POMs</h2>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="col">Name</th>
     <th class="govuk-table__header" scope="col">Previous allocation</th>

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -33,7 +33,8 @@
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
         <% if current_page?(action: :new) %>
           <%= link_to "Allocate", confirm_allocations_path(@prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
-        <% else %>
+        <% end %>
+        <% if current_page?(action: :edit) %>
           <%= link_to "Reallocate", confirm_allocations_path(@prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
         <% end %>
       </td>

--- a/app/views/allocations/edit.html.erb
+++ b/app/views/allocations/edit.html.erb
@@ -1,0 +1,15 @@
+<%= render :partial => "/shared/backlink", :locals => {:page => summary_path(anchor: 'awaiting-allocation')} %>
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
+
+<%= render 'shared/basic_prisoner_info' %>
+
+<%= render 'allocations/pom_info' %>
+
+<%= render 'shared/offence_info' %>
+
+<%= render 'allocations/case_information' %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible"/>
+
+<%= render 'allocations/pom_tables' %>

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -8,7 +8,6 @@
 <div>
   <%= form_tag(overrides_path, method: :post)  do %>
     <h1 class="govuk-heading-xl govuk-!-margin-top-4">Choose reason for changing recommended grade</h1>
-
     <div class='govuk-!-margin-top-6'>
       <div class="govuk-form-group <% if @override.errors[:override_reasons].present? %>govuk-form-group--error<% end %>">
         <fieldset class="govuk-fieldset" aria-describedby="override-conditional-hint">

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => "/shared/backlink", :locals => {:page => poms_path(id: @pom.staff_id)} %>
 
 <div>
-  <%= form_tag poms_update_path(@pom.staff_id), method: :put do %>
+  <%= form_tag pom_path(nomis_staff_id: @pom.staff_id), method: :put do %>
     <h1 class="govuk-heading-xl govuk-!-margin-top-4">Edit profile</h1>
     <h2 class="govuk-heading-l"><%= @pom.full_name %></h2>
 
@@ -79,7 +79,7 @@
 
     <div class="govuk-form-group">
       <button type="submit" class="govuk-button">Save</button>
-      <a href="<%= poms_path(id: @pom.staff_id) %> class=" govuk-link">Cancel</a>
+      <a href="<%= poms_path(nomis_staff_id: @pom.staff_id) %>" class="govuk-link">Cancel</a>
     </div>
 
     </form>

--- a/app/views/summary/_allocated.html.erb
+++ b/app/views/summary/_allocated.html.erb
@@ -21,7 +21,7 @@
         <td aria-label="Release date" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
         <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name %></td>
         <td aria-label="Allocation date" class="govuk-table__cell">NA</td>
-        <td aria-label="Action" class="govuk-table__cell "><%= link_to "Reallocate", new_allocations_path(offender.offender_no) %></td>
+        <td aria-label="Action" class="govuk-table__cell "><%= link_to "Reallocate", edit_allocations_path(offender.offender_no) %></td>
       </tr>
     <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   get('/summary' => 'summary#index')
   get('/prisoners/:id' => 'prisoners#show', as: 'prisoners_show')
   get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocations')
-  put('/poms/:nomis_staff_id' => 'poms#update', as: 'poms_update')
   get('/poms/:nomis_staff_id/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
   get('/poms/:nomis_staff_id/new_cases' => 'poms#new_cases', as: 'new_cases')
   
@@ -14,9 +13,10 @@ Rails.application.routes.draw do
   resources :status, only: %i[ index ], controller: 'status'
   resources :poms, only: %i[ index show edit ], param: :nomis_staff_id
   resource :overrides,  only: %i[ new create ], path_names: { new: 'new/:nomis_offender_id/:nomis_staff_id'}
-  resource :allocations, only: %i[ new create ], path_names: {
-      new: 'new/:nomis_offender_id',
-      confirm: 'confirm/:nomis_offender_id/:nomis_staff_id'
+  resource :allocations, only: %i[ new create edit ], path_names: {
+    new: 'new/:nomis_offender_id',
+    edit: 'edit/:nomis_offender_id',
+    confirm: 'confirm/:nomis_offender_id/:nomis_staff_id'
   }
   resource :case_information, only: %i[new create edit update], controller: 'case_information', path_names: {
       new: 'new/:nomis_offender_id',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
   
   resources :health, only: %i[ index ], controller: 'health'
   resources :status, only: %i[ index ], controller: 'status'
-  resources :poms, only: %i[ index show edit ], param: :nomis_staff_id
   resource :overrides,  only: %i[ new create ], path_names: { new: 'new/:nomis_offender_id/:nomis_staff_id'}
+  resources :poms, only: %i[ index show edit update ], param: :nomis_staff_id
   resource :allocations, only: %i[ new create edit ], path_names: {
     new: 'new/:nomis_offender_id',
     edit: 'edit/:nomis_offender_id',

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -112,6 +112,6 @@ feature 'Allocation' do
       click_link 'Reallocate'
     end
 
-    expect(page).to have_current_path new_allocations_path(nomis_offender_id)
+    expect(page).to have_current_path edit_allocations_path(nomis_offender_id)
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -116,7 +116,5 @@ feature 'Allocation' do
     expect(page).to have_current_path edit_allocations_path(nomis_offender_id)
     expect(page).to have_css('.current_pom_full_name', text: 'Duckett, Jenny')
     expect(page).to have_css('.current_pom_grade', text: 'Prison POM')
-
-
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -97,6 +97,7 @@ feature 'Allocation' do
   scenario 're-allocating', vcr: { cassette_name: :re_allocate_feature } do
     probation_officer_pom_detail.allocations.create!(
       nomis_offender_id: nomis_offender_id,
+      nomis_staff_id: probation_officer_nomis_staff_id,
       nomis_booking_id: 1_153_753,
       prison: 'LEI',
       allocated_at_tier: 'A',
@@ -113,5 +114,9 @@ feature 'Allocation' do
     end
 
     expect(page).to have_current_path edit_allocations_path(nomis_offender_id)
+    expect(page).to have_css('.current_pom_full_name', text: 'Duckett, Jenny')
+    expect(page).to have_css('.current_pom_grade', text: 'Prison POM')
+
+
   end
 end


### PR DESCRIPTION
When a user is allocating we want relevant links to be labelled 'Allocate', when a user is reallocating then we want the label to be 'Reallocate'. The current pom details now also displays on `edit_allocation_path`.

One yucky aspect of this is that the PR introduces a new `edit` action on the controller in order to differentiate the  behaviour. We are not really updating a resource - a new allocation event is created every time. 