### PR TITLE
Adds validation to override form

### DIFF
--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -1,25 +1,37 @@
 class OverridesController < ApplicationController
   def new
     @prisoner = OffenderService.new.get_offender(params.require(:nomis_offender_id))
-    @recommended_pom = @prisoner.current_responsibility
     @pom = PrisonOffenderManagerService.get_pom(caseload, params[:nomis_staff_id])
+    @override = Override.new
   end
 
+  # rubocop:disable Metrics/MethodLength
   def create
-    AllocationService.create_override(
+    @override = AllocationService.create_override(
       nomis_staff_id: override_params[:nomis_staff_id],
       nomis_offender_id: override_params[:nomis_offender_id],
       override_reasons: override_params[:override_reasons],
       more_detail: override_params[:more_detail]
-      )
+    )
 
+    return redirect_on_success if @override.valid?
+
+    @prisoner = OffenderService.new.get_offender(override_params[:nomis_offender_id])
+    @pom = PrisonOffenderManagerService.get_pom(
+      caseload, override_params[:nomis_staff_id])
+
+    render :new
+  end
+# rubocop:enable Metrics/MethodLength
+
+private
+
+  def redirect_on_success
     redirect_to confirm_allocations_path(
       override_params[:nomis_offender_id],
       override_params[:nomis_staff_id]
     )
   end
-
-private
 
   def override_params
     params.require(:override).permit(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,8 @@ module ApplicationHelper
       'PRO' => 'Probation POM'
     }[level]
   end
+
+  def override_reason_contains(override, val)
+    override.override_reasons.present? && override.override_reasons.include?(val)
+  end
 end

--- a/app/models/override.rb
+++ b/app/models/override.rb
@@ -1,3 +1,10 @@
 class Override < ApplicationRecord
-  validates :nomis_staff_id, :nomis_offender_id, :override_reasons, presence: true
+  validates :nomis_staff_id, presence: { message: 'must be provided' }
+  validates :nomis_offender_id, presence: { message: 'must be provided' }
+  validates :override_reasons, presence: { message: 'must be provided' }
+  validates :more_detail,
+    presence: { message: 'must be provided when Other is selected' },
+    if: proc { |o|
+          o.override_reasons.present? && o.override_reasons.include?('other')
+        }
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -30,14 +30,14 @@ class AllocationService
   end
 
   def self.create_override(params)
-    o = Override.find_or_create_by(
+    Override.find_or_create_by(
       nomis_staff_id: params[:nomis_staff_id],
       nomis_offender_id: params[:nomis_offender_id]
-    )
-    o.override_reasons = params[:override_reasons]
-    o.more_detail = params[:more_detail]
-    o.save!
-    o
+    ).tap { |o|
+      o.override_reasons = params[:override_reasons]
+      o.more_detail = params[:more_detail]
+      o.save
+    }
   end
 
 private

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -1,47 +1,54 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_allocations_path } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => new_allocations_path(@prisoner.offender_no) } %>
+
+
+<% if @override.errors.count > 0 %>
+  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @override.errors } %>
+<% end %>
 
 <div>
-    <%= form_tag(overrides_path, method: :post)  do %>
-      <h1 class="govuk-heading-xl govuk-!-margin-top-4">Choose reason for changing recommended grade</h1>
+  <%= form_tag(overrides_path, method: :post)  do %>
+    <h1 class="govuk-heading-xl govuk-!-margin-top-4">Choose reason for changing recommended grade</h1>
 
-      <div class='govuk-!-margin-top-6'>
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" aria-describedby="override-conditional-hint">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-              <h1 class="govuk-fieldset__heading">Choose reason for changing
-                recommended grade</h1>
-            </legend>
-            <div class="govuk-checkboxes" data-module="checkboxes">
-              <%= hidden_field_tag("override[nomis_offender_id]", @prisoner.offender_no) %>
-              <%= hidden_field_tag("override[nomis_staff_id]", @pom.staff_id) %>
-              <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reasons][]", "complex",  false, id: "override-1", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "Prisoner assessed as too complex for #{@recommended_pom} officer POM", class: 'govuk-label govuk-checkboxes__label' %>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reasons][]", "no-staff", false, id: "override-2", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "No avaliable staff at recommended grade", class: 'govuk-label govuk-checkboxes__label' %>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reasons][]", "continuity", false, id: "override-3", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "Maintain continuity of previous POM", class: 'govuk-label govuk-checkboxes__label' %>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="override-conditional-4" name="override[override_reasons][]" type="checkbox" value="other" data-aria-controls="override-4">
-                <label class="govuk-label govuk-checkboxes__label"
-                       for="override-conditional-4">Other</label>
-              </div>
-              <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="override-4">
-                <div class="govuk-form-group">
-                  <label class="govuk-label" for="provide-detail">Please provide detail
-                    here</label>
-                  <textarea class="govuk-textarea" id="more-detail" name="override[more_detail]" rows="3" aria-describedby="more-detail-hint"></textarea>
-                </div>
+    <div class='govuk-!-margin-top-6'>
+      <div class="govuk-form-group <% if @override.errors[:override_reasons].present? %>govuk-form-group--error<% end %>">
+        <fieldset class="govuk-fieldset" aria-describedby="override-conditional-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            <h1 class="govuk-fieldset__heading">Choose reason for changing
+              recommended grade</h1>
+          </legend>
+          <div class="govuk-checkboxes" data-module="checkboxes">
+            <%= hidden_field_tag("override[nomis_offender_id]", @prisoner.offender_no) %>
+            <%= hidden_field_tag("override[nomis_staff_id]", @pom.staff_id) %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag("override[override_reasons][]", "complex",  override_reason_contains(@override, 'complex'), id: "override-1", class: "govuk-checkboxes__input") %>
+              <%= label_tag "override[override_reasons][]", "Prisoner assessed as too complex for #{@recommended_pom} officer POM", class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag("override[override_reasons][]", "no-staff", override_reason_contains(@override, 'no-staff'), id: "override-2", class: "govuk-checkboxes__input") %>
+              <%= label_tag "override[override_reasons][]", "No avaliable staff at recommended grade", class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag("override[override_reasons][]", "continuity", override_reason_contains(@override, 'continuity'), id: "override-3", class: "govuk-checkboxes__input") %>
+              <%= label_tag "override[override_reasons][]", "Maintain continuity of previous POM", class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="override-conditional-4" name="override[override_reasons][]" type="checkbox" value="other" data-aria-controls="override-4"
+                <%= 'checked=checked' if override_reason_contains(@override, 'other') %> >
+              <label class="govuk-label govuk-checkboxes__label"
+                      for="override-conditional-4">Other</label>
+            </div>
+
+            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="override-4">
+              <div class="govuk-form-group <% if @override.errors[:more_detail].present? %>govuk-form-group--error<% end %>">
+                <label class="govuk-label" for="provide-detail">Please provide detail
+                  here</label>
+                <textarea class="govuk-textarea" id="more-detail" name="override[more_detail]" rows="3" aria-describedby="more-detail-hint"></textarea>
               </div>
             </div>
-          </fieldset>
-        </div>
-        <%= submit_tag "Continue", role: "button", draggable: "false", class: "govuk-button" %>
+          </div>
+        </fieldset>
       </div>
-    <% end %>
+      <%= submit_tag "Continue", role: "button", draggable: "false", class: "govuk-button" %>
+    </div>
+  <% end %>
   </div>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -61,6 +61,39 @@ feature 'Allocation' do
     expect(Override.count).to eq(0)
   end
 
+  scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: :override_allocation_feature } do
+    signin_user
+
+    visit new_allocations_path(nomis_offender_id)
+
+    within('.not_recommended_pom_row_0') do
+      click_link 'Allocate'
+    end
+
+    expect(page).to have_css('h1', text: 'Choose reason for changing recommended grade')
+
+    click_button('Continue')
+    expect(page).to have_content('Override reasons must be provided')
+    expect(Override.count).to eq(0)
+  end
+
+  scenario 'overriding an allocation can validate missing Other detail', vcr: { cassette_name: :override_allocation_feature } do
+    signin_user
+
+    visit new_allocations_path(nomis_offender_id)
+
+    within('.not_recommended_pom_row_0') do
+      click_link 'Allocate'
+    end
+
+    expect(page).to have_css('h1', text: 'Choose reason for changing recommended grade')
+
+    check('override-conditional-4')
+    click_button('Continue')
+    expect(page).to have_content('More detail must be provided when Other is selected')
+    expect(Override.count).to eq(0)
+  end
+
   scenario 're-allocating', vcr: { cassette_name: :re_allocate_feature } do
     probation_officer_pom_detail.allocations.create!(
       nomis_offender_id: nomis_offender_id,

--- a/spec/models/override_spec.rb
+++ b/spec/models/override_spec.rb
@@ -1,7 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Override, type: :model do
-  it { is_expected.to validate_presence_of(:nomis_offender_id) }
-  it { is_expected.to validate_presence_of(:nomis_staff_id) }
-  it { is_expected.to validate_presence_of(:override_reasons) }
+  it {
+    expect(subject).to validate_presence_of(:nomis_offender_id).with_message('must be provided')
+  }
+
+  it {
+    expect(subject).to validate_presence_of(:nomis_staff_id).with_message('must be provided')
+  }
+
+  it {
+    expect(subject).to validate_presence_of(:override_reasons).with_message('must be provided')
+  }
+
+  it {
+    o = described_class.create(nomis_offender_id: 'A', nomis_staff_id: 1, override_reasons: ['other'])
+    expect(o.valid?).to be false
+    expect(o.errors[:more_detail].count).to eq(1)
+    expect(o.errors[:more_detail].first).to eq('must be provided when Other is selected')
+  }
+
+  it {
+    o = described_class.create(nomis_offender_id: 'A', nomis_staff_id: 1, override_reasons: ['cats'])
+    expect(o.valid?).to be true
+    expect(o.errors[:more_detail].count).to eq(0)
+  }
 end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -54,7 +54,7 @@ describe PrisonOffenderManagerService do
     vcr: { cassette_name: :pom_service_get_poms } do
     poms = described_class.get_poms('LEI')
     expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(7)
+    expect(poms.count).to eq(8)
   end
 
   it "can get a filtered list of POMs",
@@ -63,13 +63,13 @@ describe PrisonOffenderManagerService do
       pom.status == 'active'
     }
     expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(6)
+    expect(poms.count).to eq(7)
   end
 
   it "can get the names for POMs when given IDs",
     vcr: { cassette_name: :pom_service_get_poms } do
     names = described_class.get_pom_names('LEI')
     expect(names).to be_kind_of(Hash)
-    expect(names.count).to eq(6)
+    expect(names.count).to eq(7)
   end
 end


### PR DESCRIPTION
Currently the override form does not show any validation.  This PR
ensures that error messages (for failed validation) and shown on the
screen.

The checks are:

* An override reason must be provided
* More detail must be provided IFF the user selected 'Other'.