### PR TITLE
Refactor unallocation

### DIFF
--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -40,6 +40,14 @@ class AllocationService
     }
   end
 
+  def self.deallocate_pom(nomis_staff_id)
+    Allocation.where(nomis_staff_id: nomis_staff_id).update_all(active: false)
+  end
+
+  def self.deallocate_offender(nomis_offender_id)
+    Allocation.where(nomis_offender_id: nomis_offender_id).update_all(active: false)
+  end
+
 private
 
   def self.delete_overrides(params)

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -66,13 +66,8 @@ class PrisonOffenderManagerService
     pom.working_pattern = params[:working_pattern] || pom.working_pattern
     pom.status = params[:status] || pom.status
     pom.save!
-    deallocate(params[:nomis_staff_id]) if pom.status == 'inactive'
+    AllocationService.deallocate_pom(params[:nomis_staff_id]) if pom.status == 'inactive'
     pom
   end
 
-private
-
-  def self.deallocate(nomis_staff_id)
-    Allocation.where(nomis_staff_id: nomis_staff_id).update_all(active: false)
-  end
 end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -69,5 +69,4 @@ class PrisonOffenderManagerService
     AllocationService.deallocate_pom(params[:nomis_staff_id]) if pom.status == 'inactive'
     pom
   end
-
 end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe AllocationService do
     alloc = described_class.active_allocations([allocation.nomis_offender_id])
     expect(alloc).to be_instance_of(Hash)
   end
+
+  it "can deallocate for a POM" do
+    staff_id = allocation.nomis_staff_id
+    described_class.deallocate_pom(staff_id)
+    alloc = PrisonOffenderManagerService.get_allocations_for_pom(staff_id)
+    expect(alloc).to eq([])
+  end
+
+  it "can deallocate for an offender" do
+    offender_id = allocation.nomis_offender_id
+    described_class.deallocate_offender(offender_id)
+    alloc = described_class.active_allocations([offender_id])
+    expect(alloc).to eq({})
+  end
 end


### PR DESCRIPTION
Moves the deallocate function to AllocationService, and renames it to
deallocate_pom adding a deallocate_offender at the same time.  This
allows us to:

- disassocaite offenders for a POM
- remove an offender from the POM's list