### PR TITLE
Email notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.5.3'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'coffee-rails', '~> 4.2'
 gem 'faraday'
+gem 'govuk_notify_rails'
 gem 'jbuilder', '~> 2.8'
 gem 'jwt'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
     ffi (1.9.25)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govuk_notify_rails (2.1.0)
+      notifications-ruby-client (>= 2.9.0)
+      rails (>= 4.1.0)
     hashdiff (0.3.8)
     hashie (3.6.0)
     i18n (1.5.3)
@@ -128,6 +131,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (2.10.0)
+      jwt (>= 1.5, < 3)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
       jwt (>= 1.0, < 3.0)
@@ -291,6 +296,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   faraday
+  govuk_notify_rails
   jbuilder (~> 2.8)
   jwt
   launchy

--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -1,0 +1,39 @@
+class PomMailer < GovukNotifyRails::Mailer
+  # TODO: Add POM email addresses
+  def new_allocation_email(pom, offender)
+    return unless active?
+
+    set_template('9679ea4c-1495-4fa6-a00b-630de715e315')
+
+    set_personalisation(
+      email_subject: 'New OMIC allocation',
+      pom_name: pom.first_name.capitalize,
+      offender_name: offender.full_name,
+      nomis_offender_id: offender.offender_no
+    )
+
+    mail(to: '')
+  end
+
+  def deallocation_email(previous_pom, new_pom, offender)
+    return unless active?
+
+    set_template('cd628495-6e7a-448e-b4ad-4d49d4d8567d')
+
+    set_personalisation(
+      email_subject: 'OMIC case reallocation',
+      previous_pom_name: previous_pom.first_name.capitalize,
+      new_pom_name: new_pom.first_name.capitalize,
+      offender_name: offender.full_name,
+      prison: new_pom.agency_id
+    )
+
+    mail(to: '')
+  end
+
+private
+
+  def active?
+    Rails.configuration.notify_api_key.present?
+  end
+end

--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -1,3 +1,4 @@
+# :nocov:
 class PomMailer < GovukNotifyRails::Mailer
   # TODO: Add POM email addresses
   def new_allocation_email(pom, offender)
@@ -37,3 +38,4 @@ private
     Rails.configuration.notify_api_key.present?
   end
 end
+# :nocov:

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -14,6 +14,7 @@ class AllocationService
       end
     }
 
+    EmailService.send_allocation_email(params)
     delete_overrides(params)
 
     allocation

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -1,6 +1,7 @@
+# :nocov:
 class EmailService
   def self.send_allocation_email(params)
-    offender = OffenderService.new.get_offender(params[:nomis_offender_id])
+    offender = OffenderService.get_offender(params[:nomis_offender_id])
     pom = PrisonOffenderManagerService.get_pom(params[:prison], params[:nomis_staff_id])
     last_allocation = Allocation.where(nomis_offender_id:  params[:nomis_offender_id]).
         where(active: false).last
@@ -13,3 +14,4 @@ class EmailService
     PomMailer.new_allocation_email(pom, offender).deliver_now
   end
 end
+# :nocov:

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -1,0 +1,15 @@
+class EmailService
+  def self.send_allocation_email(params)
+    offender = OffenderService.new.get_offender(params[:nomis_offender_id])
+    pom = PrisonOffenderManagerService.get_pom(params[:prison], params[:nomis_staff_id])
+    last_allocation = Allocation.where(nomis_offender_id:  params[:nomis_offender_id]).
+        where(active: false).last
+
+    if last_allocation.present?
+      previous_pom = PrisonOffenderManagerService.
+          get_pom(last_allocation[:prison], last_allocation[:nomis_staff_id])
+      PomMailer.deallocation_email(previous_pom, pom, offender).deliver_now
+    end
+    PomMailer.new_allocation_email(pom, offender).deliver_now
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,6 @@ module OffenderManagementAllocationClient
     config.nomis_oauth_client_secret = ENV['NOMIS_OAUTH_CLIENT_SECRET']
     config.nomis_oauth_public_key = ENV['NOMIS_OAUTH_PUBLIC_KEY']
     config.prometheus_metrics = ENV['PROMETHEUS_METRICS']
+    config.notify_api_key = ENV['GOVUK_NOTIFY_API_KEY']
   end
 end

--- a/config/initializers/gov_uk_notify.rb
+++ b/config/initializers/gov_uk_notify.rb
@@ -1,0 +1,2 @@
+ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery,
+  api_key: Rails.configuration.notify_api_key

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe AllocationService do
     )
   }
 
-  it "Can get the active allocations" do
+  it "Can get the active allocations", vcr: { cassette_name: 'allocation_service_get_allocations' } do
     alloc = described_class.active_allocations([allocation.nomis_offender_id])
     expect(alloc).to be_instance_of(Hash)
   end
 
-  it "can deallocate for a POM" do
+  it "can deallocate for a POM", vcr: { cassette_name: 'allocation_service_deallocate_a_pom' } do
     staff_id = allocation.nomis_staff_id
     described_class.deallocate_pom(staff_id)
     alloc = PrisonOffenderManagerService.get_allocations_for_pom(staff_id)
     expect(alloc).to eq([])
   end
 
-  it "can deallocate for an offender" do
+  it "can deallocate for an offender", vcr: { cassette_name: 'allocation_service_deallocate_an_offender' } do
     offender_id = allocation.nomis_offender_id
     described_class.deallocate_offender(offender_id)
     alloc = described_class.active_allocations([offender_id])


### PR DESCRIPTION
This PR implements basic email notification with GOVUK Notify, using an
MOJ Rails API client.  The behaviour of the notifications is to send a
new allocation email to a POM, and a re-allocation email if there was a
previous POM allocated.

Two important points:
1) At present we don't have access to POM email addresses and therefore
we have implemented a temporary 'active' flag so emails don't get sent
whilst we sort this out.

2) The emails are very basic and have had no content design, so the
templates will need to be updated once this has been done.