### PR TITLE
Adds form events to record them in GA.

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,0 +1,26 @@
+function createFunctionWithTimeout(callback, opt_timeout) {
+    var called = false;
+    function fn() {
+      if (!called) {
+        called = true;
+        callback();
+      }
+    }
+    setTimeout(fn, opt_timeout || 1000);
+    return fn;
+  }
+
+function analytics_form_event(form_id, event_name, event_action) {
+    var form = document.getElementById(form_id);
+    form.addEventListener('submit', function(event) {
+      event.preventDefault();
+      gtag('send', 'event', event_name, event_action, {
+        hitCallback: createFunctionWithTimeout(function() {
+          form.submit();
+        })
+      });
+    });
+}
+
+
+

--- a/app/assets/javascripts/status.coffee
+++ b/app/assets/javascripts/status.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/views/allocations/confirm.html.erb
+++ b/app/views/allocations/confirm.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => "/shared/backlink", :locals => { :page => new_allocations_path() } %>
 
 <div>
-    <%= form_tag(allocations_path, method: :post) do %>
+    <%= form_tag(allocations_path, method: :post, id: "confirm_allocation_form") do %>
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">Confirm allocation</h1>
       <p class="govuk-body">You are allocating <%= @prisoner.full_name %> to <%= @pom.full_name %></p>
       <p class="govuk-body">We'll be using the email address below to let them know about their new allocation</p>
@@ -11,3 +11,11 @@
       <%= submit_tag "Complete allocation", role: "button", draggable: "false", class: "govuk-button" %>
     <% end %>
 </div>
+
+  <%= render :partial => "/shared/analytics_form_event",
+             :locals => {
+                :form_id => 'confirm_allocation_form',
+                :event_name => 'Allocate confirmation Form',
+                :event_action => 'submit'
+              }
+  %>

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -1,5 +1,5 @@
 
-<%= form_tag(action, method: method) do %>
+<%= form_tag(action, method: method, id: "case_info_form") do %>
   <p>Please provide information on:</p>
 
   <div class="govuk-form-group <% if @case_info.errors[:case_allocation].present? %>govuk-form-group--error<% end %>">
@@ -68,3 +68,11 @@
   <%= submit_tag save_text, role: "button", draggable: "false", class: "govuk-button govuk govuk-!-margin-top-4" %>
 
 <% end %>
+
+  <%= render :partial => "/shared/analytics_form_event",
+             :locals => {
+                :form_id => 'case_info_form',
+                :event_name => 'Edit offender case info',
+                :event_action => 'submit'
+              }
+  %>

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div>
-  <%= form_tag(overrides_path, method: :post)  do %>
+  <%= form_tag(overrides_path, method: :post, id: "override_form")  do %>
     <h1 class="govuk-heading-xl govuk-!-margin-top-4">Choose reason for changing recommended grade</h1>
     <div class='govuk-!-margin-top-6'>
       <div class="govuk-form-group <% if @override.errors[:override_reasons].present? %>govuk-form-group--error<% end %>">
@@ -51,3 +51,11 @@
     </div>
   <% end %>
   </div>
+
+  <%= render :partial => "/shared/analytics_form_event",
+             :locals => {
+                :form_id => 'override_form',
+                :event_name => 'Override POM recommendation',
+                :event_action => 'submit'
+              }
+  %>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => "/shared/backlink", :locals => {:page => poms_path(id: @pom.staff_id)} %>
 
 <div>
-  <%= form_tag pom_path(nomis_staff_id: @pom.staff_id), method: :put do %>
+  <%= form_tag pom_path(nomis_staff_id: @pom.staff_id), method: :put, id: "edit_pom_form" do %>
     <h1 class="govuk-heading-xl govuk-!-margin-top-4">Edit profile</h1>
     <h2 class="govuk-heading-l"><%= @pom.full_name %></h2>
 
@@ -85,3 +85,11 @@
     </form>
   <% end %>
 </div>
+
+  <%= render :partial => "/shared/analytics_form_event",
+             :locals => {
+                :form_id => 'edit_pom_form',
+                :event_name => 'Edit POM',
+                :event_action => 'submit'
+              }
+  %>

--- a/app/views/shared/_analytics_form_event.html.erb
+++ b/app/views/shared/_analytics_form_event.html.erb
@@ -1,0 +1,5 @@
+<% if ga_enabled? %>
+<script>
+  analytics_form_event("<%= form_id %>", "<%= event_name %>", "<%= event_action %>");
+</script>
+<% end %>

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -105,6 +105,11 @@ spec:
                 secretKeyRef:
                   name: allocation-manager-secrets
                   key: nomis_oauth_host
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: allocation-manager-secrets
+                  key: ga_tracking_id
         - name: allocation-manager-metrics
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -105,6 +105,11 @@ spec:
                 secretKeyRef:
                   name: allocation-manager-secrets
                   key: nomis_oauth_host
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: allocation-manager-secrets
+                  key: ga_tracking_id
         - name: allocation-manager-metrics
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always


### PR DESCRIPTION
This PR will record form submissions as events in google analytics so
that we can track usage over time for specific features.

Also changes the deployment files so that the tracking ID is actually
available to the pods.