### PR TITLE
Add node_modules/govuk-frontend to the asset paths

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,6 +7,7 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join('node_modules/govuk-frontend')
 Rails.application.config.assets.paths << Rails.root.join('node_modules/govuk-frontend/assets')
 
 # Precompile additional assets.


### PR DESCRIPTION
Outside of development, the app is trying to load
assets/images/govuk-crest.png and so this PR adds the
node_modules/govuk-frontend to the path so that the assets/images folder
can be found.