### PR TITLE
Changes the url() function used by govuk-frontend

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,9 @@
  *= require_self
  */
 
+ $govuk-image-url-function: "image-url";
+ $govuk-font-url-function: "asset-url";
+
 @import "tables";
 @import "pagination";
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,7 +7,6 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
-Rails.application.config.assets.paths << Rails.root.join('node_modules/govuk-frontend')
 Rails.application.config.assets.paths << Rails.root.join('node_modules/govuk-frontend/assets')
 
 # Precompile additional assets.


### PR DESCRIPTION
Changes what govuk-frontend uses for loading images and fonts from using
url() which does not work with the asset pipeline, to image-url and
asset-url instead.

Found the description of how to do this at https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#alternative-solution in the Optional section.