### PR TITLE
Don't intercept 404 errors for non-HTML requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: 'dashboard#index'
 
   match "/401", :to => "errors#unauthorized", :via => :all
-  match "/404", :to => "errors#not_found", :via => :all
+  match "/404", :to => "errors#not_found", :via => :all, constraints: lambda { |req| req.format == :html }
   match "/500", :to => "errors#internal_server_error", :via => :all
   match "/503", :to => "errors#internal_server_error", :via => :all
 


### PR DESCRIPTION
As it was set up, if a PNG request wanted to return a 404 it would
instead try and render a PNG template from errors/ folder. This is
wrong. We should only show the 404 page when the request is coming from
a browser