### PR TITLE
Allow staff without POM role to access the service

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,6 @@ class DashboardController < ApplicationController
   before_action :authenticate_user
 
   def index
-    @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
+    @user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user)
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,5 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user
 
-  def index
-    @user = Nomis::Elite2::Api.fetch_nomis_user_details(current_user)
-  end
+  def index; end
 end

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -38,13 +38,15 @@ class PomsController < ApplicationController
 
   def my_caseload
     @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
-    @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
-    @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id)
+    if @pom.present?
+      @allocations = PrisonOffenderManagerService.get_allocated_offenders(@pom.staff_id)
+      @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id)
+    end
   end
 
   def new_cases
     @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
-    @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id)
+    @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id) if @pom.present?
   end
 
 private

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -6,9 +6,9 @@ class PomsController < ApplicationController
     -> {  poms_path(params[:nomis_staff_id]) }, only: [:show]
   breadcrumb 'My caseload', :my_caseload_path, only: [:new_cases]
   breadcrumb -> { 'My caseload' },
-    -> { my_caseload_path(1) }, only: [:my_caseload]
+    -> { my_caseload_path }, only: [:my_caseload]
   breadcrumb -> { 'New cases' },
-    -> { new_cases_path(1) }, only: [:new_cases]
+    -> { new_cases_path }, only: [:new_cases]
 
   def index
     poms = PrisonOffenderManagerService.get_poms(caseload)

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -46,7 +46,9 @@ class PomsController < ApplicationController
 
   def new_cases
     @pom = PrisonOffenderManagerService.get_signed_in_pom_details(current_user)
-    @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id) if @pom.present?
+    if @pom.present?
+      @new_cases = PrisonOffenderManagerService.get_new_cases(@pom.staff_id)
+    end
   end
 
 private

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -35,7 +35,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "My caseload", my_caseload_path(@user.staff_id), class:"govuk-link" %>
+        <%= link_to "My caseload", my_caseload_path, class:"govuk-link" %>
       </h1>
       <p class="govuk-body">All cases allocated to you.</p>
     </div>
@@ -43,7 +43,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "New allocations", new_cases_path(@user.staff_id), class:"govuk-link" %>
+        <%= link_to "New allocations", new_cases_path, class:"govuk-link" %>
       </h1>
       <p class="govuk-body">Cases allocated to you in the last 7 days.</p>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -35,7 +35,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "My caseload", my_caseload_path(@pom.staff_id), class:"govuk-link" %>
+        <%= link_to "My caseload", my_caseload_path(@user.staff_id), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">All cases allocated to you.</p>
     </div>
@@ -43,7 +43,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "New allocations", new_cases_path(@pom.staff_id), class:"govuk-link" %>
+        <%= link_to "New allocations", new_cases_path(@user.staff_id), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">Cases allocated to you in the last 7 days.</p>
     </div>

--- a/app/views/poms/my_caseload.html.erb
+++ b/app/views/poms/my_caseload.html.erb
@@ -1,3 +1,6 @@
+<% if @pom.blank? %>
+  <h2 class="govuk-heading-l">No allocated cases </h2>
+<% else %>
 <h2 class="govuk-heading-l">My caseload (<%= @allocations.count  %>)</h2>
 
 <div class="govuk-grid-row">
@@ -41,3 +44,4 @@
   <% end %>
   </tbody>
 </table>
+<% end %>

--- a/app/views/poms/new_cases.html.erb
+++ b/app/views/poms/new_cases.html.erb
@@ -1,31 +1,35 @@
-<h2 class="govuk-heading-l">New allocations</h2>
+<% if @pom.blank? %>
+  <h2 class="govuk-heading-l">No new cases </h2>
+<% else %>
+  <h2 class="govuk-heading-l">New allocations</h2>
 
-<table class="govuk-table responsive tablesorter">
-  <thead class="govuk-table__head">
-  <tr class="govuk-table__row">
-    <th class="govuk-table__header" scope="col"><a
-      class='table-sorter__link' href='#'>Prisoner name</a></th>
-    <th class="govuk-table__header" scope="col">Prisoner number</th>
-    <th class="govuk-table__header" scope="col">
-      <a class="table-sorter__link" href="#">Arrival date</a></th>
-    <th class="govuk-table__header" scope="col">
-      <a class="table-sorter__link" href="#">Release date/parole eligibility</a></th>
-    <th class="govuk-table__header" scope="col">
-      <a class="table-sorter__link" href="#">Allocation date</a></th>
-    <th class="govuk-table__header" scope="col">
-      <a class="table-sorter__link" href="#">Role</a></th>
-  </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-  <% @new_cases.each do |allocation, sentence| %>
+  <table class="govuk-table responsive tablesorter">
+    <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
-      <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
-      <td aria-label="Arrival date" class="govuk-table__cell ">ARRIVAL DATE</td>
-      <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
-      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
-      <td aria-label="Role" class="govuk-table__cell ">ROLE</td>
+      <th class="govuk-table__header" scope="col"><a
+        class='table-sorter__link' href='#'>Prisoner name</a></th>
+      <th class="govuk-table__header" scope="col">Prisoner number</th>
+      <th class="govuk-table__header" scope="col">
+        <a class="table-sorter__link" href="#">Arrival date</a></th>
+      <th class="govuk-table__header" scope="col">
+        <a class="table-sorter__link" href="#">Release date/parole eligibility</a></th>
+      <th class="govuk-table__header" scope="col">
+        <a class="table-sorter__link" href="#">Allocation date</a></th>
+      <th class="govuk-table__header" scope="col">
+        <a class="table-sorter__link" href="#">Role</a></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% @new_cases.each do |allocation, sentence| %>
+      <tr class="govuk-table__row">
+        <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
+        <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
+        <td aria-label="Arrival date" class="govuk-table__cell ">ARRIVAL DATE</td>
+        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
+        <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
+        <td aria-label="Role" class="govuk-table__cell ">ROLE</td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
   get('/summary' => 'summary#index')
   get('/prisoners/:id' => 'prisoners#show', as: 'prisoners_show')
   get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocations')
-  get('/poms/:nomis_staff_id/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
-  get('/poms/:nomis_staff_id/new_cases' => 'poms#new_cases', as: 'new_cases')
+  get('/poms/my_caseload' => 'poms#my_caseload', as: 'my_caseload')
+  get('/poms/new_cases' => 'poms#new_cases', as: 'new_cases')
 
   resources :health, only: %i[ index ], controller: 'health'
   resources :status, only: %i[ index ], controller: 'status'

--- a/spec/features/view_allocations_spec.rb
+++ b/spec/features/view_allocations_spec.rb
@@ -33,4 +33,10 @@ feature "view POM's caseload" do
     expect(page).to have_content("New allocations")
     expect(page).to have_content("Abbella, Ozullirn")
   end
+
+  it 'allows staff without the POM role to view the my casload page', vcr: { cassette_name: :non_pom_my_caseload }  do
+    signin_user('NON_POM_GEN')
+    visit "/poms/485767/my_caseload"
+    expect(page).to have_text("No allocated cases")
+  end
 end

--- a/spec/features/view_allocations_spec.rb
+++ b/spec/features/view_allocations_spec.rb
@@ -15,7 +15,7 @@ feature "view POM's caseload" do
 
     click_button 'Complete allocation'
 
-    visit "/poms/485637/my_caseload"
+    visit "/poms/my_caseload"
 
     expect(page).to have_content("My caseload")
     expect(page).to have_content("Abbella, Ozullirn")
@@ -27,7 +27,7 @@ feature "view POM's caseload" do
     visit confirm_allocations_path(nomis_offender_id, nomis_staff_id)
     click_button 'Complete allocation'
 
-    visit "/poms/485637/my_caseload"
+    visit "/poms/my_caseload"
     click_link('1')
 
     expect(page).to have_content("New allocations")
@@ -36,7 +36,7 @@ feature "view POM's caseload" do
 
   it 'allows staff without the POM role to view the my casload page', vcr: { cassette_name: :non_pom_my_caseload }  do
     signin_user('NON_POM_GEN')
-    visit "/poms/485767/my_caseload"
+    visit "/poms/my_caseload"
     expect(page).to have_text("No allocated cases")
   end
 end


### PR DESCRIPTION
Following the implementation of the 'my caseload' and 'new allocations'
pages there was an issue that only staff with the POM role could access
all of the application.  This PR removes the reliance on people needing
to have a POM role and if they click on the aforementioned pages they
will be presented with a message confirming they don't have any
allocated cases.