### PR TITLE
Add welsh_address to the two offender models

### DIFF
--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -32,6 +32,7 @@ module Nomis
       attribute :sentence_date, :date
       attribute :tier, :string
       attribute :case_allocation, :string
+      attribute :welsh_address, :boolean
 
       def current_responsibility
         @current_responsibility = ResponsibilityService.calculate_responsibility(self)

--- a/app/services/nomis/models/offender_short.rb
+++ b/app/services/nomis/models/offender_short.rb
@@ -28,6 +28,7 @@ module Nomis
       attribute :allocated_pom_name, :string
       attribute :allocation_date, :date
       attribute :case_allocation, :string
+      attribute :welsh_address, :boolean
 
       def awaiting_allocation_for
         return 0 if sentence_date.blank?

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -47,8 +47,11 @@ class OffenderService
       offender.release_date = sentence_details[offender.offender_no].release_date
       if offender.release_date.present?
         record = tier_map[offender.offender_no]
-        offender.tier = record.tier if record
-        offender.case_allocation = record.case_allocation if record
+        if record
+          offender.tier = record.tier
+          offender.case_allocation = record.case_allocation
+          offender.welsh_address = record.welsh_address
+        end
         offender.sentence_date = sentence_details[offender.offender_no].sentence_date
         true
       else


### PR DESCRIPTION
So that we know when an offender has a welsh address (specified in the
case information controller) this PR adds that field to the two offender
models.