### PR TITLE
Cleanup attempts to send events to Google

### DIFF
--- a/app/views/shared/_analytics_form_event.html.erb
+++ b/app/views/shared/_analytics_form_event.html.erb
@@ -3,11 +3,18 @@
     var form = document.getElementById("<%= form_id %>");
     form.addEventListener('submit', function(event) {
       event.preventDefault();
-      window.dataLayer.push(["send", "event", "<%= event_name %>", "<%= event_action %>", {
-        hitCallback: createFunctionWithTimeout(function() {
-          form.submit();
-        })
-      }]);
+
+      createFunctionWithTimeout(function() {
+        form.submit();
+      })();
+
+      window.dataLayer.push({
+        "event": "send",
+        "event_category": "event",
+        "event_label": "<%= event_name %>",
+        "value": "<%= event_action %>"
+      });
+
     });
 </script>
 <% end %>


### PR DESCRIPTION
dataLayer.push takes a {}, not a [] (which is sugar for the gtag
function).