### PR TITLE
Content changes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,7 +28,7 @@
      margin-top: 20px;
 
      .wrapper {
-        min-height: 130px;
+        min-height: 160px;
         background-color: #f9f9f9;
     }
     .govuk-heading-s {

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -27,10 +27,10 @@
   text-align: right;
 }
 
-.hmpps-table-cell__key {
-  width: 55%;
-}
-
 .poms-table-cell__key {
   width: 25%;
+}
+
+.pull-right {
+  float: right;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,4 +25,17 @@ module ApplicationHelper
   def override_reason_contains(override, val)
     override.override_reasons.present? && override.override_reasons.include?(val)
   end
+
+  def service_provider_label(provider)
+    {
+      'CRC' => 'Community Rehabilitation Company (CRC)',
+      'NPS' => 'National Probation Service (NPS)'
+    }[provider]
+  end
+
+  def working_pattern_name(pattern)
+    return 'Full time' if pattern.to_f == 1.0
+
+    'Part time'
+  end
 end

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -5,20 +5,24 @@
     <td class="govuk-table__cell"></td>
   </tr>
   <tr class="govuk-table__row">
-    <td class="govuk-table__cell hmpps-table-cell__key">Current responsibility</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= @prisoner.current_responsibility %></td>
-  </tr>
-
-  <tr class="govuk-table__row">
-    <td class="govuk-table__cell hmpps-table-cell__key">Case allocation</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key">
-      <a href="<%= edit_case_information_path(@prisoner.offender_no) %>"><%= @prisoner.case_allocation %></a>
+    <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
+    <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+      <%= @prisoner.current_responsibility %>
+        <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
     </td>
   </tr>
   <tr class="govuk-table__row">
-    <td class="govuk-table__cell hmpps-table-cell__key">Tiering calculation</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key">
-      <a href="<%= edit_case_information_path(@prisoner.offender_no) %>"><%= @prisoner.tier %></a>
+    <td class="govuk-table__cell">Case allocation</td>
+    <td class="govuk-table__cell table_cell__left_align">
+      <%= service_provider_label(@prisoner.case_allocation) %>
+      <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
+    </td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">Tiering calculation</td>
+    <td class="govuk-table__cell table_cell__left_align">
+    Tier <%= @prisoner.tier %>
+      <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
     </td>
   </tr>
   </tbody>

--- a/app/views/allocations/_pom_info.html.erb
+++ b/app/views/allocations/_pom_info.html.erb
@@ -1,8 +1,8 @@
 <table class="govuk-table">
   <tbody class="govuk-table__body">
   <tr class="govuk-table__row">
-    <td class="govuk-table__header" scope="row">Current POM</td>
-    <td class="govuk-table__cell"></td>
+    <td class="govuk-table__header govuk-!-width-one-half" scope="row">Current POM</td>
+    <td class="govuk-table__cell  govuk-!-width-one-half"></td>
   </tr>
   <tr class="govuk-table__row">
     <td class="govuk-table__cell hmpps-table-cell__key">Name</td>

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -1,21 +1,22 @@
 <h4 class="govuk-heading-m">
-  Recommendation: <%= @prisoner.current_responsibility %> POMs
+  Recommendation: <%= @prisoner.current_responsibility %> POM
 </h4>
 
-<p>Based on the prisoner's tiering calculation.</p>
+<p>This recommendation takes the prisoner's tier and
+time left to serve into account.</p>
 
 <table class="govuk-table responsive">
   <thead class="govuk-table__head">
-  <h2 class="govuk-heading-s"><%= @prisoner.current_responsibility %> POMs</h2>
+  <h2 class="govuk-heading-s">Active <%= @prisoner.current_responsibility %> POMs</h2>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="col">Name</th>
-    <th class="govuk-table__header" scope="col">Previous allocation</th>
-    <th class="govuk-table__header" scope="col">Tier A cases</th>
-    <th class="govuk-table__header" scope="col">Tier B cases</th>
-    <th class="govuk-table__header" scope="col">Tier C cases</th>
-    <th class="govuk-table__header" scope="col">Tier D cases</th>
+    <th class="govuk-table__header" scope="col">Previous<br/>allocation</th>
+    <th class="govuk-table__header" scope="col">Tier A<br/>cases</th>
+    <th class="govuk-table__header" scope="col">Tier B<br/>cases</th>
+    <th class="govuk-table__header" scope="col">Tier C<br/>cases</th>
+    <th class="govuk-table__header" scope="col">Tier D<br/>cases</th>
     <th class="govuk-table__header" scope="col">Total</th>
-    <th class="govuk-table__header" scope="col">Working pattern</th>
+    <th class="govuk-table__header" scope="col">Working<br/>pattern</th>
     <th class="govuk-table__header" scope="col">Action</th>
   </tr>
   </thead>
@@ -29,7 +30,7 @@
       <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
       <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
-      <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
+      <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
         <% if current_page?(action: :new) %>
           <%= link_to "Allocate", confirm_allocations_path(@prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
@@ -52,9 +53,9 @@
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       <% if @prisoner.current_responsibility == 'Probation' %>
-        Show prison officer POMs
+        Show active Prison officer POMs
       <% else %>
-        Show probation officer POMs
+        Show active Probation officer POMs
       <% end %>
     </span>
   </summary>
@@ -65,13 +66,13 @@
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Name</th>
-        <th class="govuk-table__header" scope="col">Previous allocation</th>
-        <th class="govuk-table__header" scope="col">Tier A cases</th>
-        <th class="govuk-table__header" scope="col">Tier B cases</th>
-        <th class="govuk-table__header" scope="col">Tier C cases</th>
-        <th class="govuk-table__header" scope="col">Tier D cases</th>
+        <th class="govuk-table__header" scope="col">Previous<br/>allocation</th>
+        <th class="govuk-table__header" scope="col">Tier A<br/>cases</th>
+        <th class="govuk-table__header" scope="col">Tier B<br/>cases</th>
+        <th class="govuk-table__header" scope="col">Tier C<br/>cases</th>
+        <th class="govuk-table__header" scope="col">Tier D<br/>cases</th>
         <th class="govuk-table__header" scope="col">Total</th>
-        <th class="govuk-table__header" scope="col">Working pattern</th>
+        <th class="govuk-table__header" scope="col">Working<br/>pattern</th>
         <th class="govuk-table__header" scope="col">Action</th>
       </tr>
       </thead>
@@ -85,7 +86,7 @@
           <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
           <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
           <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
-          <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
+          <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
           <td aria-label="Action" class="govuk-table__cell table_cell__right_align">
             <% if current_page?(action: :new) %>
               <%= link_to "Allocate", new_overrides_path(@prisoner.offender_no, pom.staff_id), class: "govuk-link" %>

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -2,15 +2,13 @@
 <%= form_tag(action, method: method, id: "case_info_form") do %>
     <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
 
-    <p>You can find this information in nDelius</p>
-
     <div class="govuk-form-group <% if @case_info.errors[:welsh_address].present? %>govuk-form-group--error<% end %>">
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend--m">
+        <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-2">
           Was this prisoner's last known address in Wales?
         </legend>
         <p>
-        Only prisoners with a Welsh address can be allocated a prison or probation POM
+          Only prisoners with a Welsh address can be allocated a prison or probation POM
         </p>
 
         <% if @case_info.errors[:welsh_address].present? %>
@@ -32,9 +30,9 @@
       </fieldset>
     </div>
 
-    <div class="govuk-form-group <% if @case_info.errors[:case_allocation].present? %>govuk-form-group--error<% end %>">
+    <div class="govuk-!-margin-top-8 govuk-form-group <% if @case_info.errors[:case_allocation].present? %>govuk-form-group--error<% end %>">
       <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend--m">
+        <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-4">
             Who is the service provider for this case?
         </legend>
         <% if @case_info.errors[:case_allocation].present? %>
@@ -56,9 +54,9 @@
       </fieldset>
     </div>
 
-  <div class="govuk-form-group <% if @case_info.errors[:tier].present? %>govuk-form-group--error<% end %>">
-    <fieldset class="govuk-fieldset govuk-!-margin-top-6">
-      <legend class="govuk-fieldset__legend--m">
+  <div class="govuk-!-margin-top-8 govuk-form-group <% if @case_info.errors[:tier].present? %>govuk-form-group--error<% end %>">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend--s  govuk-!-margin-bottom-4">
         What tier has the prisoner been assigned to?
       </legend>
 
@@ -71,19 +69,19 @@
       <div class="govuk-radios">
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "A", @case_info[:tier] == 'A', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "Tier A", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information[tier]", "A", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "B", @case_info[:tier] == 'B', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "Tier B", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information[tier]", "B", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "C", @case_info[:tier] == 'C', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "Tier C", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information[tier]", "C", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "D", @case_info[:tier] == 'D', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "Tier D", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information[tier]", "D", class: "govuk-label govuk-radios__label" %>
         </div>
       </div>
     </fieldset>

--- a/app/views/case_information/new.html.erb
+++ b/app/views/case_information/new.html.erb
@@ -5,8 +5,10 @@
   <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>
 <% end %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-top-4">Case information</h1>
-<h2 class="govuk-heading-l"><%= @prisoner.full_name %> - <%= @prisoner.offender_no %></h2>
+<h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Case information</h1>
+<h2 class="govuk-heading-m"><%= @prisoner.full_name %> - <%= @prisoner.offender_no %></h2>
+<p class="govuk-!-margin-bottom-8">You can find this information in nDelius</p>
+
 
 <%= render :partial => "form", :locals => {
       :action => case_information_path(),

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "Allocated prisoners", summary_path(anchor: 'allocated'), class:"govuk-link" %>
+        <%= link_to "See all allocated prisoners", summary_path(anchor: 'allocated'), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">All prisoners who have been allocated a Prison Offender Manager.</p>
     </div>
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "Awaiting allocation", summary_path(anchor: 'awaiting-allocation'), class:"govuk-link" %>
+        <%= link_to "Make new allocations", summary_path(anchor: 'awaiting-allocation'), class:"govuk-link" %>
       </h1>
       <p class="govuk-body">Prisoners who need to be allocated a Prison Offender Manager.</p>
     </div>
@@ -22,9 +22,9 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "Awaiting information", summary_path(anchor: 'awaiting-information'), class:"govuk-link" %>
+        <%= link_to "Update case information", summary_path(anchor: 'awaiting-information'), class:"govuk-link" %>
       </h1>
-      <p class="govuk-body">Prisoners for whom we require case information adding before being allocated already</p>
+      <p class="govuk-body">Prisoners with missing case information. This needs to be updated before they can be allocated</p>
     </div>
   </div>
 </div>
@@ -35,7 +35,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "My caseload", my_caseload_path, class:"govuk-link" %>
+        <%= link_to "Your caseload", my_caseload_path, class:"govuk-link" %>
       </h1>
       <p class="govuk-body">All cases allocated to you.</p>
     </div>

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-phase-banner govuk-width-container app-site-
+width-container">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag hmpps-tag__beta govuk-phase-banner__content__tag ">beta</strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 
   <body class="govuk-template__body js-enabled">
     <%= render '/layouts/header' %>
+    <%= render '/layouts/phase_banner' %>
 
     <div class='govuk-width-container'>
       <main class='govuk-main-wrapper' id='main-content' role='main'>

--- a/app/views/shared/_basic_prisoner_info.html.erb
+++ b/app/views/shared/_basic_prisoner_info.html.erb
@@ -6,12 +6,11 @@
       <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell hmpps-table-cell__key">Name</td>
-      <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><a
-          href="#"><%= @prisoner.full_name %></a></td>
+      <td class="govuk-table__cell govuk-!-width-one-half">Name</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.full_name %></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell hmpps-table-cell__key">Number</td>
+      <td class="govuk-table__cell hmpps-table-cell__key">Prisoner number</td>
       <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= @prisoner.offender_no %></td>
     </tr>
     <tr class="govuk-table__row">

--- a/app/views/shared/_current_pom_info.html.erb
+++ b/app/views/shared/_current_pom_info.html.erb
@@ -1,16 +1,16 @@
   <table class="govuk-table">
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <td class="govuk-table__header" scope="row">Current POM</td>
-      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Current POM</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell hmpps-table-cell__key">Name</td>
-      <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key">Green, Samantha</td>
+      <td class="govuk-table__cell">Name</td>
+      <td class="govuk-table__cell table_cell__left_align">Green, Samantha</td>
     </tr>
     <tr class="govuk-table__row">
-        <td class="govuk-table__cell hmpps-table-cell__key">Grade</td>
-        <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key">Probation POM</td>
+        <td class="govuk-table__cell">Grade</td>
+        <td class="govuk-table__cell table_cell__left_align">Probation POM</td>
       </tr>
     </tbody>
   </table>

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -1,16 +1,16 @@
 <table class="govuk-table">
   <tbody class="govuk-table__body">
   <tr class="govuk-table__row">
-    <td class="govuk-table__header" scope="row">Offence</td>
-    <td class="govuk-table__cell"></td>
+    <td class="govuk-table__header govuk-!-width-one-half" scope="row">Offence</td>
+    <td class="govuk-table__cell govuk-!-width-one-half"></td>
   </tr>
   <tr class="govuk-table__row">
-    <td class="govuk-table__cell hmpps-table-cell__key">Main Offence</td>
-    <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= @prisoner.main_offence %></td>
+    <td class="govuk-table__cell govuk-!-width-one-half">Main Offence</td>
+    <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.main_offence %></td>
   </tr>
   <tr class="govuk-table__row">
-      <td class="govuk-table__cell hmpps-table-cell__key">Release date / parole eligibility</td>
-      <td class="govuk-table__cell table_cell__left_align hmpps-table-cell__key"><%= format_date(@prisoner.release_date) %></td>
+      <td class="govuk-table__cell">Release date / parole eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align"><%= format_date(@prisoner.release_date) %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/summary/_allocated.html.erb
+++ b/app/views/summary/_allocated.html.erb
@@ -5,7 +5,7 @@
       <th class="govuk-table__header" scope="col"><a
         class='table-sorter__link' href='#'>Prisoner name</a></th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
-      <th class="govuk-table__header sorter-false" scope="col">Release date/Parole eligibility</th>
+      <th class="govuk-table__header sorter-false" scope="col">Release/parole<br/>eligibility</th>
       <th class="govuk-table__header" scope="col"><a
         class='table-sorter__link' href='#'>POM</a></th>
       <th class="govuk-table__header" scope="col"><a

--- a/app/views/summary/_awaiting.html.erb
+++ b/app/views/summary/_awaiting.html.erb
@@ -5,26 +5,23 @@
       <th class="govuk-table__header" scope="col"><a
         class='table-sorter__link' href='#'>Prisoner name</th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
-      <th class="govuk-table__header sorter-false" scope="col">Awaiting allocation for</th>
-      <th class="govuk-table__header sorter-false" scope="col">Release date/Parole eligibility</th>
-      <th class="govuk-table__header header-width__8" scope="col">
-        <a href='#' class='table-sorter__link'>Tier</a>
+      <th class="govuk-table__header sorter-false" xscope="col">Release/parole<br/>eligibility</th>
+      <th class="govuk-table__header sorter-false" scope="col">Responsibility</th>
+      <th class="govuk-table__header sorter-false" scope="col">Waiting</th>
       </th>
-      <th class="govuk-table__header" scope="col">Action</th>
+      <th class="govuk-table__header sorter-false" scope="col">Action</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <% @summary.unallocated_offenders.each_with_index do |offender, i| %>
       <tr class="govuk-table__row offender_row_<%= i %>">
-        <td aria-label="Action" class="govuk-table__cell "><%= offender.full_name %></td>
-        <td aria-label="Prisoner number" class="govuk-table__cell "><%= offender.offender_no %></td>
-        <td aria-label="Awaiting allocation for" class="govuk-table__cell ">
+        <td aria-label="Prisoner name" class="govuk-table__cell "><%= offender.full_name %></td>
+        <td aria-label="Prisoner number" class="govuk-table__cell"><%= offender.offender_no %></td>
+        <td aria-label="Release/parole eligibility" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
+        <td aria-label="Responsibility" class="govuk-table__cell"> NEW-FIELD </td>
+        <td aria-label="Awaiting allocation for" class="govuk-table__cell">
           <%= offender.awaiting_allocation_for %> days
         </td>
-        <td aria-label="Release date/Parole eligibility" class="govuk-table__cell ">
-          <%= format_date(offender.release_date) %>
-        </td>
-        <td aria-label="Tier" class="govuk-table__cell "><%= offender.tier %></td>
         <td aria-label="Action" class="govuk-table__cell ">
           <a href="<%= new_allocations_path(offender.offender_no) %>">Allocate</a>
         </td>

--- a/app/views/summary/_awaiting_information.html.erb
+++ b/app/views/summary/_awaiting_information.html.erb
@@ -4,9 +4,9 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col"><a href='#' class='table-sorter__link'>Prisoner name</a></th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
-      <th class="govuk-table__header" scope="col"><a href="#">Case allocation</a></th>
+      <th class="govuk-table__header" scope="col"><a href="#">Service provider</a></th>
       <th class="govuk-table__header" scope="col"><a href="#">Tier</a></th>
-      <th class="govuk-table__header" scope="col"><a href="#">Awaiting for</a></th>
+      <th class="govuk-table__header" scope="col"><a href="#">Waiting</a></th>
       <th class="govuk-table__header sorter-false" scope="col">Action</th>
     </tr>
     </thead>
@@ -17,7 +17,7 @@
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= offender.offender_no %></td>
 
         <!-- Todo: REFACTOR THIS SECTION TO USE PRESENTERS -->
-        <td aria-label="Case allocation" class="govuk-table__cell ">
+        <td aria-label="Service provider" class="govuk-table__cell ">
           <% if offender.case_allocation %>
             <%= offender.case_allocation %>
           <% else %>
@@ -31,7 +31,7 @@
             Not provided
           <% end %>
         </td>
-        <td aria-label="Awaiting for" class="govuk-table__cell"><%= offender.awaiting_allocation_for %> days</td>
+        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %> days</td>
         <td aria-label="Action" class="govuk-table__cell "><%= link_to "Edit", new_case_information_path(offender.offender_no) %></td>
       </tr>
     <% end %>

--- a/app/views/summary/index.html.erb
+++ b/app/views/summary/index.html.erb
@@ -7,17 +7,17 @@
   <ul class="govuk-tabs__list" role='tablist'>
       <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#allocated">
-          Allocated (<%= @summary.allocated_total %>)
+          See allocations (<%= @summary.allocated_total %>)
       </a>
       </li>
       <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#awaiting-allocation">
-          Awaiting allocation (<%= @summary.unallocated_total %>)
+          Make allocations (<%= @summary.unallocated_total %>)
       </a>
       </li>
       <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#awaiting-information">
-          Awaiting information (<%= @summary.missing_info_total %>)
+          Update information (<%= @summary.missing_info_total %>)
       </a>
       </li>
   </ul>

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -7,7 +7,8 @@ feature 'summary summary feature' do
 
       visit 'summary#awaiting-information'
 
-      expect(page).to have_css('.govuk-tabs__tab', text: 'Awaiting information')
+      expect(page).to have_css('.govuk-tabs__tab')
+      expect(page).to have_content('Update information')
       within('#awaiting-information') do
         expect(page).to have_css('.pagination ul.links li', count: 7)
       end
@@ -18,7 +19,8 @@ feature 'summary summary feature' do
 
       visit 'summary#awaiting-allocation'
 
-      expect(page).to have_css('.govuk-tabs__tab', text: 'Awaiting allocation')
+      expect(page).to have_css('.govuk-tabs__tab')
+      expect(page).to have_content('Update information')
       within('#awaiting-allocation') do
         expect(page).to have_css('.pagination ul.links li', count: 0)
       end
@@ -29,7 +31,8 @@ feature 'summary summary feature' do
 
       visit 'summary#allocated'
 
-      expect(page).to have_css('.govuk-tabs__tab', text: 'Allocated')
+      expect(page).to have_css('.govuk-tabs__tab')
+      expect(page).to have_content('See allocations')
       within('#allocated') do
         expect(page).to have_css('.pagination ul.links li', count: 0)
       end

--- a/spec/features/dashboard_feature_spec.rb
+++ b/spec/features/dashboard_feature_spec.rb
@@ -7,8 +7,8 @@ feature 'get dashboard' do
     visit '/'
 
     expect(page).to have_css('.dashboard-row', count: 3)
-    expect(page).to have_link('Allocated prisoners', href: summary_path(anchor: 'allocated'))
-    expect(page).to have_link('Awaiting allocation', href: summary_path(anchor: 'awaiting-allocation'))
-    expect(page).to have_link('Awaiting information', href: summary_path(anchor: 'awaiting-information'))
+    expect(page).to have_link('See all allocated prisoners', href: summary_path(anchor: 'allocated'))
+    expect(page).to have_link('Make new allocations', href: summary_path(anchor: 'awaiting-allocation'))
+    expect(page).to have_link('Update case information', href: summary_path(anchor: 'awaiting-information'))
   end
 end


### PR DESCRIPTION
This PR changes some of the content in the following pages:

* Summary
* Edit case info
* Allocate an offender

At the same time the tables in the allocate an offender page have been
changed to use govuk styles to ensure a 50/50 layout and the custom
style removed.

The full list of changes, and a link to the prototype are in https://trello.com/c/yPqHV4QV/515-content-design-updates-for-w-c-25-02-2019 