### PR TITLE
Show previous allocations when allocating a POM

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -3,12 +3,16 @@ class AllocationsController < ApplicationController
 
   def new
     @prisoner = prisoner(nomis_offender_id_from_url)
+    @previously_allocated_pom_ids =
+      AllocationService.previously_allocated_poms(nomis_offender_id_from_url)
     @recommended_poms, @not_recommended_poms =
       recommended_and_nonrecommended_poms_for(@prisoner)
   end
 
   def edit
     @prisoner = prisoner(nomis_offender_id_from_url)
+    @previously_allocated_pom_ids =
+      AllocationService.previously_allocated_poms(nomis_offender_id_from_url)
     @recommended_poms, @not_recommended_poms =
       recommended_and_nonrecommended_poms_for(@prisoner)
     @current_pom = current_pom_for(nomis_offender_id_from_url)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -9,7 +9,7 @@ class AllocationService
         get_pom_detail(params[:nomis_staff_id]).id
 
       Allocation.create!(params) do |alloc|
-        alloc.active = true
+        alloc.active = params.fetch(:active, true)
         alloc.save!
       end
     }
@@ -28,6 +28,12 @@ class AllocationService
         a
       ]
     }.to_h
+  end
+
+  def self.previously_allocated_poms(nomis_offender_id)
+    Allocation.where(
+      nomis_offender_id: nomis_offender_id, active: false
+    ).map(&:nomis_staff_id)
   end
 
   def self.create_override(params)

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -23,7 +23,9 @@
   <% @recommended_poms.each_with_index do |pom, i| %>
     <tr class="govuk-table__row recommended_pom_row_<%= i %>">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
-      <td aria-label="Previous allocation" class="govuk-table__cell">-</td>
+      <td aria-label="Previous allocation" class="govuk-table__cell">
+        <%= 'Yes' if @previously_allocated_pom_ids.include?(pom.staff_id) %>
+      </td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>
       <td aria-label="Tier B cases" class="govuk-table__cell "><%= pom.tier_b %></td>
       <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
@@ -79,7 +81,9 @@
       <% @not_recommended_poms.each_with_index do |pom, i| %>
         <tr class="govuk-table__row not_recommended_pom_row_<%= i %>">
           <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
-          <td aria-label="Previous allocation" class="govuk-table__cell">-</td>
+          <td aria-label="Previous allocation" class="govuk-table__cell">
+            <%= 'Yes' if @previously_allocated_pom_ids.include?(pom.staff_id) %>
+          </td>
           <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>
           <td aria-label="Tier B cases" class="govuk-table__cell "><%= pom.tier_b %></td>
           <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -10,7 +10,7 @@ feature 'Allocation' do
       nomis_staff_id: probation_officer_nomis_staff_id,
       working_pattern: 1.0,
       status: 'Active'
-  )
+    )
   }
 
   let!(:case_information) {

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -12,9 +12,32 @@ RSpec.describe AllocationService do
     )
   }
 
+  let(:inactive_allocation) {
+    described_class.create_allocation(
+      nomis_staff_id: 485_595,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 0,
+      allocated_at_tier: 'A',
+      prison: 'LEI',
+      active: false
+    )
+  }
+
   it "Can get the active allocations", vcr: { cassette_name: 'allocation_service_get_allocations' } do
     alloc = described_class.active_allocations([allocation.nomis_offender_id])
     expect(alloc).to be_instance_of(Hash)
+  end
+
+  it "Can get previous allocations for an offender where there are none", vcr: { cassette_name: 'allocation_service_previous_allocations_none' } do
+    staff_ids = described_class.previously_allocated_poms(allocation.nomis_offender_id)
+    expect(staff_ids).to eq([])
+  end
+
+  it "Can get previous allocations for an offender where there are some", vcr: { cassette_name: 'allocation_service_previous_allocations' } do
+    staff_ids = described_class.previously_allocated_poms(inactive_allocation.nomis_offender_id)
+    expect(staff_ids.count).to eq(1)
+    expect(staff_ids.first).to eq(485_595)
   end
 
   it "can deallocate for a POM", vcr: { cassette_name: 'allocation_service_deallocate_a_pom' } do


### PR DESCRIPTION
When we allocate a POM to an offender, we also show in the list of
available POMs, which one has a previous allocation with that offender.
This is regardless of where and when, essentially a non-active
allocation between the two.