### PR TITLE
Optimise the check for 'has caseinfo'.

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -3,7 +3,8 @@ class CaseInformationController < ApplicationController
 
   def new
     @case_info = CaseInformation.new(
-      nomis_offender_id: nomis_offender_id_from_url
+      nomis_offender_id: nomis_offender_id_from_url,
+      prison: caseload
     )
 
     @prisoner = prisoner(nomis_offender_id_from_url)
@@ -11,7 +12,8 @@ class CaseInformationController < ApplicationController
 
   def edit
     @case_info = CaseInformation.find_by(
-      nomis_offender_id: nomis_offender_id_from_url
+      nomis_offender_id: nomis_offender_id_from_url,
+      prison: caseload
     )
 
     @prisoner = prisoner(nomis_offender_id_from_url)
@@ -22,7 +24,8 @@ class CaseInformationController < ApplicationController
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
       welsh_address: case_information_params[:welsh_address],
-      case_allocation: case_information_params[:case_allocation]
+      case_allocation: case_information_params[:case_allocation],
+      prison: caseload
     )
 
     return redirect_to summary_pending_path if @case_info.valid?
@@ -35,6 +38,7 @@ class CaseInformationController < ApplicationController
     case_info = CaseInformation.find_by(
       nomis_offender_id: case_information_params[:nomis_offender_id]
     )
+    case_info.prison = caseload
     case_info.tier = case_information_params[:tier]
     case_info.case_allocation = case_information_params[:case_allocation]
     case_info.welsh_address = case_information_params[:welsh_address]

--- a/app/services/case_information_service.rb
+++ b/app/services/case_information_service.rb
@@ -1,0 +1,8 @@
+class CaseInformationService
+  def self.get_case_information(prison)
+    cases = CaseInformation.where(prison: prison)
+    cases.each_with_object({}) do |c, hash|
+      hash[c.nomis_offender_id] = c
+    end
+  end
+end

--- a/db/migrate/20190301092256_add_prison_to_case_info.rb
+++ b/db/migrate/20190301092256_add_prison_to_case_info.rb
@@ -1,0 +1,9 @@
+class AddPrisonToCaseInfo < ActiveRecord::Migration[5.2]
+  def up
+    add_column :case_information, :prison, :text
+  end
+
+  def down
+    remove_column :case_information, :prison
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_26_132354) do
+ActiveRecord::Schema.define(version: 2019_03_01_092256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2019_02_26_132354) do
     t.string "case_allocation"
     t.string "nomis_offender_id"
     t.text "welsh_address"
+    t.text "prison"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,23 +53,27 @@ AllocationService.create_allocation(
 CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G7806VO',
   tier: 'A',
-  case_allocation: 'NPS'
+  case_allocation: 'NPS',
+  prison: 'LEI'
 )
 
 CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G3462VT',
   tier: 'B',
-  case_allocation: 'NPS'
+  case_allocation: 'NPS',
+  prison: 'LEI'
 )
 
 CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G3536UF',
   tier: 'C',
-  case_allocation: 'CRC'
+  case_allocation: 'CRC',
+  prison: 'LEI'
 )
 
 CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G2911GD',
   tier: 'D',
-  case_allocation: 'CRC'
+  case_allocation: 'CRC',
+  prison: 'LEI'
 )

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -14,7 +14,7 @@ feature 'Allocation' do
   }
 
   let!(:case_information) {
-    CaseInformation.create!(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_address: 'No')
+    CaseInformation.create!(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_address: 'No', prison: 'LEI')
   }
 
   scenario 'accepting a recommended allocation', vcr: { cassette_name: :create_allocation_feature } do

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -5,7 +5,7 @@ feature "edit a POM's details" do
   let(:nomis_offender_id) { 'G4273GI' }
 
   before do
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC', welsh_address: 'Yes')
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC', welsh_address: 'Yes', prison: 'LEI')
   end
 
   it "makes an inactive POM active", vcr: { cassette_name: :edit_poms_activate_pom_feature } do

--- a/spec/features/view_allocations_spec.rb
+++ b/spec/features/view_allocations_spec.rb
@@ -5,7 +5,7 @@ feature "view POM's caseload" do
   let(:nomis_offender_id) { 'G4273GI' }
 
   before do
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_address: 'Yes')
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_address: 'Yes', prison: 'LEI')
   end
 
   it 'displays all cases for a specific POM',  vcr: { cassette_name: :show_poms_caseload } do

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -18,7 +18,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     nomis_offender_id = 'G4273GI'
 
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_address: 'Yes')
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_address: 'Yes', prison: 'LEI')
     offender = OffenderService.get_offender(nomis_offender_id)
 
     expect(offender).to be_kind_of(Nomis::Models::Offender)


### PR DESCRIPTION
Currently when we are returning the list of offenders for the summary
page, we do so in blocks of N at a time.  We then send a query with a
subselect for CaseInformation objects.  This is very slow.

This PR adds a prison field to the case information, which means we can
get them all at once for a given prison (and summary page).  The
downside is that if there is an offender movement, we need to change
this field (but that is recorded in another ticket).

Once deployed to staging, we should run ..

```
update case_information set prison='LEI';
```

against the database.

Also included is a test for sorting to ensure coverage as it seems to
not have been in the last PR.