### PR TITLE
Installs a cache for some API calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 gem 'loaf'
 gem 'typhoeus'
+gem 'api_cache'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    api_cache (0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.5.0)
@@ -289,6 +290,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  api_cache
   bootsnap (>= 1.1.0)
   brakeman
   byebug

--- a/app/services/nomis/elite2/prison_offender_manager_api.rb
+++ b/app/services/nomis/elite2/prison_offender_manager_api.rb
@@ -1,3 +1,5 @@
+require 'api_cache'
+
 module Nomis
   module Elite2
     class PrisonOffenderManagerApi
@@ -6,8 +8,11 @@ module Nomis
       def self.list(prison)
         route = "/elite2api/api/staff/roles/#{prison}/role/POM"
 
-        response = e2_client.get(route) { |data|
-          raise Nomis::Elite2::Client::APIError, 'No data was returned' if data.empty?
+        key = "pom_list_#{prison}"
+        response = APICache.get(key, cache: 600) {
+          e2_client.get(route) { |data|
+            raise Nomis::Elite2::Client::APIError, 'No data was returned' if data.empty?
+          }
         }
 
         response.map { |pom|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,9 @@ if ENV['CIRCLE_ARTIFACTS']
   SimpleCov.coverage_dir(dir)
 end
 
+require 'api_cache'
+APICache.store = APICache::NullStore.new
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Because getting a list of offenders is slow, and because we get a list
of POMs all the time, this PR introduces APICache.

Currently this uses an in-memory cache for the calls, but can reasonably
easily be extended to point at Redis (in another PR).