### PR TITLE
Configures REDIS and api_cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'loaf'
 gem 'typhoeus'
 gem 'api_cache'
+gem 'redis'
+gem 'moneta', '>= 1.0'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    moneta (1.0.0)
     msgpack (1.2.6)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -187,6 +188,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.0)
     regexp_parser (1.3.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -306,11 +308,13 @@ DEPENDENCIES
   loaf
   lograge
   logstash-event
+  moneta (>= 1.0)
   omniauth-oauth2
   pg
   prometheus_exporter
   puma (~> 3.11)
   rails (~> 5.2.2)
+  redis
   rspec-rails
   rubocop
   rubocop-rspec

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -56,7 +56,12 @@ module Nomis
 
         route = '/elite2api/api/offender-sentences'
 
-        data = e2_client.post(route, offender_ids)
+        h = Digest::SHA256.hexdigest( offender_ids.to_s )
+        key = "bulk_sentence_#{h}"
+
+        data = APICache.get(key, cache: 300) {
+          e2_client.post(route, offender_ids)
+        }
 
         data.each_with_object({}) { |record, hash|
           oid = record['offenderNo']

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -66,7 +66,9 @@ module Nomis
 
           data.each_with_object({}) { |record, hash|
             oid = record['offenderNo']
-            hash[oid] = api_deserialiser.deserialise(Nomis::Models::SentenceDetail, record)
+            hash[oid] = api_deserialiser.deserialise(
+              Nomis::Models::SentenceDetail, record
+            )
           }
         }
       end

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -51,12 +51,13 @@ module Nomis
         data.first['offenceDescription']
       end
 
+      # rubocop:disable Metrics/MethodLength
       def self.get_bulk_sentence_details(offender_ids)
         return {} if offender_ids.empty?
 
         route = '/elite2api/api/offender-sentences'
 
-        h = Digest::SHA256.hexdigest( offender_ids.to_s )
+        h = Digest::SHA256.hexdigest(offender_ids.to_s)
         key = "bulk_sentence_#{h}"
 
         data = APICache.get(key, cache: 300) {
@@ -68,6 +69,7 @@ module Nomis
           hash[oid] = api_deserialiser.deserialise(Nomis::Models::SentenceDetail, record)
         }
       end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/services/nomis/elite2/prison_offender_manager_api.rb
+++ b/app/services/nomis/elite2/prison_offender_manager_api.rb
@@ -10,13 +10,13 @@ module Nomis
 
         key = "pom_list_#{prison}"
         response = APICache.get(key, cache: 600) {
-          e2_client.get(route) { |data|
+          response = e2_client.get(route) { |data|
             raise Nomis::Elite2::Client::APIError, 'No data was returned' if data.empty?
           }
-        }
 
-        response.map { |pom|
-          api_deserialiser.deserialise(Nomis::Models::PrisonOffenderManager, pom)
+          response.map { |pom|
+            api_deserialiser.deserialise(Nomis::Models::PrisonOffenderManager, pom)
+          }
         }
       end
     end

--- a/app/services/nomis/elite2/prison_offender_manager_api.rb
+++ b/app/services/nomis/elite2/prison_offender_manager_api.rb
@@ -9,7 +9,7 @@ module Nomis
         route = "/elite2api/api/staff/roles/#{prison}/role/POM"
 
         key = "pom_list_#{prison}"
-        response = APICache.get(key, cache: 600) {
+        APICache.get(key, cache: 600) {
           response = e2_client.get(route) { |data|
             raise Nomis::Elite2::Client::APIError, 'No data was returned' if data.empty?
           }

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,7 @@ module OffenderManagementAllocationClient
     config.notify_api_key = ENV['GOVUK_NOTIFY_API_KEY']
     config.ga_tracking_id = ENV['GA_TRACKING_ID']
     config.support_email = ENV['SUPPORT_EMAIL']
+    config.redis_url = ENV['REDIS_URL']
+    config.redis_auth = ENV['REDIS_AUTH']
   end
 end

--- a/config/initializers/apicache.rb
+++ b/config/initializers/apicache.rb
@@ -1,0 +1,12 @@
+def build_redis_url
+  if Rails.env.production?
+    "rediss://:#{Rails.configuration.redis_auth}@#{Rails.configuration.redis_url}:6379/"
+  end
+
+  "redis://:#{Rails.configuration.redis_auth}@#{Rails.configuration.redis_url}:6379/"
+end
+
+if Rails.configuration.redis_url.present?
+  require 'moneta'
+  APICache.store = Moneta.new(:Redis, url: build_redis_url)
+end

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -115,6 +115,14 @@ spec:
                 secretKeyRef:
                   name: allocation-manager-secrets
                   key: support_email
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef: elasticache-offender-management-allocation-manager-token-cache-production
+                key: primary_endpoint_address
+            - name: REDIS_AUTH
+              valueFrom:
+                secretKeyRef: elasticache-offender-management-allocation-manager-token-cache-production
+                key: auth_token
         - name: allocation-manager-metrics
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -115,6 +115,14 @@ spec:
                 secretKeyRef:
                   name: allocation-manager-secrets
                   key: support_email
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef: elasticache-offender-management-allocation-manager-token-cache-staging
+                key: primary_endpoint_address
+            - name: REDIS_AUTH
+              valueFrom:
+                secretKeyRef: elasticache-offender-management-allocation-manager-token-cache-staging
+                key: auth_token
         - name: allocation-manager-metrics
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always


### PR DESCRIPTION
Configures the new REDIS instance, and tells api_cache to use it. This
should hopefully work well enough for the short-term but is unlikely to
be a good long-term solution.

Requires a bundle install.