### PR TITLE
Show responsibility on Make Allocations page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,11 @@ module ApplicationHelper
 
     'Part time'
   end
+
+  def responsibility_label(offender_responsibility)
+    {
+      'Probation' => 'Community',
+      'Prison' => 'Prison'
+    }[offender_responsibility]
+  end
 end

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -22,7 +22,9 @@
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= offender.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell"><%= offender.offender_no %></td>
         <td aria-label="Release/parole eligibility" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
-        <td aria-label="Responsibility" class="govuk-table__cell"> NEW-FIELD </td>
+        <td aria-label="Responsibility" class="govuk-table__cell">
+          <%= responsibility_label(ResponsibilityService.calculate_responsibility(offender)) %>
+        </td>
         <td aria-label="Awaiting allocation for" class="govuk-table__cell">
           <%= offender.awaiting_allocation_for %> days
         </td>


### PR DESCRIPTION
This is a presentation only change, so uses a helper to choose what to
display.  The use of Probation/Prison - Community/Probation is being
discussed and so there are no changes to any of the underlying
terminology.

We rely in a few places on the offender's responsibility to generate the
POM title (see Reponsibility section in allocate an offender).  This is
currently Probation POM but we don't want to change this to Community
POM based on a change of text when calculating the reponsibility.