### PR TITLE
Fix small auth bug

### DIFF
--- a/app/models/signon_identity.rb
+++ b/app/models/signon_identity.rb
@@ -1,6 +1,8 @@
 class SignonIdentity
   class << self
     def from_omniauth(omniauth_data)
+      return nil if omniauth_data.blank?
+
       new(omniauth_data)
     end
   end

--- a/spec/models/signon_identity_spec.rb
+++ b/spec/models/signon_identity_spec.rb
@@ -28,15 +28,4 @@ describe SignonIdentity, model: true do
 
     expect(signon_identity.to_session).to eq(session)
   end
-
-  it 'creates session data' do
-    session = {
-      username: 'Fred',
-      active_caseload: 'LEI',
-      caseloads: %w[LEI RNI],
-      expiry: time_stamp
-    }
-
-    expect(signon_identity.to_session).to eq(session)
-  end
 end

--- a/spec/models/signon_identity_spec.rb
+++ b/spec/models/signon_identity_spec.rb
@@ -13,6 +13,22 @@ describe SignonIdentity, model: true do
     expect(signon_identity).to be_a_kind_of(SignonIdentity)
   end
 
+  it 'does not crash if from_omniauth fails' do
+    ident = SignonIdentity.from_omniauth(nil)
+    expect(ident).to be_nil
+  end
+
+  it 'creates session data' do
+    session = {
+      username: 'Fred',
+      active_caseload: 'LEI',
+      caseloads: %w[LEI RNI],
+      expiry: time_stamp
+    }
+
+    expect(signon_identity.to_session).to eq(session)
+  end
+
   it 'creates session data' do
     session = {
       username: 'Fred',


### PR DESCRIPTION
Although users shouldn't access this directly, there was an issue with
the SingleSignon model where it would crash if it was not passed valid
data from omniauth.