### PR TITLE
Handle 204 responses from API calls

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -18,11 +18,20 @@ module Nomis
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     def get(route, queryparams: {}, extra_headers: {})
       response = request(
         :get, route, queryparams: queryparams, extra_headers: extra_headers
       )
-      data = JSON.parse(response.body)
+
+      # Elite2 can return a 204 to mean empty results, and we don't know if
+      # it is meant to be a {} or a []. For now, we are going to use nil and
+      # let the caller handle it.
+      if response.status == 204
+        data = nil
+      else
+        data = JSON.parse(response.body)
+      end
 
       if block_given?
         yield data, response
@@ -37,6 +46,7 @@ module Nomis
       )
       JSON.parse(response.body)
     end
+  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/app/services/nomis/elite2/user_api.rb
+++ b/app/services/nomis/elite2/user_api.rb
@@ -5,7 +5,10 @@ module Nomis
 
       def self.fetch_email_addresses(nomis_staff_id)
         route = "/elite2api/api/staff/#{nomis_staff_id}/emails"
-        e2_client.get(route)
+        data = e2_client.get(route)
+        return [] if data.nil?
+
+        data
       end
     end
   end


### PR DESCRIPTION
Elite2, in places, uses 204 (no content) to mean that there was
nothing to return, but that the call succeeded. This means however we do
not know whether the intended type of the response was [] or {}.  As it
would be dangerous for us to guess, instead we will return nil from
Client#get and leave it up to the caller to determine the correct type.