### PR TITLE
Implements search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+.DS_Store
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,5 +1,8 @@
 
 .pagination {
+    font-family: "nta", Arial, sans-serif;
+    font-size: 19px;
+
     .result-count {
         text-align: right;
     }

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,0 +1,21 @@
+
+
+.search-box {
+    background-color:#f9f9f9;
+    padding: 12px;
+
+    input[type=text] {
+        width: 80%;
+    }
+
+    input[type=submit] {
+        margin-left: 20px;
+    }
+}
+
+mark {
+    border-bottom: 3px solid #ffbf47;
+    margin-right: 1px;
+    background-color: #fff2d3;
+    padding: 2px 0px 0px;
+}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,14 +15,17 @@ class SearchController < ApplicationController
 
 private
 
-  # At this point @offenders contains ALL of the offenders at the prison that
-  # match the search term. We will only show 10 at a time, so there is no need
-  # to get the allcocated POM name for all of them.
   def get_slice_for_page(offenders, page_number)
     start = [(page_number - 1) * 10, 0].max
     slice = offenders.slice(start, 10)
 
+    # At this point offenders contains ALL of the offenders at the prison that
+    # match the search term, slice is the current page worth of offenders.
+    # We will only show 10 at a time, so there is no need
+    # to get the allocated POM name for offenders, we will just get them
+    # for the much smaller slice.
     OffenderService.set_allocated_pom_name(slice, active_caseload)
+
     slice
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -27,8 +27,6 @@ private
     # to get the allocated POM name for offenders, we will just get them
     # for the much smaller slice.
     OffenderService.set_allocated_pom_name(slice, active_caseload)
-
-    slice
   end
 
   def create_page_meta(total_records, current_view)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,6 +3,8 @@ class SearchController < ApplicationController
 
   breadcrumb 'Search', :search_path, only: [:search]
 
+  PAGE_SIZE = 10
+
   def search
     @q = search_term
 
@@ -16,12 +18,12 @@ class SearchController < ApplicationController
 private
 
   def get_slice_for_page(offenders, page_number)
-    start = [(page_number - 1) * 10, 0].max
-    slice = offenders.slice(start, 10)
+    start = [(page_number - 1) * PAGE_SIZE, 0].max
+    slice = offenders.slice(start, PAGE_SIZE)
 
     # At this point offenders contains ALL of the offenders at the prison that
     # match the search term, slice is the current page worth of offenders.
-    # We will only show 10 at a time, so there is no need
+    # We will only show PAGE_SIZE at a time, so there is no need
     # to get the allocated POM name for offenders, we will just get them
     # for the much smaller slice.
     OffenderService.set_allocated_pom_name(slice, active_caseload)
@@ -31,8 +33,8 @@ private
 
   def create_page_meta(total_records, current_view)
     PageMeta.new.tap{ |p|
-      p.size = 10
-      p.total_pages = (total_records / 10.0).ceil
+      p.size = PAGE_SIZE
+      p.total_pages = (total_records / PAGE_SIZE.to_f).ceil
       p.total_elements = total_records
       p.number = page
       p.items_on_page = current_view

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,46 @@
+class SearchController < ApplicationController
+  before_action :authenticate_user
+
+  breadcrumb 'Search', :search_path, only: [:search]
+
+  def search
+    @q = search_term
+
+    offenders = SearchService.search_for_offenders(@q, active_caseload)
+    total = offenders.count
+
+    @offenders = get_slice_for_page(offenders, page)
+    @page_meta = create_page_meta(total, @offenders.count)
+  end
+
+private
+
+  # At this point @offenders contains ALL of the offenders at the prison that
+  # match the search term. We will only show 10 at a time, so there is no need
+  # to get the allcocated POM name for all of them.
+  def get_slice_for_page(offenders, page_number)
+    start = [(page_number - 1) * 10, 0].max
+    slice = offenders.slice(start, 10)
+
+    OffenderService.set_allocated_pom_name(slice, active_caseload)
+    slice
+  end
+
+  def create_page_meta(total_records, current_view)
+    PageMeta.new.tap{ |p|
+      p.size = 10
+      p.total_pages = (total_records / 10.0).ceil
+      p.total_elements = total_records
+      p.number = page
+      p.items_on_page = current_view
+    }
+  end
+
+  def page
+    params.fetch('page', 1).to_i
+  end
+
+  def search_term
+    params['q']
+  end
+end

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -31,8 +31,7 @@ private
 
     params = SummaryService::SummaryParams.new(
       sort_field: field,
-      sort_direction: direction,
-      search: search_term
+      sort_direction: direction
     )
 
     SummaryService.new.summary(
@@ -42,10 +41,6 @@ private
 
   def page
     params.fetch('page', 1).to_i
-  end
-
-  def search_term
-    params['q']
   end
 
   def sort_params(summary_type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,12 @@ module ApplicationHelper
     date_obj.strftime('%d/%m/%Y')
   end
 
+  def format_date_string(date_string)
+    return '' if date_string.nil?
+
+    Date.parse(date_string).strftime('%d/%m/%Y')
+  end
+
   def pom_level(level)
     {
       'PO' => 'Prison POM',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
   end
 
   def format_date_string(date_string)
-    return '' if date_string.nil?
+    return '' if date_string.empty?
 
     Date.parse(date_string).strftime('%d/%m/%Y')
   end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,23 @@
+module SearchHelper
+  # rubocop:disable Metrics/MethodLength
+  def cta_for_offender(offender)
+    offender_id = offender.offender_no
+
+    if offender.tier.blank?
+      return link_to(
+        'Edit',
+        new_case_information_path(nomis_offender_id: offender_id)
+      )
+    end
+
+    if offender.allocated_pom_name.blank?
+      return link_to(
+        'Allocate',
+        new_allocations_path(nomis_offender_id: offender_id)
+      )
+    end
+
+    link_to('Reallocate', new_allocations_path(nomis_offender_id: offender_id))
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/app/models/page_meta.rb
+++ b/app/models/page_meta.rb
@@ -18,10 +18,6 @@ class PageMeta
     number
   end
 
-  def page_count
-    total_pages
-  end
-
   def previous?
     current_page > 1
   end

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -45,6 +45,7 @@ module Nomis
       response = request(
         :post, route, body: body
       )
+
       JSON.parse(response.body)
     end
   # rubocop:enable Metrics/MethodLength

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -33,6 +33,7 @@ module Nomis
       attribute :tier, :string
       attribute :case_allocation, :string
       attribute :welsh_address, :boolean
+      attribute :allocated_pom_name, :string
 
       def current_responsibility
         @current_responsibility = ResponsibilityService.calculate_responsibility(self)

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -68,7 +68,7 @@ class OffenderService
     ).preload(:pom_detail)
   end
 
-  # Takes a list of OffenderShort objects, and returns them with their
+  # Takes a list of OffenderShort or Offender objects, and returns them with their
   # allocated POM name set in :allocated_pom_name
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/LineLength

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,0 +1,46 @@
+class SearchService
+  # Fetch all of the offenders (for a given prison) filtering
+  # out offenders based on the provided text.
+  # rubocop:disable Metrics/MethodLength
+  def self.search_for_offenders(text, prison)
+    number_of_requests = max_requests_count(prison)
+    tier_map = CaseInformationService.get_case_information(prison)
+
+    search_term = text.upcase
+    search_results = []
+
+    (0..number_of_requests).each do |request_no|
+      offenders = OffenderService.get_offenders_for_prison(
+        prison,
+        page_number: request_no,
+        page_size: 250,
+        tier_map: tier_map
+      )
+      break if offenders.blank?
+
+      new_offenders = offenders.select { |offender|
+        offender.last_name.start_with?(search_term) ||
+        offender.first_name.start_with?(search_term) ||
+        offender.offender_no.include?(search_term)
+      }
+      next if new_offenders.blank?
+
+      search_results += new_offenders
+    end
+
+    search_results
+  end
+# rubocop:enable Metrics/MethodLength
+
+private
+
+  def self.max_requests_count(prison)
+    # Fetch the first 1 prisoners just for the total number of pages so that we
+    # can send batched queries.
+    info_request = Nomis::Elite2::OffenderApi.list(prison, 1, page_size: 1)
+
+    # The maximum number of pages we need to fetch before we have all of
+    # the offenders
+    (info_request.meta.total_pages / 250) + 1
+  end
+end

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -5,10 +5,9 @@ class SummaryService
   class SummaryParams
     attr_reader :sort_field, :sort_direction, :search
 
-    def initialize(sort_field: nil, sort_direction: :asc, search: nil)
+    def initialize(sort_field: nil, sort_direction: :asc)
       @sort_field = sort_field
       @sort_direction = sort_direction
-      @search = search
     end
   end
 
@@ -22,7 +21,7 @@ class SummaryService
 
     # We want to store the total number of each item so we can show totals for
     # each type of record.
-    @counts = { allocated: 0, unallocated: 0, pending: 0 }
+    @counts = { allocated: 0, unallocated: 0, pending: 0, all: 0 }
 
     tier_map = CaseInformationService.get_case_information(prison)
 
@@ -30,15 +29,6 @@ class SummaryService
     (0..number_of_requests).each do |request_no|
       offenders = get_page_of_offenders(prison, request_no, tier_map)
       break if offenders.blank?
-
-      if params.search.present?
-        search_term = params.search.upcase
-        offenders = offenders.select { |offender|
-          offender.last_name.start_with?(search_term) ||
-          offender.first_name.start_with?(search_term) ||
-          offender.offender_no.include?(search_term)
-        }
-      end
 
       # Group the offenders without a tier, and the remaining ones
       # are either allocated or unallocated

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,9 @@
 <h1 class="govuk-heading-xl">Dashboard</h1>
 
+<div class="govuk-!-margin-bottom-6 govuk-!-margin-top-6">
+<%= render "search/search_box" %>
+</div>
+
 <h2 class="govuk-heading-m no-bottom-margin">Allocate a prisoner to an offender manager</h2>
 <hr class="govuk-section-break govuk-section-break--visible">
 <div class="govuk-grid-row dashboard-row">

--- a/app/views/search/_search_box.html.erb
+++ b/app/views/search/_search_box.html.erb
@@ -1,0 +1,13 @@
+
+<div class="search-box govuk-grid-row">
+  <%= form_tag(search_path, method: :get, id: "search_form") do %>
+    <div class="govuk-form-group" style="display: inline;" >
+      <label class="govuk-label" for="q">
+        Enter a prisoner name or number
+      </label>
+      <input class="govuk-input" id="q" name="q" type="text" value="<%= @q %>" autofocus="true">
+
+      <input id="search-button" type="submit" class="govuk-button" value="    Search    "/>
+    </div>
+  <% end %>
+</div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,0 +1,50 @@
+
+<h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Search</h1>
+
+<%= render 'search/search_box' %>
+
+<div>
+
+<% if @offenders.blank? %>
+<p>
+  No offenders were found. Please try a different search.
+</p>
+<% else %>
+  <table class="govuk-table responsive tablesorter govuk-!-margin-top-4">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Prisoner name</th>
+      <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
+      <th class="govuk-table__header sorter-false" scope="col">Date of birth</th>
+      <th class="govuk-table__header sorter-false" scope="col">Tier</th>
+      <th class="govuk-table__header" scope="col">POM</th>
+      <th class="govuk-table__header" scope="col"><a
+      <th class="govuk-table__header sorter-false" scope="col">Action</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% @offenders.each_with_index do |offender, i| %>
+      <tr class="govuk-table__row allocated_offender_row_<%= i %>">
+        <td aria-label="Prisoner name" class="govuk-table__cell"><%= highlight(offender.full_name, @q) %></td>
+        <td aria-label="Prisoner number" class="govuk-table__cell"><%= highlight(offender.offender_no, @q) %></td>
+        <td aria-label="Date of birth" class="govuk-table__cell"><%= format_date_string(offender.date_of_birth) %></td>
+        <td aria-label="Tier" class="govuk-table__cell"><%= offender.tier || '-' %></td>
+        <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name || '-' %></td>
+        <td aria-label="Action" class="govuk-table__cell "><%=
+          cta_for_offender(offender)
+        %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+
+<%= render(
+          :partial => 'shared/pagination',
+          :locals => {
+              :page_data => @page_meta,
+              :param_name => 'page',
+          }) %>
+
+</div>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get('/summary/unallocated' => 'summary#unallocated')
   get('/summary/pending' => 'summary#pending')
 
+  get('/search' => 'search#search')
 
   resources :health, only: %i[ index ], controller: 'health'
   resources :status, only: %i[ index ], controller: 'status'

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+feature 'Search for offenders' do
+  it 'Can search from the dashboard', vcr: { cassette_name: :search_feature } do
+    signin_user
+    visit root_path
+
+    expect(page).to have_text('Dashboard')
+    fill_in 'q', with: 'Cal'
+    click_on('search-button')
+
+    expect(page).to have_current_path(search_path, ignore_query: true)
+    expect(page).to have_css('tbody tr', count: 4)
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe 'formatting date strings' do
+    it "will parse dates into strings" do
+      expect(format_date_string('1973-02-21')).to eq('21/02/1973')
+    end
+  end
+
+  describe 'returns the correct label' do
+    it "for service provider CRC" do
+      expect(service_provider_label('CRC')).to eq('Community Rehabilitation Company (CRC)')
+    end
+
+    it "for service provider NPS" do
+      expect(service_provider_label('NPS')).to eq('National Probation Service (NPS)')
+    end
+  end
+end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SearchHelper do
+  describe 'the CTA' do
+    it "will change to edit if there is no tier" do
+      offender = Nomis::Models::Offender.new(
+        offender_no: 'A'
+      )
+      text, _link = cta_for_offender(offender)
+      expect(text).to eq('<a href="/case_information/new/A">Edit</a>')
+    end
+
+    it "will change to allocate if there is no allocation" do
+      offender = Nomis::Models::Offender.new(
+        offender_no: 'A',
+        tier: 'A'
+      )
+      text, _link = cta_for_offender(offender)
+      expect(text).to eq('<a href="/allocations/new/A">Allocate</a>')
+    end
+
+    it "will change to reallocate if there is an allocation" do
+      offender = Nomis::Models::Offender.new(
+        offender_no: 'A',
+        tier: 'A',
+        allocated_pom_name: 'Bob'
+      )
+      text, _link = cta_for_offender(offender)
+      expect(text).to eq('<a href="/allocations/new/A">Reallocate</a>')
+    end
+  end
+end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe SearchService do
+  it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
+    offenders = described_class.search_for_offenders('', 'LEI')
+    expect(offenders.count).to eq(623)
+  end
+
+  it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do
+    offenders = described_class.search_for_offenders('Cal', 'LEI')
+    expect(offenders.count).to eq(4)
+  end
+end

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -9,13 +9,6 @@ describe SummaryService do
     expect(summary.page_count).to eq(63)
   end
 
-  it "can search the summary", vcr: { cassette_name: :allocation_summary_service_summary_search } do
-    params = SummaryService::SummaryParams.new(search: 'AB')
-    summary = described_class.new.summary(:pending, 'LEI', 0, params)
-
-    expect(summary.page_count).to eq(1)
-  end
-
   it "will sort a summary", vcr: { cassette_name: :allocation_summary_service_summary_sort } do
     asc_summary = described_class.new.summary(
       :pending,


### PR DESCRIPTION
Adds a search controller and a search service that allows the user to
search for offenders by providing a string that is matched with their
first name, last name or offender number.

Currently we do this in memory because of missing functionality in
Elite2 but will often be working with offenders from the cache.  There
is no relevance as we are doing partial matches and not searching in a
corpus of documents so we can't use td/idf to determine relevance at
all.