### PR TITLE
Display POM responsibility

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -37,6 +37,7 @@ class AllocationsController < ApplicationController
       prison: active_caseload,
       override_reasons: override_reasons,
       override_detail: override_detail,
+      responsibility: ResponsibilityService.calculate_pom_responsibility(prisoner),
       message: allocation_params[:message]
     )
 
@@ -69,7 +70,7 @@ private
     }
 
     pom_response.partition { |pom|
-      pom.position_description.include?(prisoner.current_responsibility)
+      pom.position_description.include?(prisoner.case_owner)
     }
   end
 

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -3,7 +3,7 @@ class OverridesController < ApplicationController
     @prisoner = OffenderService.get_offender(params.require(:nomis_offender_id))
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, params[:nomis_staff_id])
     @override = Override.new
-    @recommended_pom = ResponsibilityService.calculate_responsibility(@prisoner)
+    @recommended_pom = ResponsibilityService.calculate_case_owner(@prisoner)
 
     @complex_label = complex_reason_label
   end
@@ -20,7 +20,7 @@ class OverridesController < ApplicationController
     return redirect_on_success if @override.valid?
 
     @prisoner = OffenderService.get_offender(override_params[:nomis_offender_id])
-    @recommended_pom = ResponsibilityService.calculate_responsibility(@prisoner)
+    @recommended_pom = ResponsibilityService.calculate_case_owner(@prisoner)
     @pom = PrisonOffenderManagerService.get_pom(
       active_caseload, override_params[:nomis_staff_id])
     @complex_label = complex_reason_label

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -3,7 +3,7 @@ class OverridesController < ApplicationController
     @prisoner = OffenderService.get_offender(params.require(:nomis_offender_id))
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, params[:nomis_staff_id])
     @override = Override.new
-    @recommended_pom = ResponsibilityService.calculate_case_owner(@prisoner)
+    @recommended_case_owner = ResponsibilityService.calculate_case_owner(@prisoner)
 
     @complex_label = complex_reason_label
   end
@@ -20,7 +20,7 @@ class OverridesController < ApplicationController
     return redirect_on_success if @override.valid?
 
     @prisoner = OffenderService.get_offender(override_params[:nomis_offender_id])
-    @recommended_pom = ResponsibilityService.calculate_case_owner(@prisoner)
+    @recommended_case_owner = ResponsibilityService.calculate_case_owner(@prisoner)
     @pom = PrisonOffenderManagerService.get_pom(
       active_caseload, override_params[:nomis_staff_id])
     @complex_label = complex_reason_label
@@ -32,7 +32,7 @@ class OverridesController < ApplicationController
 private
 
   def complex_reason_label
-    if @recommended_pom == 'Prison'
+    if @recommended_case_owner == 'Prison'
       return 'Prisoner assessed as not suitable for a prison officer POM'
     end
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -6,5 +6,6 @@ class Allocation < ApplicationRecord
     :nomis_booking_id,
     :prison,
     :allocated_at_tier,
+    :responsibility,
     :created_by, presence: true
 end

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -35,8 +35,8 @@ module Nomis
       attribute :welsh_address, :boolean
       attribute :allocated_pom_name, :string
 
-      def current_responsibility
-        @current_responsibility = ResponsibilityService.calculate_responsibility(self)
+      def case_owner
+        @current_responsibility ||= ResponsibilityService.calculate_case_owner(self)
       end
 
       def full_name

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -36,7 +36,7 @@ module Nomis
       attribute :allocated_pom_name, :string
 
       def case_owner
-        @current_responsibility ||= ResponsibilityService.calculate_case_owner(self)
+        @case_owner ||= ResponsibilityService.calculate_case_owner(self)
       end
 
       def full_name

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -1,5 +1,5 @@
 class ResponsibilityService
-  def self.calculate_responsibility(offender)
+  def self.calculate_case_owner(offender)
     case offender.case_allocation
     when 'NPS'
       nps_calculation(offender)
@@ -10,9 +10,19 @@ class ResponsibilityService
     end
   end
 
+  def self.calculate_pom_responsibility(offender)
+    return 'Unknown' if offender.release_date.nil?
+    return 'Responsible' if offender.welsh_address == true && release_date_gt_10_months(offender)
+    'Supporting'
+  end
+
   def self.nps_calculation(offender)
     return 'No release date' if offender.release_date.nil?
 
     offender.tier == 'A' || offender.tier == 'B' ? 'Probation' : 'Prison'
+  end
+
+  def self.release_date_gt_10_months(offender)
+    offender.release_date > DateTime.now.utc.to_date + 10.months
   end
 end

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -12,7 +12,8 @@ class ResponsibilityService
 
   def self.calculate_pom_responsibility(offender)
     return 'Unknown' if offender.release_date.nil?
-    return 'Responsible' if offender.welsh_address == true && release_date_gt_10_months(offender)
+    return 'Responsible' if assign_responsible?(offender)
+
     'Supporting'
   end
 
@@ -22,7 +23,8 @@ class ResponsibilityService
     offender.tier == 'A' || offender.tier == 'B' ? 'Probation' : 'Prison'
   end
 
-  def self.release_date_gt_10_months(offender)
-    offender.release_date > DateTime.now.utc.to_date + 10.months
+  def self.assign_responsible?(offender)
+    offender.welsh_address == true &&
+      offender.release_date > DateTime.now.utc.to_date + 10.months
   end
 end

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -7,7 +7,7 @@
   <tr class="govuk-table__row">
     <td class="govuk-table__cell govuk-!-width-one-half">Current case owner</td>
     <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-      <%= responsibility_label(@prisoner.current_responsibility) %>
+      <%= responsibility_label(@prisoner.case_owner) %>
         <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
     </td>
   </tr>

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -1,5 +1,5 @@
 <h4 class="govuk-heading-m">
-  Recommendation: <%= @prisoner.current_responsibility %> POM
+  Recommendation: <%= @prisoner.case_owner %> POM
 </h4>
 
 <p>This recommendation takes the prisoner's tier and
@@ -7,7 +7,7 @@ time left to serve into account.</p>
 
 <table class="govuk-table responsive">
   <thead class="govuk-table__head">
-  <h2 class="govuk-heading-s">Active <%= @prisoner.current_responsibility.downcase %> POMs</h2>
+  <h2 class="govuk-heading-s">Active <%= @prisoner.case_owner.downcase %> POMs</h2>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="col">Name</th>
     <th class="govuk-table__header" scope="col">Previous<br/>allocation</th>
@@ -54,7 +54,7 @@ time left to serve into account.</p>
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      <% if @prisoner.current_responsibility == 'Probation' %>
+      <% if @prisoner.case_owner == 'Probation' %>
         Show active prison officer POMs
       <% else %>
         Show active probation officer POMs

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -8,8 +8,8 @@
     <%= form_tag(overrides_path, method: :post, id: "override_form")  do %>
 
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">
-        <%= "Why are you allocating a probation officer POM?" if @recommended_pom == 'Prison' %>
-        <%= "Why are you allocating a prison officer POM?" if @recommended_pom == 'Probation' %>
+        <%= "Why are you allocating a probation officer POM?" if @recommended_case_owner == 'Prison' %>
+        <%= "Why are you allocating a prison officer POM?" if @recommended_case_owner == 'Probation' %>
       </h1>
       <div class='govuk-!-margin-top-4'>
         <div class="govuk-form-group <% if @override.errors[:override_reasons].present? %>govuk-form-group--error<% end %>">
@@ -26,7 +26,7 @@
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "no-staff", override_reason_contains(@override, 'no-staff'), id: "override-2", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "No available #{@recommended_pom.downcase} officer POMs", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= label_tag "override[override_reasons][]", "No available #{@recommended_case_owner.downcase} officer POMs", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "continuity", override_reason_contains(@override, 'continuity'), id: "override-3", class: "govuk-checkboxes__input") %>

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -23,7 +23,7 @@
       <td aria-label="Release date" class="govuk-table__cell "><%= sentence.release_date %></td>
       <td aria-label="Tier" class="govuk-table__cell "><%= allocation.allocated_at_tier %></td>
       <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
-      <td aria-label="Role" class="govuk-table__cell ">N/A</td>
+      <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/poms/my_caseload.html.erb
+++ b/app/views/poms/my_caseload.html.erb
@@ -39,7 +39,7 @@
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
       <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
       <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
-      <td aria-label="Role" class="govuk-table__cell ">N/A</td>
+      <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/poms/new_cases.html.erb
+++ b/app/views/poms/new_cases.html.erb
@@ -27,7 +27,7 @@
         <td aria-label="Arrival date" class="govuk-table__cell ">ARRIVAL DATE</td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
-        <td aria-label="Role" class="govuk-table__cell ">ROLE</td>
+        <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -23,7 +23,7 @@
         <td aria-label="Prisoner number" class="govuk-table__cell"><%= offender.offender_no %></td>
         <td aria-label="Release/parole eligibility" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
         <td aria-label="Responsibility" class="govuk-table__cell">
-          <%= responsibility_label(ResponsibilityService.calculate_responsibility(offender)) %>
+          <%= responsibility_label(ResponsibilityService.calculate_case_owner(offender)) %>
         </td>
         <td aria-label="Awaiting allocation for" class="govuk-table__cell">
           <%= offender.awaiting_allocation_for %> days

--- a/db/migrate/20190314112354_add_reponsibility_column_to_allocations.rb
+++ b/db/migrate/20190314112354_add_reponsibility_column_to_allocations.rb
@@ -1,0 +1,9 @@
+class AddReponsibilityColumnToAllocations < ActiveRecord::Migration[5.2]
+  def up
+    add_column :allocations, :responsibility, :text
+  end
+
+  def down
+    remove_column :allocations, :responsibility
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_01_092256) do
+ActiveRecord::Schema.define(version: 2019_03_14_112354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_03_01_092256) do
     t.integer "nomis_staff_id"
     t.integer "nomis_booking_id"
     t.text "message"
+    t.text "responsibility"
     t.index ["nomis_offender_id"], name: "index_allocations_on_nomis_offender_id"
     t.index ["nomis_staff_id"], name: "index_allocations_on_nomis_staff_id"
   end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -100,6 +100,7 @@ feature 'Allocation' do
       nomis_staff_id: probation_officer_nomis_staff_id,
       nomis_booking_id: 1_153_753,
       prison: 'LEI',
+      responsibility: 'Supporting',
       allocated_at_tier: 'A',
       created_by: 'spo@leeds.hmpps.gov.uk',
       active: true

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe Allocation, type: :model do
   it { is_expected.to validate_presence_of(:nomis_booking_id) }
   it { is_expected.to validate_presence_of(:prison) }
   it { is_expected.to validate_presence_of(:allocated_at_tier) }
+  it { is_expected.to validate_presence_of(:responsibility) }
   it { is_expected.to validate_presence_of(:created_by) }
 end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AllocationService do
       nomis_offender_id: 'G2911GD',
       created_by: 'Test User',
       nomis_booking_id: 0,
+      responsibility: 'Supporting',
       allocated_at_tier: 'A',
       prison: 'LEI'
     )
@@ -18,6 +19,7 @@ RSpec.describe AllocationService do
       nomis_offender_id: 'G2911GD',
       created_by: 'Test User',
       nomis_booking_id: 0,
+      responsibility: 'Supporting',
       allocated_at_tier: 'A',
       prison: 'LEI',
       active: false

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -39,6 +39,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
       nomis_offender_id: offenders.first.offender_no,
       nomis_booking_id: 1_153_753,
       prison: 'LEI',
+      responsibility: 'Supporting',
       allocated_at_tier: 'C',
       created_by: 'user@username.com',
       nomis_staff_id: 485_752

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -1,6 +1,4 @@
 require 'rails_helper'
-require_relative '../../app/services/nomis/models/sentence_detail'
-require_relative '../../app/services/nomis/models/offender'
 
 describe PrisonOffenderManagerService do
   let(:staff_id) { 485_737 }
@@ -11,6 +9,7 @@ describe PrisonOffenderManagerService do
       nomis_offender_id: 'G2911GD',
       created_by: 'Test User',
       nomis_booking_id: 0,
+      responsibility: 'Supporting',
       allocated_at_tier: 'A',
       prison: 'LEI'
     )
@@ -22,6 +21,7 @@ describe PrisonOffenderManagerService do
       nomis_offender_id: 'G8060UF',
       created_by: 'Test User',
       nomis_booking_id: 1,
+      responsibility: 'Supporting',
       allocated_at_tier: 'A',
       prison: 'LEI'
     )

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -19,22 +19,53 @@ describe ResponsibilityService do
       o.release_date = DateTime.now.utc.to_date + 6.months
     }
   }
+  let(:offender_welsh_gt_10){
+    Nomis::Models::Offender.new.tap { |o|
+      o.release_date = DateTime.now.utc.to_date + 12.months
+      o.welsh_address = true
+    }
+  }
+  let(:offender_welsh_lt_10){
+    Nomis::Models::Offender.new.tap { |o|
+      o.release_date = DateTime.now.utc.to_date + 6.months
+      o.welsh_address = false
+    }
+  }
   let(:offender_nps_no_release_date){
     Nomis::Models::Offender.new.tap { |o| o.case_allocation = 'NPS' }
   }
 
-  it "CRC allocations means Prison" do
-    resp = described_class.calculate_responsibility(offender_crc)
-    expect(resp).to eq 'Prison'
+  describe 'case owner' do
+    it "CRC allocations means Prison" do
+      resp = described_class.calculate_case_owner(offender_crc)
+      expect(resp).to eq 'Prison'
+    end
+
+    it "NPS allocations with no release date" do
+      resp = described_class.calculate_case_owner(offender_nps_no_release_date)
+      expect(resp).to eq 'No release date'
+    end
+
+    it "No allocation" do
+      resp = described_class.calculate_case_owner(offender_none)
+      expect(resp).to eq 'Unknown'
+    end
   end
 
-  it "NPS allocations with no release date" do
-    resp = described_class.calculate_responsibility(offender_nps_no_release_date)
-    expect(resp).to eq 'No release date'
-  end
+  describe 'pom responsibility' do
+    it "is 'Responsible' if offender is Welsh and release date is greater than 10 months" do
+      resp = described_class.calculate_pom_responsibility(offender_welsh_gt_10)
+      expect(resp).to eq 'Responsible'
+    end
 
-  it "No allocation" do
-    resp = described_class.calculate_responsibility(offender_none)
-    expect(resp).to eq 'Unknown'
+    it "is 'Responsible' if offender is Welsh and release date is greater than 10 months" do
+      resp = described_class.calculate_pom_responsibility(offender_welsh_lt_10)
+      expect(resp).to eq 'Supporting'
+    end
+
+    it "is 'Unknown' if offender has no release date" do
+      resp = described_class.calculate_pom_responsibility(offender_nps_no_release_date)
+      expect(resp).to eq 'Unknown'
+    end
   end
 end

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -58,7 +58,7 @@ describe ResponsibilityService do
       expect(resp).to eq 'Responsible'
     end
 
-    it "is 'Responsible' if offender is Welsh and release date is greater than 10 months" do
+    it "is 'Responsible' if offender is Welsh and release date is less than 10 months" do
       resp = described_class.calculate_pom_responsibility(offender_welsh_lt_10)
       expect(resp).to eq 'Supporting'
     end


### PR DESCRIPTION
- Display a POM's responsibility in relation to an allocated offender. 
- Uses rules to determine whether the responsibility is 'Responsible' or 'Supporting' ...
POM is 'Responsible' if offender is 'Welsh' and release date is greater than 10 months, else 'Supporting'
