### PR TITLE
Use the same batch size everywhere.

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,4 +1,6 @@
 class SearchService
+  FETCH_SIZE = 200
+
   # Fetch all of the offenders (for a given prison) filtering
   # out offenders based on the provided text.
   # rubocop:disable Metrics/MethodLength
@@ -13,7 +15,7 @@ class SearchService
       offenders = OffenderService.get_offenders_for_prison(
         prison,
         page_number: request_no,
-        page_size: 250,
+        page_size: FETCH_SIZE,
         tier_map: tier_map
       )
       break if offenders.blank?
@@ -41,6 +43,6 @@ private
 
     # The maximum number of pages we need to fetch before we have all of
     # the offenders
-    (info_request.meta.total_pages / 250) + 1
+    (info_request.meta.total_pages / FETCH_SIZE) + 1
   end
 end


### PR DESCRIPTION
Make sure we use the same batch size everywhere so that caching doesn't
fill up with multiple versions of the same data.  Once we have
refactored the way we fetch all of the offenders, then this will be
unnecessary