### PR TITLE
Processes movement events from the movements API

### DIFF
--- a/app/services/case_information_service.rb
+++ b/app/services/case_information_service.rb
@@ -5,4 +5,14 @@ class CaseInformationService
       hash[c.nomis_offender_id] = c
     end
   end
+
+  def self.change_prison(nomis_offender_id, old_prison, new_prison)
+    CaseInformation.where(
+      nomis_offender_id: nomis_offender_id, prison: old_prison
+    ).update_all(prison: new_prison)
+  end
+
+  def self.delete_information(nomis_offender_id)
+    CaseInformation.where(nomis_offender_id: nomis_offender_id).destroy_all
+  end
 end

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -18,4 +18,46 @@ class MovementService
     movements
   end
   # rubocop:enable Metrics/MethodLength
+
+  def self.process_movement(movement)
+    if movement.movement_type == Nomis::Models::MovementType::RELEASE
+      return process_release(movement)
+    end
+
+    # We think that an ADM without a fromAgency is from court so there
+    # will be nothing to delete/change.
+    if movement.movement_type == Nomis::Models::MovementType::ADMISSION &&
+        movement.direction_code == Nomis::Models::MovementDirection::IN &&
+        movement.from_agency.present?
+      return process_transfer(movement)
+    end
+
+    false
+  end
+
+private
+
+  def self.process_transfer(transfer)
+    Rails.logger.info("Processing transfer for #{transfer.offender_no}")
+
+    AllocationService.deallocate_offender(transfer.offender_no)
+    CaseInformationService.change_prison(
+      transfer.offender_no,
+      transfer.from_agency,
+      transfer.to_agency
+    )
+
+    true
+  end
+
+  # When an offender is released, we can no longer rely on their
+  # case information (in case they come back one day), and we
+  # should de-activate any current allocations.
+  def self.process_release(release)
+    Rails.logger.info("Processing release for #{release.offender_no}")
+    CaseInformationService.delete_information(release.offender_no)
+    AllocationService.deallocate_offender(release.offender_no)
+
+    true
+  end
 end

--- a/lib/tasks/movements.rake
+++ b/lib/tasks/movements.rake
@@ -1,0 +1,26 @@
+require 'rake'
+require_relative '../../app//models/concerns/memory_model.rb'
+require_relative '../../app/services/nomis/models/movement.rb'
+
+namespace :movements do
+  desc 'Process the movement events in the previous 24 hours'
+  task process: :environment do
+    if defined?(Rails) && Rails.env.development?
+      Rails.logger = Logger.new(STDOUT)
+    end
+
+    yesterday = Time.zone.today - 1.day
+
+    movements = MovementService.movements_on(
+      yesterday,
+      type_filters: [
+        Nomis::Models::MovementType::ADMISSION,
+        Nomis::Models::MovementType::RELEASE
+      ]
+    )
+
+    movements.each { |movement|
+      MovementService.process_movement(movement)
+    }
+  end
+end

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe CaseInformationService, vcr: { cassette_name: :caseinfo_service_spec } do
+  let(:caseinfo) {
+    CaseInformation.find_or_create_by!(
+      nomis_offender_id: 'X1000XX',
+      tier: 'A',
+      case_allocation: 'NPS',
+      welsh_address: 'Yes',
+      prison: 'LEI'
+    )
+  }
+
+  it "can get case information" do
+    cases = CaseInformationService.get_case_information(caseinfo.prison)
+    expect(cases).to be_kind_of(Hash)
+    expect(cases.length).to eq(1)
+    expect(cases[caseinfo.nomis_offender_id]).to be_kind_of(CaseInformation)
+  end
+
+  it "can delete case information" do
+    cases = CaseInformationService.get_case_information(caseinfo.prison)
+    expect(cases.length).to eq(1)
+
+    CaseInformationService.delete_information(caseinfo.nomis_offender_id)
+
+    cases = CaseInformationService.get_case_information(caseinfo.prison)
+    expect(cases.length).to eq(0)
+  end
+
+  it "can change prisons for case information" do
+    cases = CaseInformationService.get_case_information(caseinfo.prison)
+    expect(cases.length).to eq(1)
+
+    CaseInformationService.change_prison(caseinfo.nomis_offender_id, 'LEI', 'SWI')
+
+    cases = CaseInformationService.get_case_information('LEI')
+    expect(cases.length).to eq(0)
+
+    cases = CaseInformationService.get_case_information('SWI')
+    expect(cases.length).to eq(1)
+  end
+end

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -2,10 +2,45 @@ require 'rails_helper'
 require_relative '../../app/services/nomis/models/movement'
 
 describe MovementService, vcr: { cassette_name: :movement_service_spec } do
+  let(:new_offender) {
+    Nomis::Models::Movement.new.tap { |m|
+      m.offender_no = 'G4273GI'
+      m.to_agency = 'SWI'
+      m.direction_code = 'IN'
+      m.movement_type = 'ADM'
+    }
+  }
+  let(:transfer_adm) {
+    Nomis::Models::Movement.new.tap { |m|
+      m.offender_no = 'G4273GI'
+      m.from_agency = 'LEI'
+      m.to_agency = 'SWI'
+      m.direction_code = 'IN'
+      m.movement_type = 'ADM'
+    }
+  }
+  let(:transfer_out) {
+    Nomis::Models::Movement.new.tap { |m|
+      m.offender_no = 'G4273GI'
+      m.from_agency = 'LEI'
+      m.to_agency = 'SWI'
+      m.direction_code = 'OUT'
+      m.movement_type = 'TRN'
+    }
+  }
+  let(:release) {
+    Nomis::Models::Movement.new.tap { |m|
+      m.offender_no = 'G4273GI'
+      m.from_agency = 'LEI'
+      m.direction_code = 'OUT'
+      m.movement_type = 'REL'
+    }
+  }
+
   it "can get recent movements" do
     movements = MovementService.movements_on(Date.iso8601('2019-02-20'))
     expect(movements).to be_kind_of(Array)
-    expect(movements.length).to eq(3)
+    expect(movements.length).to eq(2)
     expect(movements.first).to be_kind_of(Nomis::Models::Movement)
   end
 
@@ -20,7 +55,7 @@ describe MovementService, vcr: { cassette_name: :movement_service_spec } do
 
   it "can filter admissions" do
     movements = MovementService.movements_on(
-      Date.iso8601('2019-02-20'),
+      Date.iso8601('2019-03-12'),
       type_filters: [Nomis::Models::MovementType::ADMISSION]
     )
     expect(movements).to be_kind_of(Array)
@@ -42,7 +77,7 @@ describe MovementService, vcr: { cassette_name: :movement_service_spec } do
 
   it "can filter results by direction IN" do
     movements = MovementService.movements_on(
-      Date.iso8601('2019-02-20'),
+      Date.iso8601('2019-03-12'),
       direction_filters: [Nomis::Models::MovementDirection::IN]
     )
     expect(movements).to be_kind_of(Array)
@@ -60,5 +95,25 @@ describe MovementService, vcr: { cassette_name: :movement_service_spec } do
     expect(movements.length).to eq(2)
     expect(movements.first).to be_kind_of(Nomis::Models::Movement)
     expect(movements.first.direction_code).to eq(Nomis::Models::MovementDirection::OUT)
+  end
+
+  it "can process transfer movements IN" do
+    processed = MovementService.process_movement(transfer_adm)
+    expect(processed).to be true
+  end
+
+  it "can process release movements" do
+    processed = MovementService.process_movement(release)
+    expect(processed).to be true
+  end
+
+  it "can ignore movements OUT" do
+    processed = MovementService.process_movement(transfer_out)
+    expect(processed).to be false
+  end
+
+  it "can ignore new offenders arriving at prison" do
+    processed = MovementService.process_movement(new_offender)
+    expect(processed).to be false
   end
 end

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -7,7 +7,7 @@ describe Nomis::Elite2::MovementApi do
 
       movements = described_class.movements_on_date(Date.iso8601('2019-02-20'))
       expect(movements).to be_kind_of(Array)
-      expect(movements.length).to eq(3)
+      expect(movements.length).to eq(2)
       expect(movements.first).to be_kind_of(Nomis::Models::Movement)
     end
   end


### PR DESCRIPTION
We expect that we need to handle movements of offenders, both between
prisons and as a result of being released.

This PR is expected to be run nightly and will process the list of
movement events for the previous 24 hours.

Currently there is a hard-coded date in the rake task as we do not have
a way of creating movements on demand for testing/development purposes.
We also need some transfers to be created in legacy nomis for
dev/testing to ensure the code is correct.

The events received are:

Prisoner leaves a prison: TRN-OUT (fromAgency -> toAgency) - a prisoner
who is in transit will always show as a TRN-OUT.

Prisoner arrives: ADM-IN (fromAgency->toAgency)

What isn't 100% clear, is how we tell an ADM is a new offender, or the
result of a TRANSFER. For now, we can only assume that if fromAgency is
set that it is a transfer.