### PR TITLE
Display flash messages

### DIFF
--- a/app/assets/stylesheets/notification.scss
+++ b/app/assets/stylesheets/notification.scss
@@ -1,0 +1,11 @@
+.notification {
+  border: 4px solid green;
+  padding: 15px;
+  font-weight: bold;
+}
+
+.alert {
+  border: 4px solid red;
+  padding: 15px;
+  font-weight: bold;
+}

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -51,7 +51,7 @@ class AllocationsController < ApplicationController
     if AllocationService.create_allocation allocation
       flash[:notice] = "#{offender.full_name_ordered} has been allocated to #{pom.full_name_ordered} (#{pom.grade})"
     else
-      flash[:alert] = 'Something went wrong - please try again'
+      flash[:alert] = "#{offender.full_name_ordered} has not been allocated  - please try again"
     end
 
     redirect_to summary_unallocated_path

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -2,7 +2,7 @@ class AllocationsController < ApplicationController
   before_action :authenticate_user
 
   def new
-    @prisoner = prisoner(nomis_offender_id_from_url)
+    @prisoner = offender(nomis_offender_id_from_url)
     @previously_allocated_pom_ids =
       AllocationService.previously_allocated_poms(nomis_offender_id_from_url)
     @recommended_poms, @not_recommended_poms =
@@ -10,7 +10,7 @@ class AllocationsController < ApplicationController
   end
 
   def edit
-    @prisoner = prisoner(nomis_offender_id_from_url)
+    @prisoner = offender(nomis_offender_id_from_url)
     @previously_allocated_pom_ids =
       AllocationService.previously_allocated_poms(nomis_offender_id_from_url)
     @recommended_poms, @not_recommended_poms =
@@ -19,26 +19,33 @@ class AllocationsController < ApplicationController
   end
 
   def confirm
-    @prisoner = prisoner(nomis_offender_id_from_url)
+    @prisoner = offender(nomis_offender_id_from_url)
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, nomis_staff_id_from_url)
   end
 
   # rubocop:disable Metrics/MethodLength
   def create
-    prisoner  = prisoner(allocation_params[:nomis_offender_id])
-    @override = override
+    offender  = offender(allocation_params[:nomis_offender_id])
+    pom = PrisonOffenderManagerService.get_pom(active_caseload, allocation_params[:nomis_staff_id])
 
-    AllocationService.create_allocation(
+    @override = override
+    allocation = {
       nomis_staff_id: allocation_params[:nomis_staff_id].to_i,
       nomis_offender_id: allocation_params[:nomis_offender_id],
       created_by: current_user,
-      nomis_booking_id: prisoner.latest_booking_id,
-      allocated_at_tier: prisoner.tier,
+      nomis_booking_id: offender.latest_booking_id,
+      allocated_at_tier: offender.tier,
       prison: active_caseload,
       override_reasons: override_reasons,
       override_detail: override_detail,
       message: allocation_params[:message]
-    )
+    }
+
+    if AllocationService.create_allocation allocation
+      flash[:notice] = "#{offender.full_name_ordered} has been allocated to #{pom.full_name_ordered} (#{pom.grade})"
+    else
+      flash[:alert]   = "Something went wrong - please try again"
+    end
 
     redirect_to summary_unallocated_path
   end
@@ -46,7 +53,7 @@ class AllocationsController < ApplicationController
 
 private
 
-  def prisoner(nomis_offender_id)
+  def offender(nomis_offender_id)
     OffenderService.get_offender(nomis_offender_id)
   end
 

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -20,13 +20,20 @@ class AllocationsController < ApplicationController
 
   def confirm
     @prisoner = offender(nomis_offender_id_from_url)
-    @pom = PrisonOffenderManagerService.get_pom(active_caseload, nomis_staff_id_from_url)
+    @pom = PrisonOffenderManagerService.get_pom(
+      active_caseload,
+      nomis_staff_id_from_url
+    )
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/LineLength
   def create
-    offender  = offender(allocation_params[:nomis_offender_id])
-    pom = PrisonOffenderManagerService.get_pom(active_caseload, allocation_params[:nomis_staff_id])
+    offender = offender(allocation_params[:nomis_offender_id])
+    pom = PrisonOffenderManagerService.get_pom(
+      active_caseload,
+      allocation_params[:nomis_staff_id]
+    )
 
     @override = override
     allocation = {
@@ -44,12 +51,13 @@ class AllocationsController < ApplicationController
     if AllocationService.create_allocation allocation
       flash[:notice] = "#{offender.full_name_ordered} has been allocated to #{pom.full_name_ordered} (#{pom.grade})"
     else
-      flash[:alert]   = "Something went wrong - please try again"
+      flash[:alert] = 'Something went wrong - please try again'
     end
 
     redirect_to summary_unallocated_path
   end
 # rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/LineLength
 
 private
 

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -42,6 +42,10 @@ module Nomis
       def full_name
         "#{last_name}, #{first_name}".titleize
       end
+
+      def full_name_ordered
+        "#{first_name} #{last_name}".titleize
+      end
     end
   end
 end

--- a/app/services/nomis/models/prison_offender_manager.rb
+++ b/app/services/nomis/models/prison_offender_manager.rb
@@ -31,6 +31,10 @@ module Nomis
         "#{last_name}, #{first_name}".titleize
       end
 
+      def full_name_ordered
+        "#{first_name} #{last_name}".titleize
+      end
+
       def grade
         "#{position_description.split(' ').first} POM"
       end

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -1,3 +1,15 @@
+<% if notice.present? %>
+  <p class="notification govuk-!-margin-bottom-9" role="group" aria-labelledby="notice-heading">
+    <%= notice %>
+  </p>
+<% end %>
+
+<% if alert.present? %>
+  <p class="alert govuk-!-margin-bottom-9" role="group" aria-labelledby="error-summary-heading">
+    <%= alert %>
+  </p>
+<% end %>
+
 <h1 class="govuk-heading-xl">Allocations</h1>
 
 <%= render(:partial => 'tabs_start', :locals => {:active => :unallocated}) %>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -32,6 +32,7 @@ feature 'Allocation' do
     click_button 'Complete allocation'
 
     expect(page).to have_current_path summary_unallocated_path
+    expect(page).to have_css('.notification', text: 'Ozullirn Abbella has been allocated to Ross Jones (Probation POM)')
   end
 
   scenario 'overriding an allocation', vcr: { cassette_name: :override_allocation_feature } do
@@ -58,6 +59,7 @@ feature 'Allocation' do
     click_button 'Complete allocation'
 
     expect(page).to have_current_path summary_unallocated_path
+    expect(page).to have_css('.notification', text: 'Ozullirn Abbella has been allocated to Toby Retallick (Prison POM)')
     expect(Override.count).to eq(0)
   end
 
@@ -116,5 +118,21 @@ feature 'Allocation' do
     expect(page).to have_current_path edit_allocations_path(nomis_offender_id)
     expect(page).to have_css('.current_pom_full_name', text: 'Duckett, Jenny')
     expect(page).to have_css('.current_pom_grade', text: 'Prison POM')
+  end
+
+  scenario 'allocation fails', vcr: { cassette_name: :allocation_fails_feature } do
+    allow(AllocationService).to receive(:create_allocation).and_return(false)
+    signin_user
+
+    visit new_allocations_path(nomis_offender_id)
+
+    within('.recommended_pom_row_0') do
+      click_link 'Allocate'
+    end
+
+    click_button 'Complete allocation'
+
+    expect(page).to have_current_path summary_unallocated_path
+    expect(page).to have_css('.alert', text: 'Something went wrong - please try again')
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -133,6 +133,9 @@ feature 'Allocation' do
     click_button 'Complete allocation'
 
     expect(page).to have_current_path summary_unallocated_path
-    expect(page).to have_css('.alert', text: 'Something went wrong - please try again')
+    expect(page).to have_css(
+      '.alert',
+      text: 'Ozullirn Abbella has not been allocated - please try again'
+                    )
   end
 end


### PR DESCRIPTION
- When an allocation is saved successfully the user will see a 'Success'
flash message appear once they are re-directed to the 'Make allocations'
tab
- Conversely, if the save is unsuccessful an 'unsuccessful' flash
message will appear

![flash](https://user-images.githubusercontent.com/5256922/54526999-746d5d80-4970-11e9-9543-e9b30e3c1353.jpg)
