### PR TITLE
Fix API call to fetch POMs

### DIFF
--- a/app/services/nomis/elite2/prison_offender_manager_api.rb
+++ b/app/services/nomis/elite2/prison_offender_manager_api.rb
@@ -9,7 +9,9 @@ module Nomis
         key = "pom_list_#{prison}"
 
         data = Rails.cache.fetch(key, expires_in: 10.minutes) {
-          e2_client.get(route) || []
+          e2_client.get(route,  extra_headers: paging_options { |result|
+            raise Nomis::Client::APIError, 'No data was returned' if result.empty?
+          })
         }
 
         data.map { |pom|
@@ -23,6 +25,15 @@ module Nomis
         return [] if data.nil?
 
         data
+      end
+
+    private
+
+      def self.paging_options
+        {
+          'Page-Limit' => '100',
+          'Page-Offset' => '0'
+        }
       end
     end
   end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -52,7 +52,7 @@ describe PrisonOffenderManagerService do
     vcr: { cassette_name: :pom_service_get_poms } do
     poms = described_class.get_poms('LEI')
     expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(10)
+    expect(poms.count).to eq(13)
   end
 
   it "can get a filtered list of POMs",
@@ -61,13 +61,13 @@ describe PrisonOffenderManagerService do
       pom.status == 'active'
     }
     expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(9)
+    expect(poms.count).to eq(12)
   end
 
   it "can get the names for POMs when given IDs",
     vcr: { cassette_name: :pom_service_get_poms } do
     names = described_class.get_pom_names('LEI')
     expect(names).to be_kind_of(Hash)
-    expect(names.count).to eq(9)
+    expect(names.count).to eq(12)
   end
 end


### PR DESCRIPTION
Whilst adding extra team members to NOMIS (T3) as POMs we noticed that
we were only ever getting 10 back, regardless of anyone else being added
or removed.  We realised that Elite2 defaults to returning 10 and so
this PR adds in extra headers to increase this to 100.