### PR TITLE
Restrict access to users with role ALLOC_MGR

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,12 @@ class ApplicationController < ActionController::Base
   include SSOIdentity
 
   def authenticate_user
+    user_roles = roles
+    unless user_roles.present? && user_roles.include?('ROLE_ALLOC_MGR')
+      redirect_to '/401'
+      return
+    end
+
     if sso_identity.nil? || session_expired?
       session[:redirect_path] = request.original_fullpath
       redirect_to '/auth/hmpps_sso'
@@ -22,6 +28,10 @@ class ApplicationController < ActionController::Base
 
   def update_active_caseload(code)
     session[:sso_data]['active_caseload'] = code
+  end
+
+  def roles
+    sso_identity['roles'] if sso_identity.present?
   end
 
   def caseloads

--- a/app/models/signon_identity.rb
+++ b/app/models/signon_identity.rb
@@ -12,28 +12,10 @@ class SignonIdentity
     @active_caseload = omniauth_data.fetch('info').active_caseload
     @caseloads = omniauth_data.fetch('info').caseloads
     @expiry = omniauth_data.fetch('credentials').expires_at
-    @roles = get_roles(omniauth_data.fetch('credentials'))
-  end
-
-  def get_roles(credentials)
-    return ['ROLE_ALLOC_MGR'] if Rails.env.test?
-    byebug
-    public_key = Base64.urlsafe_decode64(
-        Rails.configuration.nomis_oauth_public_key
-    )
-
-    decoded_token = JWT.decode(
-        credentials.token,
-        OpenSSL::PKey::RSA.new(public_key),
-        true,
-        algorithm: 'RS256'
-    )
-
-    decoded_token.first.fetch('authorities', [])
+    @roles = omniauth_data.fetch('info').roles
   end
 
   def to_session
-    p @roles
     {
       username: @username,
       active_caseload: @active_caseload,

--- a/app/models/signon_identity.rb
+++ b/app/models/signon_identity.rb
@@ -12,14 +12,34 @@ class SignonIdentity
     @active_caseload = omniauth_data.fetch('info').active_caseload
     @caseloads = omniauth_data.fetch('info').caseloads
     @expiry = omniauth_data.fetch('credentials').expires_at
+    @roles = get_roles(omniauth_data.fetch('credentials'))
+  end
+
+  def get_roles(credentials)
+    return ['ROLE_ALLOC_MGR'] if Rails.env.test?
+    byebug
+    public_key = Base64.urlsafe_decode64(
+        Rails.configuration.nomis_oauth_public_key
+    )
+
+    decoded_token = JWT.decode(
+        credentials.token,
+        OpenSSL::PKey::RSA.new(public_key),
+        true,
+        algorithm: 'RS256'
+    )
+
+    decoded_token.first.fetch('authorities', [])
   end
 
   def to_session
+    p @roles
     {
       username: @username,
       active_caseload: @active_caseload,
       caseloads: @caseloads,
-      expiry: @expiry
+      expiry: @expiry,
+      roles: @roles
     }
   end
 end

--- a/spec/lib/hmpps_sso_spec.rb
+++ b/spec/lib/hmpps_sso_spec.rb
@@ -27,6 +27,9 @@ describe OmniAuth::Strategies::HmppsSso do
 
         allow(Nomis::Custody::UserApi).to receive(:user_details).and_return(response)
         allow(strategy).to receive(:username).and_return(username)
+        allow(strategy).to receive(:decode_roles).and_return(['ROLE_ALLOC_MGR'])
+
+        # allow(strategy).to receive(:access_token).and_return(access_token)
 
         expect(strategy.info[:username]).to eq(username)
         expect(strategy.info[:active_caseload]).to eq(leeds_prison)

--- a/spec/lib/hmpps_sso_spec.rb
+++ b/spec/lib/hmpps_sso_spec.rb
@@ -29,8 +29,6 @@ describe OmniAuth::Strategies::HmppsSso do
         allow(strategy).to receive(:username).and_return(username)
         allow(strategy).to receive(:decode_roles).and_return(['ROLE_ALLOC_MGR'])
 
-        # allow(strategy).to receive(:access_token).and_return(access_token)
-
         expect(strategy.info[:username]).to eq(username)
         expect(strategy.info[:active_caseload]).to eq(leeds_prison)
       end

--- a/spec/models/signon_identity_spec.rb
+++ b/spec/models/signon_identity_spec.rb
@@ -2,7 +2,14 @@ require 'rails_helper'
 
 describe SignonIdentity, model: true do
   let(:time_stamp) { 123_456 }
-  let(:user_auth_data) { double('user_auth_data', username: 'Fred', active_caseload: 'LEI', caseloads: %w[LEI RNI]) }
+  let(:user_auth_data) {
+    double('user_auth_data',
+      username: 'Fred',
+      active_caseload: 'LEI',
+      caseloads: %w[LEI RNI],
+      roles: ['ROLE_ALLOC_MGR']
+    )
+  }
   let(:credentials) { double('credentials', expires_at: time_stamp) }
   let(:omniauth_data) do
     { 'info' => user_auth_data, 'credentials' => credentials }

--- a/spec/models/signon_identity_spec.rb
+++ b/spec/models/signon_identity_spec.rb
@@ -23,7 +23,8 @@ describe SignonIdentity, model: true do
       username: 'Fred',
       active_caseload: 'LEI',
       caseloads: %w[LEI RNI],
-      expiry: time_stamp
+      expiry: time_stamp,
+      roles: ['ROLE_ALLOC_MGR']
     }
 
     expect(signon_identity.to_session).to eq(session)

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -1,8 +1,9 @@
 module FeaturesHelper
   def signin_user(name = 'Fred')
     hmpps_sso_response = {
-      'info' => double('user_info', username: name, active_caseload: 'LEI', caseloads: %w[LEI RSI]),
-      'credentials' => double('credentials', expires_at: Time.zone.local(2030, 1, 1).to_i)
+      'info' => double('user_info', username: name, active_caseload: 'LEI', caseloads: %w[LEI RSI], roles: %w[ROLE_ALLOC_MGR]),
+      'credentials' => double('credentials', expires_at: Time.zone.local(2030, 1, 1).to_i,
+                                             'authorities': ['ROLE_ALLOC_MGR'])
     }
 
     OmniAuth.config.add_mock(:hmpps_sso, hmpps_sso_response)


### PR DESCRIPTION
To access the application, users must have the NOMIS ALLOC_MGR role set.
This PR, during the login callback, extracts the list of the roles from
the encoded token inside the encoded payload and stores them in the user
session.  The presence of the ROLE_ALLOC_MGR string is used to determine
whether the user should have access or not.

Currently the allowed? check is not done in the test environment as it
relies on encrypted data that is not available.  It _should_ be possible
to provide an encrypted token containing the roles so that tests can
complete