### PR TITLE
Show POM responsibility during allocation

### DIFF
--- a/app/assets/stylesheets/prison_switcher.scss
+++ b/app/assets/stylesheets/prison_switcher.scss
@@ -5,7 +5,7 @@
         display: inline-block;
     }
     a {
-        line-height: 40px;
+        line-height: 24px;
         margin-bottom: 0;
         margin-left: 20px;
         float: right;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,6 +45,10 @@ module ApplicationHelper
     'Part time'
   end
 
+  def pom_responsibility_label(offender)
+    ResponsibilityService.calculate_pom_responsibility(offender)
+  end
+
   def responsibility_label(offender_responsibility)
     {
       'Probation' => 'Community',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,7 +46,7 @@ module ApplicationHelper
   end
 
   def pom_responsibility_label(offender)
-    ResponsibilityService.calculate_pom_responsibility(offender)
+    ResponsibilityService.new.calculate_pom_responsibility(offender)
   end
 
   def responsibility_label(offender_responsibility)

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -2,17 +2,17 @@ class OffenderService
   # rubocop:disable Metrics/MethodLength
   def self.get_offender(offender_no)
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
-      record = CaseInformation.where(nomis_offender_id: offender_no)
+      record = CaseInformation.find_by(nomis_offender_id: offender_no)
 
-      unless record.empty?
-        o.tier = record.first.tier
-        o.case_allocation = record.first.case_allocation
+      if record.present?
+        o.tier = record.tier
+        o.case_allocation = record.case_allocation
+        o.welsh_address = record.welsh_address
       end
 
       sentence_detail = get_sentence_details([offender_no])
       o.release_date = sentence_detail[offender_no].release_date
       o.sentence_date = sentence_detail[offender_no].sentence_date
-
       o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)
     }
   end

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -24,6 +24,12 @@ class ResponsibilityService
   end
 
   def self.assign_responsible?(offender)
+    # TODO: When we do this check, we should also check what the responsibility
+    # was yesterday, so that we can determine if it has changed.  This will allow
+    # us to persist the responsibility at the time of allocation, and when the
+    # responsibility changes do:
+    #   * Notifications
+    #   * Deactive and recreate allocation (with new responsibility)
     offender.welsh_address == true &&
       offender.release_date > DateTime.now.utc.to_date + 10.months
   end

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -8,13 +8,19 @@
     <td class="govuk-table__cell govuk-!-width-one-half">Current case owner</td>
     <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
       <%= responsibility_label(@prisoner.case_owner) %>
-        <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
     </td>
   </tr>
   <tr class="govuk-table__row">
+    <td class="govuk-table__cell">POM role</td>
+    <td class="govuk-table__cell table_cell__left_align">
+      <%= pom_responsibility_label(@prisoner) %>
+    </td>
+  </tr>
+
+  <tr class="govuk-table__row">
     <td class="govuk-table__cell">Service provider</td>
     <td class="govuk-table__cell table_cell__left_align">
-      <%= @prisoner.case_allocation %>
+      <%= service_provider_label(@prisoner.case_allocation) %>
       <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
     </td>
   </tr>

--- a/app/views/layouts/_prison_switcher.html.erb
+++ b/app/views/layouts/_prison_switcher.html.erb
@@ -1,7 +1,7 @@
 <% if show_prison_switcher?(caseloads) %>
   <div class="govuk-phase-banner govuk-width-container app-site-
   width-container govuk-!-padding-bottom-0 prison-switcher">
-      <h2 class="govuk-heading-l govuk-!-margin-0 govuk-!-padding-0">
+      <h2 class="govuk-heading-m govuk-!-margin-0 govuk-!-padding-0">
         <%= prison_title(active_caseload) %>
       </h2>
       <a href="<%= prisons_path %>">Switch prison</a>


### PR DESCRIPTION
When we allocate an offender we need to show the POM responsibility for
that allocations.  This is to enable future changes where we might store
this responsibility with the allocation.

Also contains a fly-by change removing a few pixels from the prison
switcher