### PR TITLE
Add more flexible way of getting all offenders

### DIFF
--- a/app/services/nomis/elite2/offender_list.rb
+++ b/app/services/nomis/elite2/offender_list.rb
@@ -1,0 +1,69 @@
+# Fetching a list of offenders from the Elite2 API is something that hapens
+# frequently, often then filtered and enriched with local data.  The
+# OffenderList class encapsulates this functionality in one place to provide
+# some consistency with how it is done.
+#
+# Usage:
+#   # Fetch all offenders for a prison
+#   offender_list = OffenderList.new('LEI')
+#   offender_list.all
+#
+module Nomis::Elite2
+  class OffenderList
+    def initialize(prison, batch_size: 250)
+      @prison = prison
+      @batch_size = batch_size
+      @batch_filters = []
+      @enrichment_funcs = []
+    end
+
+    def add_batch_filter(func)
+      # The Proc provided to this method, will be provided an entire
+      # batch of offenders, and is expected to return a list. The returned
+      # list will replace the current batch.
+
+      # Multiple filters can be registered and will be run in the order
+      # that they were added
+      @batch_filters << func
+    end
+
+    def fetch
+      offenders = []
+
+      (0..number_required_requests).each do |page|
+        batch = get_page_of_offenders(page)
+        next if batch.empty?
+
+        @batch_filters.each do |filter|
+          batch = filter.call(batch)
+        end
+
+        offenders += batch
+      end
+
+      offenders
+    end
+
+  private
+
+    def number_required_requests
+      # Fetch the first 1 prisoners just for the total number of pages so that we
+      # can send batched queries.
+      info_request = OffenderApi.list(@prison, 1, page_size: 1)
+
+      # The maximum number of pages we need to fetch before we have all of
+      # the offenders
+      @number_required_requests ||= (info_request.meta.total_pages / @batch_size) + 1
+    end
+
+    def get_page_of_offenders(page_number)
+      # Retrieves a specific page of offenders based on the previously defined
+      # batch size (or the default of 250).
+      Nomis::Elite2::OffenderApi.list(
+        @prison,
+        page_number,
+        page_size: @batch_size
+      ).data
+    end
+  end
+end

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -96,7 +96,7 @@ class SummaryService
 private
 
   def max_requests_count(prison)
-    # Fetch the first 1 prisoners just for the total number of pages so that we
+    # Fetch the a single offender just for the total number of pages so that we
     # can send batched queries.
     info_request = Nomis::Elite2::OffenderApi.list(prison, 1, page_size: 1)
 

--- a/spec/services/nomis/elite2/offender_list_spec.rb
+++ b/spec/services/nomis/elite2/offender_list_spec.rb
@@ -52,10 +52,10 @@ describe Nomis::Elite2::OffenderList do
 
   it "can perform filter+update", vcr: { cassette_name: 'offender_list_filterupdate_spec' } do
     filter_map_func = lambda { |offenders|
-      offender_ids = offenders.map(&:offender_no)
+      booking_ids = offenders.map(&:booking_id)
       sentence_details = if offenders.count > 0
                            Nomis::Elite2::OffenderApi.get_bulk_sentence_details(
-                             offender_ids
+                             booking_ids
                            )
                          else
                            {}
@@ -71,16 +71,16 @@ describe Nomis::Elite2::OffenderList do
     offender_list.add_batch_filter(filter_map_func)
     offender_results = offender_list.fetch
 
-    expect(offender_results.count).to eq(623)
+    expect(offender_results.count).to eq(794)
   end
 
   it "can run several filters", vcr: { cassette_name: 'offender_list_several_filters_spec' } do
     # Filter our results that have no release date
     filter_map_func = lambda { |offenders|
-      offender_ids = offenders.map(&:offender_no)
+      booking_ids = offenders.map(&:booking_id)
       sentence_details = if offenders.count > 0
                            Nomis::Elite2::OffenderApi.get_bulk_sentence_details(
-                             offender_ids
+                             booking_ids
                            )
                          else
                            {}
@@ -108,6 +108,6 @@ describe Nomis::Elite2::OffenderList do
     offender_list.add_batch_filter(add_tiers)
     offender_results = offender_list.fetch
 
-    expect(offender_results.count).to eq(623)
+    expect(offender_results.count).to eq(794)
   end
 end

--- a/spec/services/nomis/elite2/offender_list_spec.rb
+++ b/spec/services/nomis/elite2/offender_list_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe Nomis::Elite2::OffenderList do
+  let(:prison) { 'LEI' }
+
+  it "Can simply retrieve all offenders from a prison", vcr: { cassette_name: 'offender_list_all_spec' } do
+    offender_list = described_class.new(prison)
+    offenders = offender_list.fetch
+    expect(offenders.count).to eq(1168)
+  end
+
+  it "Can perform a simple filter", vcr: { cassette_name: 'offender_list_simple_filter_spec' } do
+    offender_list = described_class.new(prison)
+    offender_list.add_batch_filter(lambda { |offenders|
+      offenders.select { |offender|
+        offender.first_name[0] == 'C'
+      }
+    })
+    offenders = offender_list.fetch
+
+    expect(offenders.count).to eq(56)
+  end
+
+  it "Stops running filters when no records", vcr: { cassette_name: 'offender_list_simple_stop_spec' } do
+    offender_list = described_class.new(prison)
+    offender_list.add_batch_filter(lambda { |offenders|
+      offenders.select { |_| false }
+    })
+    offenders = offender_list.fetch
+
+    expect(offenders.count).to eq(0)
+  end
+
+  it "Can add to records", vcr: { cassette_name: 'offender_list_add_to_records_spec' } do
+    mapped_tiers = {
+      'G1103VT' => 'A'
+    }
+
+    offender_list = described_class.new(prison)
+    offender_list.add_batch_filter(lambda { |offenders|
+      offenders.map { |offender|
+        offender.tier = mapped_tiers[offender.offender_no]
+        offender
+      }
+    })
+    offenders = offender_list.fetch
+
+    any_with_tier = offenders.any? { |offender| offender.tier.present? }
+    expect(offenders.count).to eq(1168)
+    expect(any_with_tier).to be true
+  end
+
+  it "can perform filter+update", vcr: { cassette_name: 'offender_list_filterupdate_spec' } do
+    filter_map_func = lambda { |offenders|
+      offender_ids = offenders.map(&:offender_no)
+      sentence_details = if offenders.count > 0
+                           Nomis::Elite2::OffenderApi.get_bulk_sentence_details(
+                             offender_ids
+                           )
+                         else
+                           {}
+                         end
+
+      offenders.select { |offender|
+        offender.release_date = sentence_details[offender.offender_no].release_date
+        offender.release_date.present?
+      }
+    }
+
+    offender_list = described_class.new(prison)
+    offender_list.add_batch_filter(filter_map_func)
+    offender_results = offender_list.fetch
+
+    expect(offender_results.count).to eq(623)
+  end
+
+  it "can run several filters", vcr: { cassette_name: 'offender_list_several_filters_spec' } do
+    # Filter our results that have no release date
+    filter_map_func = lambda { |offenders|
+      offender_ids = offenders.map(&:offender_no)
+      sentence_details = if offenders.count > 0
+                           Nomis::Elite2::OffenderApi.get_bulk_sentence_details(
+                             offender_ids
+                           )
+                         else
+                           {}
+                         end
+
+      offenders.select { |offender|
+        offender.release_date = sentence_details[offender.offender_no].release_date
+        offender.release_date.present?
+      }
+    }
+
+    # Add a tier to offenders where we have them
+    mapped_tiers = {
+      'G1103VT' => 'A'
+    }
+    add_tiers = lambda { |offenders|
+      offenders.map { |offender|
+        offender.tier = mapped_tiers[offender.offender_no]
+        offender
+      }
+    }
+
+    offender_list = described_class.new(prison)
+    offender_list.add_batch_filter(filter_map_func)
+    offender_list.add_batch_filter(add_tiers)
+    offender_results = offender_list.fetch
+
+    expect(offender_results.count).to eq(623)
+  end
+end


### PR DESCRIPTION
Currently we have more than one way to get lists of offenders (summary
service and search) that are complex and messy and not necessarily doing
identical things - primarily because search doesn't need all of the
information.

This PR is a bit of an experiment on how we might simplify the fetching
of lists of offenders, at the same time that we filter them and add
local data to them.

The intent is that the local API looks as follows where the arguments
passed to add_batch_filter are lambdas that receive a batch of
offenders, optionally adds data to them, and optionally removes some
records.

```ruby
offender_list = OffenderList.new('LEI', batch_size: 200)
offender_list.add_batch_filter(add_release_date)
offender_list.add_batch_filter(remove_no_release_date)
offender_list.add_batch_filter(add_case_information)

offenders = offender_list.fetch
```

Longer term, and as long as the batch filters are re-entrant (
anything captured in the closure is read-only) if should in future be
possible to introduce threads in the fetch method to dramatically reduce
the cold-start time w/o the cache.