### PR TITLE
Use omicable rather than welsh_address on the backend

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -23,7 +23,7 @@ class CaseInformationController < ApplicationController
     @case_info = CaseInformation.create(
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
-      welsh_address: case_information_params[:welsh_address],
+      omicable: case_information_params[:omicable],
       case_allocation: case_information_params[:case_allocation],
       prison: active_caseload
     )
@@ -41,7 +41,7 @@ class CaseInformationController < ApplicationController
     case_info.prison = active_caseload
     case_info.tier = case_information_params[:tier]
     case_info.case_allocation = case_information_params[:case_allocation]
-    case_info.welsh_address = case_information_params[:welsh_address]
+    case_info.omicable = case_information_params[:omicable]
     case_info.save
 
     redirect_to new_allocations_path(case_info.nomis_offender_id)
@@ -59,6 +59,6 @@ private
 
   def case_information_params
     params.require(:case_information).
-      permit(:nomis_offender_id, :tier, :case_allocation, :welsh_address)
+      permit(:nomis_offender_id, :tier, :case_allocation, :omicable)
   end
 end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -1,7 +1,13 @@
 class CaseInformation < ApplicationRecord
   self.table_name = 'case_information'
   validates :nomis_offender_id, presence: true
-  validates :welsh_address, presence: { message: 'must be selected' }
-  validates :tier, presence: { message: 'must be provided' }
-  validates :case_allocation, presence: { message: 'must be provided' }
+  validates :omicable, presence: {
+    message: 'Select yes if the prisoner’s last known address was in Wales'
+  }
+  validates :tier, presence: {
+    message: 'Select the prisoner’s tier'
+  }
+  validates :case_allocation, presence: {
+    message: 'Select the service provider for this case'
+  }
 end

--- a/app/models/override.rb
+++ b/app/models/override.rb
@@ -1,9 +1,17 @@
 class Override < ApplicationRecord
-  validates :nomis_staff_id, presence: { message: 'must be provided' }
-  validates :nomis_offender_id, presence: { message: 'must be provided' }
-  validates :override_reasons, presence: { message: 'must be provided' }
+  validates :nomis_staff_id, presence: {
+    message: 'NOMIS Staff ID is required'
+  }
+  validates :nomis_offender_id, presence: {
+    message: 'NOMIS Offender ID is required'
+  }
+  validates :override_reasons, presence: {
+    message: 'Select one or more reasons for not accepting the recommendation'
+  }
   validates :more_detail,
-    presence: { message: 'must be provided when Other is selected' },
+    presence: { message:
+      'Please provide extra detail when Other is selected'
+    },
     if: proc { |o|
           o.override_reasons.present? && o.override_reasons.include?('other')
         }

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -32,7 +32,7 @@ module Nomis
       attribute :sentence_date, :date
       attribute :tier, :string
       attribute :case_allocation, :string
-      attribute :welsh_address, :boolean
+      attribute :omicable, :boolean
       attribute :allocated_pom_name, :string
 
       def case_owner

--- a/app/services/nomis/models/offender_short.rb
+++ b/app/services/nomis/models/offender_short.rb
@@ -28,7 +28,7 @@ module Nomis
       attribute :allocated_pom_name, :string
       attribute :allocation_date, :date
       attribute :case_allocation, :string
-      attribute :welsh_address, :boolean
+      attribute :omicable, :boolean
 
       def awaiting_allocation_for
         return 0 if sentence_date.blank?

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -7,7 +7,7 @@ class OffenderService
       if record.present?
         o.tier = record.tier
         o.case_allocation = record.case_allocation
-        o.welsh_address = record.welsh_address
+        o.omicable = record.omicable
       end
 
       sentence_detail = get_sentence_details([offender_no])
@@ -46,7 +46,7 @@ class OffenderService
         if record
           offender.tier = record.tier
           offender.case_allocation = record.case_allocation
-          offender.welsh_address = record.welsh_address
+          offender.omicable = record.omicable
         end
         offender.sentence_date = sentence_details[offender.offender_no].sentence_date
         true

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -24,7 +24,7 @@ class ResponsibilityService
 
   def calculate_pom_responsibility(offender)
     return UNKNOWN if offender.release_date.nil?
-    return SUPPORTING unless welsh?(offender)
+    return SUPPORTING unless omicable?(offender)
 
     return RESPONSIBLE if nps_case?(offender) &&
       new_case?(offender) &&
@@ -51,8 +51,8 @@ class ResponsibilityService
 
 private
 
-  def welsh?(offender)
-    offender.welsh_address == true
+  def omicable?(offender)
+    offender.omicable == true
   end
 
   def nps_case?(offender)
@@ -88,7 +88,7 @@ private
     # responsibility changes do:
     #   * Notifications
     #   * Deactive and recreate allocation (with new responsibility)
-    offender.welsh_address == true &&
+    offender.omicable == true &&
       offender.release_date > DateTime.now.utc.to_date + 10.months
   end
 end

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -2,7 +2,7 @@
 <%= form_tag(action, method: method, id: "case_info_form") do %>
     <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
 
-    <div class="govuk-form-group <% if @case_info.errors[:welsh_address].present? %>govuk-form-group--error<% end %>">
+    <div class="govuk-form-group <% if @case_info.errors[:omicable].present? %>govuk-form-group--error<% end %>">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-2">
           Was this prisoner's last known address in Wales?
@@ -11,20 +11,20 @@
           Only prisoners with a Welsh address will be allocated a responsible<br/> prison or probation POM.
         </p>
 
-        <% if @case_info.errors[:welsh_address].present? %>
+        <% if @case_info.errors[:omicable].present? %>
           <span class="govuk-error-message">
-            Last known address <%= @case_info.errors[:welsh_address].first %>
+            <%= @case_info.errors[:omicable].first %>
           </span>
         <% end %>
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[welsh_address]", 'Yes', @case_info.welsh_address == 'Yes', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[welsh_address]", 'Yes', class: "govuk-label govuk-radios__label" %>
+            <%= radio_button_tag("case_information[omicable]", 'Yes', @case_info.omicable == 'Yes', class: "govuk-radios__input") %>
+            <%= label_tag "case_information[omicable]", 'Yes', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[welsh_address]", 'No', @case_info.welsh_address == 'No', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[welsh_address]", "No", class: "govuk-label govuk-radios__label" %>
+            <%= radio_button_tag("case_information[omicable]", 'No', @case_info.omicable == 'No', class: "govuk-radios__input") %>
+            <%= label_tag "case_information[omicable]", "No", class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>
@@ -37,7 +37,7 @@
         </legend>
         <% if @case_info.errors[:case_allocation].present? %>
           <span class="govuk-error-message">
-            Case allocation <%= @case_info.errors[:case_allocation].first %>
+            <%= @case_info.errors[:case_allocation].first %>
           </span>
         <% end %>
 
@@ -62,7 +62,7 @@
 
       <% if @case_info.errors[:tier].present? %>
         <span class="govuk-error-message">
-          Tier <%= @case_info.errors[:tier].first %>
+          <%= @case_info.errors[:tier].first %>
         </span>
       <% end %>
 

--- a/app/views/shared/_validation_errors.html.erb
+++ b/app/views/shared/_validation_errors.html.erb
@@ -5,9 +5,9 @@
   </h2>
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
-      <% errors.full_messages.each do |message| %>
+      <% errors.messages.each do |_field, message| %>
       <li>
-          <%= message %>
+          <%= message.first %>
       </li>
       <% end %>
     </ul>

--- a/db/migrate/20190320130118_change_welshness_name.rb
+++ b/db/migrate/20190320130118_change_welshness_name.rb
@@ -1,0 +1,9 @@
+class ChangeWelshnessName < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :case_information, :welsh_address, :omicable
+  end
+
+  def down
+    rename_column :case_information, :omicable, :welsh_address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_01_092256) do
+ActiveRecord::Schema.define(version: 2019_03_20_130118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2019_03_01_092256) do
     t.string "tier"
     t.string "case_allocation"
     t.string "nomis_offender_id"
-    t.text "welsh_address"
+    t.text "omicable"
     t.text "prison"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,7 +54,7 @@ CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G7806VO',
   tier: 'A',
   case_allocation: 'NPS',
-  welsh_address: 'Yes',
+  omicable: 'Yes',
   prison: 'LEI'
 )
 
@@ -62,7 +62,7 @@ CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G3462VT',
   tier: 'B',
   case_allocation: 'NPS',
-  welsh_address: 'Yes',
+  omicable: 'Yes',
   prison: 'LEI'
 )
 
@@ -70,7 +70,7 @@ CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G3536UF',
   tier: 'C',
   case_allocation: 'CRC',
-  welsh_address: 'No',
+  omicable: 'No',
   prison: 'LEI'
 )
 
@@ -78,6 +78,6 @@ CaseInformation.find_or_create_by!(
   nomis_offender_id: 'G2911GD',
   tier: 'D',
   case_allocation: 'CRC',
-  welsh_address: 'No',
+  omicable: 'No',
   prison: 'LEI'
 )

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -14,7 +14,7 @@ feature 'Allocation' do
   }
 
   let!(:case_information) {
-    CaseInformation.create!(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_address: 'No', prison: 'LEI')
+    CaseInformation.create!(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'No', prison: 'LEI')
   }
 
   scenario 'accepting a recommended allocation', vcr: { cassette_name: :create_new_allocation_feature } do
@@ -75,7 +75,7 @@ feature 'Allocation' do
     expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
 
     click_button('Continue')
-    expect(page).to have_content('Override reasons must be provided')
+    expect(page).to have_content('Select one or more reasons for not accepting the recommendation')
     expect(Override.count).to eq(0)
   end
 
@@ -92,7 +92,7 @@ feature 'Allocation' do
 
     check('override-conditional-4')
     click_button('Continue')
-    expect(page).to have_content('More detail must be provided when Other is selected')
+    expect(page).to have_content('Please provide extra detail when Other is selected')
     expect(Override.count).to eq(0)
   end
 

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -7,7 +7,7 @@ feature 'case information feature' do
     signin_user
     visit new_case_information_path(nomis_offender_id)
 
-    choose('case_information_welsh_address_Yes')
+    choose('case_information_omicable_Yes')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'
@@ -32,8 +32,8 @@ feature 'case information feature' do
     click_button 'Save'
 
     expect(CaseInformation.count).to eq(0)
-    expect(page).to have_content("Case allocation must be provided")
-    expect(page).to have_content("Welsh address must be selected")
+    expect(page).to have_content("Select the service provider for this case")
+    expect(page).to have_content("Select yes if the prisoner’s last known address was in Wales")
   end
 
   it 'complains if all data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_all_feature } do
@@ -46,9 +46,9 @@ feature 'case information feature' do
     click_button 'Save'
 
     expect(CaseInformation.count).to eq(0)
-    expect(page).to have_content("Case allocation must be provided")
-    expect(page).to have_content("Tier must be provided")
-    expect(page).to have_content("Welsh address must be selected")
+    expect(page).to have_content("Select the service provider for this case")
+    expect(page).to have_content("Select the prisoner’s tier")
+    expect(page).to have_content("Select yes if the prisoner’s last known address was in Wales")
   end
 
   it 'complains if tier data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_tier_feature } do
@@ -62,7 +62,7 @@ feature 'case information feature' do
     click_button 'Save'
 
     expect(CaseInformation.count).to eq(0)
-    expect(page).to have_content("Tier must be provided")
+    expect(page).to have_content("Select the prisoner’s tier")
   end
 
   it 'allows editing case information for a prisoner', :raven_intercept_exception, vcr: { cassette_name: :case_information_editing_feature } do
@@ -70,7 +70,7 @@ feature 'case information feature' do
 
     signin_user
     visit new_case_information_path(nomis_offender_id)
-    choose('case_information_welsh_address_No')
+    choose('case_information_omicable_No')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'
@@ -79,7 +79,7 @@ feature 'case information feature' do
 
     expect(page).to have_content('Case information')
     expect(page).to have_content('G1821VA')
-    choose('case_information_welsh_address_No')
+    choose('case_information_omicable_No')
     choose('case_information_case_allocation_CRC')
     click_button 'Update'
 

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -5,7 +5,7 @@ feature "edit a POM's details" do
   let(:nomis_offender_id) { 'G4273GI' }
 
   before do
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC', welsh_address: 'Yes', prison: 'LEI')
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC', omicable: 'Yes', prison: 'LEI')
   end
 
   it "makes an inactive POM active", vcr: { cassette_name: :edit_poms_activate_pom_feature } do

--- a/spec/features/view_allocations_spec.rb
+++ b/spec/features/view_allocations_spec.rb
@@ -5,7 +5,7 @@ feature "view POM's caseload" do
   let(:nomis_offender_id) { 'G4273GI' }
 
   before do
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_address: 'Yes', prison: 'LEI')
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'Yes', prison: 'LEI')
   end
 
   it 'displays all cases for a specific POM',  vcr: { cassette_name: :show_poms_caseload } do

--- a/spec/models/override_spec.rb
+++ b/spec/models/override_spec.rb
@@ -2,22 +2,22 @@ require 'rails_helper'
 
 RSpec.describe Override, type: :model do
   it {
-    expect(subject).to validate_presence_of(:nomis_offender_id).with_message('must be provided')
+    expect(subject).to validate_presence_of(:nomis_offender_id).with_message('NOMIS Offender ID is required')
   }
 
   it {
-    expect(subject).to validate_presence_of(:nomis_staff_id).with_message('must be provided')
+    expect(subject).to validate_presence_of(:nomis_staff_id).with_message('NOMIS Staff ID is required')
   }
 
   it {
-    expect(subject).to validate_presence_of(:override_reasons).with_message('must be provided')
+    expect(subject).to validate_presence_of(:override_reasons).with_message('Select one or more reasons for not accepting the recommendation')
   }
 
   it {
     o = described_class.create(nomis_offender_id: 'A', nomis_staff_id: 1, override_reasons: ['other'])
     expect(o.valid?).to be false
     expect(o.errors[:more_detail].count).to eq(1)
-    expect(o.errors[:more_detail].first).to eq('must be provided when Other is selected')
+    expect(o.errors[:more_detail].first).to eq('Please provide extra detail when Other is selected')
   }
 
   it {

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -6,7 +6,7 @@ describe CaseInformationService, vcr: { cassette_name: :caseinfo_service_spec } 
       nomis_offender_id: 'X1000XX',
       tier: 'A',
       case_allocation: 'NPS',
-      welsh_address: 'Yes',
+      omicable: 'Yes',
       prison: 'LEI'
     )
   }

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -18,7 +18,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     nomis_offender_id = 'G4273GI'
 
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_address: 'Yes', prison: 'LEI')
+    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', omicable: 'Yes', prison: 'LEI')
     offender = OffenderService.get_offender(nomis_offender_id)
 
     expect(offender).to be_kind_of(Nomis::Models::Offender)

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -32,14 +32,14 @@ describe ResponsibilityService do
 
   let(:offender_not_welsh) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = false
+      o.omicable = false
       o.release_date = DateTime.now.utc.to_date + 6.months
     }
   }
 
   let(:offender_welsh_crc_lt_12_wk) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'CRC'
       o.release_date = DateTime.now.utc.to_date + 2.weeks
     }
@@ -47,7 +47,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_crc_gt_12_wk) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'CRC'
       o.release_date = DateTime.now.utc.to_date + 13.weeks
     }
@@ -55,7 +55,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_gt_10_mths) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'NPS'
       o.release_date = DateTime.now.utc.to_date + 11.months
     }
@@ -63,7 +63,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_lt_10_mths) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'NPS'
       o.release_date = DateTime.now.utc.to_date + 9.months
     }
@@ -71,7 +71,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_old_case_gt_15_mths) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'NPS'
       o.sentence_date = DateTime.new(2019, 1, 19).utc
       o.release_date = DateTime.now.utc.to_date + 16.months
@@ -80,7 +80,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_old_case_lt_15_mths) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'NPS'
       o.sentence_date = DateTime.new(2019, 2, 20).utc
       o.release_date = DateTime.now.utc.to_date + 9.months
@@ -89,7 +89,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_new_case_gt_10_mths) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'NPS'
       o.sentence_date = DateTime.new(2019, 1, 19).utc
       o.release_date = DateTime.now.utc.to_date + 16.months
@@ -98,7 +98,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_new_case_lt_10_mths) {
     Nomis::Models::Offender.new.tap { |o|
-      o.welsh_address = true
+      o.omicable = true
       o.case_allocation = 'NPS'
       o.sentence_date = DateTime.new(2019, 2, 20).utc
       o.release_date = DateTime.now.utc.to_date + 9.months


### PR DESCRIPTION
As the welsh_address check is just another way of saying "does this
offender fall within the omic rules?" we don't want the welshness test
to hang around.  To this end this PR renames welsh_address everywhere
EXCEPT in the labels to omicable.

This means that in another PR we can separate out the welshness test out
into a partial (with a partial for england containing a hidden input) so
that we can deploy to an English prison.