### PR TITLE
Filter out offenders on remand

### DIFF
--- a/app/services/nomis/models/offender_short.rb
+++ b/app/services/nomis/models/offender_short.rb
@@ -29,6 +29,7 @@ module Nomis
       attribute :allocation_date, :date
       attribute :case_allocation, :string
       attribute :omicable, :boolean
+      attribute :convicted_status, :string
 
       def awaiting_allocation_for
         return 0 if sentence_date.blank?

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -40,19 +40,22 @@ class OffenderService
                        end
 
     offenders.select { |offender|
+      # If the offender is explicitly on remand, then exclude them.  Until this Elite2
+      # change is in production, we can't constrain this to just processing "Convicted"
+      # records.
+      next false if offender.convicted_status == 'Remand'
+
       offender.release_date = sentence_details[offender.offender_no].release_date
-      if offender.release_date.present?
-        record = mapped_tiers[offender.offender_no]
-        if record
-          offender.tier = record.tier
-          offender.case_allocation = record.case_allocation
-          offender.omicable = record.omicable
-        end
-        offender.sentence_date = sentence_details[offender.offender_no].sentence_date
-        true
-      else
-        false
+      next false if offender.release_date.blank?
+
+      record = mapped_tiers[offender.offender_no]
+      if record
+        offender.tier = record.tier
+        offender.case_allocation = record.case_allocation
+        offender.omicable = record.omicable
       end
+      offender.sentence_date = sentence_details[offender.offender_no].sentence_date
+      true
     }
   end
   # rubocop:enable Metrics/MethodLength

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe SearchService do
   it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
     offenders = described_class.search_for_offenders('', 'LEI')
-    expect(offenders.count).to eq(623)
+    expect(offenders.count).to eq(612)
   end
 
   it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -6,7 +6,7 @@ describe SummaryService do
     summary = described_class.new.summary(:pending, 'LEI', 15, SummaryService::SummaryParams.new)
 
     expect(summary.offenders.count).to eq(10)
-    expect(summary.page_count).to eq(63)
+    expect(summary.page_count).to eq(62)
   end
 
   it "will sort a summary", vcr: { cassette_name: :allocation_summary_service_summary_sort } do


### PR DESCRIPTION
Where an offender is on Remand (from the new convicted_status field in
OffenderShort) then exclude them from processing.  This will eventually
be the opposite, include the offender if convicted_status == 'Convicted'
but until the Elite2 change is in production, this field will be nil and
so we can't check for Convicted.

This is a much better check than just checking the absence of a release
date and we will eventually be able to filter them out on the server.