### PR TITLE
Update email fields

### DIFF
--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -6,6 +6,7 @@ class PomMailer < GovukNotifyRails::Mailer
     set_personalisation(
       email_subject: 'New OMIC allocation',
       pom_name: params[:pom_name],
+      responsibility: params[:responsibility],
       offender_name: params[:offender_name],
       nomis_offender_id: params[:offender_no],
       message: message || '',
@@ -21,6 +22,7 @@ class PomMailer < GovukNotifyRails::Mailer
     set_personalisation(
       email_subject: 'OMIC case reallocation',
       previous_pom_name: params[:previous_pom_name],
+      responsibility: params[:responsibility],
       new_pom_name: params[:new_pom_name],
       offender_name: params[:offender_name],
       nomis_offender_id: params[:offender_no],

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -18,7 +18,7 @@ class EmailService
 
       PomMailer.deallocation_email(
         previous_pom_name: previous_pom.first_name.capitalize,
-        responsibility: current_responsibility(offender),
+        responsibility: current_responsibility(offender).downcase,
         previous_pom_email: previous_pom.emails.first,
         new_pom_name: pom.full_name,
         offender_name: offender.full_name,
@@ -32,7 +32,7 @@ class EmailService
 
     PomMailer.new_allocation_email(
       pom_name: pom.first_name.capitalize,
-      responsibility: current_responsibility(offender),
+      responsibility: current_responsibility(offender).downcase,
       pom_email: pom.emails.first,
       offender_name: offender.full_name,
       offender_no: offender.offender_no,

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -18,6 +18,7 @@ class EmailService
 
       PomMailer.deallocation_email(
         previous_pom_name: previous_pom.first_name.capitalize,
+        responsibility: current_responsibility(offender),
         previous_pom_email: previous_pom.emails.first,
         new_pom_name: pom.full_name,
         offender_name: offender.full_name,
@@ -31,6 +32,7 @@ class EmailService
 
     PomMailer.new_allocation_email(
       pom_name: pom.first_name.capitalize,
+      responsibility: current_responsibility(offender),
       pom_email: pom.emails.first,
       offender_name: offender.full_name,
       offender_no: offender.offender_no,
@@ -38,5 +40,11 @@ class EmailService
       url: url
                                    ).deliver_later
   end
-  # rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/MethodLength
+
+private
+
+  def self.current_responsibility(offender)
+    ResponsibilityService.new.calculate_pom_responsibility(offender)
+  end
 end

--- a/spec/mailers/pom_mailer_spec.rb
+++ b/spec/mailers/pom_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PomMailer, type: :mailer do
       {
         pom_name: "Jones, Ross",
         pom_email: "something@example.com",
-        responsibility: "Supporting",
+        responsibility: "supporting",
         offender_name: "Franks, Jason",
         offender_no: "AB1234S",
         message: "This is just a test",

--- a/spec/mailers/pom_mailer_spec.rb
+++ b/spec/mailers/pom_mailer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PomMailer, type: :mailer do
       {
         pom_name: "Jones, Ross",
         pom_email: "something@example.com",
+        responsibility: "Supporting",
         offender_name: "Franks, Jason",
         offender_no: "AB1234S",
         message: "This is just a test",
@@ -29,6 +30,7 @@ RSpec.describe PomMailer, type: :mailer do
           to eq(
             email_subject: 'New OMIC allocation',
             pom_name: params[:pom_name],
+            responsibility: params[:responsibility],
             offender_name: params[:offender_name],
             nomis_offender_id: params[:offender_no],
             message: "Additional information: " + params[:message],
@@ -43,6 +45,7 @@ RSpec.describe PomMailer, type: :mailer do
             to eq(
               email_subject: 'New OMIC allocation',
               pom_name: params[:pom_name],
+              responsibility: params[:responsibility],
               offender_name: params[:offender_name],
               nomis_offender_id: params[:offender_no],
               message: params[:message],
@@ -56,6 +59,7 @@ RSpec.describe PomMailer, type: :mailer do
     let(:params) do
       {
         previous_pom_name: "Pobee-Norris, Kath",
+        responsibility: "Supporting",
         previous_pom_email: "another@example.com",
         new_pom_name: "Jones, Ross",
         offender_name: "Marks, Simon",
@@ -81,6 +85,7 @@ RSpec.describe PomMailer, type: :mailer do
           to eq(
             email_subject: 'OMIC case reallocation',
             previous_pom_name: params[:previous_pom_name],
+            responsibility: params[:responsibility],
             new_pom_name: params[:new_pom_name],
             offender_name: params[:offender_name],
             nomis_offender_id: params[:offender_no],


### PR DESCRIPTION
The Notify template has been updated with new content and therefore we
need to pass in the required fields as without it the emails aren't able
to be sent.  The addition to the template is to include whether the POM
is responsible or supporting in regards to that specific
allocated/deallocated offender.