### PR TITLE
Add text box to overrides

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -44,6 +44,7 @@ class AllocationsController < ApplicationController
       allocated_at_tier: offender.tier,
       prison: active_caseload,
       override_reasons: override_reasons,
+      suitability_detail: suitability_detail,
       override_detail: override_detail,
       message: allocation_params[:message]
     }
@@ -106,5 +107,9 @@ private
 
   def override_detail
     @override[:more_detail] if @override.present?
+  end
+
+  def suitability_detail
+    @override[:suitability_detail] if @override.present?
   end
 end

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -11,6 +11,7 @@ class OverridesController < ApplicationController
       nomis_staff_id: override_params[:nomis_staff_id],
       nomis_offender_id: override_params[:nomis_offender_id],
       override_reasons: override_params[:override_reasons],
+      suitability_detail: override_params[:suitability_detail],
       more_detail: override_params[:more_detail]
     )
 
@@ -35,7 +36,11 @@ private
 
   def override_params
     params.require(:override).permit(
-      :nomis_offender_id, :nomis_staff_id, :more_detail, override_reasons: []
+      :nomis_offender_id,
+      :nomis_staff_id,
+      :more_detail,
+      :suitability_detail,
+      override_reasons: []
     )
   end
 end

--- a/app/models/override.rb
+++ b/app/models/override.rb
@@ -15,4 +15,12 @@ class Override < ApplicationRecord
     if: proc { |o|
           o.override_reasons.present? && o.override_reasons.include?('other')
         }
+
+  validates :suitability_detail,
+    presence: { message:
+                    'Please provide extra detail when suitability is selected'
+    },
+    if: proc { |o|
+      o.override_reasons.present? && o.override_reasons.include?('suitability')
+    }
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -42,6 +42,7 @@ class AllocationService
       nomis_offender_id: params[:nomis_offender_id]
     ).tap { |o|
       o.override_reasons = params[:override_reasons]
+      o.suitability_detail = params[:suitability_detail]
       o.more_detail = params[:more_detail]
       o.save
     }

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -21,8 +21,16 @@
               <%= hidden_field_tag("override[nomis_offender_id]", @prisoner.offender_no) %>
               <%= hidden_field_tag("override[nomis_staff_id]", @pom.staff_id) %>
               <div class="govuk-checkboxes__item">
-                <%= check_box_tag("override[override_reasons][]", "complex",  override_reason_contains(@override, 'complex'), id: "override-1", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", complex_reason_label(@prisoner), class: 'govuk-label govuk-checkboxes__label' %>
+                <input class="govuk-checkboxes__input" id="override-conditional-1" name="override[override_reasons][]" type="checkbox" value="suitability" data-aria-controls="override-1"
+                       <%= 'checked=checked' if override_reason_contains(@override, 'suitability') %> >
+                <label class="govuk-label govuk-checkboxes__label"
+                       for="override-conditional-1"><%= complex_reason_label(@prisoner) %></label>
+              </div>
+              <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="override-1">
+                <div class="govuk-form-group <% if @override.errors[:suitability_detail].present? %>govuk-form-group--error<% end %>">
+                  <label class="govuk-label" for="provide-detail">Enter your reason for this decision</label>
+                  <textarea class="govuk-textarea" id="suitability-detail" name="override[suitability_detail]" rows="3" aria-describedby="suitability-detail-hint"></textarea>
+                </div>
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "no-staff", override_reason_contains(@override, 'no-staff'), id: "override-2", class: "govuk-checkboxes__input") %>

--- a/db/migrate/20190322094954_add_suitability_detail_column_to_overrides.rb
+++ b/db/migrate/20190322094954_add_suitability_detail_column_to_overrides.rb
@@ -1,0 +1,11 @@
+class AddSuitabilityDetailColumnToOverrides < ActiveRecord::Migration[5.2]
+  def up
+    add_column :overrides, :suitability_detail, :string
+    add_column :allocations, :suitability_detail, :string
+  end
+
+  def down
+    remove_column :overrides, :suitability_detail
+    remove_column :allocations, :suitability_detail
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_20_130118) do
+ActiveRecord::Schema.define(version: 2019_03_22_094954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_03_20_130118) do
     t.integer "nomis_staff_id"
     t.integer "nomis_booking_id"
     t.text "message"
+    t.string "suitability_detail"
     t.index ["nomis_offender_id"], name: "index_allocations_on_nomis_offender_id"
     t.index ["nomis_staff_id"], name: "index_allocations_on_nomis_staff_id"
   end
@@ -47,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_03_20_130118) do
     t.string "nomis_offender_id"
     t.string "override_reasons"
     t.string "more_detail"
+    t.string "suitability_detail"
   end
 
   create_table "pom_details", force: :cascade do |t|

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -96,6 +96,23 @@ feature 'Allocation' do
     expect(Override.count).to eq(0)
   end
 
+  scenario 'overriding an allocation can validate missing suitabilitydetail', vcr: { cassette_name: :override_suitability_allocation_feature } do
+    signin_user
+
+    visit new_allocations_path(nomis_offender_id)
+
+    within('.not_recommended_pom_row_0') do
+      click_link 'Allocate'
+    end
+
+    expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
+
+    check('override-conditional-1')
+    click_button('Continue')
+    expect(page).to have_content('Please provide extra detail when suitability is selected')
+    expect(Override.count).to eq(0)
+  end
+
   scenario 're-allocating', vcr: { cassette_name: :re_allocate_feature } do
     probation_officer_pom_detail.allocations.create!(
       nomis_offender_id: nomis_offender_id,

--- a/spec/models/override_spec.rb
+++ b/spec/models/override_spec.rb
@@ -25,4 +25,17 @@ RSpec.describe Override, type: :model do
     expect(o.valid?).to be true
     expect(o.errors[:more_detail].count).to eq(0)
   }
+
+  it {
+    o = described_class.create(nomis_offender_id: 'A', nomis_staff_id: 1, override_reasons: ['suitability'])
+    expect(o.valid?).to be false
+    expect(o.errors[:suitability_detail].count).to eq(1)
+    expect(o.errors[:suitability_detail].first).to eq('Please provide extra detail when suitability is selected')
+  }
+
+  it {
+    o = described_class.create(nomis_offender_id: 'A', nomis_staff_id: 1, override_reasons: ['dogs'])
+    expect(o.valid?).to be true
+    expect(o.errors[:suitability_detail].count).to eq(0)
+  }
 end


### PR DESCRIPTION
When going through the allocation flow you have the option to override
the POM type/level.  When overriding you are directed to a page where
you are required to choose the reason(s) from a list of checkboxes.
This piece of work implements the addition of a new text box which
asks for further detail if the overriding choice is related to
suitability.