### PR TITLE
Handle missing release date

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,8 +51,24 @@ module ApplicationHelper
 
   def responsibility_label(offender_responsibility)
     {
+      'No release date' => 'Custody',
       'Probation' => 'Community',
       'Prison' => 'Custody'
     }[offender_responsibility]
+  end
+
+  def parole_or_release_date(offender)
+    # FIXME: This should say Indeterminate for indeterminate
+    # release dates, but we depend on imprisonmentStatus
+    # which we need adding to the multi-offender endpoint.
+    if offender.has_indeterminate_release_date
+      return ''
+    end
+
+    if offender.parole_eligibility_date.present?
+      return format_date(offender.parole_eligibility_date)
+    end
+
+    format_date(offender.release_date)
   end
 end

--- a/app/services/bucket.rb
+++ b/app/services/bucket.rb
@@ -24,7 +24,7 @@ class Bucket
   end
 
   def valid_sort_fields
-    [:last_name, :sentence_date, :release_date]
+    [:last_name]
   end
 
   def take(count, from)

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -34,6 +34,8 @@ module Nomis
       attribute :case_allocation, :string
       attribute :omicable, :boolean
       attribute :allocated_pom_name, :string
+      attribute :parole_eligibility_date, :date
+      attribute :has_indeterminate_release_date
 
       def case_owner
         @case_owner ||= ResponsibilityService.new.calculate_case_owner(self)

--- a/app/services/nomis/models/offender_short.rb
+++ b/app/services/nomis/models/offender_short.rb
@@ -30,11 +30,17 @@ module Nomis
       attribute :case_allocation, :string
       attribute :omicable, :boolean
       attribute :convicted_status, :string
+      attribute :parole_eligibility_date, :date
+      attribute :has_indeterminate_release_date
 
       def awaiting_allocation_for
-        return 0 if sentence_date.blank?
+        omic_start_date = Date.new(2019, 2, 4)
 
-        (Time.zone.today - sentence_date).to_i
+        if sentence_date.nil? || sentence_date < omic_start_date
+          (Time.zone.today - omic_start_date).to_i
+        else
+          (Time.zone.today - sentence_date).to_i
+        end
       end
 
       def full_name

--- a/app/services/nomis/models/sentence_detail.rb
+++ b/app/services/nomis/models/sentence_detail.rb
@@ -22,6 +22,18 @@ module Nomis
         sentence_detail['release_date']
       end
 
+      def tariff_date
+        sentence_detail['tariff_date']
+      end
+
+      def parole_eligibility_date
+        sentence_detail['parole_eligibility_date']
+      end
+
+      def indeterminate_release_date?
+        release_date.nil? && tariff_date.present?
+      end
+
       def full_name
         "#{last_name}, #{first_name}".titleize
       end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -13,6 +13,11 @@ class OffenderService
       sentence_detail = get_sentence_details([offender_no])
       o.release_date = sentence_detail[offender_no].release_date
       o.sentence_date = sentence_detail[offender_no].sentence_date
+      o.parole_eligibility_date =
+        sentence_detail[offender_no].parole_eligibility_date
+      o.has_indeterminate_release_date =
+        sentence_detail[offender_no].indeterminate_release_date?
+
       o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)
     }
   end
@@ -45,16 +50,20 @@ class OffenderService
       # records.
       next false if offender.convicted_status == 'Remand'
 
-      offender.release_date = sentence_details[offender.offender_no].release_date
-      next false if offender.release_date.blank?
-
       record = mapped_tiers[offender.offender_no]
       if record
         offender.tier = record.tier
         offender.case_allocation = record.case_allocation
         offender.omicable = record.omicable
       end
+
+      offender.release_date = sentence_details[offender.offender_no].release_date
       offender.sentence_date = sentence_details[offender.offender_no].sentence_date
+      offender.parole_eligibility_date =
+        sentence_details[offender.offender_no].parole_eligibility_date
+      offender.has_indeterminate_release_date =
+        sentence_details[offender.offender_no].indeterminate_release_date?
+
       true
     }
   end

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -23,7 +23,7 @@ class ResponsibilityService
   end
 
   def calculate_pom_responsibility(offender)
-    return UNKNOWN if offender.release_date.nil?
+    return RESPONSIBLE if offender.release_date.nil?
     return SUPPORTING unless omicable?(offender)
 
     return RESPONSIBLE if nps_case?(offender) &&

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -10,7 +10,9 @@
   </tr>
   <tr class="govuk-table__row">
       <td class="govuk-table__cell">Release parole/eligibility</td>
-      <td class="govuk-table__cell table_cell__left_align"><%= format_date(@prisoner.release_date) %></td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= parole_or_release_date(@prisoner) %>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -23,7 +23,9 @@
       <tr class="govuk-table__row allocated_offender_row_<%= i %>">
         <td aria-label="Prisoner name" class="govuk-table__cell"><%= offender.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell"><%= offender.offender_no %></td>
-        <td aria-label="Release date" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell">
+          <%= parole_or_release_date(offender) %>
+        </td>
         <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name %></td>
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
         <td aria-label="Action" class="govuk-table__cell "><%= link_to "Reallocate", edit_allocations_path(offender.offender_no) %></td>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -36,7 +36,9 @@
       <tr class="govuk-table__row offender_row_<%= i %>">
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= offender.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell"><%= offender.offender_no %></td>
-        <td aria-label="Release/parole eligibility" class="govuk-table__cell"><%= format_date(offender.release_date) %></td>
+        <td aria-label="Release/parole eligibility" class="govuk-table__cell">
+          <%= parole_or_release_date(offender) %>
+        </td>
         <td aria-label="Case owner" class="govuk-table__cell">
           <%= responsibility_label(ResponsibilityService.new.calculate_case_owner(offender)) %>
         </td>

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -10,6 +10,6 @@ feature 'Search for offenders' do
     click_on('search-button')
 
     expect(page).to have_current_path(search_path, ignore_query: true)
-    expect(page).to have_css('tbody tr', count: 4)
+    expect(page).to have_css('tbody tr', count: 6)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,4 +16,39 @@ RSpec.describe ApplicationHelper do
       expect(service_provider_label('NPS')).to eq('National Probation Service (NPS)')
     end
   end
+
+  describe 'release or parole date' do
+    it "has parole but no release" do
+      offender = Nomis::Models::Offender.new.tap { |o|
+        o.parole_eligibility_date = Date.new(2019, 1, 1)
+      }
+
+      expect(parole_or_release_date(offender)).to eq('01/01/2019')
+    end
+
+    it "has release but no parole" do
+      offender = Nomis::Models::Offender.new.tap { |o|
+        o.release_date = Date.new(2019, 1, 1)
+      }
+
+      expect(parole_or_release_date(offender)).to eq('01/01/2019')
+    end
+
+    it "has both parole and release" do
+      offender = Nomis::Models::Offender.new.tap { |o|
+        o.parole_eligibility_date = Date.new(2020, 1, 1)
+        o.release_date = Date.new(2021, 1, 1)
+      }
+
+      expect(parole_or_release_date(offender)).to eq('01/01/2020')
+    end
+
+    it "is indeterminate" do
+      offender = Nomis::Models::Offender.new.tap { |o|
+        o.has_indeterminate_release_date = true
+      }
+
+      expect(parole_or_release_date(offender)).to eq('')
+    end
+  end
 end

--- a/spec/models/nomis/models/sentence_details_spec.rb
+++ b/spec/models/nomis/models/sentence_details_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Nomis::Models::SentenceDetail, model: true do
+  it 'can work out indeterminate release dates' do
+    sentence_data = described_class.new.tap { |details|
+      details.sentence_detail = {
+        'tariff_date' => '2020-01-01'
+      }
+    }
+    expect(sentence_data.indeterminate_release_date?).to be true
+  end
+end

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -4,14 +4,14 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
   it "get first page of offenders for a specific prison" do
     offenders = OffenderService.get_offenders_for_prison('LEI')
     expect(offenders).to be_kind_of(Array)
-    expect(offenders.length).to eq(5)
+    expect(offenders.length).to eq(9)
     expect(offenders.first).to be_kind_of(Nomis::Models::OffenderShort)
   end
 
   it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
     offenders = OffenderService.get_offenders_for_prison('LEI', page_number: 116)
     expect(offenders).to be_kind_of(Array)
-    expect(offenders.length).to eq(5)
+    expect(offenders.length).to eq(6)
     expect(offenders.first).to be_kind_of(Nomis::Models::OffenderShort)
   end
 

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -127,7 +127,7 @@ describe ResponsibilityService do
       scenario 'is supporting' do
         resp = subject.calculate_pom_responsibility(offender_no_release_date)
 
-        expect(resp).to eq 'Unknown'
+        expect(resp).to eq 'Responsible'
       end
     end
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe SearchService do
   it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
     offenders = described_class.search_for_offenders('', 'LEI')
-    expect(offenders.count).to eq(612)
+    expect(offenders.count).to eq(932)
   end
 
   it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do
     offenders = described_class.search_for_offenders('Cal', 'LEI')
-    expect(offenders.count).to eq(4)
+    expect(offenders.count).to eq(6)
   end
 end

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -6,7 +6,7 @@ describe SummaryService do
     summary = described_class.new.summary(:pending, 'LEI', 15, SummaryService::SummaryParams.new)
 
     expect(summary.offenders.count).to eq(10)
-    expect(summary.page_count).to eq(62)
+    expect(summary.page_count).to eq(94)
   end
 
   it "will sort a summary", vcr: { cassette_name: :allocation_summary_service_summary_sort } do


### PR DESCRIPTION
We need to show offenders who may not have a release date. This PR
starts that as well as adding:

- Fields for marking release_date as indeterminate, not currently used
- Parole date (so we can show it in the Release/Parole date column)

Temporarily disabled sorting on dates as this would break with nil release_date