### PR TITLE
Fixes a crash when no offence is available for an offender

### DIFF
--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -45,6 +45,8 @@ module Nomis
       def self.get_offence(booking_id)
         route = "/elite2api/api/bookings/#{booking_id}/mainOffence"
         data = e2_client.get(route)
+        return '' if data.empty?
+
         data.first['offenceDescription']
       end
 


### PR DESCRIPTION
When trying to edit case information, if there is no offence for an offender, then there was a crash trying to retrieve the description of the offence.  This was likely introduced when we started handling 204s by returning nil so that the caller could decide what to do with the missing info.