### PR TITLE
Ignore JWT::ExpiredSignature when reporting to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,6 +2,7 @@ sentry_dsn = Rails.configuration.sentry_dsn
 if sentry_dsn
   Raven.configure do |config|
     config.dsn = sentry_dsn
+    config.excluded_exceptions << 'JWT::ExpiredSignature'
   end
 else
   Rails.logger.warn '[WARN] Sentry is not configured (SENTRY_DSN)'


### PR DESCRIPTION
We get a lot of ExpiredSignature messages, and they're not really
exceptions that we can do much about, so let's ignore them.