### PR TITLE
Custody was never valid for nps_calculation 

### DIFF
--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -76,7 +76,7 @@ private
   end
 
   def nps_calculation(offender)
-    return 'Custody' if offender.release_date.nil?
+    return PRISON if offender.earliest_release_date.nil?
 
     offender.tier == 'A' || offender.tier == 'B' ? PROBATION : PRISON
   end

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -113,7 +113,7 @@ describe ResponsibilityService do
 
     it "NPS allocations with no release date" do
       resp = subject.calculate_case_owner(offender_nps_no_release_date)
-      expect(resp).to eq 'Custody'
+      expect(resp).to eq 'Prison'
     end
 
     it "No allocation" do


### PR DESCRIPTION
Whilst we were allowing nil release_dates, we set the responsibility to Custody but it should have been PRISON.  Now we're only setting this if there is no earliest_release_date - which there should always be.