### PR TITLE
Change how dates are presented

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,8 +9,8 @@ module ApplicationHelper
     uri.to_s
   end
 
-  def format_date(date_obj)
-    return '' if date_obj.nil?
+  def format_date(date_obj, replacement: '')
+    return replacement if date_obj.nil?
 
     date_obj.strftime('%d/%m/%Y')
   end

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -1,17 +1,35 @@
 <table class="govuk-table">
   <tbody class="govuk-table__body">
-  <tr class="govuk-table__row">
-    <td class="govuk-table__header govuk-!-width-one-half" scope="row">Offence</td>
-    <td class="govuk-table__cell govuk-!-width-one-half"></td>
-  </tr>
-  <tr class="govuk-table__row">
-    <td class="govuk-table__cell govuk-!-width-one-half">Main offence</td>
-    <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.main_offence %></td>
-  </tr>
-  <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Release / parole eligibility</td>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Offence</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Main offence</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.main_offence %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Release date</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= format_date(@prisoner.earliest_release_date) %>
+        <%= format_date(@prisoner.release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Parole eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.parole_eligibility_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Home detention curfew eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.home_detention_curfew_eligibility_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Tariff date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.tariff_date, replacement: 'N/A') %>
       </td>
     </tr>
   </tbody>

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -12,7 +12,7 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Prisoner name</th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
-      <th class="govuk-table__header sorter-false" scope="col">Release/parole<br/>eligibility</th>
+      <th class="govuk-table__header sorter-false" scope="col">Earliest release date</th>
       <th class="govuk-table__header" scope="col">POM</th>
       <th class="govuk-table__header" scope="col">Allocation date</th>
       <th class="govuk-table__header sorter-false" scope="col">Action</th>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -24,7 +24,7 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Prisoner name</th>
       <th class="govuk-table__header sorter-false" scope="col">Prisoner number</th>
-      <th class="govuk-table__header sorter-false" xscope="col">Release/parole<br/>eligibility</th>
+      <th class="govuk-table__header sorter-false" xscope="col">Earliest release<br/>date</th>
       <th class="govuk-table__header sorter-false" scope="col">Case owner</th>
       <th class="govuk-table__header sorter-false" scope="col">Waiting</th>
       </th>


### PR DESCRIPTION
Shows dates on the allocations screen, and changes the title in summary
screens to reflect what is actually shown.

Implements most of
https://trello.com/c/n5mkrcP6/635-updates-to-dates-shown-sentence-type
but not the sentence type as we don't know that yet.

There may/may-not be content changes for these new labels at a later time.