### PR TITLE
Create and use a non-root user in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,14 @@ RUN \
 COPY Gemfile Gemfile.lock package.json ./
 
 RUN bundle install --without development test --jobs 2 --retry 3
+
 COPY . /app
+
+RUN mkdir -p /home/appuser && \
+  useradd appuser --user-group --home /home/appuser && \
+  chown -R appuser:appuser /app && \
+  chown -R appuser:appuser /home/appuser
+
+USER appuser
+
 RUN RAILS_ENV=production rails assets:precompile


### PR DESCRIPTION
The pod security policy in the live-1 cluster blocks containers which run processes as root.

This change adds a non-root user after all the software installation steps have finished, and then switches to it before running Rails.