### PR TITLE
Unwhitelist staging and temporarily disable smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,23 +278,23 @@ jobs:
       - *store_test_results
       - *store_artifacts
 
-  test_production:
-    <<: *test_container_config
-    working_directory: ~/staging
-    steps:
-      - checkout
-      - *restore_cache
-      - *install_gems
-      - *save_cache
-      - run:
-          name: run smoke tests
-          command: |
-            cd offender-management-integration-tests
-            bundle exec rspec spec/smoke --no-color --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
-          environment:
-            PRODUCTION_START_PAGE: https://moic.service.justice.gov.uk
-      - *store_test_results
-      - *store_artifacts
+  # test_production:
+  #   <<: *test_container_config
+  #   working_directory: ~/staging
+  #   steps:
+  #     - checkout
+  #     - *restore_cache
+  #     - *install_gems
+  #     - *save_cache
+  #     - run:
+  #         name: run smoke tests
+  #         command: |
+  #           cd offender-management-integration-tests
+  #           bundle exec rspec spec/smoke --no-color --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
+  #         environment:
+  #           PRODUCTION_START_PAGE: https://moic.service.justice.gov.uk
+  #     - *store_test_results
+  #     - *store_artifacts
 
   deploy_production:
     <<: *deploy_container_config
@@ -377,9 +377,9 @@ workflows:
           filters:
             branches:
               only: master
-      - test_production:
-          requires:
-            - deploy_production
-          filters:
-            branches:
-              only: master
+      # - test_production:
+      #     requires:
+      #       - deploy_production
+      #     filters:
+      #       branches:
+      #         only: master

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: offender-management-staging
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "81.134.202.29/32,62.25.109.197,81.134.202.29,172.22.16.3,54.229.117.192,87.81.252.58,217.41.68.40"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Staging doesn't have any data on it, so we can remove the whitelist so we can:

* Still see it
* Run integration tests against it

We also temporarily disable smoke tests against prod until we can do this with a K8s job that is whitelisted.