### PR TITLE
Sort prison switcher

### DIFF
--- a/app/services/nomis/models/offender_short.rb
+++ b/app/services/nomis/models/offender_short.rb
@@ -21,7 +21,7 @@ module Nomis
       attribute :aliases, :string
       attribute :iep_level, :string
       attribute :category_code, :string
-      attribute :bandCode
+      attribute :band_code
       attribute :rnum, :integer
       attribute :tier, :string
       attribute :allocated_pom_name, :string

--- a/app/services/prison_service.rb
+++ b/app/services/prison_service.rb
@@ -126,11 +126,4 @@ class PrisonService
   def self.name_for(code)
     PRISONS[code]
   end
-
-  def self.prisons_from_list(codelist)
-    prisons = codelist.each_with_object({}) { |code, hash|
-      hash[code] = PRISONS[code]
-    }
-    prisons.compact
-  end
 end

--- a/app/views/prisons/index.html.erb
+++ b/app/views/prisons/index.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-4">Choose prison</h1>
 
 <ul class="govuk-list">
-  <% caseloads.each do |prison| %>
+  <% caseloads.sort.each do |prison| %>
     <li>
       <a href="<%= prisons_update_path(code: prison, next: @next) %>"><%= prison_title(prison) %></a>
     </li>

--- a/spec/services/prison_service_spec.rb
+++ b/spec/services/prison_service_spec.rb
@@ -10,12 +10,4 @@ RSpec.describe PrisonService do
     name = described_class.name_for('ZZZ')
     expect(name).to be_nil
   end
-
-  it "will return prison names from a list" do
-    prisons = described_class.prisons_from_list(%w[LEI NWEB PVI WEI])
-
-    expect(prisons).to be_kind_of(Hash)
-    expect(prisons.count).to eq(3)  #  NWEB isn't a prison
-    expect(prisons['LEI']).to eq('HMP Leeds')
-  end
 end


### PR DESCRIPTION
The prison switcher page currently displays an unsorted list, which makes it more difficult to find the prison you want the longer the list gets.  This will now be sorted alphabetically.

This PR also removes an unused method and corrects an attribute name in the OffenderShort model.