### PR TITLE
Alphabetise the prison switcher list

### DIFF
--- a/app/services/prison_service.rb
+++ b/app/services/prison_service.rb
@@ -131,6 +131,6 @@ class PrisonService
     prisons = codelist.each_with_object({}) { |code, hash|
       hash[code] = PRISONS[code]
     }
-    prisons.compact
+    prisons.compact.sort_by { |_code, prison| prison }.to_h
   end
 end


### PR DESCRIPTION
At present the prison switcher list in production isn't sorted
alphabetically, making it difficult to find a specific prison if you've
got more than 5-10.  This PR adds sorting on the title to solve this
issue and make it more user friendly.