### PR TITLE
Filter convicted offenders in API call

### DIFF
--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -20,8 +20,6 @@ class OffenderService
   end
   # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/LineLength
   def self.get_offenders_for_prison(prison, page_number: 0, page_size: 10, tier_map: nil)
@@ -44,8 +42,6 @@ class OffenderService
                        end
 
     offenders.select { |offender|
-      next false unless offender.convicted_status == 'Convicted'
-
       sentencing = sentence_details[offender.offender_no]
       offender.sentence_detail = sentencing if sentencing.present?
       next false unless offender.sentenced?
@@ -62,8 +58,6 @@ class OffenderService
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/LineLength
-  # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.get_sentence_details(booking_ids)
     Nomis::Elite2::OffenderApi.get_bulk_sentence_details(booking_ids)

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -4,14 +4,14 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
   it "get first page of offenders for a specific prison" do
     offenders = OffenderService.get_offenders_for_prison('LEI')
     expect(offenders).to be_kind_of(Array)
-    expect(offenders.length).to eq(8)
+    expect(offenders.length).to eq(9)
     expect(offenders.first).to be_kind_of(Nomis::Models::OffenderShort)
   end
 
   it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
-    offenders = OffenderService.get_offenders_for_prison('LEI', page_number: 116)
+    offenders = OffenderService.get_offenders_for_prison('LEI', page_number: 93)
     expect(offenders).to be_kind_of(Array)
-    expect(offenders.length).to eq(6)
+    expect(offenders.length).to eq(2)
     expect(offenders.first).to be_kind_of(Nomis::Models::OffenderShort)
   end
 


### PR DESCRIPTION
Currently we filter out offenders who are not convicted in the
OffenderService, but this PR allows us to filter out offenders in the
API so that they are never returned.  This should make a small
difference to performance where a prison has lots of offenders on
remand.