### PR TITLE
 Update POM caseload page table header

### DIFF
--- a/app/services/nomis/models/sentence_detail.rb
+++ b/app/services/nomis/models/sentence_detail.rb
@@ -14,6 +14,18 @@ module Nomis
       attribute :facial_image_id
       attribute :internal_location_desc
 
+      def earliest_release_date
+        dates = [
+            release_date,
+            parole_eligibility_date,
+            home_detention_curfew_eligibility_date,
+            tariff_date
+        ].compact
+        return nil if dates.empty?
+
+        dates.min.to_date
+      end
+
       def sentence_start_date
         sentence_detail['sentence_start_date']
       end

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -37,7 +37,7 @@
       <tr class="govuk-table__row">
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
-        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
       </tr>

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -27,7 +27,7 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Prisoner name</th>
       <th class="govuk-table__header" scope="col">Prisoner number</th>
-      <th class="govuk-table__header" scope="col">Release/parole<br/>eligibility</th>
+      <th class="govuk-table__header" scope="col">Earliest release<br/> date</th>
       <th class="govuk-table__header" scope="col">Allocation<br/>date</th>
       <th class="govuk-table__header" scope="col">Role</th>
     </tr>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -24,7 +24,7 @@
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
         <td aria-label="Arrival date" class="govuk-table__cell "><%= format_date_string(sentence.sentence_start_date) %></td>
-        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.release_date.to_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
       </tr>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -13,7 +13,7 @@
       <th class="govuk-table__header" scope="col">Prisoner name</th>
       <th class="govuk-table__header" scope="col">Prisoner number</th>
       <th class="govuk-table__header" scope="col">Arrival date</th>
-      <th class="govuk-table__header" scope="col">Release/parole<br/>eligibility</th>
+      <th class="govuk-table__header" scope="col">Earliest release<br/> date</th>
       <th class="govuk-table__header" scope="col">Allocation<br/>date</th>
       <th class="govuk-table__header" scope="col">Role</th>
     </tr>


### PR DESCRIPTION
The table header in the POMs caseload pages still references 'release/
parole eligibility date', but this has been updated elsewhere to display
'earliest release date', this PR just updates the pages to be in line
with the rest of the site.