### PR TITLE
Handle indeterminate imprisonment_status

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,4 +55,11 @@ module ApplicationHelper
       'Prison' => 'Custody'
     }[offender_responsibility]
   end
+
+  def sentence_type_label(offender)
+    sentence = offender.imprisonment_status
+    return 'Indeterminate' if SentenceTypeService.indeterminate_sentence?(sentence)
+
+    'Determinate'
+  end
 end

--- a/app/models/sentence_type.rb
+++ b/app/models/sentence_type.rb
@@ -4,8 +4,8 @@ class SentenceType
 
   attr_accessor :code, :description, :duration_type
 
-  def self.for_offender(offender)
-    code = offender.imprisonment_status
+  def self.create(imprisonment_status)
+    code = imprisonment_status
     code = 'UNK_SENT' if code.nil?
 
     desc, duration_type = SENTENCE_TYPES.fetch(code)

--- a/app/services/nomis/models/offender_short.rb
+++ b/app/services/nomis/models/offender_short.rb
@@ -48,7 +48,8 @@ module Nomis
         release_date.present? ||
         parole_eligibility_date.present? ||
         home_detention_curfew_eligibility_date.present? ||
-        tariff_date.present?
+        tariff_date.present? ||
+        SentenceTypeService.indeterminate_sentence?(imprisonment_status)
       end
 
       def sentence_detail=(sentence_detail)

--- a/app/services/sentence_type_service.rb
+++ b/app/services/sentence_type_service.rb
@@ -1,9 +1,10 @@
 class SentenceTypeService
-  def self.determinate_sentence?(offender)
-    SentenceType.for_offender(offender).duration_type == SentenceType::DETERMINATE
+  def self.indeterminate_sentence?(sentence_type)
+    SentenceType.create(sentence_type).duration_type ==
+      SentenceType::INDETERMINATE
   end
 
-  def self.describe_sentence(offender)
-    SentenceType.for_offender(offender).description
+  def self.describe_sentence(sentence_type)
+    SentenceType.create(sentence_type).description
   end
 end

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -32,5 +32,13 @@
         <%= format_date(@prisoner.tariff_date, replacement: 'N/A') %>
       </td>
     </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Sentence type</td>
+      <td class="govuk-table__cell table_cell__left_align">
+          <%= sentence_type_label(@prisoner) %>
+          <!-- <%= @prisoner.imprisonment_status %> -->
+
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -22,6 +22,8 @@ feature 'Allocation' do
 
     visit new_allocations_path(nomis_offender_id)
 
+    expect(page).to have_content('Determinate')
+
     within('.recommended_pom_row_0') do
       click_link 'Allocate'
     end

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -10,6 +10,6 @@ feature 'Search for offenders' do
     click_on('search-button')
 
     expect(page).to have_current_path(search_path, ignore_query: true)
-    expect(page).to have_css('tbody tr', count: 4)
+    expect(page).to have_css('tbody tr', count: 6)
   end
 end

--- a/spec/models/sentence_type_spec.rb
+++ b/spec/models/sentence_type_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SentenceType, type: :model do
   it 'can return a sentence type for an offender with known sentence' do
     off = Nomis::Models::Offender.new.tap { |o| o.imprisonment_status = 'IPP' }
-    sentence_type = described_class.for_offender(off)
+    sentence_type = described_class.create(off.imprisonment_status)
 
     expect(sentence_type.code).to eq('IPP')
     expect(sentence_type.description).to eq('Indeterminate Sent for Public Protection')
@@ -12,7 +12,7 @@ RSpec.describe SentenceType, type: :model do
 
   it 'can handle offenders with no sentence' do
     off = Nomis::Models::Offender.new
-    sentence_type = described_class.for_offender(off)
+    sentence_type = described_class.create(off.imprisonment_status)
 
     expect(sentence_type.code).to eq('UNK_SENT')
     expect(sentence_type.description).to eq('Unknown Sentenced')

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe SearchService do
   it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
     offenders = described_class.search_for_offenders('', 'LEI')
-    expect(offenders.count).to eq(779)
+    expect(offenders.count).to eq(821)
   end
 
   it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do
     offenders = described_class.search_for_offenders('Cal', 'LEI')
-    expect(offenders.count).to eq(4)
+    expect(offenders.count).to eq(6)
   end
 end

--- a/spec/services/sentence_type_service_spec.rb
+++ b/spec/services/sentence_type_service_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 describe SentenceTypeService do
   it "can determine determinate sentences" do
-    off = Nomis::Models::Offender.new.tap { |o| o.imprisonment_status = 'CRIM_CON' }
+    off = Nomis::Models::OffenderShort.new.tap { |o| o.imprisonment_status = 'CRIM_CON' }
 
-    expect(described_class.determinate_sentence?(off)).to eq true
+    expect(described_class.indeterminate_sentence?(off.imprisonment_status)).to eq false
   end
 
   it "can determine indeterminate sentences" do
-    off = Nomis::Models::Offender.new.tap { |o| o.imprisonment_status = 'IPP' }
+    off = Nomis::Models::OffenderShort.new.tap { |o| o.imprisonment_status = 'IPP' }
 
-    expect(described_class.determinate_sentence?(off)).to eq false
+    expect(described_class.indeterminate_sentence?(off.imprisonment_status)).to eq true
   end
 
   it "can describe a sentence for an offender" do
-    off = Nomis::Models::Offender.new.tap { |o| o.imprisonment_status = 'IPP' }
-    desc = described_class.describe_sentence(off)
+    off = Nomis::Models::OffenderShort.new.tap { |o| o.imprisonment_status = 'IPP' }
+    desc = described_class.describe_sentence(off.imprisonment_status)
 
     expect(desc).to eq('Indeterminate Sent for Public Protection')
   end

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -6,7 +6,7 @@ describe SummaryService do
     summary = described_class.new.summary(:pending, 'LEI', 15, SummaryService::SummaryParams.new)
 
     expect(summary.offenders.count).to eq(10)
-    expect(summary.page_count).to eq(78)
+    expect(summary.page_count).to eq(83)
   end
 
   it "will sort a summary", vcr: { cassette_name: :allocation_summary_service_summary_sort } do


### PR DESCRIPTION
Displays the Indeterminate/Determinate sentence type on the allocation
page, and includes Indeterminate sentences in the the check for whether
an offender is sentenced.  The dates alone are not enough as
indeterminate sentences generally have no dates, or dates in the past.