### PR TITLE
Ensure unavailable is checked in edit pom when appropriate

### DIFF
--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -49,7 +49,7 @@
               <%= label_tag "edit_pom[status]", "Active", class: "govuk-label govuk-radios__label" %>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-conditional-2" name="edit_pom[status]" type="radio" value="unavailable" data-aria-controls="status-2" <%= 'checked' if @pom.status == 'active-unavailable'%>>
+              <input class="govuk-radios__input" id="status-conditional-2" name="edit_pom[status]" type="radio" value="unavailable" data-aria-controls="status-2" <%= 'checked' if @pom.status == 'unavailable'%>>
               <label class="govuk-label govuk-radios__label"
                      for="status-conditional-2">Active but unavailable for new cases</label>
             </div>

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -8,6 +8,22 @@ feature "edit a POM's details" do
     CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC', omicable: 'Yes', prison: 'LEI')
   end
 
+  it "setting unavailable shows selected on re-edit", vcr: { cassette_name: :edit_poms_unavailable_check } do
+    signin_user
+
+    visit edit_pom_path(485_637)
+    expect(page).to have_css('h1', text: 'Edit profile')
+
+    choose('working_pattern-2')
+    choose('Active but unavailable for new cases')
+    click_on('Save')
+
+    visit edit_pom_path(485_637)
+    expect(page).to have_css('h1', text: 'Edit profile')
+
+    expect(page).to have_field('status-conditional-2', checked: true)
+  end
+
   it "makes an inactive POM active", vcr: { cassette_name: :edit_poms_activate_pom_feature } do
     signin_user
 


### PR DESCRIPTION
Currently if you set someone to Unavailable, it works, but the next time
you visit the edit a pom page, it is not set.  This PR fixes that.