### PR TITLE
Handle URL mangling in allocations controller.

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -10,6 +10,11 @@ class AllocationsController < ApplicationController
   end
 
   def edit
+    unless AllocationService.active_allocation?(nomis_offender_id_from_url)
+      redirect_to new_allocations_path(nomis_offender_id_from_url)
+      return
+    end
+
     @prisoner = offender(nomis_offender_id_from_url)
     @previously_allocated_pom_ids =
       AllocationService.previously_allocated_poms(nomis_offender_id_from_url)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -21,6 +21,10 @@ class AllocationService
   end
   # rubocop:enable Metrics/MethodLength
 
+  def self.active_allocation?(nomis_offender_id)
+    Allocation.where(nomis_offender_id: nomis_offender_id, active: true).count > 0
+  end
+
   def self.active_allocations(nomis_offender_ids)
     Allocation.where(nomis_offender_id: nomis_offender_ids, active: true).map { |a|
       [

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -4,6 +4,7 @@ feature 'Allocation' do
   let!(:probation_officer_nomis_staff_id) { 485_636 }
   let!(:prison_officer_nomis_staff_id) { 485_752 }
   let!(:nomis_offender_id) { 'G4273GI' }
+  let!(:never_allocated_offender) { 'G1670VU' }
 
   let!(:probation_officer_pom_detail) {
     PomDetail.create!(
@@ -156,5 +157,12 @@ feature 'Allocation' do
       '.alert',
       text: 'Ozullirn Abbella has not been allocated - please try again'
                     )
+  end
+
+  scenario 'cannot reallocate a non-allocated offender', vcr: { cassette_name: :allocation_attempt_bad_reallocate } do
+    signin_user
+
+    visit edit_allocations_path(never_allocated_offender)
+    expect(page).to have_current_path new_allocations_path(never_allocated_offender)
   end
 end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe AllocationService do
     expect(alloc).to be_instance_of(Hash)
   end
 
+  it "Can tell if an allocated offender has an active allocation", vcr: { cassette_name: 'allocation_service_has_active_allocation' } do
+    alloc = described_class.active_allocation?(allocation.nomis_offender_id)
+    expect(alloc).to eq(true)
+  end
+
+  it "Can tell if an allocated offender has no active allocation", vcr: { cassette_name: 'allocation_service_has_no_active_allocation' } do
+    alloc = described_class.active_allocation?('G1670VU')
+    expect(alloc).to eq(false)
+  end
+
   it "Can get previous allocations for an offender where there are none", vcr: { cassette_name: 'allocation_service_previous_allocations_none' } do
     staff_ids = described_class.previously_allocated_poms(allocation.nomis_offender_id)
     expect(staff_ids).to eq([])


### PR DESCRIPTION
it's perhaps overly defensive, but currently the app crashes if somebody
changes the URL to attempt to reallocate an offender who has no active
allocation.  This PR stops them from doing that by redirecting to new
allocation instead.

It introduces active_allocation? to the AllocationService which simply
checks if there are a current active allocation for the provided
nomis_id.