### PR TITLE
Add performance measuring tools in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
 
-
   gem 'rack-mini-profiler'
   gem 'flamegraph'
   gem 'stackprof'

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,12 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
+
+
+  gem 'rack-mini-profiler'
+  gem 'flamegraph'
+  gem 'stackprof'
+  gem 'memory_profiler'
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fast_underscore (0.3.1)
     ffi (1.9.25)
+    flamegraph (0.9.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_notify_rails (2.1.0)
@@ -121,6 +122,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    memory_profiler (0.9.13)
     method_source (0.9.2)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
@@ -157,6 +159,8 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.1)
     rack (2.0.6)
+    rack-mini-profiler (1.0.2)
+      rack (>= 1.2.0)
     rack-protection (2.0.5)
       rack
     rack-test (1.1.0)
@@ -265,6 +269,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.12)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -306,6 +311,7 @@ DEPENDENCIES
   database_cleaner
   faraday
   fast_underscore
+  flamegraph
   govuk_notify_rails
   jbuilder (~> 2.8)
   jwt
@@ -314,11 +320,13 @@ DEPENDENCIES
   loaf
   lograge
   logstash-event
+  memory_profiler
   omniauth-oauth2
   pg
   plissken
   prometheus_exporter
   puma (~> 3.12)
+  rack-mini-profiler
   rails (~> 5.2.3)
   redis
   rspec-rails
@@ -332,6 +340,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  stackprof
   turbolinks (~> 5)
   typhoeus
   tzinfo-data

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,3 +48,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
+
+Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore


### PR DESCRIPTION
In development now adds a speed button at the top left of the page, from
where you can see how long the page took, where it spent most of its
time, how many queries were executed (and what they were).

In addition, adding a queryparam to any page can show extra info. You
should add ?pp=ACTION where ACTION is one of:

* flamegraph - to see a flamegraph of where time was spend
* profile-gc - profiling garbage collection
* profile-memory - memory profile
* trace-exceptions - shows where all exceptions are raised