### PR TITLE
Speed up the caseload page

### DIFF
--- a/app/services/case_information_service.rb
+++ b/app/services/case_information_service.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class CaseInformationService
+  def self.get_case_info_for_offenders(nomis_id_list, prison)
+    CaseInformation.where(
+      nomis_offender_id: nomis_id_list, prison: prison
+    ).each_with_object({}) { |caseinfo, hash|
+      hash[caseinfo.nomis_offender_id] = caseinfo
+    }
+  end
+
   def self.get_case_information(prison)
     cases = CaseInformation.where(prison: prison)
     cases.each_with_object({}) do |c, hash|

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -50,16 +50,33 @@ class PrisonOffenderManagerService
       allocation_list = allocation_list.offset(offset).limit(limit)
     end
 
+    offender_ids = allocation_list.map(&:nomis_offender_id)
     booking_ids = allocation_list.map(&:nomis_booking_id)
 
+    # Get an offender map of offender_id to sentence details and a hash of
+    # offender_no to case info details so we can fill in a fake offender
+    # object for each allocation. This will allow us to calculate the
+    # pom responsibility without having to make an API request per-offender.
+    offender_map = OffenderService.get_sentence_details(booking_ids)
+    case_info = CaseInformationService.get_case_info_for_offenders(offender_ids, prison)
+
     allocation_list_with_responsibility = allocation_list.map { |alloc|
-      offender = OffenderService.get_offender(alloc.nomis_offender_id)
+      offender_stub = Nomis::Models::Offender.new
+      if offender_map.key?(alloc.nomis_offender_id)
+        offender_stub.sentence_detail = offender_map[alloc.nomis_offender_id]
+      end
+
+      record = case_info[alloc.nomis_offender_id]
+      if record.present?
+        offender_stub.tier = record.tier
+        offender_stub.case_allocation = record.case_allocation
+        offender_stub.omicable = record.omicable
+      end
+
       alloc.responsibility =
-        ResponsibilityService.new.calculate_pom_responsibility(offender)
+        ResponsibilityService.new.calculate_pom_responsibility(offender_stub)
       alloc
     }
-
-    offender_map = OffenderService.get_sentence_details(booking_ids)
 
     allocations_and_offender = []
     allocation_list_with_responsibility.each do |alloc|

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -19,7 +19,7 @@ describe CaseInformationService, vcr: { cassette_name: :caseinfo_service_spec } 
   end
 
   it "can get case information for multiple offenders at once" do
-    cases = CaseInformationService.get_case_info_for_offenders(['X1000XX'],caseinfo.prison)
+    cases = CaseInformationService.get_case_info_for_offenders(['X1000XX'], caseinfo.prison)
     expect(cases).to be_kind_of(Hash)
     expect(cases.length).to eq(1)
     expect(cases[caseinfo.nomis_offender_id]).to be_kind_of(CaseInformation)

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -18,6 +18,13 @@ describe CaseInformationService, vcr: { cassette_name: :caseinfo_service_spec } 
     expect(cases[caseinfo.nomis_offender_id]).to be_kind_of(CaseInformation)
   end
 
+  it "can get case information for multiple offenders at once" do
+    cases = CaseInformationService.get_case_info_for_offenders(['X1000XX'],caseinfo.prison)
+    expect(cases).to be_kind_of(Hash)
+    expect(cases.length).to eq(1)
+    expect(cases[caseinfo.nomis_offender_id]).to be_kind_of(CaseInformation)
+  end
+
   it "can delete case information" do
     cases = CaseInformationService.get_case_information(caseinfo.prison)
     expect(cases.length).to eq(1)


### PR DESCRIPTION
The caseload page was fetching active allocations for the POM, but then
for each offender they were allocated to, was calling the get_offender
method in the OffenderService.  The only reason to call that API was to
have the case information and sentence_details set so that the pom's
responsibility could be calculated.

This PR uses a stub offender model, with the sentence_details and
case_information fetched in bulk and assigned to the fake offender
object.  This can then be used to calculate the POM's responsibility
with that offender.

The page now loads significantly faster as it reduces the number of API
calls to Elite2.