### PR TITLE
Expand the range of working patterns

### DIFF
--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -8,4 +8,20 @@ module PomHelper
       "Part time - #{pattern}"
     end
   end
+
+  # rubocop:disable Metrics/MethodLength
+  def working_pattern_to_days(pattern)
+    ['',
+     'half a day',
+     'one day',
+     'one and a half days',
+     'two days',
+     'two and a half days',
+     'three days',
+     'three and a half days',
+     'four days',
+     'four and a half days'
+    ][pattern]
+  end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -5,5 +5,9 @@ class PomDetail < ApplicationRecord
   has_many :allocations
   # rubocop:enable HasManyOrHasOneDependent
 
-  validates :nomis_staff_id, :working_pattern, :status, presence: true
+  validates :nomis_staff_id, presence: true
+  validates :status, presence: true
+  validates :working_pattern, presence: {
+    message: 'Select number of days worked'
+  }
 end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -91,10 +91,14 @@ class PrisonOffenderManagerService
 
   def self.update_pom(params)
     pom = PomDetail.where(nomis_staff_id: params[:nomis_staff_id]).first
-    pom.working_pattern = params[:working_pattern] || pom.working_pattern
+    pom.working_pattern = params[:working_pattern]
     pom.status = params[:status] || pom.status
-    pom.save!
-    AllocationService.deallocate_pom(params[:nomis_staff_id]) if pom.status == 'inactive'
+    pom.save
+
+    if pom.valid? && pom.status == 'inactive'
+      AllocationService.deallocate_pom(params[:nomis_staff_id])
+    end
+
     pom
   end
 end

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -6,35 +6,43 @@
     <h2 class="govuk-heading-l"><%= @pom.first_name.titleize %> <%= @pom.last_name.titleize %></h2>
 
     <div class='govuk-!-margin-top-6'>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h1 class="govuk-fieldset__heading">Working pattern</h1>
-          </legend>
+      <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <h1 class="govuk-fieldset__heading">Working pattern</h1>
+        </legend>
+        <div class="govuk-form-group <% if @errors[:working_pattern].present? %>govuk-form-group--error<% end %>">
+        <% if @errors[:working_pattern].present? %>
+          <span class="govuk-error-message">
+            <%= @errors[:working_pattern].first %>
+          </span>
+        <% end %>
+
           <div class="govuk-radios" data-module="radios">
-            <div class="govuk-radios__item">
-              <%= radio_button_tag("edit_pom[working_pattern]", "1.0", @pom.working_pattern == '1.0', id: "working_pattern-1", class: "govuk-radios__input") %>
-              <%= label_tag "edit_pom[working_pattern]", "Full time", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= radio_button_tag("edit_pom[working_pattern]", "0.8", @pom.working_pattern == '0.8', id: "working_pattern-2", class: "govuk-radios__input") %>
-              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.8", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= radio_button_tag("edit_pom[working_pattern]", "0.6", @pom.working_pattern == '0.6', id: "working_pattern-3", class: "govuk-radios__input") %>
-              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.6", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= radio_button_tag("edit_pom[working_pattern]", "0.4", @pom.working_pattern == '0.4', id: "working_pattern-4", class: "govuk-radios__input") %>
-              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.4", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= radio_button_tag("edit_pom[working_pattern]", "0.2", @pom.working_pattern == '0.2', id: "working_pattern-5", class: "govuk-radios__input") %>
-              <%= label_tag "edit_pom[working_pattern]", "Part time - 0.2", class: "govuk-label govuk-radios__label" %>
+            <div class="govuk-form-group">
+              <div class="govuk-radios__item">
+                <%= radio_button_tag("edit_pom[description]", "FT", @pom.working_pattern == '1.0', id: "working_pattern-ft", class: "govuk-radios__input") %>
+                <%= label_tag "edit_pom[description]", "Full time", class: "govuk-label govuk-radios__label" %>
+              </div>
+              <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="part-time-conditional-1" name="edit_pom[description]" type="radio" value="PT" data-aria-controls="conditional-part-time-conditional-1" <%= 'checked="checked"' if @pom.working_pattern != '1.0'%>>
+                  <label class="govuk-label govuk-radios__label" for="part-time-conditional-1">
+                    Part time
+                  </label>
+                </div>
+                <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-part-time-conditional-1">
+                  <% 9.downto(1).each do |value| %>
+                    <div class="govuk-radios__item">
+                      <%= radio_button_tag("edit_pom[working_pattern]", "0.#{value}", @pom.working_pattern == "0.#{value}", id: "working_pattern-#{value}", class: "govuk-radios__input") %>
+                      <%= label_tag "edit_pom[working_pattern]", "Part time 0.#{value} - #{working_pattern_to_days(value)}", class: "govuk-label govuk-radios__label" %>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
             </div>
           </div>
-        </fieldset>
-      </div>
+        </div>
+      </fieldset>
     </div>
 
     <div class='govuk-!-margin-top-6'>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -49,7 +49,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(page).to have_css('h1', text: 'Why are you allocating a probation officer POM?')
+    expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
 
     check('override-2')
     check('override-3')
@@ -75,7 +75,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(page).to have_css('h1', text: 'Why are you allocating a probation officer POM?')
+    expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
 
     click_button('Continue')
     expect(page).to have_content('Select one or more reasons for not accepting the recommendation')
@@ -91,7 +91,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(page).to have_css('h1', text: 'Why are you allocating a probation officer POM?')
+    expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
 
     check('override-conditional-4')
     click_button('Continue')
@@ -108,7 +108,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(page).to have_css('h1', text: 'Why are you allocating a probation officer POM?')
+    expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
 
     check('override-conditional-1')
     click_button('Continue')

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -36,10 +36,12 @@ feature "edit a POM's details" do
 
     expect(page).to have_css('h1', text: 'Edit profile')
 
-    choose('working_pattern-2')
-    choose('Active')
+    choose('working_pattern-5')
+    choose('status-1')
 
-    expect(page).to have_content('Part time - 0.8')
+    click_button('Save')
+
+    expect(page).to have_content('0.5')
     expect(page).to have_content('Active')
   end
 

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -33,7 +33,7 @@ feature "get poms list" do
     visit "/poms/485752/edit"
 
     expect(page).to have_css(".govuk-button", count: 1)
-    expect(page).to have_css(".govuk-radios__item", count: 8)
+    expect(page).to have_css(".govuk-radios__item", count: 14)
     expect(page).to have_content("Edit profile")
     expect(page).to have_content("Working pattern")
     expect(page).to have_content("Status")

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe PomDetail, type: :model do
   it { is_expected.to validate_presence_of(:nomis_staff_id) }
-  it { is_expected.to validate_presence_of(:working_pattern) }
+  it { is_expected.to validate_presence_of(:working_pattern).with_message('Select number of days worked') }
   it { is_expected.to validate_presence_of(:status) }
 end


### PR DESCRIPTION
Currently we only support 0.0, 0.2, 0.4, 0.6, 0.8 and 1.0. Our first
user went straight for 0.5.

This PR expands the options from 0.0->0.9 in 0.1 intervals, but 1.0
being handled by a separate radio button.  Selecting Full time will set
to 1.0, selecting Part time will give the option of choosing from 0 to
0.9

Unfortunately we have to jump through hoops because of the way we are
modelling POMs.  The main POM model is held in memory and we add a few
extra fields based from our local database.  The controller typically
works with the in-memory model when creating the details, but we need to
work with the subset of fields when persisting the data.  Our options
are:

* Re-write the controller to focus on working with the POMDetail model
  instead of the POM.
* Persist the POM details (name, pom_type etc) in our local database,
  and provide the ability to remove a POM from a given prison.

The latter, whilst putting more responsibility on the SPO to maintain
the list would reduce the number of API calls we would have to make and
should make a lot of the system simpler (as for instance, we can
reference allocations to a full model).