### PR TITLE
Update case owner calculation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,11 +51,12 @@ module ApplicationHelper
     ResponsibilityService.new.calculate_pom_responsibility(offender)
   end
 
-  def responsibility_label(offender_responsibility)
-    {
-      'Probation' => 'Community',
-      'Prison' => 'Custody'
-    }[offender_responsibility]
+  def responsibility_label(offender)
+    if pom_responsibility_label(offender) == 'Responsible'
+      'Custody'
+    else
+      'Community'
+    end
   end
 
   def sentence_type_label(offender)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,8 +51,8 @@ module ApplicationHelper
     ResponsibilityService.new.calculate_pom_responsibility(offender)
   end
 
-  def responsibility_label(offender)
-    if pom_responsibility_label(offender) == 'Responsible'
+  def case_owner_label(offender)
+    if offender.case_owner == 'Prison'
       'Custody'
     else
       'Community'

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -2,7 +2,7 @@
 
 module Nomis
   module Models
-    class Offender
+    class Offender < OffenderBase
       include MemoryModel
 
       attribute :convicted_status, :string
@@ -28,39 +28,6 @@ module Nomis
       attribute :sentence_start_date, :date
       attribute :tariff_date, :date
       attribute :tier, :string
-
-      def sentence_detail=(sentence_detail)
-        self.release_date = sentence_detail.release_date
-        self.sentence_start_date = sentence_detail.sentence_start_date
-        self.parole_eligibility_date = sentence_detail.parole_eligibility_date
-        self.tariff_date = sentence_detail.tariff_date
-        self.home_detention_curfew_eligibility_date =
-          sentence_detail.home_detention_curfew_eligibility_date
-      end
-
-      def earliest_release_date
-        dates = [
-          release_date,
-          parole_eligibility_date,
-          home_detention_curfew_eligibility_date,
-          tariff_date
-        ].compact
-        return nil if dates.empty?
-
-        dates.min
-      end
-
-      def case_owner
-        @case_owner ||= ResponsibilityService.new.calculate_case_owner(self)
-      end
-
-      def full_name
-        "#{last_name}, #{first_name}".titleize
-      end
-
-      def full_name_ordered
-        "#{first_name} #{last_name}".titleize
-      end
     end
   end
 end

--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -1,0 +1,41 @@
+module Nomis
+  module Models
+    class OffenderBase
+      def case_owner
+        pom_responsibility = ResponsibilityService.new.calculate_pom_responsibility(self)
+        return 'Prison' if pom_responsibility == ResponsibilityService::RESPONSIBLE
+
+        'Probation'
+      end
+
+      def sentence_detail=(sentence_detail)
+        self.release_date = sentence_detail.release_date
+        self.sentence_start_date = sentence_detail.sentence_start_date
+        self.parole_eligibility_date = sentence_detail.parole_eligibility_date
+        self.tariff_date = sentence_detail.tariff_date
+        self.home_detention_curfew_eligibility_date =
+          sentence_detail.home_detention_curfew_eligibility_date
+      end
+
+      def earliest_release_date
+        dates = [
+          release_date,
+          parole_eligibility_date,
+          home_detention_curfew_eligibility_date,
+          tariff_date
+        ].compact
+        return nil if dates.empty?
+
+        dates.min
+      end
+
+      def full_name
+        "#{last_name}, #{first_name}".titleize
+      end
+
+      def full_name_ordered
+        "#{first_name} #{last_name}".titleize
+      end
+    end
+  end
+end

--- a/app/services/nomis/models/offender_summary.rb
+++ b/app/services/nomis/models/offender_summary.rb
@@ -2,7 +2,7 @@
 
 module Nomis
   module Models
-    class OffenderSummary
+    class OffenderSummary < OffenderBase
       include MemoryModel
 
       attribute :agency_id, :string
@@ -44,27 +44,6 @@ module Nomis
         SentenceTypeService.indeterminate_sentence?(imprisonment_status)
       end
 
-      def sentence_detail=(sentence_detail)
-        self.release_date = sentence_detail.release_date
-        self.sentence_start_date = sentence_detail.sentence_start_date
-        self.parole_eligibility_date = sentence_detail.parole_eligibility_date
-        self.tariff_date = sentence_detail.tariff_date
-        self.home_detention_curfew_eligibility_date =
-          sentence_detail.home_detention_curfew_eligibility_date
-      end
-
-      def earliest_release_date
-        dates = [
-          release_date,
-          parole_eligibility_date,
-          home_detention_curfew_eligibility_date,
-          tariff_date
-        ].compact
-        return nil if dates.empty?
-
-        dates.min
-      end
-
       def awaiting_allocation_for
         omic_start_date = Date.new(2019, 2, 4)
 
@@ -73,10 +52,6 @@ module Nomis
         else
           (Time.zone.today - sentence_start_date).to_i
         end
-      end
-
-      def full_name
-        "#{last_name}, #{first_name}".titleize
       end
     end
   end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -9,7 +9,7 @@ class OffenderService
       if record.present?
         o.tier = record.tier
         o.case_allocation = record.case_allocation
-        o.omicable = record.omicable
+        o.omicable = record.omicable == 'Yes'
       end
 
       sentence_detail = get_sentence_details([o.latest_booking_id])
@@ -52,7 +52,7 @@ class OffenderService
       if record
         offender.tier = record.tier
         offender.case_allocation = record.case_allocation
-        offender.omicable = record.omicable
+        offender.omicable = record.omicable == 'Yes'
       end
 
       true

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -1,29 +1,13 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/MethodLength
-# rubocop:disable Metrics/LineLength
-# rubocop:disable Metrics/PerceivedComplexity
-# rubocop:disable Metrics/CyclomaticComplexity
 class ResponsibilityService
-  NPS = 'NPS'
-  CRC = 'CRC'
-  PRISON = 'Prison'
-  PROBATION = 'Probation'
-  UNKNOWN = 'Unknown'
   RESPONSIBLE = 'Responsible'
   SUPPORTING = 'Supporting'
+  NPS = 'NPS'
 
-  def calculate_case_owner(offender)
-    case offender.case_allocation
-    when NPS
-      nps_calculation(offender)
-    when CRC
-      PRISON
-    else
-      UNKNOWN
-    end
-  end
-
+  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
   def calculate_pom_responsibility(offender)
     return RESPONSIBLE if offender.earliest_release_date.nil?
     return SUPPORTING unless omicable?(offender)
@@ -50,6 +34,9 @@ class ResponsibilityService
       !new_case?(offender) &&
       !release_date_gt_15_mths?(offender)
   end
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/PerceivedComplexity
+# rubocop:enable Metrics/CyclomaticComplexity
 
 private
 
@@ -62,42 +49,21 @@ private
   end
 
   def release_date_gt_10_mths?(offender)
-    @release_date_gt_10_mths = offender.earliest_release_date > DateTime.now.utc.to_date + 10.months
+    @release_date_gt_10_mths = offender.earliest_release_date >
+      DateTime.now.utc.to_date + 10.months
   end
 
   def release_date_gt_15_mths?(offender)
-    @release_date_gt_15_mths ||= offender.earliest_release_date > DateTime.new(2019, 2, 4).utc.to_date + 15.months
+    @release_date_gt_15_mths ||= offender.earliest_release_date >
+      DateTime.new(2019, 2, 4).utc.to_date + 15.months
   end
 
   def release_date_gt_12_weeks?(offender)
-    @release_date_gt_12_weeks ||= offender.earliest_release_date > DateTime.now.utc.to_date + 12.weeks
+    @release_date_gt_12_weeks ||= offender.earliest_release_date >
+      DateTime.now.utc.to_date + 12.weeks
   end
 
   def new_case?(offender)
     @new_case ||= offender.sentence_start_date > DateTime.new(2019, 2, 4).utc
   end
-
-  def nps_calculation(offender)
-    if offender.omicable
-      return PRISON if SentenceTypeService.indeterminate_sentence?(offender.imprisonment_status)
-      return PRISON if release_date_gt_10_mths?(offender)
-    end
-
-    PROBATION
-  end
-
-  def assign_responsible?(offender)
-    # TODO: When we do this check, we should also check what the responsibility
-    # was yesterday, so that we can determine if it has changed.  This will allow
-    # us to persist the responsibility at the time of allocation, and when the
-    # responsibility changes do:
-    #   * Notifications
-    #   * Deactive and recreate allocation (with new responsibility)
-    offender.omicable == true &&
-      offender.earliest_release_date > DateTime.now.utc.to_date + 10.months
-  end
 end
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/PerceivedComplexity
-# rubocop:enable Metrics/CyclomaticComplexity
-# rubocop:enable Metrics/LineLength

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -7,7 +7,7 @@
   <tr class="govuk-table__row">
     <td class="govuk-table__cell govuk-!-width-one-half">Current case owner</td>
     <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-      <%= responsibility_label(@prisoner.case_owner) %>
+      <%= responsibility_label(@prisoner) %>
     </td>
   </tr>
   <tr class="govuk-table__row">

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -7,7 +7,7 @@
   <tr class="govuk-table__row">
     <td class="govuk-table__cell govuk-!-width-one-half">Current case owner</td>
     <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-      <%= responsibility_label(@prisoner) %>
+      <%= case_owner_label(@prisoner) %>
     </td>
   </tr>
   <tr class="govuk-table__row">

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -40,7 +40,7 @@
           <%= format_date(offender.earliest_release_date) %>
         </td>
         <td aria-label="Case owner" class="govuk-table__cell">
-          <%= responsibility_label(offender) %>
+          <%= case_owner_label(offender) %>
         </td>
         <td aria-label="Awaiting allocation for" class="govuk-table__cell">
           <%= offender.awaiting_allocation_for %> days

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -40,7 +40,7 @@
           <%= format_date(offender.earliest_release_date) %>
         </td>
         <td aria-label="Case owner" class="govuk-table__cell">
-          <%= responsibility_label(ResponsibilityService.new.calculate_case_owner(offender)) %>
+          <%= responsibility_label(offender) %>
         </td>
         <td aria-label="Awaiting allocation for" class="govuk-table__cell">
           <%= offender.awaiting_allocation_for %> days

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -1,48 +1,6 @@
 require 'rails_helper'
 
 describe ResponsibilityService do
-  let(:offender_none) {
-    Nomis::Models::Offender.new
-  }
-  let(:offender_crc) {
-    Nomis::Models::Offender.new.tap { |o| o.case_allocation = 'CRC' }
-  }
-  let(:offender_nps_gt_10) {
-    Nomis::Models::Offender.new.tap { |o|
-      o.case_allocation = 'NPS'
-      o.release_date = DateTime.now.utc.to_date + 12.months
-    }
-  }
-  let(:offender_nps_lt_10) {
-    Nomis::Models::Offender.new.tap { |o|
-      o.case_allocation = 'NPS'
-      o.release_date = DateTime.now.utc.to_date + 6.months
-    }
-  }
-
-  let(:offender_omicable_nps_12months) {
-    Nomis::Models::Offender.new.tap { |o|
-      o.omicable = true
-      o.case_allocation = 'NPS'
-      o.release_date = DateTime.now.utc.to_date + 12.months
-    }
-  }
-
-  let(:offender_omicable_nps_3months) {
-    Nomis::Models::Offender.new.tap { |o|
-      o.omicable = true
-      o.case_allocation = 'NPS'
-      o.release_date = DateTime.now.utc.to_date + 3.months
-    }
-  }
-
-  let(:offender_not_omicable) {
-    Nomis::Models::Offender.new.tap { |o|
-      o.omicable = false
-      o.case_allocation = 'NPS'
-    }
-  }
-
   let(:offender_no_release_date) {
     Nomis::Models::Offender.new.tap { |o|
       o.release_date = nil
@@ -123,33 +81,6 @@ describe ResponsibilityService do
       o.release_date = DateTime.now.utc.to_date + 9.months
     }
   }
-
-  describe 'case owner' do
-    it "CRC allocations means Prison" do
-      resp = subject.calculate_case_owner(offender_crc)
-      expect(resp).to eq 'Prison'
-    end
-
-    it "NPS allocations with omic and > 12m" do
-      resp = subject.calculate_case_owner(offender_omicable_nps_12months)
-      expect(resp).to eq 'Prison'
-    end
-
-    it "NPS allocations with omic and 3 months" do
-      resp = subject.calculate_case_owner(offender_omicable_nps_3months)
-      expect(resp).to eq 'Probation'
-    end
-
-    it "NPS allocations with no omic" do
-      resp = subject.calculate_case_owner(offender_not_omicable)
-      expect(resp).to eq 'Probation'
-    end
-
-    it "No allocation" do
-      resp = subject.calculate_case_owner(offender_none)
-      expect(resp).to eq 'Unknown'
-    end
-  end
 
   describe 'pom responsibility' do
     context 'when offender has no release date' do


### PR DESCRIPTION
We have been advised that whenever a POM has a supporting role then the
case will always be owned by the community, and if the POM has a
responsible role then the case will always been owned by custody.  This
PR changes the calculation to just check the outcome of the current role
and set the case owner from that.