### PR TITLE
Use rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - rubocop-performance
 
 AllCops:
   # Exclude anything that isn't really part of our code.

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rubocop'
   gem 'rubocop-rspec'
+  gem 'rubocop-performance'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
@@ -331,6 +333,7 @@ DEPENDENCIES
   redis
   rspec-rails
   rubocop
+  rubocop-performance
   rubocop-rspec
   sass-rails (~> 5.0)
   selenium-webdriver


### PR DESCRIPTION
The performance cops are being deprecated, and so now we need to use a
separate gem. Rubocop also seems a little faster after this PR.