### PR TITLE
Clean up how we handle sentence details

### DIFF
--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -76,8 +76,11 @@ module Nomis
 
           oid = record['offenderNo']
           hash[oid] = api_deserialiser.deserialise(
-            Nomis::Models::SentenceDetail, record
+            Nomis::Models::SentenceDetail, record['sentenceDetail']
           )
+          hash[oid].first_name = record['firstName']
+          hash[oid].last_name = record['lastName']
+          hash
         }
       end
     # rubocop:enable Metrics/MethodLength

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -21,13 +21,9 @@ module Nomis
       # custom attributes
       attribute :allocated_pom_name, :string
       attribute :case_allocation, :string
-      attribute :home_detention_curfew_eligibility_date, :date
       attribute :omicable, :boolean
-      attribute :parole_eligibility_date, :date
-      attribute :release_date, :date
-      attribute :sentence_start_date, :date
-      attribute :tariff_date, :date
       attribute :tier, :string
+      attribute :sentence
     end
   end
 end

--- a/app/services/nomis/models/offender.rb
+++ b/app/services/nomis/models/offender.rb
@@ -5,25 +5,12 @@ module Nomis
     class Offender < OffenderBase
       include MemoryModel
 
-      attribute :convicted_status, :string
-      attribute :date_of_birth, :date
-      attribute :first_name, :string
       attribute :gender, :string
-      attribute :imprisonment_status, :string
-      attribute :last_name, :string
       attribute :latest_booking_id, :integer
       attribute :main_offence, :string
       attribute :nationalities, :string
       attribute :noms_id, :string
-      attribute :offender_no, :string
       attribute :reception_date, :date
-
-      # custom attributes
-      attribute :allocated_pom_name, :string
-      attribute :case_allocation, :string
-      attribute :omicable, :boolean
-      attribute :tier, :string
-      attribute :sentence
     end
   end
 end

--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -1,6 +1,22 @@
 module Nomis
   module Models
     class OffenderBase
+      include MemoryModel
+
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :date_of_birth, :string
+      attribute :offender_no, :string
+      attribute :convicted_status, :string
+      attribute :imprisonment_status, :string
+
+      # Custom attributes
+      attribute :allocated_pom_name, :string
+      attribute :case_allocation, :string
+      attribute :omicable, :boolean
+      attribute :tier, :string
+      attribute :sentence
+
       def sentenced?
         # A prisoner will have had a sentence calculation and for our purposes
         # this means that they will either have a:

--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -1,6 +1,33 @@
 module Nomis
   module Models
     class OffenderBase
+      def sentenced?
+        # A prisoner will have had a sentence calculation and for our purposes
+        # this means that they will either have a:
+        # 1) Release date, or
+        # 2) Parole eligibility date, or
+        # 3) HDC release date (homeDetentionCurfewEligibilityDate field).
+        # If they do not have any of these we should be checking for a tariff date
+        # Once we have all the dates we then need to display whichever is the
+        # earliest one.
+        sentence.release_date.present? ||
+        sentence.parole_eligibility_date.present? ||
+        sentence.home_detention_curfew_eligibility_date.present? ||
+        sentence.tariff_date.present? ||
+        SentenceTypeService.indeterminate_sentence?(imprisonment_status)
+      end
+
+      def awaiting_allocation_for
+        omic_start_date = Date.new(2019, 2, 4)
+
+        if sentence.sentence_start_date.nil? ||
+            sentence.sentence_start_date < omic_start_date
+          (Time.zone.today - omic_start_date).to_i
+        else
+          (Time.zone.today - sentence.sentence_start_date).to_i
+        end
+      end
+
       def case_owner
         pom_responsibility = ResponsibilityService.new.calculate_pom_responsibility(self)
         return 'Prison' if pom_responsibility == ResponsibilityService::RESPONSIBLE
@@ -8,25 +35,8 @@ module Nomis
         'Probation'
       end
 
-      def sentence_detail=(sentence_detail)
-        self.release_date = sentence_detail.release_date
-        self.sentence_start_date = sentence_detail.sentence_start_date
-        self.parole_eligibility_date = sentence_detail.parole_eligibility_date
-        self.tariff_date = sentence_detail.tariff_date
-        self.home_detention_curfew_eligibility_date =
-          sentence_detail.home_detention_curfew_eligibility_date
-      end
-
       def earliest_release_date
-        dates = [
-          release_date,
-          parole_eligibility_date,
-          home_detention_curfew_eligibility_date,
-          tariff_date
-        ].compact
-        return nil if dates.empty?
-
-        dates.min
+        sentence.earliest_release_date
       end
 
       def full_name

--- a/app/services/nomis/models/offender_summary.rb
+++ b/app/services/nomis/models/offender_summary.rb
@@ -8,21 +8,9 @@ module Nomis
       attribute :agency_id, :string
       attribute :aliases, :string
       attribute :booking_id, :integer
-      attribute :date_of_birth, :string
-      attribute :facial_image_id, :string
-      attribute :first_name, :string
-      attribute :last_name, :string
-      attribute :offender_no, :string
 
       # custom attributes
-      attribute :allocated_pom_name, :string
       attribute :allocation_date, :date
-      attribute :case_allocation, :string
-      attribute :convicted_status, :string
-      attribute :imprisonment_status, :string
-      attribute :omicable, :boolean
-      attribute :tier, :string
-      attribute :sentence
     end
   end
 end

--- a/app/services/nomis/models/offender_summary.rb
+++ b/app/services/nomis/models/offender_summary.rb
@@ -19,40 +19,10 @@ module Nomis
       attribute :allocation_date, :date
       attribute :case_allocation, :string
       attribute :convicted_status, :string
-      attribute :home_detention_curfew_eligibility_date, :date
       attribute :imprisonment_status, :string
       attribute :omicable, :boolean
-      attribute :parole_eligibility_date, :date
-      attribute :release_date, :date
-      attribute :sentence_start_date, :date
-      attribute :tariff_date, :date
       attribute :tier, :string
-
-      def sentenced?
-        # A prisoner will have had a sentence calculation and for our purposes
-        # this means that they will either have a:
-        # 1) Release date, or
-        # 2) Parole eligibility date, or
-        # 3) HDC release date (homeDetentionCurfewEligibilityDate field).
-        # If they do not have any of these we should be checking for a tariff date
-        # Once we have all the dates we then need to display whichever is the
-        # earliest one.
-        release_date.present? ||
-        parole_eligibility_date.present? ||
-        home_detention_curfew_eligibility_date.present? ||
-        tariff_date.present? ||
-        SentenceTypeService.indeterminate_sentence?(imprisonment_status)
-      end
-
-      def awaiting_allocation_for
-        omic_start_date = Date.new(2019, 2, 4)
-
-        if sentence_start_date.nil? || sentence_start_date < omic_start_date
-          (Time.zone.today - omic_start_date).to_i
-        else
-          (Time.zone.today - sentence_start_date).to_i
-        end
-      end
+      attribute :sentence
     end
   end
 end

--- a/app/services/nomis/models/sentence_detail.rb
+++ b/app/services/nomis/models/sentence_detail.rb
@@ -7,14 +7,11 @@ module Nomis
 
       attribute :first_name, :string
       attribute :last_name, :string
-      attribute :booking_id, :integer
-      attribute :offender_no
-      attribute :agency_location_id
-      attribute :sentence_detail
-      attribute :date_of_birth
-      attribute :agency_location_desc
-      attribute :facial_image_id
-      attribute :internal_location_desc
+      attribute :home_detention_curfew_eligibility_date, :date
+      attribute :parole_eligibility_date, :date
+      attribute :release_date, :date
+      attribute :sentence_start_date, :date
+      attribute :tariff_date, :date
 
       def earliest_release_date
         dates = [
@@ -26,26 +23,6 @@ module Nomis
         return nil if dates.empty?
 
         dates.min.to_date
-      end
-
-      def sentence_start_date
-        sentence_detail['sentence_start_date']
-      end
-
-      def release_date
-        sentence_detail['release_date']
-      end
-
-      def tariff_date
-        sentence_detail['tariff_date']
-      end
-
-      def parole_eligibility_date
-        sentence_detail['parole_eligibility_date']
-      end
-
-      def home_detention_curfew_eligibility_date
-        sentence_detail['home_detention_curfew_eligibility_date']
       end
 
       def full_name

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -14,7 +14,7 @@ class OffenderService
 
       sentence_detail = get_sentence_details([o.latest_booking_id])
       if sentence_detail.present? && sentence_detail.key?(offender_no)
-        o.sentence_detail = sentence_detail[offender_no]
+        o.sentence = sentence_detail[offender_no]
       end
 
       o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)
@@ -45,7 +45,7 @@ class OffenderService
 
     offenders.select { |offender|
       sentencing = sentence_details[offender.offender_no]
-      offender.sentence_detail = sentencing if sentencing.present?
+      offender.sentence = sentencing if sentencing.present?
       next false unless offender.sentenced?
 
       record = mapped_tiers[offender.offender_no]

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -62,9 +62,7 @@ class PrisonOffenderManagerService
 
     allocation_list_with_responsibility = allocation_list.map { |alloc|
       offender_stub = Nomis::Models::Offender.new
-      if offender_map.key?(alloc.nomis_offender_id)
-        offender_stub.sentence_detail = offender_map[alloc.nomis_offender_id]
-      end
+      offender_stub.sentence = offender_map[alloc.nomis_offender_id]
 
       record = case_info[alloc.nomis_offender_id]
       if record.present?

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -9,7 +9,7 @@ class ResponsibilityService
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
   def calculate_pom_responsibility(offender)
-    return RESPONSIBLE if offender.earliest_release_date.nil?
+    return RESPONSIBLE if offender.sentence.earliest_release_date.nil?
     return SUPPORTING unless omicable?(offender)
 
     return RESPONSIBLE if nps_case?(offender) &&
@@ -49,21 +49,21 @@ private
   end
 
   def release_date_gt_10_mths?(offender)
-    @release_date_gt_10_mths = offender.earliest_release_date >
+    @release_date_gt_10_mths = offender.sentence.earliest_release_date >
       DateTime.now.utc.to_date + 10.months
   end
 
   def release_date_gt_15_mths?(offender)
-    @release_date_gt_15_mths ||= offender.earliest_release_date >
+    @release_date_gt_15_mths ||= offender.sentence.earliest_release_date >
       DateTime.new(2019, 2, 4).utc.to_date + 15.months
   end
 
   def release_date_gt_12_weeks?(offender)
-    @release_date_gt_12_weeks ||= offender.earliest_release_date >
+    @release_date_gt_12_weeks ||= offender.sentence.earliest_release_date >
       DateTime.now.utc.to_date + 12.weeks
   end
 
   def new_case?(offender)
-    @new_case ||= offender.sentence_start_date > DateTime.new(2019, 2, 4).utc
+    @new_case ||= offender.sentence.sentence_start_date > DateTime.new(2019, 2, 4).utc
   end
 end

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -23,7 +23,7 @@
       <tr class="govuk-table__row">
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
-        <td aria-label="Arrival date" class="govuk-table__cell "><%= format_date_string(sentence.sentence_start_date) %></td>
+        <td aria-label="Arrival date" class="govuk-table__cell "><%= format_date(sentence.sentence_start_date) %></td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -15,7 +15,7 @@
     <tr class="govuk-table__row pom_cases_row_<%= i %>">
       <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
-      <td aria-label="Earliest release date" class="govuk-table__cell "><%= sentence.earliest_release_date %></td>
+      <td aria-label="Earliest release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
       <td aria-label="Tier" class="govuk-table__cell "><%= allocation.allocated_at_tier %></td>
       <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.created_at) %></td>
       <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -11,25 +11,25 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Release date</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= format_date(@prisoner.release_date, replacement: 'N/A') %>
+        <%= format_date(@prisoner.sentence.release_date, replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Parole eligibility</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= format_date(@prisoner.parole_eligibility_date, replacement: 'N/A') %>
+        <%= format_date(@prisoner.sentence.parole_eligibility_date, replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Home detention curfew eligibility</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= format_date(@prisoner.home_detention_curfew_eligibility_date, replacement: 'N/A') %>
+        <%= format_date(@prisoner.sentence.home_detention_curfew_eligibility_date, replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Tariff date</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= format_date(@prisoner.tariff_date, replacement: 'N/A') %>
+        <%= format_date(@prisoner.sentence.tariff_date, replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row">

--- a/spec/models/nomis/models/offender_summary_spec.rb
+++ b/spec/models/nomis/models/offender_summary_spec.rb
@@ -3,16 +3,18 @@ require 'rails_helper'
 describe Nomis::Models::OffenderSummary, model: true do
   it "handles no earliest date" do
     o = described_class.new
-    expect(o.earliest_release_date).to be_nil
+    o.sentence = Nomis::Models::SentenceDetail.new
+    expect(o.sentence.earliest_release_date).to be_nil
     expect(o.sentenced?).to be false
   end
 
   it "handles an earliest date" do
     o = described_class.new.tap { |off|
-      off.release_date = Date.new(2010, 1, 1)
-      off.parole_eligibility_date = Date.new(2009, 1, 1)
+      off.sentence = Nomis::Models::SentenceDetail.new
+      off.sentence.release_date = Date.new(2010, 1, 1)
+      off.sentence.parole_eligibility_date = Date.new(2009, 1, 1)
     }
-    expect(o.earliest_release_date).to eq(Date.new(2009, 1, 1))
+    expect(o.sentence.earliest_release_date).to eq(Date.new(2009, 1, 1))
     expect(o.sentenced?).to be true
   end
 end

--- a/spec/services/nomis/elite2/offender_api_spec.rb
+++ b/spec/services/nomis/elite2/offender_api_spec.rb
@@ -31,7 +31,7 @@ describe Nomis::Elite2::OffenderApi do
 
       records = response.values
       expect(records.first).to be_instance_of(Nomis::Models::SentenceDetail)
-      expect(records.first.release_date).to eq('2020-02-07')
+      expect(records.first.release_date).to eq(Date.new(2020, 2, 7))
       expect(records.first.full_name).to eq('Abbella, Ozullirn')
     end
   end

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -22,7 +22,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
     offender = OffenderService.get_offender(nomis_offender_id)
 
     expect(offender).to be_kind_of(Nomis::Models::Offender)
-    expect(offender.release_date).to eq Date.new(2020, 2, 7)
+    expect(offender.sentence.release_date).to eq Date.new(2020, 2, 7)
     expect(offender.tier).to eq 'C'
     expect(offender.main_offence).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
     expect(offender.case_allocation).to eq 'CRC'

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -19,7 +19,7 @@ describe PrisonOffenderManagerService do
       nomis_staff_id: staff_id,
       nomis_offender_id: 'G8060UF',
       created_by: 'Test User',
-      nomis_booking_id: 1,
+      nomis_booking_id: 971_856,
       allocated_at_tier: 'A',
       prison: 'LEI'
     )
@@ -30,7 +30,7 @@ describe PrisonOffenderManagerService do
       nomis_staff_id: staff_id,
       nomis_offender_id: 'G8624GK',
       created_by: 'Test User',
-      nomis_booking_id: 2,
+      nomis_booking_id: 76_908,
       allocated_at_tier: 'B',
       prison: 'LEI'
     )
@@ -41,7 +41,7 @@ describe PrisonOffenderManagerService do
       nomis_staff_id: staff_id,
       nomis_offender_id: 'G1714GU',
       created_by: 'Test User',
-      nomis_booking_id: 3,
+      nomis_booking_id: 31_777,
       allocated_at_tier: 'C',
       prison: 'LEI'
     )

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -3,14 +3,16 @@ require 'rails_helper'
 describe ResponsibilityService do
   let(:offender_no_release_date) {
     Nomis::Models::Offender.new.tap { |o|
-      o.release_date = nil
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.release_date = nil
     }
   }
 
   let(:offender_not_welsh) {
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = false
-      o.release_date = DateTime.now.utc.to_date + 6.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.release_date = DateTime.now.utc.to_date + 6.months
     }
   }
 
@@ -18,7 +20,8 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'CRC'
-      o.release_date = DateTime.now.utc.to_date + 2.weeks
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.release_date = DateTime.now.utc.to_date + 2.weeks
     }
   }
 
@@ -26,7 +29,8 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'CRC'
-      o.release_date = DateTime.now.utc.to_date + 13.weeks
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.release_date = DateTime.now.utc.to_date + 13.weeks
     }
   }
 
@@ -34,7 +38,8 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'NPS'
-      o.release_date = DateTime.now.utc.to_date + 11.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.release_date = DateTime.now.utc.to_date + 11.months
     }
   }
 
@@ -42,7 +47,8 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'NPS'
-      o.release_date = DateTime.now.utc.to_date + 9.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.release_date = DateTime.now.utc.to_date + 9.months
     }
   }
 
@@ -50,8 +56,9 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'NPS'
-      o.sentence_start_date = DateTime.new(2019, 1, 19).utc
-      o.release_date = DateTime.now.utc.to_date + 16.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.sentence_start_date = DateTime.new(2019, 1, 19).utc
+      o.sentence.release_date = DateTime.now.utc.to_date + 16.months
     }
   }
 
@@ -59,8 +66,9 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'NPS'
-      o.sentence_start_date = DateTime.new(2019, 2, 20).utc
-      o.release_date = DateTime.now.utc.to_date + 9.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.sentence_start_date = DateTime.new(2019, 2, 20).utc
+      o.sentence.release_date = DateTime.now.utc.to_date + 9.months
     }
   }
 
@@ -68,8 +76,9 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'NPS'
-      o.sentence_start_date = DateTime.new(2019, 1, 19).utc
-      o.release_date = DateTime.now.utc.to_date + 16.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.sentence_start_date = DateTime.new(2019, 1, 19).utc
+      o.sentence.release_date = DateTime.now.utc.to_date + 16.months
     }
   }
 
@@ -77,8 +86,9 @@ describe ResponsibilityService do
     Nomis::Models::Offender.new.tap { |o|
       o.omicable = true
       o.case_allocation = 'NPS'
-      o.sentence_start_date = DateTime.new(2019, 2, 20).utc
-      o.release_date = DateTime.now.utc.to_date + 9.months
+      o.sentence = Nomis::Models::SentenceDetail.new
+      o.sentence.sentence_start_date = DateTime.new(2019, 2, 20).utc
+      o.sentence.release_date = DateTime.now.utc.to_date + 9.months
     }
   }
 


### PR DESCRIPTION
This PR cleans up how we handle sentence details so that we don't have
to duplicate code between offender, offendersummary and sentencedetail
objects.