### PR TITLE
Re-enable sorting in the backend

### DIFF
--- a/app/services/bucket.rb
+++ b/app/services/bucket.rb
@@ -30,7 +30,7 @@ class Bucket
   end
 
   def valid_sort_fields
-    [:last_name]
+    [:last_name, :earliest_release_date, :awaiting_allocation_for]
   end
 
   def take(count, from)


### PR DESCRIPTION
Re-enables sorting by the offender's last name, and/or the
earliest_release_date/awaiting_allocation_for