### PR TITLE
Do not include HDC dates in earliest_release_date calc

### DIFF
--- a/app/services/nomis/models/sentence_detail.rb
+++ b/app/services/nomis/models/sentence_detail.rb
@@ -17,7 +17,6 @@ module Nomis
         dates = [
             release_date,
             parole_eligibility_date,
-            home_detention_curfew_eligibility_date,
             tariff_date
         ].compact
         return nil if dates.empty?


### PR DESCRIPTION
HDC is not useful when calculating the earliest release date so we
should not include it.  It can however be displayed on the allocation
page even though it isn't used.