### PR TITLE
Amend Recommendation Service to use POM position

### DIFF
--- a/app/services/recommendation_service.rb
+++ b/app/services/recommendation_service.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class RecommendationService
-  PRISON = 'Prison'
-  PROBATION = 'Probation'
+  PRISON_POM = 'PRO'
+  PROBATION_POM = 'PO'
 
   def self.recommended_pom_type(offender)
-    return PROBATION if %w[A B].include?(offender.tier)
+    return PROBATION_POM if %w[A B].include?(offender.tier)
 
-    PRISON
+    PRISON_POM
   end
 
   def self.recommended_poms(offender, poms)
@@ -16,7 +16,7 @@ class RecommendationService
     # `offender`
     recommended_type = recommended_pom_type(offender)
     poms.partition { |pom|
-      pom.position_description.include?(recommended_type)
+      pom.position.include?(recommended_type)
     }
   end
 end

--- a/app/views/poms/_prison_poms_table.html.erb
+++ b/app/views/poms/_prison_poms_table.html.erb
@@ -13,7 +13,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% poms.select{ |pom| pom.position_description.include?('Prison Officer')}.each_with_index do |pom, i| %>
+  <% poms.select{ |pom| pom.position.include?('PRO')}.each_with_index do |pom, i| %>
     <tr class="govuk-table__row prison_pom_row_<%= i %>">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>

--- a/app/views/poms/_probation_poms_table.html.erb
+++ b/app/views/poms/_probation_poms_table.html.erb
@@ -13,7 +13,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% poms.select{ |pom| pom.position_description.include?('Probation Officer')}.each_with_index do |pom, i| %>
+  <% poms.select{ |pom| pom.position.include?('PO')}.each_with_index do |pom, i| %>
     <tr class="govuk-table__row probation_pom_row_<%= i %>">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -11,29 +11,29 @@ describe RecommendationService do
     [
       Nomis::Models::PrisonOffenderManager.new.tap { |p|
         p.first_name = 'Alice'
-        p.position_description = 'Prison offender manager'
+        p.position = 'PRO'
       },
       Nomis::Models::PrisonOffenderManager.new.tap { |p|
         p.first_name = 'Bob'
-        p.position_description = 'Prison offender manager'
+        p.position = 'PRO'
       },
       Nomis::Models::PrisonOffenderManager.new.tap { |p|
         p.first_name = 'Clare'
-        p.position_description = 'Probation offender manager'
+        p.position = 'PO'
       },
       Nomis::Models::PrisonOffenderManager.new.tap { |p|
         p.first_name = 'Dave'
-        p.position_description = 'Probation offender manager'
+        p.position = 'PO'
       }
     ]
   }
 
   it "can determine the best type of POM for Tier A" do
-    expect(described_class.recommended_pom_type(tierA)).to eq(described_class::PROBATION)
+    expect(described_class.recommended_pom_type(tierA)).to eq(described_class::PROBATION_POM)
   end
 
   it "can determine the best type of POM for Tier D" do
-    expect(described_class.recommended_pom_type(tierD)).to eq(described_class::PRISON)
+    expect(described_class.recommended_pom_type(tierD)).to eq(described_class::PRISON_POM)
   end
 
   it "can partition POMs for a tier A offender" do


### PR DESCRIPTION
Cardiff have been setting up POMs in readiness to start using the
service, however a check in production showed an issue where the active
POM count was 12, but only 8 were displaying.  We have been using
'position_description' to filter which POMs to show, but we're not 100%
sure where this field gets set.  But, we do know that when setting up
POMs in NOMIS the LSA will have to add their 'position' and so this PR
makes a change to rely on this data as we feel we'll have more
confidence in it existing, hopefully fixing this POM list bug.