### PR TITLE
Use recommended type for recommdended label

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -9,8 +9,11 @@ class AllocationsController < ApplicationController
       AllocationService.previously_allocated_poms(nomis_offender_id_from_url)
     @recommended_poms, @not_recommended_poms =
       recommended_and_nonrecommended_poms_for(@prisoner)
+    @recommended_pom_type, @not_recommended_pom_type =
+      recommended_and_nonrecommended_poms_types_for(@prisoner)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def edit
     unless AllocationService.active_allocation?(nomis_offender_id_from_url)
       redirect_to new_allocations_path(nomis_offender_id_from_url)
@@ -22,8 +25,11 @@ class AllocationsController < ApplicationController
       AllocationService.previously_allocated_poms(nomis_offender_id_from_url)
     @recommended_poms, @not_recommended_poms =
       recommended_and_nonrecommended_poms_for(@prisoner)
+    @recommended_pom_type, @not_recommended_pom_type =
+      recommended_and_nonrecommended_poms_types_for(@prisoner)
     @current_pom = current_pom_for(nomis_offender_id_from_url)
   end
+  # rubocop:enable Metrics/MethodLength
 
   def confirm
     @prisoner = offender(nomis_offender_id_from_url)
@@ -84,6 +90,18 @@ private
     nomis_staff_id = current_allocation[nomis_offender_id]['nomis_staff_id']
 
     PrisonOffenderManagerService.get_pom(active_caseload, nomis_staff_id)
+  end
+
+  def recommended_and_nonrecommended_poms_types_for(offender)
+    rec_type = RecommendationService.recommended_pom_type(offender)
+
+    if rec_type == RecommendationService::PRISON_POM
+      ['Prison officer',
+       'Probation officer']
+    else
+      ['Probation officer',
+       'Prison officer']
+    end
   end
 
   def recommended_and_nonrecommended_poms_for(offender)

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -1,5 +1,5 @@
 <h4 class="govuk-heading-m">
-  Recommendation: <%= @prisoner.case_owner %> POM
+  Recommendation: <%= @recommended_pom_type %> POM
 </h4>
 
 <p>This recommendation takes the prisoner's tier and
@@ -7,7 +7,7 @@ time left to serve into account.</p>
 
 <table class="govuk-table responsive">
   <thead class="govuk-table__head">
-  <h2 class="govuk-heading-s">Active <%= @prisoner.case_owner.downcase %> POMs</h2>
+  <h2 class="govuk-heading-s">Active <%= @recommended_pom_type.downcase %> POMs</h2>
   <tr class="govuk-table__row">
     <th class="govuk-table__header" scope="col">Name</th>
     <th class="govuk-table__header" scope="col">Previous<br/>allocation</th>
@@ -49,11 +49,7 @@ time left to serve into account.</p>
 <details class="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
-      <% if @prisoner.case_owner == 'Probation' %>
-        Show active prison officer POMs
-      <% else %>
-        Show active probation officer POMs
-      <% end %>
+      Show active <%= @not_recommended_pom_type.downcase %> POMs
     </span>
   </summary>
   <div class="govuk-details__text">


### PR DESCRIPTION
We were calculating recommended type label based on case_owner, which is
incorrect, it is based solely off tier.  As a result we were showing the
correct type of POMs but the wrong label.