### PR TITLE
Add an ImageApi and show the offender's image

### DIFF
--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -3,5 +3,24 @@
 class PrisonersController < ApplicationController
   before_action :authenticate_user
 
-  def show; end
+  def show
+    @offender = offender
+  end
+
+  def image
+    image_data = Nomis::Custody::ImageApi.image_data(id)
+
+    response.headers['Expires'] = 6.months.from_now.httpdate
+    send_data image_data, type: 'image/jpg', disposition: 'inline'
+  end
+
+private
+
+  def id
+    @id ||= params[:id]
+  end
+
+  def offender
+    @offender ||= OffenderService.get_offender(id)
+  end
 end

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -21,6 +21,15 @@ module Nomis
       end
     end
 
+    # Performs a basic GET request without processing the response. This is mostly
+    # used for when we do not want a JSON response from an endpoint.
+    def raw_get(route, queryparams: {}, extra_headers: {})
+      response = request(
+        :get, route, queryparams: queryparams, extra_headers: extra_headers
+      )
+      response.body
+    end
+
     # rubocop:disable Metrics/MethodLength
     def get(route, queryparams: {}, extra_headers: {})
       response = request(

--- a/app/services/nomis/custody/image_api.rb
+++ b/app/services/nomis/custody/image_api.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Nomis
+  module Custody
+    class ImageApi
+      extend CustodyApi
+
+      def self.image_data(offender_no)
+        route = "/custodyapi/api/offenders/nomsId/#{offender_no}/images"
+        response = custody_client.get(route)
+        image_id = most_recent_image(response)
+
+        route =
+          "/custodyapi/api/offenders/nomsId/#{offender_no}/images/#{image_id}/thumbnail"
+        custody_client.raw_get(route)
+      end
+
+    private
+
+      def self.most_recent_image(images)
+        active_images = images.select { |record|
+          record['activeFlag'] == true
+        }
+
+        most_recent =
+          active_images.sort_by { |record| record['captureDateTime'] }.reverse.first
+        most_recent['offenderImageId']
+      end
+    end
+  end
+end

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -1,25 +1,25 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-5">
   <div class="govuk-grid-column-one-quarter">
-    <img src="/public/images/prisoner.png" alt="Prisoner photo will be here" width="70%">
+    <img src="<%= prisoner_image_path(@offender.offender_no) %>" alt="Prisoner photo will be here" width="95%">
   </div>
   <div class="govuk-grid-column-three-quarters">
     <div class="govuk-grid-row">
       <div class='govuk-grid-column-full'>
-        <h2 class="govuk-heading-xl">Surname, Forename</h2>
+        <h2 class="govuk-heading-xl"><%= @offender.full_name %></h2>
       </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Prisoner number</span>
-        <h3 class="govuk-heading-m">NOMS_ID</h3>
+        <h3 class="govuk-heading-m"><%= @offender.offender_no %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Nationality</span>
-        <h3 class="govuk-heading-m">NATIONALITY</h3>
+        <h3 class="govuk-heading-m"><%= @offender.nationalities %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Date of birth</span>
-        <h3 class="govuk-heading-m">DOB</h3>
+        <h3 class="govuk-heading-m"><%= format_date(@offender.date_of_birth) %></h3>
       </div>
     </div>
     <div class="govuk-grid-row">
@@ -28,18 +28,18 @@
         <h3 class="govuk-heading-m">ARRIVAL DATE</h3>
       </div>
       <div class="govuk-grid-column-one-third">
-        <span class="govuk-body">Release / parole eligibility date</span>
-        <h3 class="govuk-heading-m">RELEASE DATE</h3>
+        <span class="govuk-body">Earliest release date</span>
+        <h3 class="govuk-heading-m"><%= @offender.earliest_release_date %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">COM handover date</span>
-        <h3 class="govuk-heading-m">HANDOVER DATE</h3>
+        <h3 class="govuk-heading-m">Unknown</h3>
       </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <span class="govuk-body">Current responsibility</span>
-        <h3 class="govuk-heading-m">RESPONSIBILITY</h3>
+        <span class="govuk-body">Current case owner</span>
+        <h3 class="govuk-heading-m"><%= case_owner_label(@offender) %></h3>
       </div>
     </div>
     <div class='govuk-grid-row'>
@@ -65,27 +65,18 @@
         Allocations
       </a>
     </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#case-notes">
-        Case notes
-      </a>
-    </li>
   </ul>
 
   <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="history">
     <%= render 'allocation_history' %>
   </section>
 
-  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="case-notes">
-    <%= render 'case_notes' %>
-  </section>
-
   <section class="govuk-tabs__panel govuk-tabs__panel--hidden"
            id="prisoner-info">
     <div>
-      <%# <%= render 'shared/offence_info' %> %>
-      <%# <%= render 'prisoners/case_information' %> %>
-      <%# <%= render 'prisoners/allocation_info' %> %>
+      <%# <%= render 'shared/offence_info' %>
+      <%# <%= render 'prisoners/case_information' %>
+      <%# <%= render 'prisoners/allocation_info' %>
     </div>
   </section>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
 
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/signout', to: 'sessions#destroy'
-  get('/prisoners/:id' => 'prisoners#show', as: 'prisoners_show')
+  get('/prisoners/:id' => 'prisoners#show', as: 'prisoner_show')
+  get('/prisoners/:id/image.jpg' => 'prisoners#image', as: 'prisoner_image')
   get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocations')
 
   get('/summary' => 'summary#index')

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 feature 'View a prisoner profile page' do
-  it 'shows the prisoner information' do
+  it 'shows the prisoner information', :raven_intercept_exception, vcr: { cassette_name: :show_offender_spec } do
     signin_user
 
-    visit '/prisoners/1'
+    visit '/prisoners/G7998GJ'
 
-    expect(page).to have_css('h2', text: 'Surname, Forename')
+    expect(page).to have_css('h2', text: 'Ahmonis, Okadonah')
   end
 end

--- a/spec/services/nomis/custody/image_api_spec.rb
+++ b/spec/services/nomis/custody/image_api_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Nomis::Custody::ImageApi do
+  describe '#fetching an image' do
+    it "can get a user's jpg",
+      vcr: { cassette_name: :image_api_spec } do
+
+      data = described_class.image_data('G7998GJ')
+      expect(data).not_to be_nil
+
+      # JPEG files start with FF D8 FF as the first three bytes ...
+      # .. and end with FF D9 as the last two bytes. This should be
+      # an adequate test to see if we receive a valid JPG from the
+      # API call.
+      jpeg_start_sentinel = [0xFF, 0xD8, 0xFF]
+      jpeg_end_sentinel = [0xFF, 0xD9]
+
+      bytes = data.bytes.to_a
+      expect(bytes[0, 3]).to eq(jpeg_start_sentinel)
+      expect(bytes[-2, 2]).to eq(jpeg_end_sentinel)
+    end
+  end
+end


### PR DESCRIPTION
Now, when visiting /prisoners/NOMISID the offender's image is shown next
to their full name.  Unfortunately getting an offender's image in Elite2
requires an image id which is not available in the call used by
PrisonOffenderManagerService.get_offender() and so this uses the custody
API for the same effect.

A call is made to get the list of images for the offender, and this is
filtered to active images and sorted to use the most recent available
image.