### PR TITLE
Make allocation history available

### DIFF
--- a/app/models/allocation_list.rb
+++ b/app/models/allocation_list.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AllocationList < Array
+  # rubocop:disable Metrics/MethodLength
+  def grouped_by_prison
+    # Groups the allocations in this array by the prison that it relates to.
+    # Unfortunately we can't put this in a hash because a prisoner may have been
+    # to a prison more than once, so a visit to Cardiff, then Leeds, then Cardiff
+    # would mean they are out of order.  Instead we need to put it into a structure
+    # that looks like
+    #
+    #    [
+    #      ['PrisonA', [alloc1, alloc2]],
+    #      ['PrisonB', [alloc3]],
+    #      ['PrisonA', [alloc4]],
+    #    ]
+    return [] if empty?
+
+    idx = 0
+    last_idx = count
+    results = []
+
+    loop do
+      prison = self[idx].prison
+
+      slice_of_this = slice(idx, last_idx - idx)
+      allocations_for_prison = slice_of_this.take_while { |p|
+        p.prison == prison
+      }
+      results << [prison, allocations_for_prison]
+
+      idx += allocations_for_prison.count
+      break if idx >= last_idx
+    end
+
+    results
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -43,9 +43,11 @@ class AllocationService
   end
 
   def self.offender_allocation_history(nomis_offender_id)
-    Allocation.
+    allocations = Allocation.
       where(nomis_offender_id: nomis_offender_id).
       order('created_at DESC')
+
+    AllocationList.new(allocations)
   end
 
   def self.create_override(params)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -42,6 +42,12 @@ class AllocationService
     ).map(&:nomis_staff_id)
   end
 
+  def self.offender_allocation_history(nomis_offender_id)
+    Allocation.
+      where(nomis_offender_id: nomis_offender_id).
+      order('created_at DESC')
+  end
+
   def self.create_override(params)
     Override.find_or_create_by(
       nomis_staff_id: params[:nomis_staff_id],

--- a/spec/models/allocation_list_spec.rb
+++ b/spec/models/allocation_list_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe AllocationList, type: :model do
+  let(:current_allocation) {
+    AllocationService.create_allocation(
+      nomis_staff_id: 485_595,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 1,
+      allocated_at_tier: 'A',
+      prison: 'LEI',
+      created_at: '01/01/2019'
+    )
+  }
+
+  let(:middle_allocation1) {
+    AllocationService.create_allocation(
+      nomis_staff_id: 485_752,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 2,
+      allocated_at_tier: 'A',
+      prison: 'PVI',
+      active: false,
+      created_at: '01/01/2018'
+    )
+  }
+
+  let(:middle_allocation2) {
+    AllocationService.create_allocation(
+      nomis_staff_id: 485_752,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 3,
+      allocated_at_tier: 'A',
+      prison: 'PVI',
+      active: false,
+      created_at: '01/01/2017'
+    )
+  }
+
+  let(:old_allocation) {
+    AllocationService.create_allocation(
+      nomis_staff_id: 485_595,
+      nomis_offender_id: 'G2911GD',
+      created_by: 'Test User',
+      nomis_booking_id: 4,
+      allocated_at_tier: 'A',
+      prison: 'LEI',
+      active: false,
+      created_at: '01/01/2016'
+    )
+  }
+
+  it 'can group the allocations correctly', vcr: { cassette_name: :allocation_list_spec } do
+    list = AllocationList.new([current_allocation, middle_allocation1, middle_allocation2, old_allocation])
+    expect(list.count).to be(4)
+
+    first, second, third = list.grouped_by_prison
+
+    prison, allocations = first
+    expect(prison).to eq('LEI')
+    expect(allocations.count).to eq(1)
+
+    prison, allocations = second
+    expect(prison).to eq('PVI')
+    expect(allocations.count).to eq(2)
+
+    prison, allocations = third
+    expect(prison).to eq('LEI')
+    expect(allocations.count).to eq(1)
+  end
+end


### PR DESCRIPTION
We need to be able to view the entire allocation history for an
offender, where the most recent (and hopefully active) allocation is top
of the list, and the historic entries are lower down the list.

This will allow us to group the allocations in windows, so that we can
show a history grouped by which Prison.  We can't use a single group_by
for that because an offender may visit a prison more than once and we
don't want historical allocations mixed up with more recent ones.