### PR TITLE
Fix the allocation routes to enable allocation info page

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -5,7 +5,7 @@ class AllocationsController < ApplicationController
 
   breadcrumb 'Allocated', :summary_allocated, only: [:show]
   breadcrumb -> { offender(nomis_offender_id_from_url).full_name },
-    -> { allocations_path(nomis_offender_id_from_url) }, only: [:show]
+    -> { allocation_path(nomis_offender_id_from_url) }, only: [:show]
 
   def new
     @prisoner = offender(nomis_offender_id_from_url)
@@ -30,7 +30,7 @@ class AllocationsController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def edit
     unless AllocationService.active_allocation?(nomis_offender_id_from_url)
-      redirect_to new_allocations_path(nomis_offender_id_from_url)
+      redirect_to new_allocation_path(nomis_offender_id_from_url)
       return
     end
 

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -46,7 +46,7 @@ class CaseInformationController < ApplicationController
     case_info.omicable = case_information_params[:omicable]
     case_info.save
 
-    redirect_to new_allocations_path(case_info.nomis_offender_id)
+    redirect_to new_allocation_path(case_info.nomis_offender_id)
   end
 
 private

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -30,7 +30,7 @@ class OverridesController < ApplicationController
 private
 
   def redirect_on_success
-    redirect_to confirm_allocations_path(
+    redirect_to confirm_allocation_path(
       override_params[:nomis_offender_id],
       override_params[:nomis_staff_id]
     )

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -15,11 +15,11 @@ module SearchHelper
     if offender.allocated_pom_name.blank?
       return link_to(
         'Allocate',
-        new_allocations_path(nomis_offender_id: offender_id)
+        new_allocation_path(nomis_offender_id: offender_id)
       )
     end
 
-    link_to('Reallocate', new_allocations_path(nomis_offender_id: offender_id))
+    link_to('Reallocate', new_allocation_path(nomis_offender_id: offender_id))
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -34,7 +34,7 @@ time left to serve into account.</p>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
-      <%= link_to "Allocate", confirm_allocations_path(@prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
+      <%= link_to "Allocate", confirm_allocation_path(@prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
       </td>
     </tr>
   <% end %>

--- a/app/views/allocations/confirm.html.erb
+++ b/app/views/allocations/confirm.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_allocations_path(@prisoner.offender_no) } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => new_allocation_path(@prisoner.offender_no) } %>
 
 <div class="govuk-grid-row">
 
@@ -20,7 +20,7 @@
       <%= hidden_field_tag("allocations[nomis_offender_id]", @prisoner.offender_no) %>
       <%= hidden_field_tag("allocations[nomis_staff_id]", @pom.staff_id) %>
       <%= submit_tag "Complete allocation", role: "button", draggable: "false", class: "govuk-button" %>
-      <a class="govuk-link cancel-button" href="<%= new_allocations_path(@prisoner.offender_no) %>">Cancel</a>
+      <a class="govuk-link cancel-button" href="<%= new_allocation_path(@prisoner.offender_no) %>">Cancel</a>
     <% end %>
   </div>
 

--- a/app/views/case_information/edit.html.erb
+++ b/app/views/case_information/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_allocations_path(@prisoner.offender_no) } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => new_allocation_path(@prisoner.offender_no) } %>
 
 <% if @case_info.errors.count > 0 %>
   <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_allocations_path(@prisoner.offender_no) } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => new_allocation_path(@prisoner.offender_no) } %>
 
 <% if @override.errors.count > 0 %>
   <%= render :partial => "/shared/validation_errors", :locals => { :errors => @override.errors } %>

--- a/app/views/shared/_allocation_info.html.erb
+++ b/app/views/shared/_allocation_info.html.erb
@@ -14,7 +14,7 @@
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
         <%= link_to @pom.full_name, pom_path(@pom.staff_id), class: "govuk-link" %>
 
-        <%= link_to 'Reallocate', edit_allocations_path(@prisoner.offender_no), class: "govuk-link pull-right" %>
+        <%= link_to 'Reallocate', edit_allocation_path(@prisoner.offender_no), class: "govuk-link pull-right" %>
       </td>
     </tr>
    <!--<tr class="govuk-table__row">-->

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -38,10 +38,10 @@
         </td>
         <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name %></td>
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
-        <td aria-label="Action" class="govuk-table__cell "><%= link_to "Reallocate", edit_allocations_path(offender.offender_no) %></td>
+        <td aria-label="Action" class="govuk-table__cell "><%= link_to "Reallocate", edit_allocation_path(offender.offender_no) %></td>
         <!--
           <td aria-label="Action" class="govuk-table__cell ">
-            <#%= link_to "View", allocations_path(nomis_offender_id: offender.offender_no) %>
+            <#%= link_to "View", allocation_path(nomis_offender_id: offender.offender_no) %>
           </td>
         -->
       </tr>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -61,7 +61,7 @@
           <%= offender.awaiting_allocation_for %> days
         </td>
         <td aria-label="Action" class="govuk-table__cell ">
-          <a href="<%= new_allocations_path(offender.offender_no) %>">Allocate</a>
+          <a href="<%= new_allocation_path(offender.offender_no) %>">Allocate</a>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get('/prisoners/:id' => 'prisoners#show', as: 'prisoner_show')
   get('/prisoners/:id/image.jpg' => 'prisoners#image', as: 'prisoner_image')
 
-  get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocations')
+  get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocation')
   get('/summary' => 'summary#index')
   get('/summary/allocated' => 'summary#allocated')
   get('/summary/unallocated' => 'summary#unallocated')
@@ -27,11 +27,8 @@ Rails.application.routes.draw do
   resources :status, only: %i[ index ], controller: 'status'
   resource :overrides,  only: %i[ new create ], path_names: { new: 'new/:nomis_offender_id/:nomis_staff_id'}
   resources :poms, only: %i[ index show edit update ], param: :nomis_staff_id
-  resource :allocations, only: %i[ show new create edit ], path_names: {
-    show: ':nomis_offender_id',
-    new: 'new/:nomis_offender_id',
-    edit: 'edit/:nomis_offender_id',
-    confirm: 'confirm/:nomis_offender_id/:nomis_staff_id'
+  resources :allocations, only: %i[ show new create edit ], param: :nomis_offender_id, path_names: {
+    new: ':nomis_offender_id/new',
   }
   resource :case_information, only: %i[new create edit update], controller: 'case_information', path_names: {
       new: 'new/:nomis_offender_id',

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -21,7 +21,7 @@ feature 'Allocation' do
   scenario 'accepting a recommended allocation', vcr: { cassette_name: :create_new_allocation_feature } do
     signin_user
 
-    visit new_allocations_path(nomis_offender_id)
+    visit new_allocation_path(nomis_offender_id)
 
     expect(page).to have_content('Determinate')
 
@@ -43,7 +43,7 @@ feature 'Allocation' do
 
     signin_user
 
-    visit new_allocations_path(nomis_offender_id)
+    visit new_allocation_path(nomis_offender_id)
 
     within('.not_recommended_pom_row_0') do
       click_link 'Allocate'
@@ -57,7 +57,7 @@ feature 'Allocation' do
 
     expect(Override.count).to eq(1)
 
-    expect(page).to have_current_path confirm_allocations_path(nomis_offender_id, override_nomis_staff_id)
+    expect(page).to have_current_path confirm_allocation_path(nomis_offender_id, override_nomis_staff_id)
 
     click_button 'Complete allocation'
 
@@ -69,7 +69,7 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: :override_allocation_feature_validate_reasons } do
     signin_user
 
-    visit new_allocations_path(nomis_offender_id)
+    visit new_allocation_path(nomis_offender_id)
 
     within('.not_recommended_pom_row_0') do
       click_link 'Allocate'
@@ -85,7 +85,7 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate missing Other detail', vcr: { cassette_name: :override_allocation_feature_validate_other } do
     signin_user
 
-    visit new_allocations_path(nomis_offender_id)
+    visit new_allocation_path(nomis_offender_id)
 
     within('.not_recommended_pom_row_0') do
       click_link 'Allocate'
@@ -102,7 +102,7 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate missing suitabilitydetail', vcr: { cassette_name: :override_suitability_allocation_feature } do
     signin_user
 
-    visit new_allocations_path(nomis_offender_id)
+    visit new_allocation_path(nomis_offender_id)
 
     within('.not_recommended_pom_row_0') do
       click_link 'Allocate'
@@ -135,7 +135,7 @@ feature 'Allocation' do
       click_link 'Reallocate'
     end
 
-    expect(page).to have_current_path edit_allocations_path(nomis_offender_id)
+    expect(page).to have_current_path edit_allocation_path(nomis_offender_id)
     expect(page).to have_css('.current_pom_full_name', text: 'Duckett, Jenny')
     expect(page).to have_css('.current_pom_grade', text: 'Prison POM')
   end
@@ -144,7 +144,7 @@ feature 'Allocation' do
     allow(AllocationService).to receive(:create_allocation).and_return(false)
     signin_user
 
-    visit new_allocations_path(nomis_offender_id)
+    visit new_allocation_path(nomis_offender_id)
 
     within('.recommended_pom_row_0') do
       click_link 'Allocate'
@@ -162,7 +162,7 @@ feature 'Allocation' do
   scenario 'cannot reallocate a non-allocated offender', vcr: { cassette_name: :allocation_attempt_bad_reallocate } do
     signin_user
 
-    visit edit_allocations_path(never_allocated_offender)
-    expect(page).to have_current_path new_allocations_path(never_allocated_offender)
+    visit edit_allocation_path(never_allocated_offender)
+    expect(page).to have_current_path new_allocation_path(never_allocated_offender)
   end
 end

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -25,7 +25,7 @@ feature "view an offender's allocation information" do
     it "displays the Key Worker's details" do
       signin_user
 
-      visit allocations_path(nomis_offender_id: nomis_offender_id_with_keyworker)
+      visit allocation_path(nomis_offender_id: nomis_offender_id_with_keyworker)
 
       expect(page).to have_css('h1', text: 'Allocation information')
 
@@ -48,7 +48,7 @@ feature "view an offender's allocation information" do
     it "displays 'not assigned'" do
       signin_user
 
-      visit allocations_path(nomis_offender_id: nomis_offender_id_without_keyworker)
+      visit allocation_path(nomis_offender_id: nomis_offender_id_without_keyworker)
 
       expect(page).to have_css('h1', text: 'Allocation information')
 

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -88,7 +88,7 @@ feature 'case information feature' do
     expect(CaseInformation.first.tier).to eq('A')
     expect(CaseInformation.first.case_allocation).to eq('CRC')
 
-    expect(page).to have_current_path new_allocations_path(nomis_offender_id)
+    expect(page).to have_current_path new_allocation_path(nomis_offender_id)
     expect(page).to have_content('CRC')
   end
 end

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -11,7 +11,7 @@ feature "view POM's caseload" do
   it 'displays all cases for a specific POM',  vcr: { cassette_name: :show_poms_caseload } do
     signin_user('PK000223')
 
-    visit confirm_allocations_path(nomis_offender_id, nomis_staff_id)
+    visit confirm_allocation_path(nomis_offender_id, nomis_staff_id)
 
     click_button 'Complete allocation'
 
@@ -25,7 +25,7 @@ feature "view POM's caseload" do
   it 'displays all cases that have been allocated to a specific POM in the last week', vcr: { cassette_name: :show_new_cases } do
     signin_user('PK000223')
 
-    visit confirm_allocations_path(nomis_offender_id, nomis_staff_id)
+    visit confirm_allocation_path(nomis_offender_id, nomis_staff_id)
     click_button 'Complete allocation'
 
     visit caseload_index_path

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SearchHelper do
         tier: 'A'
       )
       text, _link = cta_for_offender(offender)
-      expect(text).to eq('<a href="/allocations/new/A">Allocate</a>')
+      expect(text).to eq('<a href="/allocations/A/new">Allocate</a>')
     end
 
     it "will change to reallocate if there is an allocation" do
@@ -26,7 +26,7 @@ RSpec.describe SearchHelper do
         allocated_pom_name: 'Bob'
       )
       text, _link = cta_for_offender(offender)
-      expect(text).to eq('<a href="/allocations/new/A">Reallocate</a>')
+      expect(text).to eq('<a href="/allocations/A/new">Reallocate</a>')
     end
   end
 end


### PR DESCRIPTION
Rails routes doesn't like a resource specifying a path_name as
':nomis_offender_id' and so this PR changes it to a 'resources' where
the param name is explicitly changed.  It also needs to change the path
for new because in our use-case new required a nomis_offender_id.