### PR TITLE
Makes get_pom a little more reslient.

### DIFF
--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -24,7 +24,11 @@ class PrisonOffenderManagerService
 
   def self.get_pom(caseload, nomis_staff_id)
     poms_list = get_poms(caseload)
+    return nil if poms_list.blank?
+
     @pom = poms_list.select { |p| p.staff_id == nomis_staff_id.to_i }.first
+    return nil if @pom.blank?
+
     @pom.emails = Nomis::Elite2::PrisonOffenderManagerApi.
         fetch_email_addresses(@pom.staff_id)
     @pom

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -124,4 +124,22 @@ describe PrisonOffenderManagerService do
     expect(names).to be_kind_of(Hash)
     expect(names.count).to eq(12)
   end
+
+  it "can fetch a single POM for a prison",
+    vcr: { cassette_name: :pom_service_get_pom_ok } do
+    pom = described_class.get_pom('LEI', staff_id)
+    expect(pom).not_to be nil
+  end
+
+  it "can handle no poms for a prison when fetching a pom",
+    vcr: { cassette_name: :pom_service_get_pom_none } do
+    pom = described_class.get_pom('CFI', 1234)
+    expect(pom).to be nil
+  end
+
+  it "can handle a pom not existing at a prison",
+    vcr: { cassette_name: :pom_service_get_pom_fail } do
+    pom = described_class.get_pom('LEI', 1234)
+    expect(pom).to be nil
+  end
 end


### PR DESCRIPTION
Currently in the get_pom method of PrisonOffenderManagerService there
were a couple of places where failures were not handled.  It was
possible that no poms would be retrieved, which guaranteed that the pom
filtered out of the list was nil, which guaranteed the fetching of their
email addresses failed.

This PR not fails early if there are no POMs, and then will fail early
again if the POM is not in the list of POMs for that prison.