### PR TITLE
Simplifies the grouping of allocation history

### DIFF
--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -1,5 +1,5 @@
 
-<% @history.grouped_by_prison.each do |row| %>
+<% @history.grouped_by_prison!.each do |row| %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -1,4 +1,3 @@
-
 <% @history.grouped_by_prison do |prison, allocations| %>
 
 <div class="govuk-grid-row">
@@ -16,12 +15,9 @@
           </p>
           <p class="time"><%= format_date_long(allocation.created_at) %> by <%= allocation.created_by_name.titlecase %></p>
         </li>
-        <% end %>
+      <% end %>
       </ul>
     </div>
   </div>
 </div>
-
-
-
 <% end %>

--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -1,12 +1,12 @@
 
-<% @history.grouped_by_prison!.each do |row| %>
+<% @history.grouped_by_prison do |prison, allocations| %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="timeline">
-      <h2 class="govuk-heading-m"><%= prison_title(row.first) %></h2>
+      <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
       <ul>
-        <% row.last.each do |allocation| %>
+        <% allocations.each do |allocation| %>
         <li class="action_needed">
           <h2 class="govuk-heading-s">Prisoner allocation</h2>
           <p>Prisoner allocated to

--- a/spec/models/allocation_list_spec.rb
+++ b/spec/models/allocation_list_spec.rb
@@ -54,9 +54,11 @@ RSpec.describe AllocationList, type: :model do
 
   it 'can group the allocations correctly', vcr: { cassette_name: :allocation_list_spec } do
     list = AllocationList.new([current_allocation, middle_allocation1, middle_allocation2, old_allocation])
-    expect(list.count).to be(4)
+    expect(list.count).to eq(4)
 
-    first, second, third = list.grouped_by_prison
+    # Extract the three expected rows from the list
+    first, second, third = list.grouped_by_prison!
+    expect(list.count).to eq(0)
 
     prison, allocations = first
     expect(prison).to eq('LEI')

--- a/spec/models/allocation_list_spec.rb
+++ b/spec/models/allocation_list_spec.rb
@@ -56,19 +56,21 @@ RSpec.describe AllocationList, type: :model do
     list = AllocationList.new([current_allocation, middle_allocation1, middle_allocation2, old_allocation])
     expect(list.count).to eq(4)
 
-    # Extract the three expected rows from the list
-    first, second, third = list.grouped_by_prison!
-    expect(list.count).to eq(0)
+    results = []
 
-    prison, allocations = first
+    list.grouped_by_prison do |prison, allocations|
+      results << [prison, allocations]
+    end
+
+    prison, allocations = results.shift
     expect(prison).to eq('LEI')
     expect(allocations.count).to eq(1)
 
-    prison, allocations = second
+    prison, allocations = results.shift
     expect(prison).to eq('PVI')
     expect(allocations.count).to eq(2)
 
-    prison, allocations = third
+    prison, allocations = results.shift
     expect(prison).to eq('LEI')
     expect(allocations.count).to eq(1)
   end


### PR DESCRIPTION
Currently the AllocationList#grouped_by_prison method keeps another copy of the data in memory, and this is wasteful, particularly where there are lots of movements and reallocations.  

This PR instead requires that the caller pass a block which resembles 
```
{ |prison, allocations| ... }
``` 
and this will be called for each change in prison.  