### PR TITLE
Prepare for Co-working POMS

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -20,8 +20,8 @@ class AllocationsController < ApplicationController
   # rubocop:disable Metrics/LineLength
   def show
     @prisoner = offender(nomis_offender_id_from_url)
-    allocation = AllocationService.active_allocations_with_pom_detail(@prisoner.offender_no).first
-    @pom = PrisonOffenderManagerService.get_pom(active_caseload, allocation.nomis_staff_id)
+    primary_pom_nomis_id = AllocationService.primary_pom_nomis_id(@prisoner.offender_no)
+    @pom = PrisonOffenderManagerService.get_pom(active_caseload, primary_pom_nomis_id)
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_caseload, @prisoner.offender_no)
     @history = AllocationService.offender_allocation_history(@prisoner.offender_no)
   end
@@ -64,7 +64,7 @@ class AllocationsController < ApplicationController
 
     @override = override
     allocation = {
-      nomis_staff_id: allocation_params[:nomis_staff_id].to_i,
+      primary_pom_nomis_id: allocation_params[:nomis_staff_id].to_i,
       nomis_offender_id: allocation_params[:nomis_offender_id],
       created_by_username: current_user,
       nomis_booking_id: offender.latest_booking_id,
@@ -101,7 +101,7 @@ private
 
   def current_pom_for(nomis_offender_id)
     current_allocation = AllocationService.active_allocations(nomis_offender_id)
-    nomis_staff_id = current_allocation[nomis_offender_id]['nomis_staff_id']
+    nomis_staff_id = current_allocation[nomis_offender_id]['primary_pom_nomis_id']
 
     PrisonOffenderManagerService.get_pom(active_caseload, nomis_staff_id)
   end

--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -36,7 +36,7 @@ class CaseloadController < ApplicationController
 private
 
   def total_allocations
-    @total_allocations ||= PrisonOffenderManagerService.get_allocations_for_pom(
+    @total_allocations ||= PrisonOffenderManagerService.get_allocations_for_primary_pom(
       pom.staff_id, active_caseload
     ).count
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,12 +1,26 @@
 # frozen_string_literal: true
 
 class Allocation < ApplicationRecord
-  belongs_to :pom_detail
-
   attr_accessor :responsibility
 
+  scope :active_allocations, lambda { |nomis_offender_ids|
+    where(nomis_offender_id: nomis_offender_ids)
+  }
+  scope :primary_poms, lambda { |nomis_staff_id|
+    where(primary_pom_nomis_id: nomis_staff_id, active: true)
+  }
+  scope :secondary_poms, lambda { |nomis_staff_id|
+    where(secondary_pom_nomis_id: nomis_staff_id)
+  }
+  scope :any_pom, lambda { |nomis_staff_id|
+    where(primary_poms(nomis_staff_id)).or(secondary_poms(nomis_staff_id))
+  }
+  scope :primary_pom_nomis_id, lambda { |nomis_offender_id|
+    active_allocations(nomis_offender_id).first.primary_pom_nomis_id
+  }
+
   validates :nomis_offender_id,
-    :nomis_staff_id,
+    :primary_pom_nomis_id,
     :nomis_booking_id,
     :prison,
     :allocated_at_tier,

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -4,16 +4,10 @@ class Allocation < ApplicationRecord
   attr_accessor :responsibility
 
   scope :active_allocations, lambda { |nomis_offender_ids|
-    where(nomis_offender_id: nomis_offender_ids)
+    where(nomis_offender_id: nomis_offender_ids, active: true)
   }
   scope :primary_poms, lambda { |nomis_staff_id|
-    where(primary_pom_nomis_id: nomis_staff_id, active: true)
-  }
-  scope :secondary_poms, lambda { |nomis_staff_id|
-    where(secondary_pom_nomis_id: nomis_staff_id)
-  }
-  scope :any_pom, lambda { |nomis_staff_id|
-    where(primary_poms(nomis_staff_id)).or(secondary_poms(nomis_staff_id))
+    where(primary_pom_nomis_id: nomis_staff_id)
   }
   scope :primary_pom_nomis_id, lambda { |nomis_offender_id|
     active_allocations(nomis_offender_id).first.primary_pom_nomis_id

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class PomDetail < ApplicationRecord
-  # rubocop:disable HasManyOrHasOneDependent
-  has_many :allocations
-  # rubocop:enable HasManyOrHasOneDependent
-
   validates :nomis_staff_id, presence: true
   validates :status, presence: true
   validates :working_pattern, presence: {

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -5,11 +5,11 @@ class AllocationService
   def self.create_allocation(params)
     set_names = proc { |alloc|
       pom_firstname, pom_secondname =
-        PrisonOffenderManagerService.get_pom_name(params[:nomis_staff_id])
+        PrisonOffenderManagerService.get_pom_name(params[:primary_pom_nomis_id])
       user_firstname, user_secondname =
         PrisonOffenderManagerService.get_user_name(params[:created_by_username])
 
-      alloc.pom_name = "#{pom_firstname} #{pom_secondname}"
+      alloc.primary_pom_name = "#{pom_firstname} #{pom_secondname}"
       alloc.created_by_name = "#{user_firstname} #{user_secondname}"
     }
 
@@ -17,15 +17,15 @@ class AllocationService
       Allocation.where(nomis_offender_id: params[:nomis_offender_id]).
         update_all(active: false)
 
-      params[:pom_detail_id] = PrisonOffenderManagerService.
-        get_pom_detail(params[:nomis_staff_id]).id
-
       Allocation.create!(params) do |alloc|
         set_names.call(alloc)
         alloc.active = params.fetch(:active, true)
         alloc.save!
       end
     }
+
+    params[:pom_detail_id] = PrisonOffenderManagerService.
+      get_pom_detail(params[:primary_pom_nomis_id]).id
 
     EmailService.instance(params).send_allocation_email
     delete_overrides(params)
@@ -50,7 +50,7 @@ class AllocationService
   def self.previously_allocated_poms(nomis_offender_id)
     Allocation.where(
       nomis_offender_id: nomis_offender_id, active: false
-    ).map(&:nomis_staff_id)
+    ).map(&:primary_pom_nomis_id)
   end
 
   def self.offender_allocation_history(nomis_offender_id)
@@ -73,8 +73,8 @@ class AllocationService
     }
   end
 
-  def self.deallocate_pom(nomis_staff_id)
-    Allocation.where(nomis_staff_id: nomis_staff_id).update_all(active: false)
+  def self.deallocate_primary_pom(nomis_staff_id)
+    Allocation.where(primary_pom_nomis_id: nomis_staff_id).update_all(active: false)
   end
 
   def self.deallocate_offender(nomis_offender_id)
@@ -94,11 +94,15 @@ class AllocationService
     ).preload(:pom_detail)
   end
 
+  def self.primary_pom_nomis_id(nomis_offender_id)
+    Allocation.active_allocations(nomis_offender_id).first.primary_pom_nomis_id
+  end
+
 private
 
   def self.delete_overrides(params)
     Override.where(
-      nomis_staff_id: params[:nomis_staff_id],
+      nomis_staff_id: params[:primary_pom_nomis_id],
       nomis_offender_id: params[:nomis_offender_id]).
         destroy_all
   end

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -3,7 +3,10 @@
 class EmailService
   def self.instance(params)
     offender = OffenderService.get_offender(params[:nomis_offender_id])
-    pom = PrisonOffenderManagerService.get_pom(params[:prison], params[:nomis_staff_id])
+    pom = PrisonOffenderManagerService.get_pom(
+      params[:prison],
+      params[:primary_pom_nomis_id]
+    )
     last_allocation = AllocationService.last_allocation(params[:nomis_offender_id])
     message = params[:message]
 
@@ -32,7 +35,7 @@ private
 
   def previous_pom
     @previous_pom ||= PrisonOffenderManagerService.
-      get_pom(@last_allocation[:prison], @last_allocation[:nomis_staff_id])
+      get_pom(@last_allocation[:prison], @last_allocation[:primary_pom_nomis_id])
   end
 
   def current_responsibility

--- a/app/services/nomis/models/prison_offender_manager.rb
+++ b/app/services/nomis/models/prison_offender_manager.rb
@@ -42,7 +42,7 @@ module Nomis
       end
 
       def add_detail(pom_detail)
-        allocations = pom_detail.allocations.where(active: true)
+        allocations = Allocation.primary_poms(pom_detail.nomis_staff_id)
         allocation_counts = allocations.group_by(&:allocated_at_tier)
 
         self.tier_a = allocation_counts.fetch('A', []).count

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -68,17 +68,17 @@ class OffenderService
   def self.set_allocated_pom_name(offenders, caseload)
     pom_names = PrisonOffenderManagerService.get_pom_names(caseload)
     nomis_offender_ids = offenders.map(&:offender_no)
-    offender_to_staff_hash = AllocationService.
-      active_allocations_with_pom_detail(nomis_offender_ids).
+    offender_to_staff_hash = Allocation.
+      active_allocations(nomis_offender_ids).
       map { |a|
-      [
-        a.nomis_offender_id,
-        {
-          pom_name: pom_names[a.pom_detail.nomis_staff_id],
-          allocation_date: a.created_at
-        }
-      ]
-    }.to_h
+        [
+          a.nomis_offender_id,
+          {
+            pom_name: pom_names[a.primary_pom_nomis_id],
+            allocation_date: a.created_at
+          }
+        ]
+      }.to_h
 
     offenders.map do |offender|
       if offender_to_staff_hash.key?(offender.offender_no)

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -51,14 +51,13 @@ class PrisonOffenderManagerService
     [user.first_name, user.last_name]
   end
 
-  def self.get_allocations_for_pom(nomis_staff_id, prison)
-    detail = get_pom_detail(nomis_staff_id)
-    detail.allocations.where(active: true, prison: prison)
+  def self.get_allocations_for_primary_pom(nomis_staff_id, prison)
+    Allocation.where(primary_pom_nomis_id: nomis_staff_id, active: true, prison: prison)
   end
 
   # rubocop:disable Metrics/MethodLength
   def self.get_allocated_offenders(nomis_staff_id, prison, offset: nil, limit: nil)
-    allocation_list = get_allocations_for_pom(nomis_staff_id, prison)
+    allocation_list = get_allocations_for_primary_pom(nomis_staff_id, prison)
 
     if offset.present? && limit.present?
       allocation_list = allocation_list.offset(offset).limit(limit)
@@ -125,7 +124,7 @@ class PrisonOffenderManagerService
     pom.save
 
     if pom.valid? && pom.status == 'inactive'
-      AllocationService.deallocate_pom(params[:nomis_staff_id])
+      AllocationService.deallocate_primary_pom(params[:nomis_staff_id])
     end
 
     pom

--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -1,23 +1,23 @@
 <% @history.grouped_by_prison do |prison, allocations| %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="timeline">
-      <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
-      <ul>
-        <% allocations.each do |allocation| %>
-        <li class="action_needed">
-          <h2 class="govuk-heading-s">Prisoner allocation</h2>
-          <p>Prisoner allocated to
-            <%= link_to( allocation.pom_name.titlecase, pom_path(allocation.nomis_staff_id) ) %>
-            <br/>
-            Tier: <%= allocation.allocated_at_tier %>
-          </p>
-          <p class="time"><%= format_date_long(allocation.created_at) %> by <%= allocation.created_by_name.titlecase %></p>
-        </li>
-      <% end %>
-      </ul>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="timeline">
+        <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
+        <ul>
+          <% allocations.each do |allocation| %>
+            <li class="action_needed">
+              <h2 class="govuk-heading-s">Prisoner allocation</h2>
+              <p>Prisoner allocated to
+                <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+                <br/>
+                Tier: <%= allocation.allocated_at_tier %>
+              </p>
+              <p class="time"><%= format_date_long(allocation.created_at) %>
+                by <%= allocation.created_by_name.titlecase %></p>
+            </li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   </div>
-</div>
 <% end %>

--- a/db/migrate/20190426085505_add_secondary_pom_to_allocations.rb
+++ b/db/migrate/20190426085505_add_secondary_pom_to_allocations.rb
@@ -1,0 +1,21 @@
+class AddSecondaryPomToAllocations < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :allocations, :nomis_staff_id, :primary_pom_nomis_id
+    rename_column :allocations, :pom_name, :primary_pom_name
+    add_column :allocations, :secondary_pom_name, :text
+    add_column :allocations, :secondary_pom_nomis_id, :int
+    add_index :allocations, :secondary_pom_nomis_id
+    remove_foreign_key :allocations, column: :pom_detail_id
+    remove_column :allocations, :pom_detail_id
+  end
+
+  def down
+    add_column :allocations, :pom_detail_id
+    add_foreign_key :allocation, column: :pom_detail_id
+    remove_index :allocations, :secondary_pom_nomis_id
+    remove_column :allocations, :secondary_pom_nomis_id
+    remove_column :allocations, :secondary_pom_name
+    rename_column :allocations, :primary_pom_name, :pom_name
+    rename_column :allocations, :primary_pom_nomis_id, :nomis_staff_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_23_095925) do
+ActiveRecord::Schema.define(version: 2019_04_26_085505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,17 +23,19 @@ ActiveRecord::Schema.define(version: 2019_04_23_095925) do
     t.string "override_detail"
     t.string "created_by_username"
     t.boolean "active"
-    t.bigint "pom_detail_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "nomis_staff_id"
+    t.integer "primary_pom_nomis_id"
     t.integer "nomis_booking_id"
     t.text "message"
     t.string "suitability_detail"
-    t.text "pom_name"
+    t.text "primary_pom_name"
     t.text "created_by_name"
+    t.text "secondary_pom_name"
+    t.integer "secondary_pom_nomis_id"
     t.index ["nomis_offender_id"], name: "index_allocations_on_nomis_offender_id"
-    t.index ["nomis_staff_id"], name: "index_allocations_on_nomis_staff_id"
+    t.index ["primary_pom_nomis_id"], name: "index_allocations_on_primary_pom_nomis_id"
+    t.index ["secondary_pom_nomis_id"], name: "index_allocations_on_secondary_pom_nomis_id"
   end
 
   create_table "case_information", force: :cascade do |t|
@@ -62,5 +64,4 @@ ActiveRecord::Schema.define(version: 2019_04_23_095925) do
     t.index ["nomis_staff_id"], name: "index_pom_details_on_nomis_staff_id"
   end
 
-  add_foreign_key "allocations", "pom_details"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,7 +38,7 @@ AllocationService.create_allocation(
   prison: 'LEI',
   allocated_at_tier: 'C',
   created_by_username: 'PK000223',
-  nomis_staff_id: 485_595
+  primary_pom_nomis_id: 485_595
   )
 
 AllocationService.create_allocation(
@@ -47,7 +47,7 @@ AllocationService.create_allocation(
   prison: 'LEI',
   allocated_at_tier: 'A',
   created_by_username: 'PK000223',
-  nomis_staff_id: 485_595
+  primary_pom_nomis_id: 485_595
   )
 
 CaseInformation.find_or_create_by!(

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -117,9 +117,9 @@ feature 'Allocation' do
   end
 
   scenario 're-allocating', vcr: { cassette_name: :re_allocate_feature } do
-    probation_officer_pom_detail.allocations.create!(
+    Allocation.create!(
       nomis_offender_id: nomis_offender_id,
-      nomis_staff_id: probation_officer_nomis_staff_id,
+      primary_pom_nomis_id: probation_officer_nomis_staff_id,
       nomis_booking_id: 1_153_753,
       prison: 'LEI',
       allocated_at_tier: 'A',

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -72,15 +72,15 @@ feature "view an offender's allocation information" do
   end
 
   def create_allocation(offender_no)
-    pom_detail.allocations.create!(
+    Allocation.create!(
       nomis_offender_id: offender_no,
-      nomis_staff_id: probation_officer_nomis_staff_id,
+      primary_pom_nomis_id: probation_officer_nomis_staff_id,
       nomis_booking_id: '1153753',
       prison: prison,
       allocated_at_tier: allocated_at_tier,
       created_by_username: 'SuperSPO',
       created_by_name: 'Super SPO',
-      pom_name: 'Ross Jones',
+      primary_pom_name: 'Ross Jones',
       active: true
     )
   end

--- a/spec/models/allocation_list_spec.rb
+++ b/spec/models/allocation_list_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AllocationList, type: :model do
   let(:current_allocation) {
     AllocationService.create_allocation(
-      nomis_staff_id: 485_595,
+      primary_pom_nomis_id: 485_595,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 1,
@@ -15,7 +15,7 @@ RSpec.describe AllocationList, type: :model do
 
   let(:middle_allocation1) {
     AllocationService.create_allocation(
-      nomis_staff_id: 485_752,
+      primary_pom_nomis_id: 485_752,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 2,
@@ -28,7 +28,7 @@ RSpec.describe AllocationList, type: :model do
 
   let(:middle_allocation2) {
     AllocationService.create_allocation(
-      nomis_staff_id: 485_752,
+      primary_pom_nomis_id: 485_752,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 3,
@@ -41,7 +41,7 @@ RSpec.describe AllocationList, type: :model do
 
   let(:old_allocation) {
     AllocationService.create_allocation(
-      nomis_staff_id: 485_595,
+      primary_pom_nomis_id: 485_595,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 4,

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Allocation, type: :model do
-  it { is_expected.to belong_to(:pom_detail) }
   it { is_expected.to validate_presence_of(:nomis_offender_id) }
   it { is_expected.to validate_presence_of(:nomis_booking_id) }
   it { is_expected.to validate_presence_of(:prison) }

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AllocationService do
   let(:allocation) {
     described_class.create_allocation(
-      nomis_staff_id: 485_595,
+      primary_pom_nomis_id: 485_595,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 1,
@@ -15,7 +15,7 @@ RSpec.describe AllocationService do
 
   let(:inactive_allocation) {
     described_class.create_allocation(
-      nomis_staff_id: 485_595,
+      primary_pom_nomis_id: 485_595,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 2,
@@ -28,7 +28,7 @@ RSpec.describe AllocationService do
 
   let(:old_inactive_allocation) {
     described_class.create_allocation(
-      nomis_staff_id: 485_752,
+      primary_pom_nomis_id: 485_752,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 3,
@@ -80,9 +80,9 @@ RSpec.describe AllocationService do
   end
 
   it "can deallocate for a POM", vcr: { cassette_name: :allocation_service_deallocate_a_pom } do
-    staff_id = allocation.nomis_staff_id
-    described_class.deallocate_pom(staff_id)
-    alloc = PrisonOffenderManagerService.get_allocations_for_pom(staff_id, 'LEI')
+    staff_id = allocation.primary_pom_nomis_id
+    described_class.deallocate_primary_pom(staff_id)
+    alloc = PrisonOffenderManagerService.get_allocations_for_primary_pom(staff_id, 'LEI')
     expect(alloc).to eq([])
   end
 

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EmailService do
   include ActiveJob::TestHelper
   let(:params) {
     {
-      nomis_staff_id: 485_637,
+      primary_pom_nomis_id: 485_637,
       nomis_offender_id: 'G2911GD',
       created_by_username: "PK000223",
       nomis_booking_id: 1_153_753,
@@ -39,7 +39,7 @@ RSpec.describe EmailService do
       allow(Allocation).to receive(:where).and_return(
         [
           Allocation.new.tap do |a|
-            a.nomis_staff_id = 485_737
+            a.primary_pom_nomis_id = 485_737
             a.nomis_offender_id = 'G2911GD'
             a.created_by_username = 'PK000223'
             a.nomis_booking_id = 0

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -32,8 +32,9 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
     vcr: { cassette_name: :offender_service_pom_names_spec } do
 
     offenders = OffenderService.get_offenders_for_prison('LEI', page_size: 3)
+    nomis_staff_id = 485_752
 
-    PomDetail.create!(nomis_staff_id: 485_752, working_pattern: 1.0, status: 'active')
+    PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
 
     AllocationService.create_allocation(
       nomis_offender_id: offenders.first.offender_no,
@@ -41,7 +42,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
       prison: 'LEI',
       allocated_at_tier: 'C',
       created_by_username: 'PK000223',
-      nomis_staff_id: 485_752
+      primary_pom_nomis_id: nomis_staff_id
     )
 
     updated_offenders = OffenderService.set_allocated_pom_name(offenders, 'LEI')

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -5,7 +5,7 @@ describe PrisonOffenderManagerService do
 
   let(:allocation_one) {
     AllocationService.create_allocation(
-      nomis_staff_id: staff_id,
+      primary_pom_nomis_id: staff_id,
       nomis_offender_id: 'G4273GI',
       created_by_username: 'RJONES',
       nomis_booking_id: 1_153_753,
@@ -16,7 +16,7 @@ describe PrisonOffenderManagerService do
 
   let(:allocation_two) {
     AllocationService.create_allocation(
-      nomis_staff_id: staff_id,
+      primary_pom_nomis_id: staff_id,
       nomis_offender_id: 'G8060UF',
       created_by_username: 'RJONES',
       nomis_booking_id: 971_856,
@@ -27,7 +27,7 @@ describe PrisonOffenderManagerService do
 
   let(:allocation_three) {
     AllocationService.create_allocation(
-      nomis_staff_id: staff_id,
+      primary_pom_nomis_id: staff_id,
       nomis_offender_id: 'G8624GK',
       created_by_username: 'RJONES',
       nomis_booking_id: 76_908,
@@ -38,7 +38,7 @@ describe PrisonOffenderManagerService do
 
   let(:allocation_four) {
     AllocationService.create_allocation(
-      nomis_staff_id: staff_id,
+      primary_pom_nomis_id: staff_id,
       nomis_offender_id: 'G1714GU',
       created_by_username: 'RJONES',
       nomis_booking_id: 31_777,
@@ -71,7 +71,7 @@ describe PrisonOffenderManagerService do
 
   it "can get allocated offenders for a POM",
     vcr: { cassette_name: :pom_service_allocated_offenders } do
-    allocated_offenders = described_class.get_allocated_offenders(allocation_one.nomis_staff_id, 'LEI')
+    allocated_offenders = described_class.get_allocated_offenders(allocation_one.primary_pom_nomis_id, 'LEI')
 
     alloc, sentence_detail = allocated_offenders.first
     expect(alloc).to be_kind_of(Allocation)
@@ -83,11 +83,11 @@ describe PrisonOffenderManagerService do
 
     expected_total = all_allocations.size
 
-    allocated_offenders = described_class.get_allocated_offenders(allocation_one.nomis_staff_id, 'LEI')
+    allocated_offenders = described_class.get_allocated_offenders(allocation_one.primary_pom_nomis_id, 'LEI')
     expect(allocated_offenders.count).to eq(expected_total)
 
     allocated_offenders = described_class.get_allocated_offenders(
-      allocation_one.nomis_staff_id, 'LEI',
+      allocation_one.primary_pom_nomis_id, 'LEI',
       offset: 2, limit: 2)
     expect(allocated_offenders.count).to eq(2)
   end
@@ -98,7 +98,7 @@ describe PrisonOffenderManagerService do
     allocation_two.created_at = 3.days.ago
     allocation_two.save!
 
-    allocated_offenders = described_class.get_new_cases(allocation_one.nomis_staff_id, 'LEI')
+    allocated_offenders = described_class.get_new_cases(allocation_one.primary_pom_nomis_id, 'LEI')
     expect(allocated_offenders.count).to eq 1
   end
 


### PR DESCRIPTION
This is the first of a series of PR's to introduce the Co-working POM feature.

In this PR, preparations are made to handle the Co-working POM in our database. The appropriate schema changes have been made and all tests / references have been updated.

Rather than store a `nomis_staff_id` against each allocation, we will now store the `primary_pom_nomis_id` and the `secondary_pom_nomis_id` (optional)

The association between an Allocation and PomDetail is now no longer makes sense has been removed