### PR TITLE
Refactoring - move database calls to Rails scopes

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -20,7 +20,7 @@ class AllocationsController < ApplicationController
   # rubocop:disable Metrics/LineLength
   def show
     @prisoner = offender(nomis_offender_id_from_url)
-    primary_pom_nomis_id = AllocationService.primary_pom_nomis_id(@prisoner.offender_no)
+    primary_pom_nomis_id = Allocation.primary_pom_nomis_id(@prisoner.offender_no)
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, primary_pom_nomis_id)
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_caseload, @prisoner.offender_no)
     @history = AllocationService.offender_allocation_history(@prisoner.offender_no)

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -18,12 +18,14 @@ class Allocation < ApplicationRecord
   scope :primary_pom_nomis_id, lambda { |nomis_offender_id|
     active_allocations(nomis_offender_id).first.primary_pom_nomis_id
   }
-  scope :deallocate_primary_pom, lambda { |nomis_staff_id|
-    all_primary_pom_allocations(nomis_staff_id).update_all(active: false)
-  }
-  scope :deallocate_offender, lambda { |nomis_offender_id|
+
+  def self.deallocate_offender(nomis_offender_id)
     active_allocations(nomis_offender_id).update_all(active: false)
-  }
+  end
+
+  def self.deallocate_primary_pom(nomis_staff_id)
+    all_primary_pom_allocations(nomis_staff_id).update_all(active: false)
+  end
 
   validates :nomis_offender_id,
     :primary_pom_nomis_id,

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -6,11 +6,23 @@ class Allocation < ApplicationRecord
   scope :active_allocations, lambda { |nomis_offender_ids|
     where(nomis_offender_id: nomis_offender_ids, active: true)
   }
-  scope :primary_poms, lambda { |nomis_staff_id|
+  scope :inactive_allocations, lambda { |nomis_offender_ids|
+    where(nomis_offender_id: nomis_offender_ids, active: false)
+  }
+  scope :all_primary_pom_allocations, lambda { |nomis_staff_id|
     where(primary_pom_nomis_id: nomis_staff_id)
+  }
+  scope :active_primary_pom_allocations, lambda { |nomis_staff_id, prison|
+    where(primary_pom_nomis_id: nomis_staff_id, prison: prison, active: true)
   }
   scope :primary_pom_nomis_id, lambda { |nomis_offender_id|
     active_allocations(nomis_offender_id).first.primary_pom_nomis_id
+  }
+  scope :deallocate_primary_pom, lambda { |nomis_staff_id|
+    all_primary_pom_allocations(nomis_staff_id).update_all(active: false)
+  }
+  scope :deallocate_offender, lambda { |nomis_offender_id|
+    active_allocations(nomis_offender_id).update_all(active: false)
   }
 
   validates :nomis_offender_id,

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class PomDetail < ApplicationRecord
+  scope :by_nomis_staff_id, lambda { |nomis_staff_id|
+    find_by(nomis_staff_id: nomis_staff_id)
+  }
   validates :nomis_staff_id, presence: true
   validates :status, presence: true
   validates :working_pattern, presence: {

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -42,7 +42,7 @@ private
   def self.process_transfer(transfer)
     Rails.logger.info("Processing transfer for #{transfer.offender_no}")
 
-    AllocationService.deallocate_offender(transfer.offender_no)
+    Allocation.deallocate_offender(transfer.offender_no)
     CaseInformationService.change_prison(
       transfer.offender_no,
       transfer.from_agency,
@@ -58,7 +58,7 @@ private
   def self.process_release(release)
     Rails.logger.info("Processing release for #{release.offender_no}")
     CaseInformationService.delete_information(release.offender_no)
-    AllocationService.deallocate_offender(release.offender_no)
+    Allocation.deallocate_offender(release.offender_no)
 
     true
   end

--- a/app/services/nomis/models/prison_offender_manager.rb
+++ b/app/services/nomis/models/prison_offender_manager.rb
@@ -42,7 +42,7 @@ module Nomis
       end
 
       def add_detail(pom_detail)
-        allocations = Allocation.primary_poms(pom_detail.nomis_staff_id)
+        allocations = Allocation.all_primary_pom_allocations(pom_detail.nomis_staff_id)
         allocation_counts = allocations.group_by(&:allocated_at_tier)
 
         self.tier_a = allocation_counts.fetch('A', []).count

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -118,7 +118,7 @@ class PrisonOffenderManagerService
   end
 
   def self.update_pom(params)
-    pom = PomDetail.where(nomis_staff_id: params[:nomis_staff_id]).first
+    pom = PomDetail.by_nomis_staff_id(params[:nomis_staff_id])
     pom.working_pattern = params[:working_pattern]
     pom.status = params[:status] || pom.status
     pom.save

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -52,7 +52,7 @@ class PrisonOffenderManagerService
   end
 
   def self.get_allocations_for_primary_pom(nomis_staff_id, prison)
-    Allocation.where(primary_pom_nomis_id: nomis_staff_id, active: true, prison: prison)
+    Allocation.active_primary_pom_allocations(nomis_staff_id, prison)
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -124,7 +124,7 @@ class PrisonOffenderManagerService
     pom.save
 
     if pom.valid? && pom.status == 'inactive'
-      AllocationService.deallocate_primary_pom(params[:nomis_staff_id])
+      Allocation.deallocate_primary_pom(params[:nomis_staff_id])
     end
 
     pom

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -78,18 +78,4 @@ RSpec.describe AllocationService do
     expect(staff_ids.count).to eq(1)
     expect(staff_ids.first).to eq(485_595)
   end
-
-  it "can deallocate for a POM", vcr: { cassette_name: :allocation_service_deallocate_a_pom } do
-    staff_id = allocation.primary_pom_nomis_id
-    described_class.deallocate_primary_pom(staff_id)
-    alloc = PrisonOffenderManagerService.get_allocations_for_primary_pom(staff_id, 'LEI')
-    expect(alloc).to eq([])
-  end
-
-  it "can deallocate for an offender", vcr: { cassette_name: :allocation_service_deallocate_an_offender } do
-    offender_id = allocation.nomis_offender_id
-    described_class.deallocate_offender(offender_id)
-    alloc = described_class.active_allocations([offender_id])
-    expect(alloc).to eq({})
-  end
 end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe EmailService do
   }
 
   context "when creating an initial POM allocation" do
-    it "Can send an allocation email", vcr: {cassette_name: :email_service_send_allocation_email} do
+    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_allocation_email } do
       subject.send_allocation_email
       expect(enqueued_jobs.size).to eq(1)
       enqueued_jobs.clear
@@ -48,7 +48,7 @@ RSpec.describe EmailService do
       )
     end
 
-    it "Can send an allocation email", vcr: {cassette_name: :email_service_send_deallocation_email} do
+    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_deallocation_email } do
       subject.send_allocation_email
       expect(enqueued_jobs.size).to eq(2)
       enqueued_jobs.clear

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe EmailService do
   }
 
   context "when creating an initial POM allocation" do
-    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_allocation_email } do
+    it "Can send an allocation email", vcr: {cassette_name: :email_service_send_allocation_email} do
       subject.send_allocation_email
       expect(enqueued_jobs.size).to eq(1)
       enqueued_jobs.clear
@@ -36,21 +36,19 @@ RSpec.describe EmailService do
 
   context "when allocating a prisoner to another POM" do
     before do
-      allow(Allocation).to receive(:where).and_return(
-        [
-          Allocation.new.tap do |a|
-            a.primary_pom_nomis_id = 485_737
-            a.nomis_offender_id = 'G2911GD'
-            a.created_by_username = 'PK000223'
-            a.nomis_booking_id = 0
-            a.allocated_at_tier = 'A'
-            a.prison = 'LEI'
-          end
-        ]
+      allow(AllocationService).to receive(:last_allocation).and_return(
+        Allocation.new.tap do |a|
+          a.primary_pom_nomis_id = 485_737
+          a.nomis_offender_id = 'G2911GD'
+          a.created_by_username = 'PK000223'
+          a.nomis_booking_id = 0
+          a.allocated_at_tier = 'A'
+          a.prison = 'LEI'
+        end
       )
     end
 
-    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_deallocation_email } do
+    it "Can send an allocation email", vcr: {cassette_name: :email_service_send_deallocation_email} do
       subject.send_allocation_email
       expect(enqueued_jobs.size).to eq(2)
       enqueued_jobs.clear


### PR DESCRIPTION
Moving database calls to scopes will dry up the code and decrease the size of services. :-)