### PR TITLE
Hides the caseload screens for non-POMs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def ensure_pom
+    pom = PrisonOffenderManagerService.get_signed_in_pom_details(
+      current_user, active_caseload
+    )
+
+    if pom.blank?
+      redirect_to '/'
+    end
+  end
+
   def current_user
     sso_identity['username'] if sso_identity.present?
   end

--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -2,6 +2,7 @@
 
 class CaseloadController < ApplicationController
   before_action :authenticate_user
+  before_action :ensure_pom
 
   breadcrumb 'Your caseload', :caseload_index_path, only: [:new]
   breadcrumb -> { 'Your caseload' },

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,5 +3,9 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user
 
-  def index; end
+  def index
+    @is_pom = PrisonOffenderManagerService.get_signed_in_pom_details(
+      current_user, active_caseload
+    ).present?
+  end
 end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -114,7 +114,7 @@ class PrisonOffenderManagerService
     user = Nomis::Custody::UserApi.user_details(current_user)
 
     poms_list = get_poms(prison)
-    @pom = poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
+    poms_list.select { |p| p.staff_id.to_i == user.staff_id.to_i }.first
   end
 
   def self.update_pom(params)

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -37,26 +37,28 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m no-bottom-margin">See all prisoners allocated to you</h2>
-<hr class="govuk-section-break govuk-section-break--visible">
-<div class="govuk-grid-row dashboard-row">
-  <div class="govuk-grid-column-one-third">
-    <div class="wrapper">
-      <h1 class="govuk-heading-s">
-        <%= link_to "See your caseload", caseload_index_path, class:"govuk-link" %>
-      </h1>
-      <p class="govuk-body">All prisoners allocated to you.</p>
+<% if @is_pom %>
+  <h2 class="govuk-heading-m no-bottom-margin">See all prisoners allocated to you</h2>
+  <hr class="govuk-section-break govuk-section-break--visible">
+  <div class="govuk-grid-row dashboard-row">
+    <div class="govuk-grid-column-one-third">
+      <div class="wrapper">
+        <h1 class="govuk-heading-s">
+          <%= link_to "See your caseload", caseload_index_path, class:"govuk-link" %>
+        </h1>
+        <p class="govuk-body">All prisoners allocated to you.</p>
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div class="wrapper">
+        <h1 class="govuk-heading-s">
+          <%= link_to "See new allocations", new_caseload_path, class:"govuk-link" %>
+        </h1>
+        <p class="govuk-body">Prisoners allocated to you in the last seven days.</p>
+      </div>
     </div>
   </div>
-  <div class="govuk-grid-column-one-third">
-    <div class="wrapper">
-      <h1 class="govuk-heading-s">
-        <%= link_to "See new allocations", new_caseload_path, class:"govuk-link" %>
-      </h1>
-      <p class="govuk-body">Prisoners allocated to you in the last seven days.</p>
-    </div>
-  </div>
-</div>
+<% end %>
 
 <h2 class="govuk-heading-m no-bottom-margin">Manage staff</h2>
 <hr class="govuk-section-break govuk-section-break--visible">

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -35,9 +35,9 @@ feature "view POM's caseload" do
     expect(page).to have_content("Abbella, Ozullirn")
   end
 
-  it 'allows staff without the POM role to view the my caseload page', vcr: { cassette_name: :non_pom_caseload }  do
+  it 'stops staff without the POM role from viewing the my caseload page', vcr: { cassette_name: :non_pom_caseload }  do
     signin_user('NON_POM_GEN')
     visit caseload_index_path
-    expect(page).to have_text("No allocated cases")
+    expect(page).to have_current_path('/')
   end
 end


### PR DESCRIPTION
Only POMs have a caseload screen, so this PR will hide the caseload
options on the dashboard if the current user is not a POM.  Attempt to
access the caseload screens by URL will result in a redirect to /