### PR TITLE
Show more info in working pattern for managing POMs

### DIFF
--- a/app/views/poms/_prison_poms_table.html.erb
+++ b/app/views/poms/_prison_poms_table.html.erb
@@ -21,7 +21,7 @@
       <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
       <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
-      <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
+      <td aria-label="Working pattern" class="govuk-table__cell"><%= format_working_pattern(pom.working_pattern) %></td>
       <td aria-label="Status" class="govuk-table__cell "><%= pom.status.capitalize %></td>
       <td aria-label="Action" class="govuk-table__cell "><%= link_to 'View', pom_path(nomis_staff_id: pom.staff_id) %></td>
     </tr>

--- a/app/views/poms/_probation_poms_table.html.erb
+++ b/app/views/poms/_probation_poms_table.html.erb
@@ -21,7 +21,7 @@
       <td aria-label="Tier C cases" class="govuk-table__cell "><%= pom.tier_c %></td>
       <td aria-label="Tier D cases" class="govuk-table__cell "><%= pom.tier_d %></td>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
-      <td aria-label="Working pattern" class="govuk-table__cell"><%= pom.working_pattern %></td>
+      <td aria-label="Working pattern" class="govuk-table__cell"><%= format_working_pattern(pom.working_pattern) %></td>
       <td aria-label="Status" class="govuk-table__cell "><%= pom.status.capitalize %></td>
       <td aria-label="Action" class="govuk-table__cell "><%= link_to 'View', pom_path(nomis_staff_id: pom.staff_id) %></td>
     </tr>


### PR DESCRIPTION
When managing POMs the pom list currently shows the working time, 0.0,
0.2, 0.4 etc.  The designs actually show:

  * Full time => for a working pattern of 1.0
  * Part-time - 0.x => for others
      e.g. Part-time - 0.4

This PR uses the helper that was already in place to update the
templates to show this.