### PR TITLE
Adds feature flag functionality to the service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'typhoeus'
 gem 'redis'
 gem 'plissken'
 gem 'fast_underscore', require: false
+gem 'flipflop'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     fast_underscore (0.3.1)
     ffi (1.10.0)
     flamegraph (0.9.5)
+    flipflop (2.6.0)
+      activesupport (>= 4.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_notify_rails (2.1.0)
@@ -312,6 +314,7 @@ DEPENDENCIES
   faraday
   fast_underscore
   flamegraph
+  flipflop
   govuk_notify_rails
   jbuilder (~> 2.8)
   jwt

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -38,12 +38,13 @@
         </td>
         <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name %></td>
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
-        <td aria-label="Action" class="govuk-table__cell "><%= link_to "Reallocate", edit_allocation_path(offender.offender_no) %></td>
-        <!--
-          <td aria-label="Action" class="govuk-table__cell ">
-            <#%= link_to "View", allocation_path(nomis_offender_id: offender.offender_no) %>
-          </td>
-        -->
+        <td aria-label="Action" class="govuk-table__cell ">
+          <% if Flipflop.link_allocation_info? %>
+            <%= link_to "View", allocation_path(nomis_offender_id: offender.offender_no) %>
+          <% else %>
+            <%= link_to "Reallocate", edit_allocation_path(offender.offender_no) %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,10 @@ Bundler.require(*Rails.groups)
 
 module OffenderManagementAllocationClient
   class Application < Rails::Application
+    # Before filter for Flipflop dashboard. Replace with a lambda or method name
+    # defined in ApplicationController to implement access control.
+    config.flipflop.dashboard_access_filter = -> { head :forbidden }
+
     config.load_defaults 5.2
     config.exceptions_app = routes
     config.generators.system_tests = nil

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,8 @@
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,8 @@
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
   config.notify_api_key = ENV['TEST_NOTIFY_API_KEY']
   # The test environment is used exclusively to run your application's

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,8 @@
+Flipflop.configure do
+  strategy :active_record
+  strategy :default
+
+  feature :link_allocation_info,
+          default: false,
+          description: 'Link allocation info page from allocated offenders tab'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,7 @@ Rails.application.routes.draw do
 
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
+
+  # TODO: Re-enable this engine for managing features when we have proper roles for admins
+  # mount Flipflop::Engine => "/flipflop"
 end

--- a/db/migrate/20190507144554_create_features.rb
+++ b/db/migrate/20190507144554_create_features.rb
@@ -1,0 +1,10 @@
+class CreateFeatures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :flipflop_features do |t|
+      t.string :key, null: false
+      t.boolean :enabled, null: false, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_26_085505) do
+ActiveRecord::Schema.define(version: 2019_05_07_144554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,13 @@ ActiveRecord::Schema.define(version: 2019_04_26_085505) do
     t.text "omicable"
     t.text "prison"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id"
+  end
+
+  create_table "flipflop_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "overrides", force: :cascade do |t|


### PR DESCRIPTION
As we need to be able to deploy, with the ability to hide certain
features, we have decided to use feature flags rather than juggling
branches to handle this.

The [flipflop gem](https://github.com/voormedia/flipflop/blob/master/README.md) allows us to easily add new features (to config/features.rb) and 
have them available to turning features on or off.  This is normally done at the
/flipflop URL (where the UI is mounted as a rails engine) but this is
currently disabled until we have a more appropriate role to manage
access.

This PR implements the feature flag for showing the link to
allocation-info on the allocated offenders tab in the summary.