### PR TITLE
Fix the recommended pom type in overrides

### DIFF
--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -4,6 +4,9 @@ class OverridesController < ApplicationController
   def new
     @prisoner = OffenderService.get_offender(params.require(:nomis_offender_id))
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, params[:nomis_staff_id])
+    @recommended_pom_type, @not_recommended_pom_type =
+      recommended_and_nonrecommended_poms_types_for(@prisoner)
+
     @override = Override.new
   end
 
@@ -22,12 +25,26 @@ class OverridesController < ApplicationController
     @prisoner = OffenderService.get_offender(override_params[:nomis_offender_id])
     @pom = PrisonOffenderManagerService.get_pom(
       active_caseload, override_params[:nomis_staff_id])
+    @recommended_pom_type, @not_recommended_pom_type =
+      recommended_and_nonrecommended_poms_types_for(@prisoner)
 
     render :new
   end
 # rubocop:enable Metrics/MethodLength
 
 private
+
+  def recommended_and_nonrecommended_poms_types_for(offender)
+    rec_type = RecommendationService.recommended_pom_type(offender)
+
+    if rec_type == RecommendationService::PRISON_POM
+      ['Prison officer',
+       'Probation officer']
+    else
+      ['Probation officer',
+       'Prison officer']
+    end
+  end
 
   def redirect_on_success
     redirect_to confirm_allocation_path(

--- a/app/helpers/override_helper.rb
+++ b/app/helpers/override_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module OverrideHelper
-  def complex_reason_label(offender)
-    if offender.case_owner == 'Prison'
+  def complex_reason_label(recommended_type)
+    if recommended_type == 'Prison officer'
       return 'Prisoner assessed as not suitable for a prison officer POM'
     end
 

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -8,8 +8,8 @@
     <%= form_tag(overrides_path, method: :post, id: "override_form")  do %>
 
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">
-        <%= "Why are you allocating a probation officer POM?" if @prisoner.case_owner == 'Prison' %>
-        <%= "Why are you allocating a prison officer POM?" if @prisoner.case_owner == 'Probation' %>
+        <%= "Why are you allocating a probation officer POM?" if @recommended_pom_type == 'Prison officer' %>
+        <%= "Why are you allocating a prison officer POM?" if @recommended_pom_type == 'Probation officer' %>
       </h1>
       <div class='govuk-!-margin-top-4'>
         <div class="govuk-form-group <% if @override.errors[:override_reasons].present? %>govuk-form-group--error<% end %>">
@@ -24,7 +24,7 @@
                 <input class="govuk-checkboxes__input" id="override-conditional-1" name="override[override_reasons][]" type="checkbox" value="suitability" data-aria-controls="override-1"
                        <%= 'checked=checked' if override_reason_contains(@override, 'suitability') %> >
                 <label class="govuk-label govuk-checkboxes__label"
-                       for="override-conditional-1"><%= complex_reason_label(@prisoner) %></label>
+                       for="override-conditional-1"><%= complex_reason_label(@recommended_pom_type) %></label>
               </div>
               <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="override-1">
                 <% if @override.errors[:suitability_detail].present? %>
@@ -39,7 +39,7 @@
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "no_staff", override_reason_contains(@override, 'no_staff'), id: "override-2", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "No available #{@prisoner.case_owner.downcase} officer POMs", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= label_tag "override[override_reasons][]", "No available #{@recommended_pom_type.downcase} POMs", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "continuity", override_reason_contains(@override, 'continuity'), id: "override-3", class: "govuk-checkboxes__input") %>

--- a/spec/helpers/override_helper_spec.rb
+++ b/spec/helpers/override_helper_spec.rb
@@ -3,21 +3,11 @@ require 'rails_helper'
 RSpec.describe OverrideHelper do
   describe 'gets a complex override reason label' do
     it "can get for a prison owned offender" do
-      # Nil release date means RESPONSIBLE which means case owner is Prison
-      off = Nomis::Models::Offender.new
-      off.sentence = Nomis::Models::SentenceDetail.new
-
-      expect(off.case_owner).to eq('Prison')
-      expect(complex_reason_label(off)).to eq('Prisoner assessed as not suitable for a prison officer POM')
+      expect(complex_reason_label('Prison officer')).to eq('Prisoner assessed as not suitable for a prison officer POM')
     end
 
     it "can get for a probation owned offender" do
-      off = Nomis::Models::Offender.new
-      off.sentence = Nomis::Models::SentenceDetail.new
-      off.sentence.release_date = Time.zone.today
-
-      expect(off.case_owner).to eq('Probation')
-      expect(complex_reason_label(off)).to eq('Prisoner assessed as suitable for a prison officer POM despite tiering calculation')
+      expect(complex_reason_label('Probation officer')).to eq('Prisoner assessed as suitable for a prison officer POM despite tiering calculation')
     end
   end
 end


### PR DESCRIPTION
When the recommended POM type was calculated in allocations, we didn't
make the change in overrides as well and it was still using the case
owner.

This PR changes it to use the recommendation service to determine what
the recommended type is.

This (along with the recommended POM type in allocations) should probably be refactored.  