### PR TITLE
Fix CircleCi build - update packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ references:
     run:
       name: Set up aws
       command: |
+        sudo apt-get update
         sudo apt-get --assume-yes install python3-pip
         sudo pip3 install awscli
 


### PR DESCRIPTION
- CircleCI breaks when trying to fetch some packages. See https://discuss.circleci.com/t/failed-to-fetch-debian/29258/2
- Run 'sudo apt-get update' to see if this fixes the issue