### PR TITLE
Kubebernetes CronJob should not use the latest deployed image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,7 @@ jobs:
       - deploy:
           name: Deploy to staging
           command: |
+            kubectl set image -f deploy/staging/cronjob.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
             kubectl set image -f deploy/staging/deployment.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
             | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local -o yaml \
             | kubectl apply --record=false \
@@ -314,6 +315,7 @@ jobs:
       - deploy:
           name: Deploy to production
           command: |
+            kubectl set image -f deploy/production/cronjob.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
             kubectl set image -f deploy/production/deployment.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
             | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local -o yaml \
             | kubectl apply --record=false \


### PR DESCRIPTION
Use `kubectl set image` on the cronjob.yaml - this is so that in production the latest image is not pulled (i.e. the version deployed by staging), rather, the version that is deployed to production (commit sha)