### PR TITLE
Fix kubectl set image error 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,20 +246,9 @@ jobs:
       - deploy:
           name: Deploy to staging
           command: |
-            kubectl set image \
-            -f deploy/staging/deployment.yaml \
-            -f deploy/staging/cronjob.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
-            | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local -o yaml \
-            | kubectl apply --record=false \
-              -f - \
-              -f ./deploy/staging/ingress.yaml \
-              -f ./deploy/staging/cronjob.yaml \
-              -f ./deploy/staging/service.yaml \
-              -f ./deploy/staging/service-monitor.yaml \
-              -f ./deploy/staging/network-policy.yaml \
-              -f ./deploy/staging/allocation-manager-secrets.yaml \
-              -f ./deploy/staging/shared-environment.yaml \
-              -f ./deploy/staging/dashboard.yaml \
+            kubectl set image deployments/allocation-manager allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}
+            kubectl annotate deployments/allocation-manager kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
+            kubectl apply --record=false -f ./deploy/staging
           environment:
             <<: *github_team_name_slug
 
@@ -316,21 +305,9 @@ jobs:
       - deploy:
           name: Deploy to production
           command: |
-            kubectl set image \
-            -f deploy/production/deployment.yaml \
-            -f deploy/production/cronjob.yaml allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} --local -o yaml \
-            | kubectl annotate -f - kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --local -o yaml \
-            | kubectl apply --record=false \
-              -f - \
-              -f ./deploy/production/ingress.yaml \
-              -f ./deploy/production/cronjob.yaml \
-              -f ./deploy/production/service.yaml \
-              -f ./deploy/production/service-monitor.yaml \
-              -f ./deploy/production/network-policy.yaml \
-              -f ./deploy/production/certificate.yaml \
-              -f ./deploy/production/allocation-manager-secrets.yaml \
-              -f ./deploy/production/shared-environment.yaml \
-              -f ./deploy/production/dashboard.yaml \
+            kubectl set image deployments/allocation-manager allocation-manager=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}
+            kubectl annotate deployments/allocation-manager kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
+            kubectl apply --record=false -f ./deploy/production
           environment:
             <<: *github_team_name_slug
 


### PR DESCRIPTION
Rather than pass in references to individual `yaml` files (which Kubernetes seems to disagree with if there is more than one), pass in the reference to the deployment instead. - Rather than pipe commands on a per-file basis, make the changes 'in place' and set the image and annotate all Kubernetes scripts

See https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-interactive/