### PR TITLE
[POM-84] Fix summary service allocations check

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -129,7 +129,7 @@ private
   end
 
   def current_pom_for(nomis_offender_id)
-    current_allocation = AllocationService.allocations(nomis_offender_id)
+    current_allocation = AllocationService.allocations(nomis_offender_id, active_caseload)
     nomis_staff_id = current_allocation[nomis_offender_id]['primary_pom_nomis_id']
 
     PrisonOffenderManagerService.get_pom(active_caseload, nomis_staff_id)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -41,8 +41,11 @@ class AllocationService
     }.to_h
   end
 
-  def self.allocations(nomis_offender_ids)
-    AllocationVersion.where(nomis_offender_id: nomis_offender_ids).map { |a|
+  def self.allocations(nomis_offender_ids, prison)
+    AllocationVersion.where(
+      nomis_offender_id: nomis_offender_ids,
+      prison: prison).
+      map { |a|
       [
         a[:nomis_offender_id],
         a

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -42,7 +42,7 @@ class SummaryService
 
       # Check the allocations for the remaining offenders who have tiers.
       offender_nos = tiered_offenders.map(&:offender_no)
-      active_allocations_hash = AllocationService.allocations(offender_nos)
+      active_allocations_hash = AllocationService.allocations(offender_nos, prison)
 
       # Put the offenders in the correct group based on whether we were able to
       # find an active allocation for them.

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -58,6 +58,41 @@ RSpec.describe AllocationService do
     expect(allocations['G2911GD']).to be_kind_of(AllocationVersion)
   end
 
+  it "Can get allocations by prison", vcr: { cassette_name: :allocation_service_get_allocations_by_prison } do
+    first_offender_id = 'JSHD000NN'
+    second_offender_id = 'SDHH87GD'
+    leeds_prison = 'LEI'
+
+    AllocationVersion.create!(
+      primary_pom_nomis_id: 456_987,
+      nomis_offender_id: first_offender_id,
+      created_by_username: 'ZZ00045',
+      nomis_booking_id: 5,
+      allocated_at_tier: 'B',
+      prison: leeds_prison,
+      created_at: '01/03/2019',
+      event: AllocationVersion::ALLOCATE_PRIMARY_POM,
+      event_trigger: AllocationVersion::USER
+    )
+
+    AllocationVersion.create!(
+      primary_pom_nomis_id: 485_595,
+      nomis_offender_id: second_offender_id,
+      created_by_username: 'AB00045',
+      nomis_booking_id: 1,
+      allocated_at_tier: 'B',
+      prison: 'USK',
+      created_at: '01/03/2019',
+      event: AllocationVersion::ALLOCATE_PRIMARY_POM,
+      event_trigger: AllocationVersion::USER
+    )
+
+    allocations = described_class.allocations([first_offender_id, second_offender_id], leeds_prison)
+
+    expect(allocations.keys.count).to be(1)
+    expect(allocations.keys.first).to eq(first_offender_id)
+  end
+
   it "Can get previous poms for an offender where there are none", versioning: true, vcr: { cassette_name: :allocation_service_previous_allocations_none } do
     staff_ids = described_class.previously_allocated_poms(allocation.nomis_offender_id)
 


### PR DESCRIPTION
When fetching allocations by `nomis_offender_id`, pass in the prison name.