### PR TITLE
POM-87: Record when a Primary Pom was allocated

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -62,6 +62,7 @@ class AllocationVersion < ApplicationRecord
       update_all(
         primary_pom_nomis_id: nil,
         primary_pom_name: nil,
+        primary_pom_allocated_at: nil,
         secondary_pom_nomis_id: nil,
         secondary_pom_name: nil,
         event: DEALLOCATE_PRIMARY_POM,
@@ -74,6 +75,7 @@ class AllocationVersion < ApplicationRecord
       update_all(
         primary_pom_nomis_id: nil,
         primary_pom_name: nil,
+        primary_pom_allocated_at: nil,
         event: DEALLOCATE_PRIMARY_POM,
         event_trigger: USER
       )
@@ -81,6 +83,7 @@ class AllocationVersion < ApplicationRecord
 
   validates :nomis_offender_id,
             :primary_pom_nomis_id,
+            :primary_pom_allocated_at,
             :nomis_booking_id,
             :prison,
             :allocated_at_tier,

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -11,6 +11,7 @@ class AllocationService
 
     params_copy[:primary_pom_name] = "#{pom_firstname} #{pom_secondname}"
     params_copy[:created_by_name] = "#{user_firstname} #{user_secondname}"
+    params_copy[:primary_pom_allocated_at] = DateTime.now.utc
 
     alloc_version = AllocationVersion.find_by(
       nomis_offender_id: params_copy[:nomis_offender_id]

--- a/db/migrate/20190516112018_add_primary_pom_allocated_at_to_allocation_version.rb
+++ b/db/migrate/20190516112018_add_primary_pom_allocated_at_to_allocation_version.rb
@@ -1,0 +1,9 @@
+class AddPrimaryPomAllocatedAtToAllocationVersion < ActiveRecord::Migration[5.2]
+  def up
+    add_column :allocation_versions, :primary_pom_allocated_at, :datetime
+  end
+
+  def down
+    remove_column :allocation_versions, :primary_pom_allocated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_144554) do
+ActiveRecord::Schema.define(version: 2019_05_16_112018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2019_05_07_144554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "created_by_username"
+    t.datetime "primary_pom_allocated_at"
     t.index ["nomis_offender_id"], name: "index_allocation_versions_on_nomis_offender_id"
     t.index ["primary_pom_nomis_id"], name: "index_allocation_versions_on_primary_pom_nomis_id"
     t.index ["secondary_pom_nomis_id"], name: "index_allocation_versions_secondary_pom_nomis_id"

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -121,6 +121,7 @@ feature 'Allocation' do
     AllocationVersion.create!(
       nomis_offender_id: nomis_offender_id,
       primary_pom_nomis_id: probation_officer_nomis_staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_booking_id: 1_153_753,
       prison: 'LEI',
       allocated_at_tier: 'A',

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -92,6 +92,7 @@ feature "view an offender's allocation information" do
     AllocationVersion.create!(
       nomis_offender_id: offender_no,
       primary_pom_nomis_id: probation_officer_nomis_staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_booking_id: '1153753',
       prison: prison,
       allocated_at_tier: allocated_at_tier,

--- a/spec/models/allocation_list_spec.rb
+++ b/spec/models/allocation_list_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe AllocationList, type: :model do
   let(:current_allocation) {
     AllocationVersion.create!(
       primary_pom_nomis_id: 485_595,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 1,
@@ -18,6 +19,7 @@ RSpec.describe AllocationList, type: :model do
   let(:middle_allocation1) {
     AllocationVersion.create!(
       primary_pom_nomis_id: 485_752,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 2,
@@ -32,6 +34,7 @@ RSpec.describe AllocationList, type: :model do
   let(:middle_allocation2) {
     AllocationVersion.create!(
       primary_pom_nomis_id: 485_752,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 3,
@@ -46,6 +49,7 @@ RSpec.describe AllocationList, type: :model do
   let(:old_allocation) {
     AllocationVersion.create!(
       primary_pom_nomis_id: 485_595,
+      primary_pom_allocated_at: DateTime.now.utc - 4.days,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 4,

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AllocationVersion, type: :model do
-  let(:nomis_staff_id) {456_789}
-  let(:nomis_offender_id) {123_456}
+  let(:nomis_staff_id) { 456_789 }
+  let(:nomis_offender_id) { 123_456 }
 
   let(:attributes) {
     {
@@ -18,16 +18,16 @@ RSpec.describe AllocationVersion, type: :model do
     }
   }
 
-  let!(:allocation) {AllocationVersion.create!(attributes)}
+  let!(:allocation) { AllocationVersion.create!(attributes) }
 
   describe 'Validations' do
-    it {is_expected.to validate_presence_of(:nomis_offender_id)}
-    it {is_expected.to validate_presence_of(:nomis_booking_id)}
-    it {is_expected.to validate_presence_of(:prison)}
-    it {is_expected.to validate_presence_of(:allocated_at_tier)}
-    it {is_expected.to validate_presence_of(:event)}
-    it {is_expected.to validate_presence_of(:event_trigger)}
-    it {is_expected.to validate_presence_of(:primary_pom_allocated_at)}
+    it { is_expected.to validate_presence_of(:nomis_offender_id) }
+    it { is_expected.to validate_presence_of(:nomis_booking_id) }
+    it { is_expected.to validate_presence_of(:prison) }
+    it { is_expected.to validate_presence_of(:allocated_at_tier) }
+    it { is_expected.to validate_presence_of(:event) }
+    it { is_expected.to validate_presence_of(:event_trigger) }
+    it { is_expected.to validate_presence_of(:primary_pom_allocated_at) }
   end
 
   describe 'Versions' do

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AllocationVersion, type: :model do
-  let(:nomis_staff_id) { 456_789 }
-  let(:nomis_offender_id) { 123_456 }
+  let(:nomis_staff_id) {456_789}
+  let(:nomis_offender_id) {123_456}
 
   let(:attributes) {
     {
@@ -11,21 +11,23 @@ RSpec.describe AllocationVersion, type: :model do
       allocated_at_tier: 'A',
       primary_pom_name: 'Bob Jones',
       primary_pom_nomis_id: nomis_staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_booking_id: 896_456,
       event: 0,
       event_trigger: 0
     }
   }
 
-  let!(:allocation) { AllocationVersion.create!(attributes) }
+  let!(:allocation) {AllocationVersion.create!(attributes)}
 
   describe 'Validations' do
-    it { is_expected.to validate_presence_of(:nomis_offender_id) }
-    it { is_expected.to validate_presence_of(:nomis_booking_id) }
-    it { is_expected.to validate_presence_of(:prison) }
-    it { is_expected.to validate_presence_of(:allocated_at_tier) }
-    it { is_expected.to validate_presence_of(:event) }
-    it { is_expected.to validate_presence_of(:event_trigger) }
+    it {is_expected.to validate_presence_of(:nomis_offender_id)}
+    it {is_expected.to validate_presence_of(:nomis_booking_id)}
+    it {is_expected.to validate_presence_of(:prison)}
+    it {is_expected.to validate_presence_of(:allocated_at_tier)}
+    it {is_expected.to validate_presence_of(:event)}
+    it {is_expected.to validate_presence_of(:event_trigger)}
+    it {is_expected.to validate_presence_of(:primary_pom_allocated_at)}
   end
 
   describe 'Versions' do
@@ -36,6 +38,30 @@ RSpec.describe AllocationVersion, type: :model do
 
       expect(allocation.versions.count).to be(2)
       expect(allocation.versions.last.reify.allocated_at_tier).to eq('A')
+    end
+  end
+
+  describe 'when a Primary Pom is inactive' do
+    it 'removes the primary pom\'s from all allocations' do
+      AllocationVersion.deallocate_primary_pom(nomis_staff_id)
+
+      deallocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
+
+      expect(deallocation.primary_pom_nomis_id).to be_nil
+      expect(deallocation.primary_pom_name).to be_nil
+      expect(deallocation.primary_pom_allocated_at).to be_nil
+    end
+  end
+
+  describe 'when an offender moves prison' do
+    it 'removes the primary pom details in an Offender\'s allocation' do
+      AllocationVersion.deallocate_offender(nomis_offender_id)
+
+      deallocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
+
+      expect(deallocation.primary_pom_nomis_id).to be_nil
+      expect(deallocation.primary_pom_name).to be_nil
+      expect(deallocation.primary_pom_allocated_at).to be_nil
     end
   end
 

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe AllocationService do
   let!(:allocation) {
-    described_class.create_or_update(
+    AllocationVersion.create!(
       primary_pom_nomis_id: 485_595,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G2911GD',
       created_by_username: 'PK000223',
       nomis_booking_id: 1,
@@ -28,6 +29,7 @@ RSpec.describe AllocationService do
       prison: 'LEI',
       allocated_at_tier: 'A',
       primary_pom_nomis_id: 485_595,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_booking_id: 1,
       event: AllocationVersion::ALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
@@ -65,6 +67,7 @@ RSpec.describe AllocationService do
 
     AllocationVersion.create!(
       primary_pom_nomis_id: 456_987,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: first_offender_id,
       created_by_username: 'ZZ00045',
       nomis_booking_id: 5,
@@ -77,6 +80,7 @@ RSpec.describe AllocationService do
 
     AllocationVersion.create!(
       primary_pom_nomis_id: 485_595,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: second_offender_id,
       created_by_username: 'AB00045',
       nomis_booking_id: 1,

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -43,6 +43,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
       allocated_at_tier: 'C',
       created_by_username: 'PK000223',
       primary_pom_nomis_id: nomis_staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       event: AllocationVersion::ALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
     )

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -4,8 +4,9 @@ describe PrisonOffenderManagerService do
   let(:staff_id) { 485_737 }
 
   let(:allocation_one) {
-    AllocationService.create_or_update(
+    AllocationVersion.create!(
       primary_pom_nomis_id: staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G4273GI',
       created_by_username: 'RJONES',
       nomis_booking_id: 1_153_753,
@@ -17,8 +18,9 @@ describe PrisonOffenderManagerService do
   }
 
   let(:allocation_two) {
-    AllocationService.create_or_update(
+    AllocationVersion.create!(
       primary_pom_nomis_id: staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G8060UF',
       created_by_username: 'RJONES',
       nomis_booking_id: 971_856,
@@ -30,8 +32,9 @@ describe PrisonOffenderManagerService do
   }
 
   let(:allocation_three) {
-    AllocationService.create_or_update(
+    AllocationVersion.create!(
       primary_pom_nomis_id: staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G8624GK',
       created_by_username: 'RJONES',
       nomis_booking_id: 76_908,
@@ -43,8 +46,9 @@ describe PrisonOffenderManagerService do
   }
 
   let(:allocation_four) {
-    AllocationService.create_or_update(
+    AllocationVersion.create!(
       primary_pom_nomis_id: staff_id,
+      primary_pom_allocated_at: DateTime.now.utc,
       nomis_offender_id: 'G1714GU',
       created_by_username: 'RJONES',
       nomis_booking_id: 31_777,


### PR DESCRIPTION
- PR adds a new column in the :allocation_versions table to record the timestamp when a Primary Pom was allocated
- This value is set to nil of the offender moves prison