### PR TITLE
 Log directly to elastic_search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'redis'
 gem 'plissken'
 gem 'fast_underscore', require: false
 gem 'flipflop'
+gem 'rails_semantic_logger'
+gem 'elasticsearch'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,14 @@ GEM
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)
+    elasticsearch (7.0.0)
+      elasticsearch-api (= 7.0.0)
+      elasticsearch-transport (= 7.0.0)
+    elasticsearch-api (7.0.0)
+      multi_json
+    elasticsearch-transport (7.0.0)
+      faraday
+      multi_json
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
@@ -193,6 +201,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails_semantic_logger (4.4.1)
+      rails (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -254,6 +265,8 @@ GEM
     selenium-webdriver (3.142.2)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    semantic_logger (4.5.0)
+      concurrent-ruby (~> 1.0)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.0.1)
@@ -320,6 +333,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 5.0)
   database_cleaner
+  elasticsearch
   factory_bot_rails
   faker
   faraday
@@ -343,6 +357,7 @@ DEPENDENCIES
   puma (~> 3.12)
   rack-mini-profiler
   rails (~> 5.2.3)
+  rails_semantic_logger
   redis
   rspec-rails
   rubocop

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,6 @@ module OffenderManagementAllocationClient
     config.support_email = ENV['SUPPORT_EMAIL']&.strip
     config.redis_url = ENV['REDIS_URL']&.strip
     config.redis_auth = ENV['REDIS_AUTH']&.strip
+    config.elastic_url = ENV['ELASTIC_URL']&.strip
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,6 @@ Rails.application.configure do
     )
   end
 
-
   if Rails.configuration.redis_url.present?
     config.cache_store = :redis_cache_store, {
       url: "rediss://#{config.redis_url}:6379/0",

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,4 +1,0 @@
-Rails.application.configure do
-  stdout_logger = ActiveSupport::Logger.new(STDOUT)
-  config.lograge.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
-end

--- a/config/puma_prod.rb
+++ b/config/puma_prod.rb
@@ -9,6 +9,11 @@ rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'production'
 
+on_worker_boot do
+  # Re-open appenders after forking the process
+  SemanticLogger.reopen
+end
+
 after_worker_boot do
   require 'prometheus_exporter/instrumentation'
   PrometheusExporter::Instrumentation::Puma.start


### PR DESCRIPTION
Using the semantic logging gem, this PR will start logging directly to
the elastic search whose URL is in the ELASTIC_URL environment variable.
The index created will be offender-management-allocation-ENV where ENV
is either staging or production.  This will allow us to create a mapping
in Kibana for the index.