### PR TITLE
Replace updated_at with primary_pom_allocated_at

### DIFF
--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 class OffenderService
   # rubocop:disable Metrics/MethodLength
   def self.get_offender(offender_no)
@@ -77,7 +76,7 @@ class OffenderService
           a.nomis_offender_id,
           {
             pom_name: pom_names[a.primary_pom_nomis_id],
-            allocation_date: a.updated_at
+            allocation_date: a.primary_pom_allocated_at
           }
         ]
       }.to_h

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -100,13 +100,13 @@ class PrisonOffenderManagerService
 
   def self.get_new_cases(nomis_staff_id, prison)
     allocations = get_allocated_offenders(nomis_staff_id, prison)
-    allocations.select { |allocation, _offender| allocation.updated_at >= 7.days.ago }
+    allocations.select { |allocation, _offender| allocation.primary_pom_allocated_at >= 7.days.ago }
   end
 
   def self.get_new_cases_count(nomis_staff_id, prison)
     allocations = get_allocated_offenders(nomis_staff_id, prison)
     allocations.select { |allocation, _offender|
-      allocation.updated_at >= 7.days.ago
+      allocation.primary_pom_allocated_at >= 7.days.ago
     }.count
   end
 

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -38,7 +38,7 @@
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
-        <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.updated_at) %></td>
+        <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
       </tr>
     <% end %>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -25,7 +25,7 @@
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
         <td aria-label="Arrival date" class="govuk-table__cell "><%= format_date(sentence.sentence_start_date) %></td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
-        <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.updated_at) %></td>
+        <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
       </tr>
     <% end %>

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -17,7 +17,7 @@
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
       <td aria-label="Earliest release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
       <td aria-label="Tier" class="govuk-table__cell "><%= allocation.allocated_at_tier %></td>
-      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.updated_at) %></td>
+      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
       <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
     </tr>
     <% end %>

--- a/app/views/poms/my_caseload.html.erb
+++ b/app/views/poms/my_caseload.html.erb
@@ -38,7 +38,7 @@
       <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
       <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>
-      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.updated_at) %></td>
+      <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
       <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
     </tr>
   <% end %>

--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -12,7 +12,7 @@
                 <br/>
                 Tier: <%= allocation.allocated_at_tier %>
               </p>
-              <p class="time"><%= format_date_long(allocation.updated_at) %>
+              <p class="time"><%= format_date_long(allocation.primary_pom_allocated_at) %>
                 by <%= allocation.created_by_name.titlecase %></p>
             </li>
           <% end %>

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -36,7 +36,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
 
     PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
 
-    AllocationService.create_or_update(
+    AllocationVersion.create!(
       nomis_offender_id: offenders.first.offender_no,
       nomis_booking_id: 1_153_753,
       prison: 'LEI',

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -85,8 +85,8 @@ describe PrisonOffenderManagerService do
   end
 
   it "will get allocations for a POM made within the last 7 days", vcr: { cassette_name: :get_new_cases } do
-    allocation_one.update!(updated_at: 10.days.ago)
-    allocation_two.update!(updated_at: 3.days.ago)
+    allocation_one.update!(primary_pom_allocated_at: 10.days.ago)
+    allocation_two.update!(primary_pom_allocated_at: 3.days.ago)
 
     allocated_offenders = described_class.get_new_cases(allocation_one.primary_pom_nomis_id, 'LEI')
     expect(allocated_offenders.count).to eq 3


### PR DESCRIPTION
We were previously using the updated_at field to generate
the allocation date for when a POM was allocated to an
offender.

We are now using the pom_allocated_at field which is
explicitly set on creation.