### PR TITLE
Remove allocation history from allocation info page

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -27,7 +27,6 @@ class AllocationsController < ApplicationController
     primary_pom_nomis_id = AllocationVersion.find_by(nomis_offender_id: @prisoner.offender_no).primary_pom_nomis_id
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, primary_pom_nomis_id)
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_caseload, @prisoner.offender_no)
-    @history = AllocationService.offender_allocation_history(@prisoner.offender_no)
   end
 
   def edit

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -4,30 +4,6 @@
 
 <%= render 'shared/allocation_info' %>
 
+<%= render 'shared/offence_info' %>
+<%= render 'allocations/case_information' %>
 
-<div class="govuk-tabs govuk-!-margin-top-9" data-module="tabs">
-  <ul class="govuk-tabs__list">
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#prisoner-info">
-        Prisoner information
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#history">
-        Allocations
-      </a>
-    </li>
-  </ul>
-
-  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="history">
-    <%= render 'shared/allocation_history' %>
-  </section>
-
-  <section class="govuk-tabs__panel govuk-tabs__panel--hidden"
-           id="prisoner-info">
-    <div>
-      <%= render 'shared/offence_info' %>
-      <%= render 'allocations/case_information' %>
-    </div>
-  </section>
-</div>


### PR DESCRIPTION
The allocation history is now going to be shown on a separate page and
so we will temporarily remove it.  This PR does not change the
allocation info page in any other way, for instance, it does not update
the page to match the latest designs.