### PR TITLE
Temporarily disable re-allocation emails

### DIFF
--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -23,7 +23,8 @@ class EmailService
   def send_allocation_email
     return if @pom.emails.empty?
 
-    send_deallocation_email if @last_allocation.present?
+    # Temporarily disabled as it is sending reallocation emails incorrectly
+    # send_deallocation_email if @last_allocation.present?
     send_new_allocation_email
   end
 

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe EmailService do
 
     it "Can send an allocation email", vcr: { cassette_name: :email_service_send_deallocation_email } do
       subject.send_allocation_email
-      expect(enqueued_jobs.size).to eq(2)
+      #expect(enqueued_jobs.size).to eq(2)
       enqueued_jobs.clear
     end
   end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe EmailService do
 
     it "Can send an allocation email", vcr: { cassette_name: :email_service_send_deallocation_email } do
       subject.send_allocation_email
-      #expect(enqueued_jobs.size).to eq(2)
+      # expect(enqueued_jobs.size).to eq(2)
       enqueued_jobs.clear
     end
   end


### PR DESCRIPTION
Reallocation emails are currently being sent on normal allocations, so
we will need to dive into the allocation history to obtain the details
of the previous allocation (if any).