### PR TITLE
[POM-103] Change how we send any reallocation emails

### DIFF
--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -29,7 +29,7 @@ class AllocationService
     EmailService.instance(
       allocation: alloc_version,
       message: params[:message]
-    ).send_allocation_email
+    ).send_email
 
     delete_overrides(params_copy)
 

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -26,7 +26,11 @@ class AllocationService
     params_copy[:pom_detail_id] = PrisonOffenderManagerService.
       get_pom_detail(params_copy[:primary_pom_nomis_id]).id
 
-    EmailService.instance(params_copy).send_allocation_email
+    EmailService.instance(
+      allocation: alloc_version,
+      message: params[:message]
+    ).send_allocation_email
+
     delete_overrides(params_copy)
 
     alloc_version
@@ -84,7 +88,7 @@ class AllocationService
     }
   end
 
-  def self.last_allocation(nomis_offender_id)
+  def self.current_allocation_for(nomis_offender_id)
     AllocationVersion.allocations(nomis_offender_id).last
   end
 

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -19,7 +19,7 @@ class EmailService
     )
   end
 
-  def send_allocation_email
+  def send_email
     return if @pom.emails.empty?
 
     if @allocation.event == 'reallocate_primary_pom' && previous_pom.present?

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -2,29 +2,30 @@
 
 class EmailService
   def self.instance(params)
-    offender = OffenderService.get_offender(params[:nomis_offender_id])
-    pom = PrisonOffenderManagerService.get_pom(
-      params[:prison],
-      params[:primary_pom_nomis_id]
-    )
-    last_allocation = AllocationService.last_allocation(params[:nomis_offender_id])
     message = params[:message]
+    allocation = params[:allocation]
 
-    new(offender, pom, last_allocation, message)
+    new(allocation, message)
   end
 
-  def initialize(offender, pom, last_allocation, message)
-    @offender = offender
-    @pom = pom
-    @last_allocation = last_allocation
+  def initialize(allocation, message)
     @message = message
+    @allocation = allocation
+
+    @offender = OffenderService.get_offender(@allocation[:nomis_offender_id])
+    @pom = PrisonOffenderManagerService.get_pom(
+      @allocation.prison,
+      @allocation.primary_pom_nomis_id
+    )
   end
 
   def send_allocation_email
     return if @pom.emails.empty?
 
-    send_deallocation_email if @last_allocation.present?
-    send_new_allocation_email
+    if @allocation.event == 'reallocate_primary_pom' && previous_pom.present?
+      send_deallocation_email
+    end
+    deliver_new_allocation_email
   end
 
 private
@@ -33,14 +34,26 @@ private
     @url ||= Rails.application.routes.url_helpers.caseload_index_url
   end
 
-  def previous_pom
-    @previous_pom ||= PrisonOffenderManagerService.
-      get_pom(@last_allocation[:prison], @last_allocation[:primary_pom_nomis_id])
-  end
-
   def current_responsibility
     @current_responsibility ||= ResponsibilityService.new.
       calculate_pom_responsibility(@offender).downcase
+  end
+
+  def previous_pom
+    # Check the versions (there MUST be previous records if this is a reallocation)
+    # and find the first version with a primary_pom id that is not the same as the
+    # allocation. That will be the POM that is notified of a reallocation.
+    versions = AllocationService.get_versions_for(@allocation)
+
+    previous = versions.first { |version|
+      version.primary_pom_nomis_id != @allocation.primary_pom_nomis_id
+    }
+    return nil if previous.blank?
+
+    @previous_pom ||= PrisonOffenderManagerService.get_pom(
+      previous.prison,
+      previous.primary_pom_nomis_id
+    )
   end
 
   def send_deallocation_email
@@ -56,7 +69,7 @@ private
     ).deliver_later
   end
 
-  def send_new_allocation_email
+  def deliver_new_allocation_email
     PomMailer.new_allocation_email(
       pom_name: @pom.first_name.capitalize,
       responsibility: current_responsibility,

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -4,7 +4,7 @@ describe AllocationService do
   let(:mock_email_service) { double('email_service_mock') }
 
   before do
-    allow(mock_email_service).to receive(:send_allocation_email)
+    allow(mock_email_service).to receive(:send_email)
     allow(EmailService).to receive(:instance).and_return(mock_email_service)
   end
 

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe EmailService do
   }
 
   it "Can send an allocation email", vcr: { cassette_name: :email_service_send_allocation_email }, versioning: true  do
-    described_class.instance(allocation: allocation, message: "").send_allocation_email
+    described_class.instance(allocation: allocation, message: "").send_email
     expect(enqueued_jobs.size).to eq(1)
     enqueued_jobs.clear
   end
@@ -55,7 +55,7 @@ RSpec.describe EmailService do
   it "Can send a reallocation email", vcr: { cassette_name: :email_service_send_deallocation_email }, versioning: true  do
     allow(AllocationService).to receive(:get_versions_for).and_return([original_allocation])
 
-    described_class.instance(allocation: reallocation, message: "").send_allocation_email
+    described_class.instance(allocation: reallocation, message: "").send_email
     expect(enqueued_jobs.size).to eq(2)
     enqueued_jobs.clear
   end


### PR DESCRIPTION
Currently the way we determine whether to send a reallocation email,
along with the allocation email, results in us always sending a
reallocation email regardless of that state.  This is because it
just pulls the last allocation and assume it is the previous one which 
worked before we changed to using papertrail.

This PR changes how it is sent, and contains slight changes to the
interface.  It is expected that only a message and the recently created
allocation object will be passed to the EmailService.instance() class
method, the other data is derived from this.

To determine if the service should send a reallocated email, we now
check that the newly created allocation is a `:reallocated_primary_pom`
event, and if so try and determine the previous pom's details.  We do
this by iterating through the previous versions to find the
first primary_pom that is not the pom in the current allocation. 

We _should_ check that there is no a 'version' without a POM in the 
history but this currently relies on the `:reallocated_primary_pom` event being
accurate (as it is over-writing a previously allocated POM) when
triggered by the user interface.  This _should_ be true. We should
ensure that there are no further edge cases. Oh to have a ruby that supports 
'design by contract' :( 

Further refactoing of the EmailService, when we look again at all of the
notifications we might send, may want to break this service up to handle
specific events explicitly rather than handling logic within the service
itself. cf modularised services.