### PR TITLE
Fix integration test cleanup cron job

### DIFF
--- a/lib/tasks/cleanup_integration_tests.rake
+++ b/lib/tasks/cleanup_integration_tests.rake
@@ -9,6 +9,12 @@ namespace :integration_tests do
 
     Rails.logger.info 'Deleting integration test data'
 
+    ids = AllocationVersion.where(
+        created_by_username: 'MOIC_INTEGRATION_TESTS').
+        pluck(:nomis_offender_id)
+    cases = CaseInformation.where(nomis_offender_id: ids)
+    cases.destroy_all
+
     AllocationVersion.where(created_by_username: 'MOIC_INTEGRATION_TESTS').destroy_all
   end
 end

--- a/lib/tasks/cleanup_integration_tests.rake
+++ b/lib/tasks/cleanup_integration_tests.rake
@@ -9,6 +9,6 @@ namespace :integration_tests do
 
     Rails.logger.info 'Deleting integration test data'
 
-    Allocation.where(created_by_username: 'MOIC_INTEGRATION_TESTS').destroy_all
+    AllocationVersion.where(created_by_username: 'MOIC_INTEGRATION_TESTS').destroy_all
   end
 end

--- a/lib/tasks/cleanup_integration_tests.rake
+++ b/lib/tasks/cleanup_integration_tests.rake
@@ -10,7 +10,7 @@ namespace :integration_tests do
     Rails.logger.info 'Deleting integration test data'
 
     ids = AllocationVersion.where(
-        created_by_username: 'MOIC_INTEGRATION_TESTS').
+      created_by_username: 'MOIC_INTEGRATION_TESTS').
         pluck(:nomis_offender_id)
     cases = CaseInformation.where(nomis_offender_id: ids)
     cases.destroy_all


### PR DESCRIPTION
We have implemented a new process regarding the way we track
allocations & reallocations.  This has resulted in a new column being
added in the database (AllocationVersions), and this is used instead of
the original Allocations column.

As part of our staging environment we have set up integration tests to
ensure that our workflows are behaving as expected. We then have a
corresponding cron job that runs every night to remove any allocations
created via the integration tests to ensure we don't get to a point
where everyone is allocated and the tests fail.  However, we have now
reached this point because the cron job still refers to the old column,
and not the new one.  This PR therefore updates the cron job to use the
new column name.