### PR TITLE
Fix POM case totals

### DIFF
--- a/app/services/nomis/models/prison_offender_manager.rb
+++ b/app/services/nomis/models/prison_offender_manager.rb
@@ -42,7 +42,8 @@ module Nomis
       end
 
       def add_detail(pom_detail)
-        allocations = AllocationVersion.all_primary_pom_allocations(pom_detail.nomis_staff_id)
+        allocations = AllocationVersion.all_primary_pom_allocations(
+          pom_detail.nomis_staff_id)
         allocation_counts = allocations.group_by(&:allocated_at_tier)
 
         self.tier_a = allocation_counts.fetch('A', []).count

--- a/app/services/nomis/models/prison_offender_manager.rb
+++ b/app/services/nomis/models/prison_offender_manager.rb
@@ -42,7 +42,7 @@ module Nomis
       end
 
       def add_detail(pom_detail)
-        allocations = Allocation.all_primary_pom_allocations(pom_detail.nomis_staff_id)
+        allocations = AllocationVersion.all_primary_pom_allocations(pom_detail.nomis_staff_id)
         allocation_counts = allocations.group_by(&:allocated_at_tier)
 
         self.tier_a = allocation_counts.fetch('A', []).count


### PR DESCRIPTION
HMP Cardiff alerted us to the fact that incorrect case totals were
displayed on the POMs page.  When explored further we realised that the
case totals counts were still looking at the old Allocations table,
rather than referring to the new AllocationVersion table.  Switching
this appears to have fixed the bug.