### PR TITLE
Fix seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ PomDetail.find_or_create_by!(
 PomDetail.find_or_create_by!(
   nomis_staff_id: 485_752,
   status: 'active',
-  working_pattern: 0.6
+  working_pattern: 0.2
 )
 
 # Dom Bull
@@ -19,11 +19,11 @@ PomDetail.find_or_create_by!(
   working_pattern: 1
 )
 
-# Jenny Ducket
+# Kath Pobee-Norris
 PomDetail.find_or_create_by!(
-  nomis_staff_id: 485_636,
+  nomis_staff_id: 485_637,
   status: 'active',
-  working_pattern: 0.6
+  working_pattern: 0.4
 )
 
 # Toby Retallick
@@ -31,32 +31,6 @@ PomDetail.find_or_create_by!(
   nomis_staff_id: 485_595,
   status: 'active',
   working_pattern: 1
-)
-AllocationService.create_allocation(
-  nomis_offender_id: 'G4273GI',
-  nomis_booking_id: 1_153_753,
-  prison: 'LEI',
-  allocated_at_tier: 'A',
-  created_by_username: 'PK000223',
-  primary_pom_nomis_id: 485_595
-  )
-
-AllocationService.create_allocation(
-  nomis_offender_id: 'G4273GI',
-  nomis_booking_id: 1_153_753,
-  prison: 'LEI',
-  allocated_at_tier: 'B',
-  created_by_username: 'PK000223',
-  primary_pom_nomis_id: 485_752
-  )
-
-AllocationService.create_allocation(
-  nomis_offender_id: 'G4273GI',
-  nomis_booking_id: 1_153_753,
-  prison: 'LEI',
-  allocated_at_tier: 'D',
-  created_by_username: 'PK000223',
-  primary_pom_nomis_id: 485_636
 )
 
 CaseInformation.find_or_create_by!(
@@ -89,4 +63,46 @@ CaseInformation.find_or_create_by!(
   case_allocation: 'CRC',
   omicable: 'No',
   prison: 'LEI'
+)
+
+CaseInformation.find_or_create_by!(
+    nomis_offender_id: 'G7998GJ',
+    tier: 'D',
+    case_allocation: 'CRC',
+    omicable: 'No',
+    prison: 'LEI'
+)
+
+AllocationService.create_or_update(
+    nomis_offender_id: 'G7806VO',
+    nomis_booking_id: 1_153_753,
+    prison: 'LEI',
+    allocated_at_tier: 'A',
+    created_by_username: 'PK000223',
+    primary_pom_nomis_id: 485_637,
+    primary_pom_allocated_at: DateTime.now.utc,
+    event: AllocationVersion::ALLOCATE_PRIMARY_POM,
+    event_trigger: AllocationVersion::USER
+  )
+
+AllocationService.create_or_update(
+  nomis_offender_id: 'G3462VT',
+  nomis_booking_id: 1_153_753,
+  prison: 'LEI',
+  allocated_at_tier: 'B',
+  created_by_username: 'PK000223',
+  primary_pom_nomis_id: 485_737,
+  event: AllocationVersion::ALLOCATE_PRIMARY_POM,
+  event_trigger: AllocationVersion::USER
+  )
+
+AllocationService.create_or_update(
+  nomis_offender_id: 'G7998GJ',
+  nomis_booking_id: 1_153_753,
+  prison: 'LEI',
+  allocated_at_tier: 'D',
+  created_by_username: 'PK000223',
+  primary_pom_nomis_id: 485_637,
+  event: AllocationVersion::ALLOCATE_PRIMARY_POM,
+  event_trigger: AllocationVersion::USER
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,9 +26,9 @@ PomDetail.find_or_create_by!(
   working_pattern: 0.4
 )
 
-# Toby Retallick
+# Andrien Ricketts
 PomDetail.find_or_create_by!(
-  nomis_staff_id: 485_595,
+  nomis_staff_id: 485_833,
   status: 'active',
   working_pattern: 1
 )
@@ -102,7 +102,7 @@ AllocationService.create_or_update(
   prison: 'LEI',
   allocated_at_tier: 'D',
   created_by_username: 'PK000223',
-  primary_pom_nomis_id: 485_637,
+  primary_pom_nomis_id: 485_833,
   event: AllocationVersion::ALLOCATE_PRIMARY_POM,
   event_trigger: AllocationVersion::USER
 )


### PR DESCRIPTION
There have been changes to the AllocationService and additional fields
are now required to be present when creating a new allocation.  This
missing/incorrect information was causing the db:seeds command to fail.
In addition to this it was found that the section where the allocations
were being created wasn't working properly, so allocations weren't
showing up in the correct tabs. Finally
there was an issue with emails being sent due to a malformed email
address in T3 for Ross (used for testing) and so Kath's POM details were
added and these cases are now allocated to her instead.  Following the changes
to the seed file users are able to run the db:seeds command successfully
again.