### PR TITLE
Avoids rubocop deprecation in next version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   # Exclude anything that isn't really part of our code.

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'rubocop'
   gem 'rubocop-rspec'
   gem 'rubocop-performance'
+  gem 'rubocop-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.3.0)
       rubocop (>= 0.68.0)
+    rubocop-rails (2.0.0)
+      rack (>= 2.0)
+      rubocop (>= 0.70.0)
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
@@ -347,6 +350,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-performance
+  rubocop-rails
   rubocop-rspec
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,14 +2,14 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render(status: 404)
+    render(status: :not_found)
   end
 
   def unauthorized
-    render(status: 401)
+    render(status: :unauthorized)
   end
 
   def internal_server_error
-    render(status: 500)
+    render(status: :internal_server_error)
   end
 end

--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module SortHelper
+  # rubocop:disable Rails/HelperInstanceVariable
   class Sorter
     include ActionView::Helpers::TagHelper
 
@@ -62,6 +63,7 @@ module SortHelper
 
       'asc'
     end
+    # rubocop:enable Rails/HelperInstanceVariable
   end
 
   def sort_link(field_name)
@@ -74,7 +76,9 @@ module SortHelper
 
 private
 
+  # rubocop:disable Rails/HelperInstanceVariable
   def sorter
     @sorter ||= Sorter.new(request.original_url)
   end
+  # rubocop:enable Rails/HelperInstanceVariable
 end


### PR DESCRIPTION
In the next version of rubocop, it will be necessary to explicitly
include rubocop-rails, so this PR does exactly that.

The PR also includes fixes introduced by the new rails cops.