### PR TITLE
Reset prison when de-allocating offender.

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -57,6 +57,7 @@ class AllocationVersion < ApplicationRecord
     !allocation.nil? && !allocation.primary_pom_nomis_id.nil?
   end
 
+  # rubocop:disable Metrics/MethodLength
   def self.deallocate_offender(nomis_offender_id)
     allocations(nomis_offender_id).
       update_all(
@@ -65,10 +66,12 @@ class AllocationVersion < ApplicationRecord
         primary_pom_allocated_at: nil,
         secondary_pom_nomis_id: nil,
         secondary_pom_name: nil,
+        prison: nil,
         event: DEALLOCATE_PRIMARY_POM,
         event_trigger: OFFENDER_MOVEMENT
       )
   end
+  # rubocop:enable Metrics/MethodLength
 
   def self.deallocate_primary_pom(nomis_staff_id)
     all_primary_pom_allocations(nomis_staff_id).


### PR DESCRIPTION
When we deallocate an offender, we need to set the prison to nil as this
should be re-populated when they are re-allocated. We do _not_ touch the
CaseInformation unless the offender completes a move at which point we
will update the prison.