### PR TITLE
Fix case responsibility calculation bug

### DIFF
--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -26,6 +26,8 @@ module Nomis
         # If they do not have any of these we should be checking for a tariff date
         # Once we have all the dates we then need to display whichever is the
         # earliest one.
+        return false if sentence.sentence_start_date.blank?
+
         sentence.release_date.present? ||
         sentence.parole_eligibility_date.present? ||
         sentence.home_detention_curfew_eligibility_date.present? ||

--- a/spec/models/nomis/models/offender_summary_spec.rb
+++ b/spec/models/nomis/models/offender_summary_spec.rb
@@ -11,6 +11,7 @@ describe Nomis::Models::OffenderSummary, model: true do
   it "handles an earliest date" do
     o = described_class.new.tap { |off|
       off.sentence = Nomis::Models::SentenceDetail.new
+      off.sentence.sentence_start_date = Date.new(2005, 2, 3)
       off.sentence.release_date = Date.new(2010, 1, 1)
       off.sentence.parole_eligibility_date = Date.new(2009, 1, 1)
     }

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe SearchService do
   it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
     offenders = described_class.search_for_offenders('', 'LEI')
-    expect(offenders.count).to eq(821)
+    expect(offenders.count).to eq(817)
   end
 
   it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -6,7 +6,7 @@ describe SummaryService do
     summary = described_class.new.summary(:pending, 'LEI', 15, SummaryService::SummaryParams.new)
 
     expect(summary.offenders.count).to eq(10)
-    expect(summary.page_count).to eq(83)
+    expect(summary.page_count).to eq(82)
   end
 
   it "will sort a summary", vcr: { cassette_name: :allocation_summary_service_summary_sort } do


### PR DESCRIPTION
We have been getting Sentry alerts for an issue around the various POM
caseload views: https://sentry.service.dsd.io/mojds/live1-allocation-manager-produ/issues/36091/.
Investigation into this issue showed that this error appears when
someone has been released and our MovementService hasn’t run yet.
On release the sentence_start_date is set to nil, which is why we’re getting the error.
From the looks of things the error will trigger when
sentence_start_date == nil && release_date == today).

This method is part of the flow where we determine whether the POM is
responsible or not.  We don’t keep a record of this responsibility/supporting
outcome anywhere as we run the checks each time we load the POM caseload page
or the unallocated summary tab, so we can’t rely on grabbing a field out of the db.

At the point we check if someone is sentenced or not we are going to
return false if the 'sentence_start_date' is blank.