### PR TITLE
[POM-63] Move allocation history

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -86,8 +86,7 @@ class AllocationsController < ApplicationController
   end
 
   def history
-    offender = offender(nomis_offender_id_from_url)
-    @prisoner_name = offender_name_by_last_name(offender)
+    @prisoner = offender(nomis_offender_id_from_url)
     @history = AllocationService.offender_allocation_history(nomis_offender_id_from_url)
   end
 
@@ -188,10 +187,6 @@ private
 
   def suitability_detail
     @override[:suitability_detail] if @override.present?
-  end
-
-  def offender_name_by_last_name(offender)
-    "#{offender.last_name.capitalize}, #{offender.first_name.capitalize}"
   end
 end
 # rubocop:enable Metrics/LineLength

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -86,6 +86,8 @@ class AllocationsController < ApplicationController
   end
 
   def history
+    offender = offender(nomis_offender_id_from_url)
+    @prisoner_name = offender_name_by_last_name(offender)
     @history = AllocationService.offender_allocation_history(nomis_offender_id_from_url)
   end
 
@@ -186,6 +188,10 @@ private
 
   def suitability_detail
     @override[:suitability_detail] if @override.present?
+  end
+
+  def offender_name_by_last_name(offender)
+    "#{offender.last_name.capitalize}, #{offender.first_name.capitalize}"
   end
 end
 # rubocop:enable Metrics/LineLength

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -85,6 +85,10 @@ class AllocationsController < ApplicationController
     redirect_to summary_unallocated_path
   end
 
+  def history
+    @history = AllocationService.offender_allocation_history(nomis_offender_id_from_url)
+  end
+
 private
 
   def unavailable_pom_count

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -1,3 +1,7 @@
+<%= render :partial => "/shared/backlink", :locals => { :page => allocation_path(@history.first.nomis_offender_id) } %>
+
+<h1 class="govuk-heading-l"><%= @prisoner_name %></h1>
+
 <% @history.grouped_by_prison do |prison, allocations| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -1,6 +1,6 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => allocation_path(@history.first.nomis_offender_id) } %>
+<%= render :partial => "/shared/backlink", :locals => { :page => allocation_path(@prisoner.offender_no) } %>
 
-<h1 class="govuk-heading-l"><%= @prisoner_name %></h1>
+<h1 class="govuk-heading-l"><%= @prisoner.full_name %></h1>
 
 <% @history.grouped_by_prison do |prison, allocations| %>
   <div class="govuk-grid-row">

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -1,0 +1,23 @@
+<% @history.grouped_by_prison do |prison, allocations| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="timeline">
+        <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
+        <ul>
+          <% allocations.each do |allocation| %>
+            <li class="action_needed">
+              <h2 class="govuk-heading-s">Prisoner allocation</h2>
+              <p>Prisoner allocated to
+                <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+                <br/>
+                Tier: <%= allocation.allocated_at_tier %>
+              </p>
+              <p class="time"><%= format_date_long(allocation.primary_pom_allocated_at) %>
+                by <%= allocation.created_by_name.titlecase %></p>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get('/prisoners/:id/image.jpg' => 'prisoners#image', as: 'prisoner_image')
 
   get('/allocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm', as: 'confirm_allocation')
+  get('/allocations/:nomis_offender_id/history' => 'allocations#history', as: 'allocation_history')
   get('/reallocations/confirm/:nomis_offender_id/:nomis_staff_id' => 'allocations#confirm_reallocation', as: 'confirm_reallocation')
 
   get('/summary' => 'summary#index')

--- a/spec/factories/allocation_versions.rb
+++ b/spec/factories/allocation_versions.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     end
 
     primary_pom_name do
-      Faker::Name.name
+      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
     end
 
     primary_pom_allocated_at do

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -174,7 +174,7 @@ feature 'Allocation' do
     expect(page).to have_current_path new_allocation_path(never_allocated_offender)
   end
 
-  scenario 'view allocation history for an offender', versioning: true, vcr: { cassette_name: 'allocation_offender_history_feature' } do
+  scenario 'view allocation history for an offender', versioning: true, vcr: { cassette_name: :view_allocation_history } do
     create(
       :allocation_version,
       nomis_offender_id: nomis_offender_id,
@@ -187,6 +187,7 @@ feature 'Allocation' do
     allocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
     formatted_date = allocation.primary_pom_allocated_at.strftime("#{allocation.primary_pom_allocated_at.day.ordinalize} %B %Y")
 
+    expect(page).to have_css('h1', text: "Abbella, Ozullirn")
     expect(page).to have_css('p', text: "Prisoner allocated to #{allocation.primary_pom_name.titlecase} Tier: #{allocation.allocated_at_tier}")
     expect(page).to have_css('.time', text: "#{formatted_date} by #{allocation.created_by_name}")
   end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -173,4 +173,21 @@ feature 'Allocation' do
     visit edit_allocation_path(never_allocated_offender)
     expect(page).to have_current_path new_allocation_path(never_allocated_offender)
   end
+
+  scenario 'view allocation history for an offender', versioning: true, vcr: { cassette_name: 'allocation_offender_history_feature' } do
+    create(
+      :allocation_version,
+      nomis_offender_id: nomis_offender_id,
+      primary_pom_nomis_id: probation_officer_nomis_staff_id
+    )
+
+    signin_user
+    visit allocation_history_path(nomis_offender_id)
+
+    allocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
+    formatted_date = allocation.primary_pom_allocated_at.strftime("#{allocation.primary_pom_allocated_at.day.ordinalize} %B %Y")
+
+    expect(page).to have_css('p', text: "Prisoner allocated to #{allocation.primary_pom_name.titlecase} Tier: #{allocation.allocated_at_tier}")
+    expect(page).to have_css('.time', text: "#{formatted_date} by #{allocation.created_by_name}")
+  end
 end


### PR DESCRIPTION
This PR creates a new route `/allocations/:nomis_offender_id/history` that will display the allocation history for an offender. The allocation history will show the prisoner allocations events grouped by prison.