### PR TITLE
Shows the category of an offender on the prisoner profile

### DIFF
--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -11,6 +11,7 @@ module Nomis
       attribute :imprisonment_status, :string
 
       # Custom attributes
+      attribute :category_code, :string
       attribute :allocated_pom_name, :string
       attribute :case_allocation, :string
       attribute :omicable, :boolean

--- a/app/services/nomis/models/offender_summary.rb
+++ b/app/services/nomis/models/offender_summary.rb
@@ -8,7 +8,6 @@ module Nomis
       attribute :agency_id, :string
       attribute :aliases, :string
       attribute :booking_id, :integer
-      attribute :category_code, :string
 
       # custom attributes
       attribute :allocation_date, :date

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -17,6 +17,7 @@ class OffenderService
         o.sentence = sentence_detail[offender_no]
       end
 
+      o.category_code = Nomis::Elite2::OffenderApi.get_category_code(o.offender_no)
       o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)
     }
   end

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -30,10 +30,8 @@
         <h3 class="govuk-heading-m"><%= format_date(@prisoner.earliest_release_date) %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
-      <!-- PENDING DATA
         <span class="govuk-body">Category</span>
-        <h3 class="govuk-heading-m">N/A</h3>
-      -->
+        <h3 class="govuk-heading-m" id="category-code"><%= @prisoner.category_code %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Tier calculation</span>

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -8,6 +8,8 @@ feature 'View a prisoner profile page' do
 
     expect(page).to have_css('h2', text: 'Ahmonis, Okadonah')
     expect(page).to have_content('07/07/1968')
+    cat_code = find('h3#category-code').text
+    expect(cat_code).to eq('C')
   end
 
   it 'shows the prisoner image', :raven_intercept_exception, vcr: { cassette_name: :show_offender_spec_image } do


### PR DESCRIPTION
When looking at the prisoner profile, this page now shows the category
of the offender.  This is (contrary to previous decision) integrated
into OffenderService.get_offender() for parity with the category_code
that is set when getting lists of prisoners for a prison.