### PR TITLE
Change allocation history date

### DIFF
--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -15,8 +15,7 @@
                 <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
                 <br/>
                 Tier: <%= allocation.allocated_at_tier %>
-              </p>
-              <p class="time"><%= format_date_long(allocation.primary_pom_allocated_at) %>
+              <p class="time"><%= format_date_long(allocation.updated_at) %>
                 by <%= allocation.created_by_name.titlecase %></p>
             </li>
           <% end %>

--- a/spec/factories/allocation_versions.rb
+++ b/spec/factories/allocation_versions.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     end
 
     primary_pom_name do
-      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+      Faker::Name.name
     end
 
     primary_pom_allocated_at do

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -188,7 +188,7 @@ feature 'Allocation' do
     formatted_date = allocation.primary_pom_allocated_at.strftime("#{allocation.updated_at.day.ordinalize} %B %Y")
 
     expect(page).to have_css('h1', text: "Abbella, Ozullirn")
-    expect(page).to have_css('p', text: "Prisoner allocated to #{allocation.primary_pom_name.titlecase} Tier: #{allocation.allocated_at_tier}")
+    expect(page).to have_css('p', text: "Prisoner allocated to #{allocation.primary_pom_name} Tier: #{allocation.allocated_at_tier}")
     expect(page).to have_css('.time', text: "#{formatted_date} by #{allocation.created_by_name}")
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -185,7 +185,7 @@ feature 'Allocation' do
     visit allocation_history_path(nomis_offender_id)
 
     allocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
-    formatted_date = allocation.primary_pom_allocated_at.strftime("#{allocation.updated_at.day.ordinalize} %B %Y")
+    formatted_date = allocation.updated_at.strftime("#{allocation.updated_at.day.ordinalize} %B %Y")
 
     expect(page).to have_css('h1', text: "Abbella, Ozullirn")
     expect(page).to have_css('p', text: "Prisoner allocated to #{allocation.primary_pom_name} Tier: #{allocation.allocated_at_tier}")

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -185,7 +185,7 @@ feature 'Allocation' do
     visit allocation_history_path(nomis_offender_id)
 
     allocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
-    formatted_date = allocation.primary_pom_allocated_at.strftime("#{allocation.primary_pom_allocated_at.day.ordinalize} %B %Y")
+    formatted_date = allocation.primary_pom_allocated_at.strftime("#{allocation.updated_at.day.ordinalize} %B %Y")
 
     expect(page).to have_css('h1', text: "Abbella, Ozullirn")
     expect(page).to have_css('p', text: "Prisoner allocated to #{allocation.primary_pom_name.titlecase} Tier: #{allocation.allocated_at_tier}")


### PR DESCRIPTION
This PR will use the field updated date instead of primary_pom_allocated_at in the allocations history page as the primary_pom_allocated_at value can be nil, which would cause failures.

In addition we will not titlecase the Faker::Name generated in tests as it causes test failures.