### PR TITLE
Do not log an error if keyworker fails

### DIFF
--- a/app/services/nomis/keyworker/keyworker_api.rb
+++ b/app/services/nomis/keyworker/keyworker_api.rb
@@ -12,8 +12,7 @@ module Nomis
           client.get(route)
         }
         ApiDeserialiser.new.deserialise(Nomis::Models::KeyworkerDetails, response)
-      rescue Nomis::Client::APIError => e
-        AllocationManager::ExceptionHandler.capture_exception(e)
+      rescue Nomis::Client::APIError
         Nomis::Models::NullKeyworker.new
       end
 

--- a/app/services/nomis/models/null_keyworker.rb
+++ b/app/services/nomis/models/null_keyworker.rb
@@ -4,7 +4,7 @@ module Nomis
   module Models
     class NullKeyworker < KeyworkerDetails
       def full_name
-        'Not assigned'
+        'Data not available'
       end
     end
   end

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -45,7 +45,7 @@ feature "view an offender's allocation information" do
       create_allocation(nomis_offender_id_without_keyworker)
     end
 
-    it "displays 'not assigned'" do
+    it "displays 'Data not available'" do
       signin_user
 
       visit allocation_path(nomis_offender_id: nomis_offender_id_without_keyworker)
@@ -57,7 +57,7 @@ feature "view an offender's allocation information" do
       # Pom
       expect(page).to have_css('.govuk-table__cell', text: 'Duckett, Jenny')
       # Keyworker
-      expect(page).to have_css('.govuk-table__cell', text: 'Not assigned')
+      expect(page).to have_css('.govuk-table__cell', text: 'Data not available')
     end
   end
 


### PR DESCRIPTION
If the keyworker API fails, typically with a 404 we currently show Not
Assigned in the views.  Instead we will not log the error, it's a
non-critical API.  Rather than show as Not Assigned, we also change the
text to 'Data not available' to cover cases where the API is actually
broken.

We need to clear the text with LM