### PR TITLE
Refactors how we fetch bulk sentence details.

### DIFF
--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -80,9 +80,9 @@ module Nomis
         }
 
         data.each_with_object({}) { |record, hash|
-          next unless record.key?('offenderNo')
+          next unless record.key?('bookingId')
 
-          oid = record['offenderNo']
+          oid = record['bookingId']
           hash[oid] = api_deserialiser.deserialise(
             Nomis::Models::SentenceDetail, record['sentenceDetail']
           )

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -13,8 +13,8 @@ class OffenderService
       end
 
       sentence_detail = get_sentence_details([o.latest_booking_id])
-      if sentence_detail.present? && sentence_detail.key?(offender_no)
-        o.sentence = sentence_detail[offender_no]
+      if sentence_detail.present? && sentence_detail.key?(o.latest_booking_id)
+        o.sentence = sentence_detail[o.latest_booking_id]
       end
 
       o.category_code = Nomis::Elite2::OffenderApi.get_category_code(o.offender_no)
@@ -42,7 +42,7 @@ class OffenderService
       next false if offender.age < 18
       next false if SentenceType.civil?(offender.imprisonment_status)
 
-      sentencing = sentence_details[offender.offender_no]
+      sentencing = sentence_details[offender.booking_id]
       offender.sentence = sentencing if sentencing.present?
       next false unless offender.sentenced?
 

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -75,7 +75,7 @@ class PrisonOffenderManagerService
 
     allocation_list_with_responsibility = allocation_list.map { |alloc|
       offender_stub = Nomis::Models::Offender.new
-      offender_stub.sentence = offender_map[alloc.nomis_offender_id]
+      offender_stub.sentence = offender_map[alloc.nomis_booking_id]
 
       record = case_info[alloc.nomis_offender_id]
       if record.present?
@@ -91,7 +91,7 @@ class PrisonOffenderManagerService
 
     allocations_and_offender = []
     allocation_list_with_responsibility.each do |alloc|
-      allocations_and_offender << [alloc, offender_map[alloc.nomis_offender_id]]
+      allocations_and_offender << [alloc, offender_map[alloc.nomis_booking_id]]
     end
 
     allocations_and_offender

--- a/spec/factories/allocation_versions.rb
+++ b/spec/factories/allocation_versions.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     end
 
     created_by_name do
-      Faker::Name.name
+      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
     end
 
     event do
@@ -35,7 +35,7 @@ FactoryBot.define do
     end
 
     primary_pom_name do
-      Faker::Name.name
+      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
     end
 
     primary_pom_allocated_at do


### PR DESCRIPTION
Inspired by finding multiple offenders with the same booking ID in T3,
which induced a crash.

To find the sentence details for a group of offenders, using the Elite2
API, we need to post a list of `booking ids`, which is the current
booking id for a given offender.  Once we had fetching this data, we
were then creating a hash where the services could lookup the sentence
details using the nomis_id.  This was slightly confusing, and introduced
a problem when we had to offenders looking up what _should_ have been
the same booking id.

In order to make this API a little more consistent, after passing in
booking IDs to the function the returned hash is also keyed on those
same IDs, rather than the nomis id for the offender.  This means we can
handle the possible situation where two offenders share a booking id
(which will never happen in prod, right?).