### PR TITLE
Allow users with ALLOC_CASE_MGR to access the service

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,8 +54,6 @@ class ApplicationController < ActionController::Base
 private
 
   def allowed?
-    return true if Rails.env.test?
-
     user_roles = roles
     user_roles.present? && (
       user_roles.include?('ROLE_ALLOC_MGR') || user_roles.include?('ROLE_ALLOC_CASE_MGR')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,9 @@ private
     return true if Rails.env.test?
 
     user_roles = roles
-    user_roles.present? && user_roles.include?('ROLE_ALLOC_MGR')
+    user_roles.present? && (
+      user_roles.include?('ROLE_ALLOC_MGR') || user_roles.include?('ROLE_ALLOC_CASE_MGR')
+    )
   end
 
   def session_expired?


### PR DESCRIPTION
ALLOC_MGR is no longer the only role we can use for the service,
ALLOC_CASE_MGR is also allowed (although a later PR will restrict the
functionality of these users).