### PR TITLE
Update Allocation Info page

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -27,6 +27,7 @@ class AllocationsController < ApplicationController
     primary_pom_nomis_id = AllocationVersion.find_by(nomis_offender_id: @prisoner.offender_no).primary_pom_nomis_id
     @pom = PrisonOffenderManagerService.get_pom(active_caseload, primary_pom_nomis_id)
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_caseload, @prisoner.offender_no)
+    @allocation = AllocationVersion.where(nomis_offender_id: @prisoner.offender_no)
   end
 
   def edit

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -52,6 +52,11 @@ class AllocationVersion < ApplicationRecord
     allocations(nomis_offender_id).primary_pom_nomis_id
   }
 
+  def self.last_event(nomis_offender_id)
+    allocation = find_by(nomis_offender_id: nomis_offender_id)
+    allocation.event.to_s.humanize + ' - ' + allocation.updated_at.strftime('%d/%m/%Y')
+  end
+
   def self.active?(nomis_offender_id)
     allocation = find_by(nomis_offender_id: nomis_offender_id)
     !allocation.nil? && !allocation.primary_pom_nomis_id.nil?

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -1,9 +1,182 @@
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocation information</h1>
 
-<%= render 'shared/basic_prisoner_info' %>
+<div class="govuk-!-margin-top-1">
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header" scope="row">Prisoner information</td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Name</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.full_name %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Prisoner number</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= @prisoner.offender_no %>
+        <%= link_to 'View NOMIS profile', digital_prison_service_profile_path(@prisoner.offender_no), class: "govuk-link pull-right", target: "_blank" %>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Date of birth</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= format_date(@prisoner.date_of_birth) %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Category</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">Cat <%= @prisoner.category_code %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Tiering calculation</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        Tier <%= @prisoner.tier %>
+        <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= case_owner_label(@prisoner) %>
+      </td>
+<!--    </tr>-->
+<!--    <tr class="govuk-table__row">-->
+<!--      <td class="govuk-table__cell govuk-!-width-one-half">Early assessment eligibility</td>-->
+<!--      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">-->
+        <%#= CODE NEEDED %>
+<!--      </td>-->
+    <!--    <tr class="govuk-table__row">-->
+    <!--      <td class="govuk-table__cell govuk-!-width-one-half">COM responsibility handover deadline</td>-->
+    <!--      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">-->
+    <%#= CODE NEEDED %>
+    <!--      </td>-->
+<!--    </tr>-->
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Last known address in Wales</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= humanized_bool(@prisoner.omicable) %>
+        <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Service provider</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= service_provider_label(@prisoner.case_allocation) %>
+        <a class="govuk-link pull-right" href="<%= edit_case_information_path(@prisoner.offender_no) %>">Change</a>
+      </td>
+    </tr>
+    </tbody>
+  </table>
 
-<%= render 'shared/allocation_info' %>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Offence</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Main offence</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.main_offence %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Sentence type</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= sentence_type_label(@prisoner) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Conditional release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.sentence.conditional_release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Automatic release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.sentence.automatic_release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Parole eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.sentence.parole_eligibility_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Home detention curfew eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.sentence.home_detention_curfew_eligibility_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Tariff date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@prisoner.sentence.tariff_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
 
-<%= render 'shared/offence_info' %>
-<%= render 'allocations/case_information' %>
-
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Prison allocation</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">POM role</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= pom_responsibility_label(@prisoner) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">POM</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= link_to @pom.full_name, pom_path(@pom.staff_id), class: "govuk-link" %>
+        <%= link_to 'Reallocate', edit_allocation_path(@prisoner.offender_no), class: "govuk-link pull-right" %>
+      </td>
+    </tr>
+<!--    <tr class="govuk-table__row">-->
+<!--      <td class="govuk-table__cell govuk-!-width-one-half">Co-working POM</td>-->
+<!--      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">-->
+        <%#= link_to @pom.full_name, pom_path(@pom.staff_id), class: "govuk-link" %>
+        <%#= link_to 'Change', edit_allocation_path(@prisoner.offender_no), class: "govuk-link pull-right" %>
+<!--      </td>-->
+<!--    </tr>-->
+    <% if Flipflop.link_allocation_info? %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Allocation history</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%=@allocation.last_event(@prisoner.offender_no) %>
+        <%= link_to 'View', allocation_history_path(@prisoner.offender_no), class: "govuk-link pull-right" %>
+      </td>
+    </tr>
+      <% end %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Keyworker</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= @keyworker.full_name %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<!--  <table class="govuk-table">-->
+<!--    <tbody class="govuk-table__body">-->
+<!--    <tr class="govuk-table__row">-->
+<!--      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Community information</td>-->
+<!--      <td class="govuk-table__cell govuk-!-width-one-half"></td>-->
+<!--    <tr class="govuk-table__row">-->
+<!--      <td class="govuk-table__cell">Local Divisional Unit</td>-->
+<!--      <td class="govuk-table__cell table_cell__left_align">ADD INFO-->
+<!--      </td>-->
+<!--    </tr>-->
+<!--    <tr class="govuk-table__row">-->
+<!--      <td class="govuk-table__cell govuk-!-width-one-half">Team</td>-->
+<!--      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">ADD INFO-->
+<!--      </td>-->
+<!--    </tr>-->
+<!--    <tr class="govuk-table__row">-->
+<!--      <td class="govuk-table__cell govuk-!-width-one-half">COM</td>-->
+<!--      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">ADD INFO-->
+<!--      </td>-->
+<!--    </tr>-->
+<!--    </tbody>-->
+<!--  </table>-->
+</div>


### PR DESCRIPTION
Further design & content changes have been made to the Allocation
Information page.  There continue to a few sections that we haven't
built the functionality for, or able to get the data for; however the
decision has been made to comment them out to ensure we remember to add
this information as soon as we have it.

There is also a feature flag on the allocation history section as we
only want this displayed once the whole feature has been completed.