### PR TITLE
Re-enable flipflop feature flags admin

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,5 @@ Rails.application.routes.draw do
 
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
-
-  # TODO: Re-enable this engine for managing features when we have proper roles for admins
-  # mount Flipflop::Engine => "/flipflop"
+  mount Flipflop::Engine => "/flip-flop-admin"
 end


### PR DESCRIPTION
We need the flipflop admin tool for staging so that we can turn features
on/off across the whole site.