### PR TITLE
Add reallocate primary pom events to allocation history

### DIFF
--- a/app/models/allocation_list.rb
+++ b/app/models/allocation_list.rb
@@ -38,4 +38,8 @@ class AllocationList < Array
     end
   end
   # rubocop:enable Metrics/MethodLength
+
+  def group_by_descending_date(allocations)
+    allocations.sort_by!(&:updated_at).reverse!
+  end
 end

--- a/app/models/allocation_list.rb
+++ b/app/models/allocation_list.rb
@@ -6,18 +6,11 @@ class AllocationList < Array
     # Groups the allocations in this array by the prison that it relates to.
     # Unfortunately we can't put this in a hash because a prisoner may have been
     # to a prison more than once, so a visit to Cardiff, then Leeds, then Cardiff
-    # would mean they are out of order.  Instead we need to put it into a structure
-    # that looks like
+    # would mean they are out of order.
     #
-    #    [
-    #      ['PrisonA', [alloc1, alloc2]],
-    #      ['PrisonB', [alloc3]],
-    #      ['PrisonA', [alloc4]],
-    #    ]
-    #
-    # Instead of returning a list, and keeping multiple copies of data in RAM, the
-    # caller must provide a block `{ |prison, allocations| ... }` which will be called
-    # each time a new prison (row) is built
+    # Each time a new prison is found in the list, we yield the current prison
+    # and all of the allocations we have captured so far to the caller via the passed
+    # block.
     return [] if empty?
 
     idx = 0
@@ -38,8 +31,4 @@ class AllocationList < Array
     end
   end
   # rubocop:enable Metrics/MethodLength
-
-  def group_by_descending_date(allocations)
-    allocations.sort_by!(&:updated_at).reverse!
-  end
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -71,8 +71,11 @@ class AllocationService
     current_allocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
 
     unless current_allocation.nil?
-      allocations = get_versions_for(current_allocation)
-      AllocationList.new(allocations.prepend current_allocation)
+      allocations = get_versions_for(current_allocation).
+          append(current_allocation).
+          sort_by!(&:updated_at).
+          reverse!
+      AllocationList.new(allocations)
     end
   end
 

--- a/app/views/allocations/_allocate_primary_pom.html.erb
+++ b/app/views/allocations/_allocate_primary_pom.html.erb
@@ -1,0 +1,9 @@
+<li class="action_needed">
+  <h2 class="govuk-heading-s">Prisoner allocation</h2>
+<p>Prisoner allocated to
+  <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+  <br/>
+  Tier: <%= allocation.allocated_at_tier %>
+<p class="time"><%= format_date_long(allocation.updated_at) %>
+  by <%= allocation.created_by_name.titlecase %></p>
+</li>

--- a/app/views/allocations/_reallocate_primary_pom.html.erb
+++ b/app/views/allocations/_reallocate_primary_pom.html.erb
@@ -1,0 +1,9 @@
+<li class="action_needed">
+  <h2 class="govuk-heading-s">Prisoner reallocated</h2>
+  <p>Prisoner reallocated to
+    <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+    <br/>
+    Tier: <%= allocation.allocated_at_tier %>
+  <p class="time"><%= format_date_long(allocation.updated_at) %>
+    by <%= allocation.created_by_name.titlecase %></p>
+</li>

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -8,16 +8,12 @@
       <div class="timeline">
         <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
         <ul>
-          <% allocations.each do |allocation| %>
-            <li class="action_needed">
-              <h2 class="govuk-heading-s">Prisoner allocation</h2>
-              <p>Prisoner allocated to
-                <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
-                <br/>
-                Tier: <%= allocation.allocated_at_tier %>
-              <p class="time"><%= format_date_long(allocation.updated_at) %>
-                by <%= allocation.created_by_name.titlecase %></p>
-            </li>
+          <% allocations.group_by_descending_date(allocations).each do |allocation| %>
+            <% if allocation.event == 'allocate_primary_pom' %>
+              <%= render :partial => "allocate_primary_pom", :locals => { allocation: allocation } %>
+            <% elsif allocation.event == 'reallocate_primary_pom' %>
+              <%= render :partial => "reallocate_primary_pom", :locals => { allocation: allocation } %>
+            <% end %>
           <% end %>
         </ul>
       </div>

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -8,7 +8,7 @@
       <div class="timeline">
         <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
         <ul>
-          <% allocations.group_by_descending_date(allocations).each do |allocation| %>
+          <% allocations.each do |allocation| %>
             <% if allocation.event == 'allocate_primary_pom' %>
               <%= render :partial => "allocate_primary_pom", :locals => { allocation: allocation } %>
             <% elsif allocation.event == 'reallocate_primary_pom' %>


### PR DESCRIPTION
The allocation history page for an offender currently displays primary pom allocation events only. This PR amends this view to include primary pom reallocation events
