### PR TITLE
Adds some role helpers for use in before_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,20 @@ class ApplicationController < ActionController::Base
     sso_identity['username'] if sso_identity.present?
   end
 
+  def admin_user?
+    r = roles
+    unless r.present? && r.include?('ROLE_ALLOC_MGR')
+      redirect_to '/'
+    end
+  end
+
+  def case_admin_user?
+    r = roles
+    unless r.present? && r.include?('ROLE_ALLOC_CASE_MGR')
+      redirect_to '/'
+    end
+  end
+
   def active_caseload
     sso_identity['active_caseload'] if sso_identity.present?
   end


### PR DESCRIPTION
So that we can restrict access to functionality based on user roles,
this PR adds two new methods that can be used in before_action
controller calls.  This will allow us to redirect users away from the
functionality unless they have the required role.