### PR TITLE
Adds a blank help page and a blank contact page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  def help; end
+
+  def contact; end
+end

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,0 +1,6 @@
+<h1 class="govuk-heading-l govuk-!-margin-bottom-5">Contact</h1>
+
+<div class="govuk-grid-row dashboard-row">
+  <div class="govuk-grid-column-two-thirds">
+  </div>
+</div>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-l govuk-!-margin-bottom-5">Help</h1>
+
+<div class="govuk-grid-row dashboard-row">
+  <div class="govuk-grid-column-two-thirds">
+  Help
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   match "/500", :to => "errors#internal_server_error", :via => :all
   match "/503", :to => "errors#internal_server_error", :via => :all
 
+  get '/help', to: 'pages#help'
+  get '/contact', to: 'pages#contact'
+
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/signout', to: 'sessions#destroy'
 

--- a/spec/features/getting_help_feature_spec.rb
+++ b/spec/features/getting_help_feature_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+feature 'Getting help' do
+  it "can show the help page", vcr: { cassette_name: :getting_help_text } do
+    visit "help"
+    expect(page).to have_content('Help')
+  end
+
+  it "can show the contact page", vcr: { cassette_name: :getting_help_contact } do
+    visit "contact"
+    expect(page).to have_content('Contact')
+  end
+end


### PR DESCRIPTION
We are going to be adding a contact form, and a help page (with static
content) so this PR simply sets up the routes and templates for these
pages.

The contact page will require a form to post (and then email a message)
but the templates are currently there for content.