### PR TITLE
Add deallocation to history

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -90,8 +90,6 @@ class AllocationVersion < ApplicationRecord
   end
 
   validates :nomis_offender_id,
-            :primary_pom_nomis_id,
-            :primary_pom_allocated_at,
             :nomis_booking_id,
             :prison,
             :allocated_at_tier,

--- a/app/views/allocations/_deallocate_primary_pom.html.erb
+++ b/app/views/allocations/_deallocate_primary_pom.html.erb
@@ -1,0 +1,8 @@
+<li class="action_needed">
+  <h2 class="govuk-heading-s">Prisoner unallocated
+    <% if allocation.event_trigger == 'offender_movement' %>
+        (transfer)
+    <% end %>
+  </h2>
+  <p class="time"><%= format_date_long(allocation.updated_at) %></p>
+</li>

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -13,6 +13,8 @@
               <%= render :partial => "allocate_primary_pom", :locals => { allocation: allocation } %>
             <% elsif allocation.event == 'reallocate_primary_pom' %>
               <%= render :partial => "reallocate_primary_pom", :locals => { allocation: allocation } %>
+            <% elsif allocation.event == 'deallocate_primary_pom' %>
+              <%= render :partial => "deallocate_primary_pom", :locals => { allocation: allocation } %>
             <% end %>
           <% end %>
         </ul>

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe AllocationVersion, type: :model do
     it { is_expected.to validate_presence_of(:allocated_at_tier) }
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:event_trigger) }
-    it { is_expected.to validate_presence_of(:primary_pom_allocated_at) }
   end
 
   describe 'Versions' do


### PR DESCRIPTION
This PR changes the allocation history page to include de-allocation events for the offender. 

This PR also allows AllocationVersion fields 'primary_pom_nomis_id' and 'primary_pom_allocated_at' to be nil