### PR TITLE
Do not reset prison when deallocating offenders

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -71,7 +71,6 @@ class AllocationVersion < ApplicationRecord
         primary_pom_allocated_at: nil,
         secondary_pom_nomis_id: nil,
         secondary_pom_name: nil,
-        prison: nil,
         event: DEALLOCATE_PRIMARY_POM,
         event_trigger: OFFENDER_MOVEMENT
       )

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -61,8 +61,6 @@ class AllocationVersion < ApplicationRecord
     allocation = find_by(nomis_offender_id: nomis_offender_id)
     !allocation.nil? && !allocation.primary_pom_nomis_id.nil?
   end
-
-  # rubocop:disable Metrics/MethodLength
   def self.deallocate_offender(nomis_offender_id)
     allocations(nomis_offender_id).
       update_all(

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -61,6 +61,7 @@ class AllocationVersion < ApplicationRecord
     allocation = find_by(nomis_offender_id: nomis_offender_id)
     !allocation.nil? && !allocation.primary_pom_nomis_id.nil?
   end
+
   def self.deallocate_offender(nomis_offender_id)
     allocations(nomis_offender_id).
       update_all(
@@ -73,7 +74,6 @@ class AllocationVersion < ApplicationRecord
         event_trigger: OFFENDER_MOVEMENT
       )
   end
-  # rubocop:enable Metrics/MethodLength
 
   def self.deallocate_primary_pom(nomis_staff_id)
     all_primary_pom_allocations(nomis_staff_id).


### PR DESCRIPTION
When we deallocate an offender, we should not set the prison to nil.  We
need to know which prison they were at when they were deallocated,
otherwise the history does not work.