### PR TITLE
Simplify delius spreadsheet parsing

### DIFF
--- a/lib/delius/processor.rb
+++ b/lib/delius/processor.rb
@@ -2,33 +2,36 @@
 
 require 'nokogiri'
 require 'zip'
-require_relative 'parser'
+require_relative 'sheet'
 require_relative 'string_collector'
 
 module Delius
   class Processor
+    # Given an XLSX file, this class is responsible for converting the data
+    # found in sheet one, into a stream of rows. These rows will contain
+    # the textual information from the original spreadsheet. XLSX files
+    # are zipped collections of XML documents but the sheet files do not
+    # contain data, they contain indexes into a shared string document.
+    # As a result, just parsing sheet1.xml will only return those indices
+    # so we also need to parse the sharedString.xml file to find the
+    # actual data.
+    #
+    # By parsing the sharedStrings.xml into an ordered list (load_lookup)
+    # we then have a mechanism to convert the indices found in sheet1.xml
+    # into actual data (process_rows).
+
     def initialize(file)
       @file = file
       @lookup_table = {}
     end
 
     def run(&block)
+      # The &block passed to this function is used to report back to
+      # the caller every time we have a row of data to give them.
       zip_file = Zip::File.open(@file)
+
       load_lookup(zip_file)
-
-      doc = Delius::Parser.new { |row| process_single_row(row, &block) }
-      parser = Nokogiri::XML::SAX::Parser.new(doc)
-
-      worksheet = zip_file.entries.filter { |entry|
-        entry.name == 'xl/worksheets/sheet1.xml'
-      }.first
-
-      parser.parse(worksheet.get_input_stream)
-    end
-
-    def process_single_row(row)
-      new_row = row.map { |i| @lookup_table[i] }
-      yield(new_row)
+      process_rows(zip_file, &block)
     end
 
   private
@@ -46,6 +49,20 @@ module Delius
 
       parser = Nokogiri::XML::SAX::Parser.new(collector)
       parser.parse(shared_strings.get_input_stream)
+    end
+
+    def process_rows(zip_file)
+      worksheet = zip_file.entries.filter { |entry|
+        entry.name == 'xl/worksheets/sheet1.xml'
+      }.first
+
+      doc = Delius::Sheet.new { |row|
+        new_row = row.map { |i| @lookup_table[i] }
+        yield(new_row)
+      }
+
+      parser = Nokogiri::XML::SAX::Parser.new(doc)
+      parser.parse(worksheet.get_input_stream)
     end
   end
 end

--- a/lib/delius/sheet.rb
+++ b/lib/delius/sheet.rb
@@ -3,7 +3,7 @@
 require 'nokogiri'
 
 module Delius
-  class Parser < Nokogiri::XML::SAX::Document
+  class Sheet < Nokogiri::XML::SAX::Document
     def initialize(&block)
       @handler = block
       @current_row = []

--- a/spec/lib/delius/sheet_spec.rb
+++ b/spec/lib/delius/sheet_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
-require 'delius/parser'
+require 'delius/sheet'
 
-describe Delius::Parser do
+describe Delius::Sheet do
   it 'parses an excel spreadsheet get get lookup ids' do
     filename = 'spec/fixtures/delius/delius_sample.xlsx'
     zip_file = Zip::File.open(filename)


### PR DESCRIPTION
This PR cleans up the delius spreadsheet parser to try not to pass
around blocks and to document why it is doing what it is doing.