### PR TITLE
Refine offender movement type

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -13,7 +13,8 @@ class AllocationVersion < ApplicationRecord
   DEALLOCATE_SECONDARY_POM = 5
 
   USER = 0
-  OFFENDER_MOVEMENT = 1
+  OFFENDER_TRANSFERRED = 1
+  OFFENDER_RELEASED = 2
 
   # When adding a new 'event' or 'event trigger'
   # make sure the constant it points to
@@ -31,7 +32,8 @@ class AllocationVersion < ApplicationRecord
   # 'Event triggers' capture the subject or action that triggered the event
   enum event_trigger: {
     user: USER,
-    offender_movement: OFFENDER_MOVEMENT
+    offender_transferred: OFFENDER_TRANSFERRED,
+    offender_released: OFFENDER_RELEASED
   }
 
   scope :allocations, lambda { |nomis_offender_ids|
@@ -63,7 +65,7 @@ class AllocationVersion < ApplicationRecord
   end
 
   # rubocop:disable Metrics/MethodLength
-  def self.deallocate_offender(nomis_offender_id)
+  def self.deallocate_offender(nomis_offender_id, movement_type)
     alloc = AllocationVersion.find_by(
       nomis_offender_id: nomis_offender_id
     )
@@ -76,7 +78,7 @@ class AllocationVersion < ApplicationRecord
     alloc.secondary_pom_nomis_id = nil
     alloc.secondary_pom_name = nil
     alloc.event = DEALLOCATE_PRIMARY_POM
-    alloc.event_trigger = OFFENDER_MOVEMENT
+    alloc.event_trigger = offender_movement_type(movement_type)
 
     alloc.save!
   end
@@ -91,6 +93,10 @@ class AllocationVersion < ApplicationRecord
         event: DEALLOCATE_PRIMARY_POM,
         event_trigger: USER
       )
+  end
+
+  def self.offender_movement_type(movement_type)
+    movement_type == 'ADM' ? OFFENDER_TRANSFERRED : OFFENDER_RELEASED
   end
 
   validates :nomis_offender_id,

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -78,7 +78,7 @@ class AllocationVersion < ApplicationRecord
     alloc.secondary_pom_nomis_id = nil
     alloc.secondary_pom_name = nil
     alloc.event = DEALLOCATE_PRIMARY_POM
-    alloc.event_trigger = offender_movement_type(movement_type)
+    alloc.event_trigger = movement_type
 
     alloc.save!
   end
@@ -93,10 +93,6 @@ class AllocationVersion < ApplicationRecord
         event: DEALLOCATE_PRIMARY_POM,
         event_trigger: USER
       )
-  end
-
-  def self.offender_movement_type(movement_type)
-    movement_type == 'ADM' ? OFFENDER_TRANSFERRED : OFFENDER_RELEASED
   end
 
   validates :nomis_offender_id,

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -43,7 +43,8 @@ private
   def self.process_transfer(transfer)
     Rails.logger.info("Processing transfer for #{transfer.offender_no}")
 
-    AllocationVersion.deallocate_offender(transfer.offender_no, transfer.movement_type)
+    AllocationVersion.deallocate_offender(transfer.offender_no,
+                                          AllocationVersion::OFFENDER_TRANSFERRED)
 
     CaseInformationService.change_prison(
       transfer.offender_no,
@@ -60,7 +61,8 @@ private
   def self.process_release(release)
     Rails.logger.info("Processing release for #{release.offender_no}")
     CaseInformationService.delete_information(release.offender_no)
-    AllocationVersion.deallocate_offender(release.offender_no, release.movement_type)
+    AllocationVersion.deallocate_offender(release.offender_no,
+                                          AllocationVersion::OFFENDER_RELEASED)
 
     true
   end

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -43,7 +43,7 @@ private
   def self.process_transfer(transfer)
     Rails.logger.info("Processing transfer for #{transfer.offender_no}")
 
-    AllocationVersion.deallocate_offender(transfer.offender_no)
+    AllocationVersion.deallocate_offender(transfer.offender_no, transfer.movement_type)
 
     CaseInformationService.change_prison(
       transfer.offender_no,
@@ -60,7 +60,7 @@ private
   def self.process_release(release)
     Rails.logger.info("Processing release for #{release.offender_no}")
     CaseInformationService.delete_information(release.offender_no)
-    AllocationVersion.deallocate_offender(release.offender_no)
+    AllocationVersion.deallocate_offender(release.offender_no, release.movement_type)
 
     true
   end

--- a/app/views/allocations/_deallocate_primary_pom.html.erb
+++ b/app/views/allocations/_deallocate_primary_pom.html.erb
@@ -1,6 +1,6 @@
 <li class="action_needed">
   <h2 class="govuk-heading-s">Prisoner unallocated
-    <% if allocation.event_trigger == 'offender_movement' %>
+    <% if allocation.event_trigger == 'offender_transferred' %>
         (transfer)
     <% end %>
   </h2>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -211,7 +211,7 @@ feature 'Allocation' do
                       updated_at: Time.zone.now - 1.day)
 
     allocation.update(event: AllocationVersion::DEALLOCATE_PRIMARY_POM,
-                      event_trigger: AllocationVersion::OFFENDER_MOVEMENT,
+                      event_trigger: AllocationVersion::OFFENDER_TRANSFERRED,
                       primary_pom_nomis_id: nil,
                       primary_pom_name: nil,
                       updated_at: Time.zone.now - 1.day,

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AllocationVersion, type: :model do
   describe 'when an offender moves prison', versioning: true, vcr: { cassette_name: :allocation_version_deallocate_offender }  do
     it 'removes the primary pom details in an Offender\'s allocation' do
       nomis_offender_id = 'G2911GD'
-      movement_type = 'ADM'
+      movement_type = AllocationVersion::OFFENDER_TRANSFERRED
       params = {
         nomis_offender_id: nomis_offender_id,
         prison: 'LEI',

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe AllocationVersion, type: :model do
   describe 'when an offender moves prison', versioning: true, vcr: { cassette_name: :allocation_version_deallocate_offender }  do
     it 'removes the primary pom details in an Offender\'s allocation' do
       nomis_offender_id = 'G2911GD'
+      movement_type = 'ADM'
       params = {
         nomis_offender_id: nomis_offender_id,
         prison: 'LEI',
@@ -59,12 +60,13 @@ RSpec.describe AllocationVersion, type: :model do
       }
       AllocationService.create_or_update(params)
 
-      AllocationVersion.deallocate_offender(nomis_offender_id)
+      AllocationVersion.deallocate_offender(nomis_offender_id, movement_type)
       deallocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
 
       expect(deallocation.primary_pom_nomis_id).to be_nil
       expect(deallocation.primary_pom_name).to be_nil
       expect(deallocation.primary_pom_allocated_at).to be_nil
+      expect(deallocation.event_trigger).to eq 'offender_transferred'
     end
   end
 


### PR DESCRIPTION
At present when we run the 'deallocate_offender' method within
AllocationVersion we only state that an offender has moved.  However,
this could mean that they were either transferred, or released.  By
tweaking the event trigger to be more specific this will assist us when
displaying the allocation history.