### PR TITLE
Adds a table for inserting current delius data.

### DIFF
--- a/app/models/delius_data.rb
+++ b/app/models/delius_data.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class DeliusData < ApplicationRecord
+  def self.upsert(record)
+    record.default = ''
+    query = statement % record
+
+    results = ActiveRecord::Base.connection.execute(query)
+    existing_tier = results.getvalue(0, 0)
+
+    if existing_tier.present? && existing_tier != record[:tier]
+      create_new_tier_change(record[:noms_no], existing_tier, record[:tier])
+    end
+  end
+
+private
+
+  def self.create_new_tier_change(noms_no, old_tier, new_tier)
+    TierChange.create!(noms_no: noms_no, old_tier: old_tier, new_tier: new_tier)
+  end
+
+  def self.statement
+    <<~HEREDOC
+      INSERT INTO delius_data(
+        crn, pnc_no, noms_no, fullname, tier, roh_cds, offender_manager, org_private_ind, org,
+        provider, provider_code, ldu, ldu_code, team, team_code, mappa, mappa_levels,
+        created_at, updated_at
+      )
+      VALUES (
+        '%<crn>s', '%<pnc_no>s', '%<noms_no>s', '%<fullname>s', '%<tier>s',
+        '%<roh_cds>s', '%<offender_manager>s', '%<org_private_ind>s', '%<org>s',
+        '%<provider>s', '%<provider_code>s', '%<ldu>s', '%<ldu_code>s',
+        '%<team>s', '%<team_code>s', '%<mappa>s', '%<mappa_levels>s', NOW(), NOW()
+      )
+      ON CONFLICT(noms_no) DO UPDATE
+        SET tier = EXCLUDED.tier,
+            updated_at = NOW()
+      RETURNING (SELECT tier FROM delius_data WHERE noms_no=noms_no)
+    HEREDOC
+  end
+end

--- a/app/models/tier_change.rb
+++ b/app/models/tier_change.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TierChange < ApplicationRecord
+end

--- a/db/migrate/20190624112547_add_delius_data_table.rb
+++ b/db/migrate/20190624112547_add_delius_data_table.rb
@@ -1,0 +1,29 @@
+class AddDeliusDataTable < ActiveRecord::Migration[5.2]
+  def up
+    create_table :delius_data do |t|
+      t.string :crn
+      t.string :pnc_no
+      t.string :noms_no, index: {unique: true}
+      t.string :fullname
+      t.string :tier
+      t.string :roh_cds
+      t.string :offender_manager
+      t.string :org_private_ind
+      t.string :org
+      t.string :provider
+      t.string :provider_code
+      t.string :ldu
+      t.string :ldu_code
+      t.string :team
+      t.string :team_code
+      t.string :mappa
+      t.string :mappa_levels
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :delius_data
+  end
+
+end

--- a/db/migrate/20190624130035_add_tier_change_table.rb
+++ b/db/migrate/20190624130035_add_tier_change_table.rb
@@ -1,0 +1,15 @@
+class AddTierChangeTable < ActiveRecord::Migration[5.2]
+  def up
+    create_table :tier_changes do |t|
+      t.string :noms_no
+      t.string :old_tier
+      t.string :new_tier
+      t.timestamps
+    end
+    add_index :tier_changes, [:noms_no]
+  end
+
+  def down
+    drop_table :tier_changes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_112018) do
+ActiveRecord::Schema.define(version: 2019_06_24_130035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,29 @@ ActiveRecord::Schema.define(version: 2019_05_16_112018) do
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id"
   end
 
+  create_table "delius_data", force: :cascade do |t|
+    t.string "crn"
+    t.string "pnc_no"
+    t.string "noms_no"
+    t.string "fullname"
+    t.string "tier"
+    t.string "roh_cds"
+    t.string "offender_manager"
+    t.string "org_private_ind"
+    t.string "org"
+    t.string "provider"
+    t.string "provider_code"
+    t.string "ldu"
+    t.string "ldu_code"
+    t.string "team"
+    t.string "team_code"
+    t.string "mappa"
+    t.string "mappa_levels"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["noms_no"], name: "index_delius_data_on_noms_no", unique: true
+  end
+
   create_table "flipflop_features", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
@@ -94,6 +117,15 @@ ActiveRecord::Schema.define(version: 2019_05_16_112018) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["nomis_staff_id"], name: "index_pom_details_on_nomis_staff_id"
+  end
+
+  create_table "tier_changes", force: :cascade do |t|
+    t.string "noms_no"
+    t.string "old_tier"
+    t.string "new_tier"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["noms_no"], name: "index_tier_changes_on_noms_no"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/spec/models/delius_data_spec.rb
+++ b/spec/models/delius_data_spec.rb
@@ -28,21 +28,3 @@ RSpec.describe DeliusData, type: :model do
     expect(TierChange.count).to eq(1)
   end
 end
-
-# t.string "crn"
-# t.string "pnc_no"
-# t.string "noms_no"
-# t.string "fullname"
-# t.string "tier"
-# t.string "roh_cds"
-# t.string "offender_manager"
-# t.string "org_private_ind"
-# t.string "org"
-# t.string "provider"
-# t.string "provider_code"
-# t.string "ldu"
-# t.string "ldu_code"
-# t.string "team"
-# t.string "team_code"
-# t.string "mappa"
-# t.string "mappa_levels"

--- a/spec/models/delius_data_spec.rb
+++ b/spec/models/delius_data_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe DeliusData, type: :model do
+  it 'can insert clean data' do
+    described_class.upsert(
+      noms_no: 'A1234Z',
+      tier: 'A'
+    )
+
+    expect(described_class.count).to eq(1)
+    expect(TierChange.count).to eq(0)
+  end
+
+  it 'can exercise upsert' do
+    described_class.upsert(
+      noms_no: 'A1234Z',
+      tier: 'A'
+    )
+    expect(described_class.first.tier).to eq('A')
+    expect(TierChange.count).to eq(0)
+
+    described_class.upsert(
+      noms_no: 'A1234Z',
+      tier: 'B'
+    )
+    expect(described_class.first.tier).to eq('B')
+    expect(described_class.count).to eq(1)
+    expect(TierChange.count).to eq(1)
+  end
+end
+
+# t.string "crn"
+# t.string "pnc_no"
+# t.string "noms_no"
+# t.string "fullname"
+# t.string "tier"
+# t.string "roh_cds"
+# t.string "offender_manager"
+# t.string "org_private_ind"
+# t.string "org"
+# t.string "provider"
+# t.string "provider_code"
+# t.string "ldu"
+# t.string "ldu_code"
+# t.string "team"
+# t.string "team_code"
+# t.string "mappa"
+# t.string "mappa_levels"


### PR DESCRIPTION
During the continuous update of offender case information, we will be
importing delius data for fast lookup/setting of the case information.

As we do not wish to query for each row, then determine what has changed
and do an insert or update as appropriate, this PR takes more direct
approach of using INSERT ON CONFLICT to insert the data and update just
those fields that we care about (currently tier).  If the tier during an
update changes from the previous value, a record is written into the
tier_changes table (via the TierChange model). There is no restriction
on the number of Tier changes for an offender, and as they are tagged
with an updated_at field, this can be used for the history.