### PR TITLE
Fix names with apostrophes cause test failures

### DIFF
--- a/app/views/allocations/_allocate_primary_pom.html.erb
+++ b/app/views/allocations/_allocate_primary_pom.html.erb
@@ -1,9 +1,9 @@
 <li class="action_needed">
   <h2 class="govuk-heading-s">Prisoner allocation</h2>
 <p>Prisoner allocated to
-  <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+  <%= link_to(allocation.primary_pom_name.titleize, pom_path(allocation.primary_pom_nomis_id)) %>
   <br/>
   Tier: <%= allocation.allocated_at_tier %>
 <p class="time"><%= format_date_long(allocation.updated_at) %>
-  by <%= allocation.created_by_name.titlecase %></p>
+  by <%= allocation.created_by_name.titleize %></p>
 </li>

--- a/app/views/allocations/_reallocate_primary_pom.html.erb
+++ b/app/views/allocations/_reallocate_primary_pom.html.erb
@@ -1,9 +1,9 @@
 <li class="action_needed">
   <h2 class="govuk-heading-s">Prisoner reallocated</h2>
   <p>Prisoner reallocated to
-    <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+    <%= link_to(allocation.primary_pom_name.titleize, pom_path(allocation.primary_pom_nomis_id)) %>
     <br/>
     Tier: <%= allocation.allocated_at_tier %>
   <p class="time"><%= format_date_long(allocation.updated_at) %>
-    by <%= allocation.created_by_name.titlecase %></p>
+    by <%= allocation.created_by_name.titleize %></p>
 </li>

--- a/app/views/prisoners/_prison_allocation.html.erb
+++ b/app/views/prisoners/_prison_allocation.html.erb
@@ -14,7 +14,7 @@
       <td class="govuk-table__cell">POM</td>
       <td class="govuk-table__cell table_cell__left_align">
         <% if @allocation %>
-          <%= @allocation.primary_pom_name.titlecase %>
+          <%= @allocation.primary_pom_name.titleize %>
         <% end %>
       </td>
     </tr>

--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -8,12 +8,12 @@
             <li class="action_needed">
               <h2 class="govuk-heading-s">Prisoner allocation</h2>
               <p>Prisoner allocated to
-                <%= link_to(allocation.primary_pom_name.titlecase, pom_path(allocation.primary_pom_nomis_id)) %>
+                <%= link_to(allocation.primary_pom_name.titleize, pom_path(allocation.primary_pom_nomis_id)) %>
                 <br/>
                 Tier: <%= allocation.allocated_at_tier %>
               </p>
               <p class="time"><%= format_date_long(allocation.primary_pom_allocated_at) %>
-                by <%= allocation.created_by_name.titlecase %></p>
+                by <%= allocation.created_by_name.titleize %></p>
             </li>
           <% end %>
         </ul>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,13 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+# encoding: utf-8
+
+module ActiveSupport
+  module Inflector
+    def titleize(word, _keep_id_suffix = false)
+      word.split(/\b/).map(&:capitalize).join
+    end
+  end
+end

--- a/spec/config/initializers/inflections_spec.rb
+++ b/spec/config/initializers/inflections_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/FilePath
+describe ActiveSupport::Inflector do
+  describe '#titleize' do
+    it 'capitalizes the letter of a string after an apostrophe' do
+      expect("BOB O'SHEA".titleize).to eq("Bob O'Shea")
+      expect("bob o'shea".titleize).to eq("Bob O'Shea")
+      expect("Bob O'Shea".titleize).to eq("Bob O'Shea")
+    end
+
+    it 'does not remove a hyphen of a string' do
+      expect("Bob Cullen-Smith".titleize).to eq("Bob Cullen-Smith")
+      expect("Molly-ann Smith".titleize).to eq("Molly-Ann Smith")
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -184,7 +184,7 @@ feature 'Allocation' do
       primary_pom_allocated_at: Time.zone.now - 4.days
     )
 
-    reallocated_pom_name = "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+    reallocated_pom_name = "#{Faker::Name.first_name} #{Faker::Name.last_name}".titleize
     allocation = AllocationVersion.find_by(nomis_offender_id: nomis_offender_id)
 
     allocation.update(event: AllocationVersion::REALLOCATE_PRIMARY_POM,
@@ -203,7 +203,7 @@ feature 'Allocation' do
 
     deallocate_date = allocation.updated_at.strftime("#{allocation.updated_at.day.ordinalize} %B %Y")
 
-    new_prison_pom_name = "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+    new_prison_pom_name = "#{Faker::Name.first_name} #{Faker::Name.last_name}".titleize
     allocation.update(event: AllocationVersion::ALLOCATE_PRIMARY_POM,
                       prison: 'PVI',
                       primary_pom_nomis_id: 485_132,

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -234,7 +234,7 @@ feature 'Allocation' do
     pvi_allocation_date = history[1].updated_at.strftime("#{history[1].updated_at.day.ordinalize} %B %Y")
 
     expect(page).to have_css('p', text: "Prisoner allocated to #{history[1].primary_pom_name} Tier: #{history[1].allocated_at_tier}")
-    expect(page).to have_css('.time', text: "#{pvi_allocation_date} by #{history[1].created_by_name}")
+    expect(page).to have_css('.time', text: "#{pvi_allocation_date} by #{history[1].created_by_name.titleize}")
 
     expect(page).to have_css('.govuk-heading-m', text: "HMP Leeds")
 
@@ -244,10 +244,10 @@ feature 'Allocation' do
     previous_formatted_date = history[2].updated_at.strftime("#{history[3].updated_at.day.ordinalize} %B %Y")
 
     expect(page).to have_css('p', text: "Prisoner reallocated to #{history[3].primary_pom_name} Tier: #{history[3].allocated_at_tier}")
-    expect(page).to have_css('.time', text: "#{previous_formatted_date} by #{history[3].created_by_name}")
+    expect(page).to have_css('.time', text: "#{previous_formatted_date} by #{history[3].created_by_name.titleize}")
 
     initial_allocated_date = history.last.updated_at.strftime("#{history.last.updated_at.day.ordinalize} %B %Y")
-    expect(page).to have_css('p', text: "Prisoner allocated to #{history.last.primary_pom_name} Tier: #{history.last.allocated_at_tier}")
-    expect(page).to have_css('.time', text: "#{initial_allocated_date} by #{history.last.created_by_name}")
+    expect(page).to have_css('p', text: "Prisoner allocated to #{history.last.primary_pom_name.titleize} Tier: #{history.last.allocated_at_tier}")
+    expect(page).to have_css('.time', text: "#{initial_allocated_date} by #{history.last.created_by_name.titleize}")
   end
 end

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -69,14 +69,14 @@ feature "edit a POM's details" do
     visit "/poms/485637"
     click_link "Edit profile"
 
-    expect(page).to have_content("Kath Pobee Norris")
+    expect(page).to have_content("Kath Pobee-Norris")
     expect(AllocationVersion.count).to eq 1
 
     choose('working_pattern-2')
     choose('Inactive')
     click_button('Save')
 
-    expect(page).to have_content("Pobee Norris, Kath")
+    expect(page).to have_content("Pobee-Norris, Kath")
     expect(page).to have_css('.pom_cases_row_0', count: 0)
   end
 end


### PR DESCRIPTION
Sometimes the tests fail due to the expectation of a name, where
that name has an apostrophe, for example "Bob O'Shea" will
appear as "Bob O'shea". This is not correct the name should be
"Bob O'Shea".

Using the methods titleize or titlecase causes the letter after
the apostrophe to be lowercase, which will cause the expectation
failure.

For consistency we no longer use the titlecase method as it
pretty much does the same thing as titleize.

To solve this issue the titleize method has been overwritten so
that it does not lower case the letter displayed after the
apostrophe.

The bonus of using this overridden method is that previously a
double barrelled name would remove the hyphen which is not ideal.
For example "Bob Cullen-Smith" would have been converted to
"Bob Cullen Smith". Now the hyphen remains in place which is
more accurate.