### PR TITLE
Stop using the primary_pom_allocated_at on the caseload

### DIFF
--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -101,14 +101,14 @@ class PrisonOffenderManagerService
   def self.get_new_cases(nomis_staff_id, prison)
     allocations = get_allocated_offenders(nomis_staff_id, prison)
     allocations.select do |allocation, _offender|
-      allocation.primary_pom_allocated_at >= 7.days.ago
+      allocation.updated_at >= 7.days.ago
     end
   end
 
   def self.get_new_cases_count(nomis_staff_id, prison)
     allocations = get_allocated_offenders(nomis_staff_id, prison)
     allocations.select { |allocation, _offender|
-      allocation.primary_pom_allocated_at >= 7.days.ago
+      allocation.updated_at >= 7.days.ago
     }.count
   end
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -84,8 +84,8 @@ describe PrisonOffenderManagerService do
   end
 
   it "will get allocations for a POM made within the last 7 days", vcr: { cassette_name: :get_new_cases } do
-    allocation_one.update!(primary_pom_allocated_at: 10.days.ago)
-    allocation_two.update!(primary_pom_allocated_at: 3.days.ago)
+    allocation_one.update!(updated_at: 10.days.ago)
+    allocation_two.update!(updated_at: 3.days.ago)
 
     allocated_offenders = described_class.get_new_cases(allocation_one.primary_pom_nomis_id, 'LEI')
     expect(allocated_offenders.count).to eq 3


### PR DESCRIPTION
The primary_pom_allocated_at is mostly unnecessary, if the current
allocation is valid (it contains a pom) then the allocation date was the
same as the updated_at field.

Once we have co-working, then it becomes more useful, but for now updated_at makes more sense.