### PR TITLE
 Switch feature flag on for prisoner profile & allocation history pages

### DIFF
--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -36,8 +36,8 @@
     </tr>
     </thead>
     <tbody class="govuk-table__body">
-    <% @allocations.each do |allocation, sentence| %>
-      <tr class="govuk-table__row">
+    <% @allocations.each_with_index do |(allocation, sentence), i| %>
+      <tr class="govuk-table__row offender_row_<%= i %>">
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(sentence.earliest_release_date) %></td>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -22,8 +22,8 @@
     </tr>
     </thead>
     <tbody class="govuk-table__body">
-    <% @new_cases.each do |allocation, sentence| %>
-      <tr class="govuk-table__row">
+    <% @new_cases.each_with_index do |(allocation, sentence), i| %>
+      <tr class="govuk-table__row offender_row_<%= i %>">
         <td aria-label="Prisoner name" class="govuk-table__cell "><%= sentence.full_name %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
         <td aria-label="Arrival date" class="govuk-table__cell "><%= format_date(sentence.sentence_start_date) %></td>

--- a/config/features.rb
+++ b/config/features.rb
@@ -3,9 +3,9 @@ Flipflop.configure do
   strategy :default
 
   feature :link_allocation_info,
-          default: false,
+          default: true,
           description: 'Link allocation info page from allocated offenders tab'
   feature :prisoner_profile,
-          default: false,
+          default: true,
           description: 'Show the prisoner profile from caseload pages'
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -129,8 +129,15 @@ feature 'Allocation' do
     visit summary_allocated_path
 
     within('.allocated_offender_row_0') do
-      click_link 'Reallocate'
+      click_link 'View'
     end
+
+    expect(page).to have_current_path allocation_path(nomis_offender_id)
+    expect(page).to have_link(nil, href: '/poms/485636')
+    expect(page).to have_css('.table_cell__left_align', text: 'Duckett, Jenny')
+    expect(page).to have_css('.table_cell__left_align', text: 'Supporting')
+
+    click_link 'Reallocate'
 
     expect(page).to have_current_path edit_allocation_path(nomis_offender_id)
     expect(page).to have_css('.current_pom_full_name', text: 'Duckett, Jenny')

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -22,6 +22,25 @@ feature "view POM's caseload" do
     expect(page).to have_content("Abbella, Ozullirn")
   end
 
+  it 'allows a POM to view the prisoner profile page for a specific offender',  vcr: { cassette_name: :show_poms_caseload_prisoner_profile } do
+    signin_user('PK000223')
+
+    visit confirm_allocation_path(nomis_offender_id, nomis_staff_id)
+
+    click_button 'Complete allocation'
+
+    visit caseload_index_path
+
+    within('.offender_row_0') do
+      click_link 'View'
+    end
+
+    expect(page).to have_css('h2', text: 'Abbella, Ozullirn')
+    expect(page).to have_content('15/08/1980')
+    cat_code = find('h3#category-code').text
+    expect(cat_code).to eq('C')
+  end
+
   it 'displays all cases that have been allocated to a specific POM in the last week', vcr: { cassette_name: :show_new_cases } do
     signin_user('PK000223')
 


### PR DESCRIPTION
We have implemented the designs for the prisoner profile & allocation
history pages.  As these are accessed via a change in the workflow they
have been hidden behind a feature flag.  We now want to start displaying
these pages so that we can get sign off/testing from the team, before we
push these out to production.  This PR therefore switches on the feature
flag and amends the relevant feature spec to include these new pages.