### PR TITLE
Use constants for XLSX xml element names.

### DIFF
--- a/lib/delius/sheet.rb
+++ b/lib/delius/sheet.rb
@@ -4,6 +4,9 @@ require 'nokogiri'
 
 module Delius
   class Sheet < Nokogiri::XML::SAX::Document
+    DATA_CELL = 'v'
+    ROW = 'row'
+
     def initialize(&block)
       @handler = block
       @current_row = []
@@ -11,7 +14,7 @@ module Delius
     end
 
     def start_element(name, _attrs = [])
-      @in_value = name == 'v'
+      @in_value = name == DATA_CELL
     end
 
     def characters(str)
@@ -19,7 +22,7 @@ module Delius
     end
 
     def end_element(name)
-      return unless name == 'row'
+      return unless name == ROW
 
       row = @current_row.map { |cell|
         cell.dup.strip.to_i

--- a/lib/delius/string_collector.rb
+++ b/lib/delius/string_collector.rb
@@ -4,13 +4,15 @@ require 'nokogiri'
 
 module Delius
   class StringCollector < Nokogiri::XML::SAX::Document
+    DATA_CELL = 't'
+
     def initialize(&block)
       @inside_cell = false
       @block = block
     end
 
     def start_element(name, _attrs)
-      @inside_cell = true if name == 't'
+      @inside_cell = true if name == DATA_CELL
     end
 
     def characters(str)


### PR DESCRIPTION
To avoid magic strings in the code, we now use constants that describe
the element name. Rather than use 't' or 'v' for the cells we now use
DATA_CELL_NAME.