### PR TITLE
Fix deallocate primary POM

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -85,14 +85,15 @@ class AllocationVersion < ApplicationRecord
   # rubocop:enable Metrics/MethodLength
 
   def self.deallocate_primary_pom(nomis_staff_id)
-    all_primary_pom_allocations(nomis_staff_id).
-      update_all(
-        primary_pom_nomis_id: nil,
-        primary_pom_name: nil,
-        primary_pom_allocated_at: nil,
-        event: DEALLOCATE_PRIMARY_POM,
-        event_trigger: USER
-      )
+    all_primary_pom_allocations(nomis_staff_id).each do |alloc|
+      alloc.primary_pom_nomis_id = nil
+      alloc.primary_pom_name = nil
+      alloc.primary_pom_allocated_at = nil
+      alloc.event = DEALLOCATE_PRIMARY_POM
+      alloc.event_trigger = USER
+
+      alloc.save!
+    end
   end
 
   validates :nomis_offender_id,


### PR DESCRIPTION
When a POM leaves, or is deactivated, we want to remove their details
from all their current allocations.  To date we have been using
update_all to update some of the fields in the current allocation for
all offenders.  However, this doesn't work with the papertrail gem and
in it's current state will mean we lose the histories.  Thereore this
removes update_all and we now iterate through each allocation, set the
specific field to nil and re-save it; creating a new version.