### PR TITLE
Insert the data from the XLSX into the delius_data table

### DIFF
--- a/app/models/delius_data.rb
+++ b/app/models/delius_data.rb
@@ -2,21 +2,33 @@
 
 class DeliusData < ApplicationRecord
   def self.upsert(record)
-    record.default = ''
-    query = statement % record
+    data = record.map { |k, v| [k, DeliusData.connection.quote(v)] }.to_h
+    data.default = "''"
+
+    query = statement % data
 
     results = ActiveRecord::Base.connection.execute(query)
     existing_tier = results.getvalue(0, 0)
 
     if existing_tier.present? && existing_tier != record[:tier]
-      create_new_tier_change(record[:noms_no], existing_tier, record[:tier])
+      create_new_tier_change(record[:crn], record[:noms_no], existing_tier, record[:tier])
     end
+  end
+
+  def omicable?
+    ldu_code.present? && ldu_code.start_with?('WPT')
+  end
+
+  def service_provider
+    return 'CRC' if provider_code.present? && provider_code[0] == 'C'
+
+    'NPS'
   end
 
 private
 
-  def self.create_new_tier_change(noms_no, old_tier, new_tier)
-    TierChange.create!(noms_no: noms_no, old_tier: old_tier, new_tier: new_tier)
+  def self.create_new_tier_change(crn, noms_no, old_tier, new_tier)
+    TierChange.create!(crn: crn, noms_no: noms_no, old_tier: old_tier, new_tier: new_tier)
   end
 
   def self.statement
@@ -27,15 +39,15 @@ private
         created_at, updated_at
       )
       VALUES (
-        '%<crn>s', '%<pnc_no>s', '%<noms_no>s', '%<fullname>s', '%<tier>s',
-        '%<roh_cds>s', '%<offender_manager>s', '%<org_private_ind>s', '%<org>s',
-        '%<provider>s', '%<provider_code>s', '%<ldu>s', '%<ldu_code>s',
-        '%<team>s', '%<team_code>s', '%<mappa>s', '%<mappa_levels>s', NOW(), NOW()
+        %<crn>s, %<pnc_no>s, %<noms_no>s, %<fullname>s, %<tier>s,
+        %<roh_cds>s, %<offender_manager>s, %<org_private_ind>s, %<org>s,
+        %<provider>s, %<provider_code>s, %<ldu>s, %<ldu_code>s,
+        %<team>s, %<team_code>s, %<mappa>s, %<mappa_levels>s, NOW(), NOW()
       )
-      ON CONFLICT(noms_no) DO UPDATE
+      ON CONFLICT(crn) DO UPDATE
         SET tier = EXCLUDED.tier,
             updated_at = NOW()
-      RETURNING (SELECT tier FROM delius_data WHERE noms_no=noms_no)
+      RETURNING (SELECT tier FROM delius_data WHERE crn=%<crn>s)
     HEREDOC
   end
 end

--- a/db/migrate/20190626062807_add_crn_to_tier_change.rb
+++ b/db/migrate/20190626062807_add_crn_to_tier_change.rb
@@ -1,0 +1,9 @@
+class AddCrnToTierChange < ActiveRecord::Migration[5.2]
+  def up
+    add_column :tier_changes, :crn, :string
+  end
+
+  def down
+    remove_column :tier_changes, :crn
+  end
+end

--- a/db/migrate/20190626063100_add_unique_constraint_to_delius_crn.rb
+++ b/db/migrate/20190626063100_add_unique_constraint_to_delius_crn.rb
@@ -1,0 +1,10 @@
+class AddUniqueConstraintToDeliusCrn < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :delius_data, :noms_no
+    add_index :delius_data, [:crn], :unique => true
+  end
+  def down
+    remove_index :delius_data, :crn
+    add_index :delius_data, [:noms_no], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_24_130035) do
+ActiveRecord::Schema.define(version: 2019_06_26_063100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2019_06_24_130035) do
     t.string "mappa_levels"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["noms_no"], name: "index_delius_data_on_noms_no", unique: true
+    t.index ["crn"], name: "index_delius_data_on_crn", unique: true
   end
 
   create_table "flipflop_features", force: :cascade do |t|
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2019_06_24_130035) do
     t.string "new_tier"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "crn"
     t.index ["noms_no"], name: "index_tier_changes_on_noms_no"
   end
 

--- a/lib/tasks/delius_import.rake
+++ b/lib/tasks/delius_import.rake
@@ -13,8 +13,34 @@ namespace :delius_import do
     Rails.logger.error('No file specified') if args[:file].blank?
     next if args[:file].blank?
 
+    total = 0
     processor = Delius::Processor.new(args[:file])
     processor.run { |row|
+      record = {}
+
+      row.each_with_index do |val, idx|
+        key = fields[idx]
+        record[key] = val
+      end
+      record[:tier] = record[:tier].present? ? record[:tier][0] : ''
+
+      if record[:noms_no].present?
+        DeliusData.upsert(record)
+        print "\r#{total}"
+        $stdout.flush
+        total += 1
+      end
     }
+  end
+
+  def fields
+    @fields ||= [
+      :crn, :pnc_no, :noms_no, :fullname, :tier, :roh_cds,
+      :offender_manager, :org_private_ind, :org,
+      :provider, :provider_code,
+      :ldu, :ldu_code,
+      :team, :team_code,
+      :mappa, :mappa_levels
+    ]
   end
 end

--- a/spec/models/delius_data_spec.rb
+++ b/spec/models/delius_data_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe DeliusData, type: :model do
   it 'can insert clean data' do
     described_class.upsert(
+      crn: '1',
       noms_no: 'A1234Z',
       tier: 'A'
     )
@@ -13,6 +14,7 @@ RSpec.describe DeliusData, type: :model do
 
   it 'can exercise upsert' do
     described_class.upsert(
+      crn: '1',
       noms_no: 'A1234Z',
       tier: 'A'
     )
@@ -20,11 +22,61 @@ RSpec.describe DeliusData, type: :model do
     expect(TierChange.count).to eq(0)
 
     described_class.upsert(
+      crn: '1',
       noms_no: 'A1234Z',
       tier: 'B'
     )
     expect(described_class.first.tier).to eq('B')
     expect(described_class.count).to eq(1)
     expect(TierChange.count).to eq(1)
+  end
+
+  it 'can tell if a record is omicable' do
+    described_class.upsert(
+      crn: '1',
+      noms_no: 'A1234Z',
+      ldu_code: 'WPT123'
+    )
+
+    expect(described_class.first.omicable?).to be true
+  end
+
+  it 'can tell if a record is not omicable' do
+    described_class.upsert(
+      crn: '1',
+      noms_no: 'A1234Z',
+      ldu_code: 'XPT123'
+    )
+
+    expect(described_class.first.omicable?).to be false
+  end
+
+  it 'can tell if a record is CRC' do
+    described_class.upsert(
+      crn: '1',
+      noms_no: 'A1234Z',
+      provider_code: 'C123'
+    )
+
+    expect(described_class.first.service_provider).to eq('CRC')
+  end
+
+  it 'can tell if a record is NPS' do
+    described_class.upsert(
+      crn: '1',
+      noms_no: 'A1234Z',
+      provider_code: 'X123'
+    )
+
+    expect(described_class.first.service_provider).to eq('NPS')
+  end
+
+  it 'can will default service provider to NPS' do
+    described_class.upsert(
+      crn: '1',
+      noms_no: 'A1234Z'
+    )
+
+    expect(described_class.first.service_provider).to eq('NPS')
   end
 end


### PR DESCRIPTION
Previous PRs had implemented the XLSX parsing, and setting up of the
delius_data and tier_changes table.

This PR implements the writing of data into the delius_data table and
adds some useful helper functions to the DeliusData model.

During this work it was discovered that noms_no is not unique and so we
had to switch to matching on existing data based on the CRN.  This means
that we may end up with tier_changes which are not accurate, so we have
also added the CRN.

It is expected that we will add the CRN to the CaseInformation table so
that we can make this available in the offender models.