### PR TITLE
Add a CRN field to the offender.

### DIFF
--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -11,6 +11,7 @@ module Nomis
       attribute :imprisonment_status, :string
 
       # Custom attributes
+      attribute :crn, :string
       attribute :category_code, :string
       attribute :allocated_pom_name, :string
       attribute :case_allocation, :string

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -10,6 +10,7 @@ class OffenderService
         o.tier = record.tier
         o.case_allocation = record.case_allocation
         o.omicable = record.omicable == 'Yes'
+        o.crn = record.crn
       end
 
       sentence_detail = get_sentence_details([o.latest_booking_id])
@@ -51,6 +52,7 @@ class OffenderService
         offender.tier = record.tier
         offender.case_allocation = record.case_allocation
         offender.omicable = record.omicable == 'Yes'
+        offender.crn = record.crn
       end
 
       true

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -14,10 +14,8 @@
         <h3 class="govuk-heading-m"><%= @prisoner.offender_no %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
-      <!-- PENDING DATA
         <span class="govuk-body">CRN number</span>
-        <h3 class="govuk-heading-m">N/A</h3>
-      -->
+        <h3 class="govuk-heading-m"><%= @prisoner.crn || "N/A" %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Date of birth</span>

--- a/db/migrate/20190626093827_add_crn_to_case_information.rb
+++ b/db/migrate/20190626093827_add_crn_to_case_information.rb
@@ -1,0 +1,9 @@
+class AddCrnToCaseInformation < ActiveRecord::Migration[5.2]
+  def up
+    add_column :case_information, :crn, :string
+  end
+
+  def down
+    remove_column :case_information, :crn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_063100) do
+ActiveRecord::Schema.define(version: 2019_06_26_093827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_063100) do
     t.string "nomis_offender_id"
     t.text "omicable"
     t.text "prison"
+    t.string "crn"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id"
   end
 


### PR DESCRIPTION
As we will soon be creating case information data for offenders, this PR
allows that CaseInformation to contain the CRN (delius ID).  This is
then displayed on the prisoner profile page.

If the data is not available, the CRN field is shown as N/A.