### PR TITLE
Install tool for decypting encypted office files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,16 @@ jobs:
           key: allocation-manager-v1-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/repo/vendor/bundle
+      - run:
+          name: Build the tool for decrypting office files
+          command: |
+            cd /tmp
+            git clone https://github.com/herumi/cybozulib
+            git clone https://github.com/herumi/msoffice
+            cd msoffice
+            make -j RELEASE=1
+            mv /tmp/msoffice/bin/msoffice-crypt.exe ~/repo/bin/msoffice-crypt
+            ls bin
       - persist_to_workspace:
           root: .
           paths:
@@ -225,7 +235,6 @@ jobs:
           at: ~/repo
       - setup_remote_docker:
           docker_layer_caching: true
-      - *install_aws_cli
       - *build_docker_image
       - *push_docker_image
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,6 @@ jobs:
             cd msoffice
             make -j RELEASE=1
             mv /tmp/msoffice/bin/msoffice-crypt.exe ~/repo/bin/msoffice-crypt
-            ls bin
       - persist_to_workspace:
           root: .
           paths:
@@ -235,6 +234,7 @@ jobs:
           at: ~/repo
       - setup_remote_docker:
           docker_layer_caching: true
+      - *install_aws_cli
       - *build_docker_image
       - *push_docker_image
 


### PR DESCRIPTION
As we will need to decrypt an office file once we have obtained it, we need a tool to do this.  We've identified a tool to do this, but it needs compiling in CI so this PR adds a process for doing that and then adding to the /app/bin folder in the docker image.