### PR TITLE
Explicitly copy the decryperator binary into the correct place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN \
   && yarn add govuk-frontend
 
 COPY Gemfile Gemfile.lock package.json ./
+COPY bin/msoffice-crypt ./bin/msoffice-crypt
 
 RUN bundle install --without development test --jobs 2 --retry 3
 


### PR DESCRIPTION
We need to make sure that the docker build puts the binary in the correct place explicitly