### PR TITLE
Add Stephen as a POM

### DIFF
--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -95,7 +95,7 @@ describe PrisonOffenderManagerService do
      vcr: { cassette_name: :pom_service_get_poms_list } do
     poms = described_class.get_poms('LEI')
     expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(13)
+    expect(poms.count).to eq(14)
   end
 
   it "can get a filtered list of POMs",
@@ -104,14 +104,14 @@ describe PrisonOffenderManagerService do
       pom.status == 'active'
     }
     expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(12)
+    expect(poms.count).to eq(13)
   end
 
   it "can get the names for POMs when given IDs",
      vcr: { cassette_name: :pom_service_get_poms_by_ids } do
     names = described_class.get_pom_names('LEI')
     expect(names).to be_kind_of(Hash)
-    expect(names.count).to eq(12)
+    expect(names.count).to eq(13)
   end
 
   it "can fetch a single POM for a prison",


### PR DESCRIPTION
We have a new developer joining the team, Stephen, and we need to add
him as a POM on T3.  This changes the numbers of POMs we have and
therefore this PR updates the specs to include the new POM.