### PR TITLE
Fix Overrides issue

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -73,8 +73,6 @@ class AllocationsController < ApplicationController
     offender = offender(allocation_params[:nomis_offender_id])
     allocation = allocation_attributes(offender)
 
-    @override = override
-
     if AllocationService.create_or_update(allocation)
       flash[:notice] =
         "#{offender.full_name_ordered} has been allocated to #{pom.full_name_ordered} (#{pom.grade})"
@@ -100,6 +98,7 @@ private
   end
 
   def allocation_attributes(offender)
+    @override = override
     {
       primary_pom_nomis_id: allocation_params[:nomis_staff_id].to_i,
       nomis_offender_id: allocation_params[:nomis_offender_id],


### PR DESCRIPTION
There appears to be an issue where are no longer correctly saving any
information related to allocation overrides.  It is not clear how long
this functionality hasn't been working for.

This came to light when starting work on
displaying override related information for an allocation on the
allocation history page.  When working on a local branch the information
for my test overrides wasn't showing up, and when I checked the
AllocationVersion in the database I noticed that those fields remained
blank.  I went on to staging, created a new allocation using
overrides and then ssh'd into the staging pod.  A check of the
AllocationVersion for the offender I had just tested again showed that
the fields related to override reasons/details were blank.

It would appear that whilst some previous refactoring was taking place a
change was implemented that stopped the overrides being recorded
properly.  All functionality around creating the override, and deleting
the override remained working, but the step where it was actually adding
the override fields to the allocation_attributes had stopped working.