### PR TITLE
Handle ConnectionFailed errors when servers disappear

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -73,6 +73,9 @@ module Nomis
         req.params.update(queryparams)
         req.body = body.to_json if body.present? && method == :post
       end
+    rescue Faraday::ConnectionFailed => cf
+      AllocationManager::ExceptionHandler.capture_exception(cf)
+      raise APIError, "Failed to connect to #{@root}"
     rescue Faraday::ResourceNotFound, Faraday::ClientError => e
       AllocationManager::ExceptionHandler.capture_exception(e)
       raise APIError, "Unexpected status #{e.response[:status]}"

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -73,8 +73,8 @@ module Nomis
         req.params.update(queryparams)
         req.body = body.to_json if body.present? && method == :post
       end
-    rescue Faraday::ConnectionFailed => cf
-      AllocationManager::ExceptionHandler.capture_exception(cf)
+    rescue Faraday::ConnectionFailed => e
+      AllocationManager::ExceptionHandler.capture_exception(e)
       raise APIError, "Failed to connect to #{@root}"
     rescue Faraday::ResourceNotFound, Faraday::ClientError => e
       AllocationManager::ExceptionHandler.capture_exception(e)

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -72,4 +72,22 @@ describe Nomis::Client do
       expect { client.get(route) }.to raise_error(Nomis::Client::APIError)
     end
   end
+
+  describe 'when the server is unreachable' do
+    let(:error) do
+      Faraday::ConnectionFailed.new('cannot connect')
+    end
+    let(:route)        { "/" }
+
+    before do
+      WebMock.stub_request(:get, /\w/).to_raise(error)
+    end
+
+    it 'raises an APIError', :raven_intercept_exception do
+      broken_client = described_class.new('nosuchhost')
+
+      expect { broken_client.get(route) }.
+        to raise_error(Nomis::Client::APIError, 'Failed to connect to nosuchhost')
+    end
+  end
 end


### PR DESCRIPTION
When a server is not reachable, the client does not currently handle it
well, instead we will now handle it as a client APIError. This will
allow each API to determine how to handle the failure.