### PR TITLE
Fixes tests on master and cleanup deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'redis'
 gem 'plissken'
 gem 'fast_underscore', require: false
 gem 'flipflop'
-gem 'roo'
+gem 'hashdiff', ['>= 1.0.0.beta1', '< 2.0.0']
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     govuk_notify_rails (2.1.0)
       notifications-ruby-client (>= 2.9.0)
       rails (>= 4.1.0)
-    hashdiff (0.4.0)
+    hashdiff (1.0.0.beta1)
     hashie (3.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -217,9 +217,6 @@ GEM
     regexp_parser (1.5.1)
     request_store (1.4.1)
       rack (>= 1.4)
-    roo (2.8.2)
-      nokogiri (~> 1)
-      rubyzip (>= 1.2.1, < 2.0.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.3)
@@ -355,6 +352,7 @@ DEPENDENCIES
   flamegraph
   flipflop
   govuk_notify_rails
+  hashdiff (>= 1.0.0.beta1, < 2.0.0)
   jbuilder (~> 2.9)
   jwt
   launchy
@@ -372,7 +370,6 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 5.2.3)
   redis
-  roo
   rspec-rails
   rubocop
   rubocop-performance

--- a/lib/delius/manual_extractor.rb
+++ b/lib/delius/manual_extractor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 module Delius
   class ManualExtractor
     # rubocop:disable Metrics/LineLength

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -248,7 +248,7 @@ feature 'Allocation' do
     expect(page).to have_css('.govuk-heading-s', text: "Prisoner unallocated")
     expect(page).to have_css('.time', text: deallocate_date.to_s)
 
-    previous_formatted_date = history[2].updated_at.strftime("#{history[3].updated_at.day.ordinalize} %B %Y")
+    previous_formatted_date = history[3].updated_at.strftime("#{history[3].updated_at.day.ordinalize} %B %Y")
 
     expect(page).to have_css('p', text: "Prisoner reallocated to #{history[3].primary_pom_name} Tier: #{history[3].allocated_at_tier}")
     expect(page).to have_css('.time', text: "#{previous_formatted_date} by #{history[3].created_by_name.titleize}")


### PR DESCRIPTION
Tests were failing on master, presumably due to a typo in the history
tests.  Also updated dependencies to remove the unused `roo` gem and to
remove the warning about hash_diff.