### PR TITLE
Add recommended POM type column

### DIFF
--- a/db/migrate/20190705150401_add_column_recommended_pom.rb
+++ b/db/migrate/20190705150401_add_column_recommended_pom.rb
@@ -1,0 +1,9 @@
+class AddColumnRecommendedPom < ActiveRecord::Migration[5.2]
+  def up
+    add_column :allocation_versions, :recommended_pom_type, :string
+  end
+
+  def down
+    remove_column :allocation_versions, :recommended_pom_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_093827) do
+ActiveRecord::Schema.define(version: 2019_07_05_150401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_093827) do
     t.datetime "updated_at", null: false
     t.string "created_by_username"
     t.datetime "primary_pom_allocated_at"
+    t.string "recommended_pom_type"
     t.index ["nomis_offender_id"], name: "index_allocation_versions_on_nomis_offender_id"
     t.index ["primary_pom_nomis_id"], name: "index_allocation_versions_on_primary_pom_nomis_id"
     t.index ["secondary_pom_nomis_id"], name: "index_allocation_versions_secondary_pom_nomis_id"


### PR DESCRIPTION
Whilst working on displaying the override reasons in the allocation
history it was established that we need to know what the original
recommended POM type was at the time the primary POM was allocated. By
storing this data we can then add context around why an override took
place, and what POM type was originally recommended.  This PR just
adds the new column so work can start on updating the allocationVersion
to start recording this data.