### PR TITLE
Record recommended POM type

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -105,6 +105,7 @@ private
       created_by_username: current_user,
       nomis_booking_id: offender.latest_booking_id,
       allocated_at_tier: offender.tier,
+      recommended_pom_type: recommended_pom_type(offender),
       prison: active_prison,
       override_reasons: override_reasons,
       suitability_detail: suitability_detail,
@@ -135,6 +136,11 @@ private
     nomis_staff_id = current_allocation[nomis_offender_id]['primary_pom_nomis_id']
 
     PrisonOffenderManagerService.get_pom(active_prison, nomis_staff_id)
+  end
+
+  def recommended_pom_type(offender)
+    rec_type = RecommendationService.recommended_pom_type(offender)
+    rec_type == RecommendationService::PRISON_POM ? 'prison' : 'probation'
   end
 
   def recommended_and_nonrecommended_poms_types_for(offender)

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -77,6 +77,7 @@ class AllocationVersion < ApplicationRecord
     alloc.primary_pom_allocated_at = nil
     alloc.secondary_pom_nomis_id = nil
     alloc.secondary_pom_name = nil
+    alloc.recommended_pom_type = nil
     alloc.event = DEALLOCATE_PRIMARY_POM
     alloc.event_trigger = movement_type
 
@@ -88,6 +89,7 @@ class AllocationVersion < ApplicationRecord
     all_primary_pom_allocations(nomis_staff_id).each do |alloc|
       alloc.primary_pom_nomis_id = nil
       alloc.primary_pom_name = nil
+      alloc.recommended_pom_type = nil
       alloc.primary_pom_allocated_at = nil
       alloc.event = DEALLOCATE_PRIMARY_POM
       alloc.event_trigger = USER

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -121,7 +121,8 @@ feature 'Allocation' do
     create(
       :allocation_version,
       nomis_offender_id: nomis_offender_id,
-      primary_pom_nomis_id: probation_officer_nomis_staff_id
+      primary_pom_nomis_id: probation_officer_nomis_staff_id,
+      recommended_pom_type: 'probation'
     )
 
     signin_user
@@ -186,6 +187,7 @@ feature 'Allocation' do
       :allocation_version,
       nomis_offender_id: nomis_offender_id,
       primary_pom_nomis_id: probation_officer_nomis_staff_id,
+      recommended_pom_type: 'probation',
       created_at: Time.zone.now - 4.days,
       updated_at: Time.zone.now - 4.days,
       primary_pom_allocated_at: Time.zone.now - 4.days
@@ -197,6 +199,7 @@ feature 'Allocation' do
     allocation.update(event: AllocationVersion::REALLOCATE_PRIMARY_POM,
                       primary_pom_nomis_id: prison_officer_nomis_staff_id,
                       primary_pom_name: reallocated_pom_name,
+                      recommended_pom_type: 'prison',
                       updated_at: Time.zone.now - 3.days
     )
 
@@ -204,6 +207,7 @@ feature 'Allocation' do
                       event_trigger: AllocationVersion::USER,
                       primary_pom_nomis_id: nil,
                       primary_pom_name: nil,
+                      recommended_pom_type: nil,
                       updated_at: Time.zone.now - 2.days,
                       primary_pom_allocated_at: nil
     )
@@ -215,12 +219,14 @@ feature 'Allocation' do
                       prison: 'PVI',
                       primary_pom_nomis_id: 485_132,
                       primary_pom_name: new_prison_pom_name,
+                      recommended_pom_type: 'prison',
                       updated_at: Time.zone.now - 1.day)
 
     allocation.update(event: AllocationVersion::DEALLOCATE_PRIMARY_POM,
                       event_trigger: AllocationVersion::OFFENDER_TRANSFERRED,
                       primary_pom_nomis_id: nil,
                       primary_pom_name: nil,
+                      recommended_pom_type: nil,
                       updated_at: Time.zone.now - 1.day,
                       primary_pom_allocated_at: nil)
 

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -8,6 +8,7 @@ feature "view an offender's allocation information" do
   let!(:nomis_offender_id_without_keyworker) { 'G9403UP' }
   let!(:allocated_at_tier) { 'A' }
   let!(:prison) { 'LEI' }
+  let!(:recommended_pom_type) { 'probation' }
   let!(:pom_detail) {
     PomDetail.create!(
       nomis_staff_id: probation_officer_nomis_staff_id,
@@ -94,7 +95,8 @@ feature "view an offender's allocation information" do
       nomis_offender_id: offender_no,
       primary_pom_nomis_id: probation_officer_nomis_staff_id,
       prison: prison,
-      allocated_at_tier: allocated_at_tier
+      allocated_at_tier: allocated_at_tier,
+      recommended_pom_type: recommended_pom_type
     )
   end
 end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe AllocationVersion, type: :model do
       expect(deallocation.primary_pom_nomis_id).to be_nil
       expect(deallocation.primary_pom_name).to be_nil
       expect(deallocation.primary_pom_allocated_at).to be_nil
+      expect(deallocation.recommended_pom_type).to be_nil
     end
   end
 
@@ -55,6 +56,7 @@ RSpec.describe AllocationVersion, type: :model do
         primary_pom_nomis_id: 485_833,
         primary_pom_allocated_at: DateTime.now.utc,
         nomis_booking_id: 1,
+        recommended_pom_type: 'probation',
         event: AllocationVersion::ALLOCATE_PRIMARY_POM,
         event_trigger: AllocationVersion::USER
       }
@@ -66,6 +68,7 @@ RSpec.describe AllocationVersion, type: :model do
       expect(deallocation.primary_pom_nomis_id).to be_nil
       expect(deallocation.primary_pom_name).to be_nil
       expect(deallocation.primary_pom_allocated_at).to be_nil
+      expect(deallocation.recommended_pom_type).to be_nil
       expect(deallocation.event_trigger).to eq 'offender_transferred'
     end
   end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -16,6 +16,7 @@ describe AllocationService do
       primary_pom_nomis_id: 485_595,
       primary_pom_allocated_at: DateTime.now.utc,
       nomis_booking_id: 1,
+      recommended_pom_type: 'probation',
       event: AllocationVersion::ALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
     }
@@ -109,6 +110,7 @@ describe AllocationService do
       primary_pom_nomis_id: 485_766,
       allocated_at_tier: 'A',
       prison: 'PVI',
+      recommended_pom_type: 'probation',
       event: AllocationVersion::REALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
     )
@@ -118,6 +120,7 @@ describe AllocationService do
       primary_pom_nomis_id: 485_737,
       allocated_at_tier: 'A',
       prison: 'LEI',
+      recommended_pom_type: 'probation',
       event: AllocationVersion::ALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
     )

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -43,6 +43,7 @@ describe OffenderService, vcr: { cassette_name: :offender_service_offenders_by_p
       created_by_username: 'PK000223',
       primary_pom_nomis_id: nomis_staff_id,
       primary_pom_allocated_at: DateTime.now.utc,
+      recommended_pom_type: 'prison',
       event: AllocationVersion::ALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
     )


### PR DESCRIPTION
We need to start recording the recommended POM type at the point where
the primary POM is allocated; this is so when we display the allocation
history  we know what the recommended POM type was at the time.