### PR TITLE
Update seeds file to include recommended POM type

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,6 +81,7 @@ AllocationService.create_or_update(
     created_by_username: 'PK000223',
     primary_pom_nomis_id: 485_637,
     primary_pom_allocated_at: DateTime.now.utc,
+    recommended_pom_type: 'probation',
     event: AllocationVersion::ALLOCATE_PRIMARY_POM,
     event_trigger: AllocationVersion::USER
   )
@@ -92,6 +93,7 @@ AllocationService.create_or_update(
   allocated_at_tier: 'B',
   created_by_username: 'PK000223',
   primary_pom_nomis_id: 485_737,
+  recommended_pom_type: 'probation',
   event: AllocationVersion::ALLOCATE_PRIMARY_POM,
   event_trigger: AllocationVersion::USER
   )
@@ -103,6 +105,7 @@ AllocationService.create_or_update(
   allocated_at_tier: 'D',
   created_by_username: 'PK000223',
   primary_pom_nomis_id: 485_833,
+  recommended_pom_type: 'prison',
   event: AllocationVersion::ALLOCATE_PRIMARY_POM,
   event_trigger: AllocationVersion::USER
 )


### PR DESCRIPTION
A recent change was made to the db where we have added
'recommended-pom-type' to the AllocationVersion.  This PR updates the
seeds file so the AllocationVersions being created have the new field.