### PR TITLE
Refactor get offenders for prison

### DIFF
--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -22,40 +22,78 @@ class OffenderService
     }
   end
 
-  # rubocop:disable Metrics/MethodLength
-  def self.get_offenders_for_prison(prison, page_number: 0, page_size: 10)
-    offenders = Nomis::Elite2::OffenderApi.list(
-      prison,
-      page_number,
-      page_size: page_size
-    ).data
+  class OffenderEnumerator
+    include Enumerable
+    FETCH_SIZE = 200 # How many records to fetch from nomis at a time
 
-    booking_ids = offenders.map(&:booking_id)
-    sentence_details = Nomis::Elite2::OffenderApi.get_bulk_sentence_details(booking_ids)
+    def initialize(prison)
+      @prison = prison
+    end
 
-    nomis_ids = offenders.map(&:offender_no)
-    mapped_tiers = CaseInformationService.get_case_information(nomis_ids)
+    def each
+      number_of_requests = max_requests_count
 
-    offenders.select { |offender|
-      next false if offender.age < 18
-      next false if SentenceType.civil?(offender.imprisonment_status)
+      (0..number_of_requests).each do |request_no|
+        offenders = get_offenders_for_prison(
+          page_number: request_no,
+          page_size: FETCH_SIZE
+        )
 
-      sentencing = sentence_details[offender.booking_id]
-      offender.sentence = sentencing if sentencing.present?
-      next false unless offender.sentenced?
-
-      record = mapped_tiers[offender.offender_no]
-      if record
-        offender.tier = record.tier
-        offender.case_allocation = record.case_allocation
-        offender.omicable = record.omicable == 'Yes'
-        offender.crn = record.crn
+        offenders.each { |offender| yield offender }
       end
+    end
 
-      true
-    }
+  private
+
+    def max_requests_count
+      # Fetch the first 1 prisoners just for the total number of pages so that we
+      # can send batched queries.
+      info_request = Nomis::Elite2::OffenderApi.list(@prison, 1, page_size: 1)
+
+      # The maximum number of pages we need to fetch before we have all of
+      # the offenders
+      (info_request.meta.total_pages / FETCH_SIZE) + 1
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def get_offenders_for_prison(page_number:, page_size:)
+      offenders = Nomis::Elite2::OffenderApi.list(
+        @prison,
+        page_number,
+        page_size: page_size
+      ).data
+
+      booking_ids = offenders.map(&:booking_id)
+      sentence_details = Nomis::Elite2::OffenderApi.get_bulk_sentence_details(booking_ids)
+
+      nomis_ids = offenders.map(&:offender_no)
+      mapped_tiers = CaseInformationService.get_case_information(nomis_ids)
+
+      offenders.select { |offender|
+        next false if offender.age < 18
+        next false if SentenceType.civil?(offender.imprisonment_status)
+
+        sentencing = sentence_details[offender.booking_id]
+        offender.sentence = sentencing if sentencing.present?
+        next false unless offender.sentenced?
+
+        record = mapped_tiers[offender.offender_no]
+        if record
+          offender.tier = record.tier
+          offender.case_allocation = record.case_allocation
+          offender.omicable = record.omicable == 'Yes'
+          offender.crn = record.crn
+        end
+
+        true
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
   end
-  # rubocop:enable Metrics/MethodLength
+
+  def self.get_offenders_for_prison(prison)
+    OffenderEnumerator.new(prison)
+  end
 
   def self.get_sentence_details(booking_ids)
     Nomis::Elite2::OffenderApi.get_bulk_sentence_details(booking_ids)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,47 +1,17 @@
 # frozen_string_literal: true
 
 class SearchService
-  FETCH_SIZE = 200
-
   # Fetch all of the offenders (for a given prison) filtering
   # out offenders based on the provided text.
   def self.search_for_offenders(text, prison)
     return [] if text.nil?
 
-    number_of_requests = max_requests_count(prison)
     search_term = text.upcase
-    search_results = []
 
-    (0..number_of_requests).each do |request_no|
-      offenders = OffenderService.get_offenders_for_prison(
-        prison,
-        page_number: request_no,
-        page_size: FETCH_SIZE
-      )
-      break if offenders.blank?
-
-      new_offenders = offenders.select { |offender|
-        offender.last_name.start_with?(search_term) ||
+    OffenderService.get_offenders_for_prison(prison).select do |offender|
+      offender.last_name.start_with?(search_term) ||
         offender.first_name.start_with?(search_term) ||
         offender.offender_no.include?(search_term)
-      }
-      next if new_offenders.blank?
-
-      search_results += new_offenders
     end
-
-    search_results
-  end
-
-private
-
-  def self.max_requests_count(prison)
-    # Fetch the first 1 prisoners just for the total number of pages so that we
-    # can send batched queries.
-    info_request = Nomis::Elite2::OffenderApi.list(prison, 1, page_size: 1)
-
-    # The maximum number of pages we need to fetch before we have all of
-    # the offenders
-    (info_request.meta.total_pages / FETCH_SIZE) + 1
   end
 end

--- a/lib/tasks/delius_etl.rake
+++ b/lib/tasks/delius_etl.rake
@@ -31,26 +31,7 @@ namespace :delius_etl do
 end
 
 def fetch_offenders(prison)
-  results = []
-
-  number_of_requests = max_requests_count(prison)
-  (0..number_of_requests).each do |request_no|
-    offenders = OffenderService.get_offenders_for_prison(
-      prison,
-      page_number: request_no,
-      page_size: 200
-    )
-    break if offenders.blank?
-
-    results << offenders.map(&:offender_no)
-  end
-
-  results.flatten
-end
-
-def max_requests_count(prison)
-  info_request = Nomis::Elite2::OffenderApi.list(prison, 1, page_size: 1)
-  (info_request.meta.total_pages / 200) + 1
+  OffenderService.get_offenders_for_prison(prison).map(&:offender_no)
 end
 
 def load_delius_records(file)

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -1,18 +1,20 @@
 require 'rails_helper'
 
 describe OffenderService do
+  let(:tier_map) { CaseInformationService.get_case_information('LEI') }
+
   it "get first page of offenders for a specific prison",
      vcr: { cassette_name: :offender_service_offenders_by_prison_first_page_spec } do
-    offenders = described_class.get_offenders_for_prison('LEI', page_number: 0, page_size: 10)
+    offenders = described_class.get_offenders_for_prison('LEI').first(9)
     expect(offenders).to be_kind_of(Array)
     expect(offenders.length).to eq(9)
     expect(offenders.first).to be_kind_of(Nomis::Models::OffenderSummary)
   end
 
   it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
-    offenders = described_class.get_offenders_for_prison('LEI', page_number: 93, page_size: 10)
+    offenders = described_class.get_offenders_for_prison('LEI').to_a
     expect(offenders).to be_kind_of(Array)
-    expect(offenders.length).to eq(1)
+    expect(offenders.length).to eq(816)
     expect(offenders.first).to be_kind_of(Nomis::Models::OffenderSummary)
   end
 
@@ -31,7 +33,7 @@ describe OffenderService do
 
   it "gets the POM names for allocated offenders",
      vcr: { cassette_name: :offender_service_pom_names_spec } do
-    offenders = described_class.get_offenders_for_prison('LEI', page_size: 3, page_number: 0)
+    offenders = described_class.get_offenders_for_prison('LEI').first(3)
     nomis_staff_id = 485_752
 
     PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov'
 
-SimpleCov.minimum_coverage 50
+SimpleCov.minimum_coverage 97
 
 SimpleCov.start 'rails' do
   add_filter '/gems/'


### PR DESCRIPTION
get_offenders_for_prison now returns an enumerator, as all 3 of its callers just want the entire list without wanting the noise of splitting the NOMIS accesses into pages.