### PR TITLE
Increase max method size

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,7 +99,7 @@ Metrics/LineLength:
 
 # Don't worry about long methods in specs.
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
   Exclude:
     - 'spec/**/*'
     - 'app/helpers/form_elements_helper.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,7 +99,7 @@ Metrics/LineLength:
 
 # Don't worry about long methods in specs.
 Metrics/MethodLength:
-  Max: 10
+  Max: 15
   Exclude:
     - 'spec/**/*'
     - 'app/helpers/form_elements_helper.rb'

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/LineLength
-# rubocop:disable Metrics/MethodLength
 class AllocationsController < PrisonsApplicationController
   delegate :update, to: :create
 
@@ -194,4 +193,3 @@ private
   end
 end
 # rubocop:enable Metrics/LineLength
-# rubocop:enable Metrics/MethodLength

--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -9,7 +9,6 @@ class CaseloadController < PrisonsApplicationController
 
   PAGE_SIZE = 10
 
-  # rubocop:disable Metrics/MethodLength
   def index
     allocations = PrisonOffenderManagerService.get_allocated_offenders(
       @pom.staff_id, active_prison
@@ -26,7 +25,6 @@ class CaseloadController < PrisonsApplicationController
 
     @page_meta = new_page_meta(@total_allocations, @allocations.count)
   end
-  # rubocop:enable Metrics/MethodLength
 
   def new
     @new_cases = PrisonOffenderManagerService.get_allocated_offenders(
@@ -51,7 +49,6 @@ private
     allocations
   end
 
-  # rubocop:disable Metrics/MethodLength
   def filter_allocations(allocations)
     if params['q'].present?
       @q = params['q']
@@ -67,7 +64,6 @@ private
     end
     allocations
   end
-  # rubocop:enable Metrics/MethodLength
 
   def ensure_pom
     @pom = PrisonOffenderManagerService.get_signed_in_pom_details(

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -10,7 +10,6 @@ class OverridesController < PrisonsApplicationController
     @override = Override.new
   end
 
-  # rubocop:disable Metrics/MethodLength
   def create
     @override = AllocationService.create_override(
       nomis_staff_id: override_params[:nomis_staff_id],
@@ -30,7 +29,6 @@ class OverridesController < PrisonsApplicationController
 
     render :new
   end
-# rubocop:enable Metrics/MethodLength
 
 private
 

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -26,7 +26,6 @@ class PomsController < PrisonsApplicationController
     @errors = {}
   end
 
-  # rubocop:disable Metrics/MethodLength
   def update
     @pom = PrisonOffenderManagerService.get_pom(active_prison, params[:nomis_staff_id])
 
@@ -44,7 +43,6 @@ class PomsController < PrisonsApplicationController
     update_record_for_errors(pom_detail)
     render :edit
   end
-# rubocop:enable Metrics/MethodLength
 
 private
 

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -9,7 +9,6 @@ module PomHelper
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
   def working_pattern_to_days(pattern)
     ['',
      'half a day',
@@ -23,5 +22,4 @@ module PomHelper
      'four and a half days'
     ][pattern]
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module SearchHelper
-  # rubocop:disable Metrics/MethodLength
   def cta_for_offender(prison, offender)
     offender_id = offender.offender_no
 
@@ -24,5 +23,4 @@ module SearchHelper
       new_prison_allocation_path(prison, nomis_offender_id: offender_id)
     )
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PomMailer < GovukNotifyRails::Mailer
-  # rubocop:disable Metrics/MethodLength
   def new_allocation_email(params = {})
     message = "Additional information: #{params[:message]}" if params[:message].present?
     set_template('9679ea4c-1495-4fa6-a00b-630de715e315')
@@ -35,4 +34,3 @@ class PomMailer < GovukNotifyRails::Mailer
     mail(to: params[:previous_pom_email])
   end
 end
-# rubocop:enable Metrics/MethodLength

--- a/app/models/allocation_list.rb
+++ b/app/models/allocation_list.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class AllocationList < Array
-  # rubocop:disable Metrics/MethodLength
   def grouped_by_prison(&_block)
     # Groups the allocations in this array by the prison that it relates to.
     # Unfortunately we can't put this in a hash because a prisoner may have been
@@ -30,5 +29,4 @@ class AllocationList < Array
       break if idx >= last_idx
     end
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -64,7 +64,6 @@ class AllocationVersion < ApplicationRecord
     !allocation.nil? && !allocation.primary_pom_nomis_id.nil?
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.deallocate_offender(nomis_offender_id, movement_type)
     alloc = AllocationVersion.find_by(
       nomis_offender_id: nomis_offender_id
@@ -83,7 +82,6 @@ class AllocationVersion < ApplicationRecord
 
     alloc.save!
   end
-  # rubocop:enable Metrics/MethodLength
 
   def self.deallocate_primary_pom(nomis_staff_id)
     all_primary_pom_allocations(nomis_staff_id).each do |alloc|

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class MovementService
-  # rubocop:disable Metrics/MethodLength
   def self.movements_on(date, direction_filters: [], type_filters: [])
     movements = Nomis::Elite2::MovementApi.movements_on_date(date)
 
@@ -19,8 +18,6 @@ class MovementService
 
     movements
   end
-
-  # rubocop:enable Metrics/MethodLength
 
   def self.process_movement(movement)
     if movement.movement_type == Nomis::Models::MovementType::RELEASE

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -30,7 +30,6 @@ module Nomis
       response.body
     end
 
-    # rubocop:disable Metrics/MethodLength
     def get(route, queryparams: {}, extra_headers: {})
       response = request(
         :get, route, queryparams: queryparams, extra_headers: extra_headers
@@ -59,11 +58,9 @@ module Nomis
 
       JSON.parse(response.body)
     end
-  # rubocop:enable Metrics/MethodLength
 
   private
 
-    # rubocop:disable Metrics/MethodLength
     def request(method, route, queryparams: {}, extra_headers: {}, body: nil)
       @connection.send(method) do |req|
         req.url(@root + route)
@@ -80,7 +77,6 @@ module Nomis
       AllocationManager::ExceptionHandler.capture_exception(e)
       raise APIError, "Unexpected status #{e.response[:status]}"
     end
-    # rubocop:enable Metrics/MethodLength
 
     def token
       Nomis::Oauth::TokenService.valid_token

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -66,7 +66,6 @@ module Nomis
         data.first['classificationCode']
       end
 
-      # rubocop:disable Metrics/MethodLength
       def self.get_bulk_sentence_details(booking_ids)
         return {} if booking_ids.empty?
 
@@ -91,7 +90,6 @@ module Nomis
           hash
         }
       end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -63,7 +63,6 @@ class OffenderService
 
   # Takes a list of OffenderSummary or Offender objects, and returns them with their
   # allocated POM name set in :allocated_pom_name
-  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/LineLength
   def self.set_allocated_pom_name(offenders, caseload)
     pom_names = PrisonOffenderManagerService.get_pom_names(caseload)
@@ -89,5 +88,4 @@ class OffenderService
     end
   end
   # rubocop:enable Metrics/LineLength
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class OffenderService
-  # rubocop:disable Metrics/MethodLength
   def self.get_offender(offender_no)
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
       record = CaseInformation.find_by(nomis_offender_id: offender_no)
@@ -22,8 +21,6 @@ class OffenderService
       o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)
     }
   end
-
-  # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/MethodLength
   def self.get_offenders_for_prison(prison, page_number: 0, page_size: 10)

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -55,7 +55,6 @@ class PrisonOffenderManagerService
     AllocationVersion.active_primary_pom_allocations(nomis_staff_id, prison)
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.get_allocated_offenders(nomis_staff_id, prison)
     allocation_list = get_allocations_for_primary_pom(nomis_staff_id, prison)
 
@@ -88,7 +87,6 @@ class PrisonOffenderManagerService
       AllocationWithSentence.new(alloc, offender_map[alloc.nomis_booking_id])
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def self.unavailable_pom_count(prison)
     poms = PrisonOffenderManagerService.get_poms(prison) { |pom|

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -7,7 +7,6 @@ class ResponsibilityService
 
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/MethodLength
   def calculate_pom_responsibility(offender)
     return RESPONSIBLE if offender.sentence.earliest_release_date.nil?
     return SUPPORTING unless omicable?(offender)
@@ -34,7 +33,7 @@ class ResponsibilityService
       !new_case?(offender) &&
       !release_date_gt_15_mths?(offender)
   end
-# rubocop:enable Metrics/MethodLength
+
 # rubocop:enable Metrics/PerceivedComplexity
 # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -5,7 +5,6 @@ class SearchService
 
   # Fetch all of the offenders (for a given prison) filtering
   # out offenders based on the provided text.
-  # rubocop:disable Metrics/MethodLength
   def self.search_for_offenders(text, prison)
     return [] if text.nil?
 
@@ -33,7 +32,6 @@ class SearchService
 
     search_results
   end
-# rubocop:enable Metrics/MethodLength
 
 private
 

--- a/lib/delius/manual_extractor.rb
+++ b/lib/delius/manual_extractor.rb
@@ -17,7 +17,6 @@ module Delius
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/MethodLength
     def fetch_records
       records = []
 
@@ -42,7 +41,6 @@ module Delius
       records
     end
   # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -11,7 +11,6 @@ class OnboardPrison
     @delius_missing = 0
   end
 
-  # rubocop:disable Metrics/MethodLength
   def complete_missing_info
     @offender_ids.each { |offender_id|
       record = @delius_records[offender_id]
@@ -31,7 +30,6 @@ class OnboardPrison
       @additions += 1
     }
   end
-# rubocop:enable Metrics/MethodLength
 
 private
 

--- a/lib/tasks/delius_etl.rake
+++ b/lib/tasks/delius_etl.rake
@@ -30,7 +30,6 @@ namespace :delius_etl do
   end
 end
 
-# rubocop:disable Metrics/MethodLength
 def fetch_offenders(prison)
   results = []
 
@@ -48,7 +47,6 @@ def fetch_offenders(prison)
 
   results.flatten
 end
-# rubocop:enable Metrics/MethodLength
 
 def max_requests_count(prison)
   info_request = Nomis::Elite2::OffenderApi.list(prison, 1, page_size: 1)


### PR DESCRIPTION
This PR increases the Rubocop-enforced maximum method length to 20 lines.

(a) Rubocop can't count - it thinks that a well-spaced 5-parameter method call is 5 lines long
(b) we currently mostly work round it by disabling Metrics/MethodLength anyway
