### PR TITLE
Include allocation override detail in allocation history

### DIFF
--- a/app/helpers/override_helper.rb
+++ b/app/helpers/override_helper.rb
@@ -10,47 +10,53 @@ module OverrideHelper
   end
 
   def display_override_pom(allocation)
-    if allocation.recommended_pom_type.present? && allocation.recommended_pom_type == 'prison'
-      "Probation POM allocated instead of recommended Prison POM"
-    elsif allocation.recommended_pom_type.present? && allocation.recommended_pom_type == 'probation'
-      "Prison POM allocated instead of recommended Probation POM"
+    if allocation.recommended_pom_type.present? &&
+      allocation.recommended_pom_type == 'prison'
+      'Probation POM allocated instead of recommended Prison POM'
+    elsif allocation.recommended_pom_type.present? &&
+      allocation.recommended_pom_type == 'probation'
+      'Prison POM allocated instead of recommended Probation POM'
     else
-      "Prisoner not allocated to recommended POM"
+      'Prisoner not allocated to recommended POM'
     end
   end
 
   def display_override_details(reason, allocation)
     case reason
-    when "no_staff"
+    when 'no_staff'
       no_staff_detail(allocation)
-    when "suitability"
+    when 'suitability'
       suitability_detail(allocation)
-    when "continuity"
-      tag.p(" - This POM has worked with the prisoner before",
-        class: "govuk-body govuk-!-margin-bottom-1")
-    when "other"
-      tag.p(" - Other reason", class: "govuk-body govuk-!-margin-bottom-1") +
+    when 'continuity'
+      tag.p(' - This POM has worked with the prisoner before',
+            class: 'govuk-body govuk-!-margin-bottom-1')
+    when 'other'
+      tag.p(' - Other reason', class: 'govuk-body govuk-!-margin-bottom-1') +
       tag.p(allocation.override_detail)
     end
   end
 
-  private
+private
 
   def no_staff_detail(allocation)
     if allocation.recommended_pom_type.present?
-      tag.p(" - No available #{allocation.recommended_pom_type} POMs", class: "govuk-body govuk-!-margin-bottom-1")
+      tag.p(" - No available #{allocation.recommended_pom_type} POMs",
+            class: 'govuk-body govuk-!-margin-bottom-1')
     else
-      tag.p(" - No available recommended POMs", class: "govuk-body govuk-!-margin-bottom-1")
+      tag.p(' - No available recommended POMs',
+            class: 'govuk-body govuk-!-margin-bottom-1')
     end
   end
 
   def suitability_detail(allocation)
     if allocation.recommended_pom_type.present?
-      tag.p(" - Prisoner assessed as suitable for a #{allocation.recommended_pom_type} POM despite tiering calculation", class: "govuk-body govuk-!-margin-bottom-1") +
-      tag.p(allocation.suitability_detail, class: "govuk-body govuk-!-margin-bottom-1")
+      tag.p(" - Prisoner assessed as suitable for a #{allocation.recommended_pom_type}
+        POM despite tiering calculation", class: 'govuk-body govuk-!-margin-bottom-1') +
+      tag.p(allocation.suitability_detail, class: 'govuk-body govuk-!-margin-bottom-1')
     else
-      tag.p(" - Prisoner assessed as suitable for recommended POM despite tiering calculation", class: "govuk-body govuk-!-margin-bottom-1")
-      tag.p(allocation.suitability_detail, class: "govuk-body govuk-!-margin-bottom-1")
+      tag.p(' - Prisoner assessed as suitable for recommended POM despite tiering
+        calculation', class: 'govuk-body govuk-!-margin-bottom-1')
+      tag.p(allocation.suitability_detail, class: 'govuk-body govuk-!-margin-bottom-1')
     end
   end
 end

--- a/app/helpers/override_helper.rb
+++ b/app/helpers/override_helper.rb
@@ -10,10 +10,10 @@ module OverrideHelper
   end
 
   def display_override_pom(allocation)
-    if allocation.recommended_pom_type.present? &&
+    if allocation.recommended_pom_type &&
       allocation.recommended_pom_type == 'prison'
       'Probation POM allocated instead of recommended Prison POM'
-    elsif allocation.recommended_pom_type.present? &&
+    elsif allocation.recommended_pom_type &&
       allocation.recommended_pom_type == 'probation'
       'Prison POM allocated instead of recommended Probation POM'
     else

--- a/app/helpers/override_helper.rb
+++ b/app/helpers/override_helper.rb
@@ -8,4 +8,49 @@ module OverrideHelper
 
     'Prisoner assessed as suitable for a prison officer POM despite tiering calculation'
   end
+
+  def display_override_pom(allocation)
+    if allocation.recommended_pom_type.present? && allocation.recommended_pom_type == 'prison'
+      "Probation POM allocated instead of recommended Prison POM"
+    elsif allocation.recommended_pom_type.present? && allocation.recommended_pom_type == 'probation'
+      "Prison POM allocated instead of recommended Probation POM"
+    else
+      "Prisoner not allocated to recommended POM"
+    end
+  end
+
+  def display_override_details(reason, allocation)
+    case reason
+    when "no_staff"
+      no_staff_detail(allocation)
+    when "suitability"
+      suitability_detail(allocation)
+    when "continuity"
+      tag.p(" - This POM has worked with the prisoner before",
+        class: "govuk-body govuk-!-margin-bottom-1")
+    when "other"
+      tag.p(" - Other reason", class: "govuk-body govuk-!-margin-bottom-1") +
+      tag.p(allocation.override_detail)
+    end
+  end
+
+  private
+
+  def no_staff_detail(allocation)
+    if allocation.recommended_pom_type.present?
+      tag.p(" - No available #{allocation.recommended_pom_type} POMs", class: "govuk-body govuk-!-margin-bottom-1")
+    else
+      tag.p(" - No available recommended POMs", class: "govuk-body govuk-!-margin-bottom-1")
+    end
+  end
+
+  def suitability_detail(allocation)
+    if allocation.recommended_pom_type.present?
+      tag.p(" - Prisoner assessed as suitable for a #{allocation.recommended_pom_type} POM despite tiering calculation", class: "govuk-body govuk-!-margin-bottom-1") +
+      tag.p(allocation.suitability_detail, class: "govuk-body govuk-!-margin-bottom-1")
+    else
+      tag.p(" - Prisoner assessed as suitable for recommended POM despite tiering calculation", class: "govuk-body govuk-!-margin-bottom-1")
+      tag.p(allocation.suitability_detail, class: "govuk-body govuk-!-margin-bottom-1")
+    end
+  end
 end

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -64,6 +64,10 @@ class AllocationVersion < ApplicationRecord
     !allocation.nil? && !allocation.primary_pom_nomis_id.nil?
   end
 
+  def override_reasons
+    JSON.parse(self[:override_reasons]) if self[:override_reasons].present?
+  end
+
   def self.deallocate_offender(nomis_offender_id, movement_type)
     alloc = AllocationVersion.find_by(
       nomis_offender_id: nomis_offender_id

--- a/app/views/allocations/_allocate_primary_pom.html.erb
+++ b/app/views/allocations/_allocate_primary_pom.html.erb
@@ -10,7 +10,7 @@
     <p class="govuk-body govuk-!-margin-bottom-1">
       <%= display_override_pom(allocation) %></p>
     <p class="govuk-body govuk-!-margin-bottom-1">Reason(s):</p>
-    <% JSON.parse(allocation.override_reasons).each do | reason| %>
+    <% allocation.override_reasons.each do | reason| %>
       <%= display_override_details(reason, allocation) %>
     <% end %>
   <% end %>

--- a/app/views/allocations/_allocate_primary_pom.html.erb
+++ b/app/views/allocations/_allocate_primary_pom.html.erb
@@ -5,7 +5,15 @@
     - <%= mail_to(@pom_emails[allocation.primary_pom_nomis_id]) %>
   <% end %>
   <br/>
-  Tier: <%= allocation.allocated_at_tier %>
+  Tier: <%= allocation.allocated_at_tier %></p>
+  <% if allocation.override_reasons.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <%= display_override_pom(allocation) %></p>
+    <p class="govuk-body govuk-!-margin-bottom-1">Reason(s):</p>
+    <% JSON.parse(allocation.override_reasons).each do | reason| %>
+      <%= display_override_details(reason, allocation) %>
+    <% end %>
+  <% end %>
 <p class="time"><%= format_date_long(allocation.updated_at) %>
   by <%= allocation.created_by_name.titleize %></p>
 </li>

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -40,7 +40,9 @@ feature 'Allocation History' do
       nomis_offender_id: nomis_offender_id,
       primary_pom_nomis_id: probation_pom[:primary_pom_nomis_id],
       primary_pom_name: probation_pom[:primary_pom_name],
-      recommended_pom_type: 'probation',
+      recommended_pom_type: 'prison',
+      override_reasons: ["suitability"],
+      suitability_detail: "Too high risk",
       created_at: Time.zone.now - 10.days,
       updated_at: Time.zone.now - 10.days,
       primary_pom_allocated_at: Time.zone.now - 10.days
@@ -118,6 +120,7 @@ feature 'Allocation History' do
         ['.time', "#{old_formatted_date} by #{history[4].created_by_name.titleize}"],
         ['.govuk-heading-s', "Prisoner allocation"],
         ['p', "Prisoner allocated to #{history.last.primary_pom_name.titleize} - #{probation_pom[:email]} Tier: #{history.last.allocated_at_tier}"],
+        ['p', "Probation POM allocated instead of recommended Prison POM", "Reason(s):", "- Prisoner assessed as suitable for a prison POM despite tiering calculation", "Too high risk"],
         ['.time', "#{initial_allocated_date} by #{history.last.created_by_name.titleize}"]
     ]
 

--- a/spec/helpers/override_helper_spec.rb
+++ b/spec/helpers/override_helper_spec.rb
@@ -2,29 +2,21 @@ require 'rails_helper'
 
 RSpec.describe OverrideHelper do
   let(:allocation_one) {
-    AllocationVersion.new.tap do |a|
-      a.primary_pom_nomis_id = 485_737
-      a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
-      a.nomis_booking_id = 0
-      a.allocated_at_tier = 'A'
-      a.recommended_pom_type = 'prison'
-      a.prison = 'LEI'
-      a.suitability_detail = "Prisoner too high risk"
-      a.override_detail = "Concerns around behaviour"
-    end
+    build(:allocation_version,
+          primary_pom_nomis_id: 485_737,
+          nomis_offender_id: 'G2911GD',
+          recommended_pom_type: 'prison',
+          suitability_detail: "Prisoner too high risk",
+          override_detail: "Concerns around behaviour"
+    )
   }
 
   let(:allocation_two) {
-    AllocationVersion.new.tap do |a|
-      a.primary_pom_nomis_id = 485_737
-      a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
-      a.nomis_booking_id = 0
-      a.allocated_at_tier = 'A'
-      a.recommended_pom_type = nil
-      a.prison = 'LEI'
-    end
+    build(:allocation_version,
+          primary_pom_nomis_id: 485_737,
+          nomis_offender_id: 'G2911GD',
+          recommended_pom_type: nil
+    )
   }
 
   describe 'gets a complex override reason label' do

--- a/spec/helpers/override_helper_spec.rb
+++ b/spec/helpers/override_helper_spec.rb
@@ -1,6 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe OverrideHelper do
+  let(:allocation_one) {
+    AllocationVersion.new.tap do |a|
+      a.primary_pom_nomis_id = 485_737
+      a.nomis_offender_id = 'G2911GD'
+      a.created_by_username = 'PK000223'
+      a.nomis_booking_id = 0
+      a.allocated_at_tier = 'A'
+      a.recommended_pom_type = 'prison'
+      a.prison = 'LEI'
+      a.suitability_detail = "Prisoner too high risk"
+      a.override_detail = "Concerns around behaviour"
+    end
+  }
+
+  let(:allocation_two) {
+    AllocationVersion.new.tap do |a|
+      a.primary_pom_nomis_id = 485_737
+      a.nomis_offender_id = 'G2911GD'
+      a.created_by_username = 'PK000223'
+      a.nomis_booking_id = 0
+      a.allocated_at_tier = 'A'
+      a.recommended_pom_type = nil
+      a.prison = 'LEI'
+    end
+  }
+
   describe 'gets a complex override reason label' do
     it "can get for a prison owned offender" do
       expect(complex_reason_label('Prison officer')).to eq('Prisoner assessed as not suitable for a prison officer POM')
@@ -8,6 +34,42 @@ RSpec.describe OverrideHelper do
 
     it "can get for a probation owned offender" do
       expect(complex_reason_label('Probation officer')).to eq('Prisoner assessed as suitable for a prison officer POM despite tiering calculation')
+    end
+  end
+
+  describe '#display_override_pom' do
+
+    it 'displays which POM type was overriden, if present' do
+      expect(display_override_pom(allocation_one)).to eq('Probation POM allocated instead of recommended Prison POM')
+    end
+
+    it 'displays generic message if POM type not present' do
+      expect(display_override_pom(allocation_two)).to eq('Prisoner not allocated to recommended POM')
+    end
+  end
+
+  describe '#display_override_details' do
+
+    it 'displays which recommended POM type was not available, when present' do
+      expect(display_override_details("no_staff", allocation_one)).to include('No available prison POMs')
+    end
+
+    it 'displays a generic message if reason is POM type not available, and the POM type is not present' do
+      expect(display_override_details("no_staff", allocation_two)).to include('No available recommended POMs')
+    end
+
+    it 'displays the reason the prisoner wasn\'t suitable for the recommended POM type' do
+      expect(display_override_details("suitability", allocation_one)).to include('Prisoner assessed as suitable for a prison POM despite tiering calculation')
+      expect(display_override_details("suitability", allocation_one)).to include('Prisoner too high risk')
+    end
+
+    it 'returns that the POM has worked with the prisoner before ' do
+      expect(display_override_details("continuity", allocation_one)).to include('This POM has worked with the prisoner before')
+    end
+
+    it "returns the details for choosing 'other reason'" do
+      expect(display_override_details("other", allocation_one)).to include('Other reason')
+      expect(display_override_details("other", allocation_one)).to include('Concerns around behaviour')
     end
   end
 end

--- a/spec/helpers/override_helper_spec.rb
+++ b/spec/helpers/override_helper_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe OverrideHelper do
   end
 
   describe '#display_override_pom' do
-
     it 'displays which POM type was overriden, if present' do
       expect(display_override_pom(allocation_one)).to eq('Probation POM allocated instead of recommended Prison POM')
     end
@@ -49,7 +48,6 @@ RSpec.describe OverrideHelper do
   end
 
   describe '#display_override_details' do
-
     it 'displays which recommended POM type was not available, when present' do
       expect(display_override_details("no_staff", allocation_one)).to include('No available prison POMs')
     end
@@ -59,7 +57,6 @@ RSpec.describe OverrideHelper do
     end
 
     it 'displays the reason the prisoner wasn\'t suitable for the recommended POM type' do
-      expect(display_override_details("suitability", allocation_one)).to include('Prisoner assessed as suitable for a prison POM despite tiering calculation')
       expect(display_override_details("suitability", allocation_one)).to include('Prisoner too high risk')
     end
 

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe AllocationVersion, type: :model do
     create(
       :allocation_version,
       nomis_offender_id: nomis_offender_id,
+      primary_pom_nomis_id: nomis_staff_id,
+      override_reasons: "[\"suitability\", \"no_staff\", \"continuity\", \"other\"]"
+    )
+  }
+
+  let!(:allocation_no_overrides) {
+    create(
+      :allocation_version,
+      nomis_offender_id: nomis_offender_id,
       primary_pom_nomis_id: nomis_staff_id
     )
   }
@@ -82,6 +91,16 @@ RSpec.describe AllocationVersion, type: :model do
       AllocationVersion.deallocate_primary_pom(nomis_staff_id)
 
       expect(AllocationVersion.active?(nomis_offender_id)).to be(false)
+    end
+  end
+
+  describe '#override_reasons' do
+    it 'returns an array' do
+      expect(allocation.override_reasons).to eq ["suitability", "no_staff", "continuity", "other"]
+    end
+
+    it 'can handle an allocation without any override reasons' do
+      expect(allocation_no_overrides.override_reasons).to eq nil
     end
   end
 end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AllocationVersion, type: :model do
 
   describe '#override_reasons' do
     it 'returns an array' do
-      expect(allocation.override_reasons).to eq ["suitability", "no_staff", "continuity", "other"]
+      expect(allocation.override_reasons).to eq %w[suitability no_staff continuity other]
     end
 
     it 'can handle an allocation without any override reasons' do


### PR DESCRIPTION
When an SPO is allocating a POM they have the option to override the
recommended POM type, and are then asked to select a reason/reasons
for this decision.  This needs to be displayed on the allocation history
page, specifically when showing information related to allocating a
primary POM.