### PR TITLE
Re-instate the cache in tests so that they succeed

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,6 @@ Rails.application.configure do
 
   config.action_controller.perform_caching = false
   config.active_job.queue_adapter = :inline
-  config.cache_store = :null_store
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
We had previously added `config.cache_store = :null_store` in an attempt
to remove caching in test, but it appears this introduced problems with
some of our longer running tests.  This is likely an issue with patterns
of usage and the T3 environment (e.g. it doesn't like large amounts of
traffic in short periods of time).

After this PR, tests run reliably.