### PR TITLE
Fix breakage when offender is allocated but not sentenced

### DIFF
--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -63,6 +63,8 @@ private
   end
 
   def new_case?(offender)
-    @new_case ||= offender.sentence.sentence_start_date > DateTime.new(2019, 2, 4).utc
+    return true unless offender.sentenced?
+
+    offender.sentence.sentence_start_date > DateTime.new(2019, 2, 4).utc
   end
 end

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "get poms list" do
+  let!(:offender_missing_sentence_case_info) { create(:case_information, nomis_offender_id: 'G7949GQ') }
+
   it "shows the page", vcr: { cassette_name: :show_poms_feature_list } do
     signin_user
 
@@ -13,6 +15,18 @@ feature "get poms list" do
 
     expect(page).to have_css('.govuk-breadcrumbs')
     expect(page).to have_css('.govuk-breadcrumbs__link', count: 2)
+  end
+
+  it "handles missing sentence data", vcr: { cassette_name: :show_poms_feature_missing_sentence } do
+    signin_user('PK000223')
+
+    visit prison_confirm_allocation_path('LEI', offender_missing_sentence_case_info.nomis_offender_id, 485_637)
+    click_button 'Complete allocation'
+
+    visit prison_pom_path('LEI', 485_637)
+
+    expect(page).to have_css(".govuk-table__row", count: 2)
+    expect(page).to have_content(offender_missing_sentence_case_info.nomis_offender_id)
   end
 
   it "allows viewing a POM", vcr: { cassette_name: :show_poms_feature_view } do


### PR DESCRIPTION
Currently it is possible that an offender may be allocated, but not
sentenced. If this is the case, the responsibility service is unable to
work out if it is a new case or not.

When determining if the offender is a new case, it will now return true
if the offender is not sentenced.