### PR TITLE
Secondary allocations on caseload page

### DIFF
--- a/app/models/allocation_with_sentence.rb
+++ b/app/models/allocation_with_sentence.rb
@@ -6,11 +6,14 @@ class AllocationWithSentence
   delegate :last_name, :full_name, :earliest_release_date,
            :sentence_start_date, to: :@sentence
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at,
-           :responsibility, :allocated_at_tier, to: :@allocation
+           :allocated_at_tier, to: :@allocation
 
-  def initialize(allocation, sentence)
+  attr_reader :responsibility
+
+  def initialize(allocation, sentence, responsibility)
     @allocation = allocation
     @sentence = sentence
+    @responsibility = responsibility
   end
 
   def new_case?

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 class PrisonOffenderManagerService
-  def self.get_pom_detail(nomis_staff_id)
-    PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id.to_i) { |s|
-      s.working_pattern = s.working_pattern || 0.0
-      s.status = s.status || 'active'
-    }
-  end
-
   # Note - get_poms and get_pom return different data...
   def self.get_poms(prison)
     poms = Nomis::Elite2::PrisonOffenderManagerApi.list(prison)
@@ -53,24 +46,24 @@ class PrisonOffenderManagerService
     [user.first_name, user.last_name]
   end
 
-  def self.get_allocations_for_primary_pom(nomis_staff_id, prison)
-    AllocationVersion.active_primary_pom_allocations(nomis_staff_id, prison)
-  end
-
+  # rubocop:disable Metrics/MethodLength
   def self.get_allocated_offenders(nomis_staff_id, prison)
-    allocation_list = get_allocations_for_primary_pom(nomis_staff_id, prison)
+    allocation_list = AllocationVersion.active_pom_allocations(
+      nomis_staff_id,
+      prison
+    )
 
     offender_ids = allocation_list.map(&:nomis_offender_id)
     booking_ids = allocation_list.map(&:nomis_booking_id)
 
     # Get an offender map of offender_id to sentence details and a hash of
-    # offender_no to case info details so we can fill in a fake offender
+    # offender_no to case_info_details so we can fill in a fake offender
     # object for each allocation. This will allow us to calculate the
     # pom responsibility without having to make an API request per-offender.
     offender_map = OffenderService.get_sentence_details(booking_ids)
     case_info = CaseInformationService.get_case_info_for_offenders(offender_ids)
 
-    allocation_list.each do |alloc|
+    allocation_list.map do |alloc|
       offender_stub = Nomis::Models::Offender.new
       offender_stub.sentence = offender_map[alloc.nomis_booking_id]
 
@@ -81,14 +74,20 @@ class PrisonOffenderManagerService
         offender_stub.omicable = record.omicable
       end
 
-      alloc.responsibility =
-        ResponsibilityService.new.calculate_pom_responsibility(offender_stub)
-    end
-
-    allocation_list.map do |alloc|
-      AllocationWithSentence.new(alloc, offender_map[alloc.nomis_booking_id])
+      if alloc.for_primary_only?
+        responsibility =
+          ResponsibilityService.new.calculate_pom_responsibility(offender_stub)
+      else
+        responsibility = 'Co-Working'
+      end
+      AllocationWithSentence.new(
+        alloc,
+        offender_map[alloc.nomis_booking_id],
+        responsibility
+      )
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def self.unavailable_pom_count(prison)
     poms = PrisonOffenderManagerService.get_poms(prison).reject { |pom|
@@ -115,5 +114,14 @@ class PrisonOffenderManagerService
     end
 
     pom
+  end
+
+private
+
+  def self.get_pom_detail(nomis_staff_id)
+    PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id.to_i) { |s|
+      s.working_pattern = s.working_pattern || 0.0
+      s.status = s.status || 'active'
+    }
   end
 end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -132,4 +132,33 @@ RSpec.describe AllocationVersion, type: :model do
       expect(allocation_no_overrides.override_reasons).to eq nil
     end
   end
+
+  describe '#active_pom_allocations' do
+    let!(:secondary_allocation) {
+      create(
+        :allocation_version,
+        nomis_offender_id: nomis_offender_id,
+        secondary_pom_nomis_id: nomis_staff_id
+      )
+    }
+    let!(:another_allocation) {
+      create(
+        :allocation_version,
+        nomis_offender_id: nomis_offender_id,
+        primary_pom_nomis_id: 27
+      )
+    }
+    let!(:another_prison) {
+      create(
+        :allocation_version,
+        nomis_offender_id: nomis_offender_id,
+        primary_pom_nomis_id: nomis_staff_id,
+        prison: 'RSI'
+      )
+    }
+
+    it 'returns both primary and secondary allocations' do
+      expect(AllocationVersion.active_pom_allocations(nomis_staff_id, 'LEI')).to match_array [secondary_allocation, allocation]
+    end
+  end
 end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe AllocationVersion, type: :model do
     )
   }
 
-  let!(:allocation_no_overrides) {
-    create(
-      :allocation_version,
-      nomis_offender_id: nomis_offender_id,
-      primary_pom_nomis_id: nomis_staff_id
-    )
-  }
-
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:nomis_offender_id) }
     it { is_expected.to validate_presence_of(:nomis_booking_id) }
@@ -124,6 +116,14 @@ RSpec.describe AllocationVersion, type: :model do
   end
 
   describe '#override_reasons' do
+    let!(:allocation_no_overrides) {
+      create(
+        :allocation_version,
+        nomis_offender_id: nomis_offender_id,
+        primary_pom_nomis_id: nomis_staff_id
+      )
+    }
+
     it 'returns an array' do
       expect(allocation.override_reasons).to eq %w[suitability no_staff continuity other]
     end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -3,120 +3,133 @@ require 'rails_helper'
 describe PrisonOffenderManagerService do
   let(:staff_id) { 485_737 }
 
-  let(:allocation_one) {
-    create(
-      :allocation_version,
-      primary_pom_nomis_id: staff_id,
-      nomis_offender_id: 'G4273GI',
-      nomis_booking_id: 1_153_753
-      )
-  }
-
-  let(:allocation_two) {
-    create(
-      :allocation_version,
-      primary_pom_nomis_id: staff_id,
-      nomis_offender_id: 'G8060UF',
-      nomis_booking_id: 971_856
-      )
-  }
-
-  let(:allocation_three) {
-    create(
-      :allocation_version,
-      primary_pom_nomis_id: staff_id,
-      nomis_offender_id: 'G8624GK',
-      nomis_booking_id: 76_908
-      )
-  }
-
-  let(:allocation_four) {
-    create(
-      :allocation_version,
-      primary_pom_nomis_id: staff_id,
-      nomis_offender_id: 'G1714GU',
-      nomis_booking_id: 31_777
-      )
-  }
-
-  let!(:all_allocations) {
-    [allocation_one, allocation_two, allocation_three, allocation_four]
-  }
-
   before(:each) {
     PomDetail.create(nomis_staff_id: 485_637, working_pattern: 1.0, status: 'inactive')
   }
 
-  it "can get staff names",
-     vcr: { cassette_name: :pom_service_staff_name } do
-    fname, lname = described_class.get_pom_name(staff_id)
-    expect(fname).to eq('JAY')
-    expect(lname).to eq('HEAL')
+  describe '#get_pom_name' do
+    it "can get staff names",
+       vcr: { cassette_name: :pom_service_staff_name } do
+      fname, lname = described_class.get_pom_name(staff_id)
+      expect(fname).to eq('JAY')
+      expect(lname).to eq('HEAL')
+    end
   end
 
-  it "can get user names",
-     vcr: { cassette_name: :pom_service_user_name } do
-    fname, lname = described_class.get_user_name('RJONES')
-    expect(fname).to eq('ROSS')
-    expect(lname).to eq('JONES')
+  describe '#get_user_name' do
+    it "can get user names",
+       vcr: { cassette_name: :pom_service_user_name } do
+      fname, lname = described_class.get_user_name('RJONES')
+      expect(fname).to eq('ROSS')
+      expect(lname).to eq('JONES')
+    end
   end
 
-  it "can get allocated offenders for a POM",
-     vcr: { cassette_name: :pom_service_allocated_offenders } do
-    allocated_offenders = described_class.get_allocated_offenders(allocation_one.primary_pom_nomis_id, 'LEI')
-
-    alloc = allocated_offenders.first
-    expect(alloc).to be_kind_of(AllocationWithSentence)
-  end
-
-  it "will get allocations for a POM made within the last 7 days", vcr: { cassette_name: :get_new_cases } do
-    allocation_one.update!(updated_at: 10.days.ago)
-    allocation_two.update!(updated_at: 3.days.ago)
-
-    allocated_offenders = described_class.
-                            get_allocated_offenders(allocation_one.primary_pom_nomis_id, 'LEI').
-                            select(&:new_case?)
-    expect(allocated_offenders.count).to eq 3
-  end
-
-  it "can get a list of POMs",
-     vcr: { cassette_name: :pom_service_get_poms_list } do
-    poms = described_class.get_poms('LEI')
-    expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(14)
-  end
-
-  it "can get a filtered list of POMs",
-     vcr: { cassette_name: :pom_service_get_poms_filtered } do
-    poms = described_class.get_poms('LEI').select { |pom|
-      pom.status == 'active'
+  describe '#get_allocated_offenders' do
+    let(:allocation_one) {
+      create(
+        :allocation_version,
+        primary_pom_nomis_id: staff_id,
+        nomis_offender_id: 'G4273GI',
+        nomis_booking_id: 1_153_753
+      )
     }
-    expect(poms).to be_kind_of(Array)
-    expect(poms.count).to eq(13)
+
+    let(:allocation_two) {
+      create(
+        :allocation_version,
+        primary_pom_nomis_id: staff_id,
+        nomis_offender_id: 'G8060UF',
+        nomis_booking_id: 971_856
+      )
+    }
+
+    let(:allocation_three) {
+      create(
+        :allocation_version,
+        secondary_pom_nomis_id: staff_id,
+        nomis_offender_id: 'G8624GK',
+        nomis_booking_id: 76_908
+      )
+    }
+
+    let(:allocation_four) {
+      create(
+        :allocation_version,
+        primary_pom_nomis_id: staff_id,
+        nomis_offender_id: 'G1714GU',
+        nomis_booking_id: 31_777
+      )
+    }
+
+    let!(:all_allocations) {
+      [allocation_one, allocation_two, allocation_three, allocation_four]
+    }
+
+    it "can get allocated offenders for a POM",
+       vcr: { cassette_name: :pom_service_allocated_offenders } do
+      allocated_offenders = described_class.get_allocated_offenders(allocation_one.primary_pom_nomis_id, 'LEI')
+
+      alloc = allocated_offenders.first
+      expect(alloc).to be_kind_of(AllocationWithSentence)
+    end
+
+    it "will get allocations for a POM made within the last 7 days", vcr: { cassette_name: :get_new_cases } do
+      allocation_one.update!(updated_at: 10.days.ago)
+      allocation_two.update!(updated_at: 3.days.ago)
+
+      allocated_offenders = described_class.
+        get_allocated_offenders(allocation_one.primary_pom_nomis_id, 'LEI').
+        select(&:new_case?)
+      expect(allocated_offenders.count).to eq 3
+      expect(allocated_offenders.map(&:responsibility)).to match_array [ResponsibilityService::SUPPORTING] * 2 + ['Co-Working']
+    end
   end
 
-  it "can get the names for POMs when given IDs",
-     vcr: { cassette_name: :pom_service_get_poms_by_ids } do
-    names = described_class.get_pom_names('LEI')
-    expect(names).to be_kind_of(Hash)
-    expect(names.count).to eq(13)
+  describe '#get_poms' do
+    it "can get a list of POMs",
+       vcr: { cassette_name: :pom_service_get_poms_list } do
+      poms = described_class.get_poms('LEI')
+      expect(poms).to be_kind_of(Array)
+      expect(poms.count).to eq(14)
+    end
+
+    it "can get a filtered list of POMs",
+       vcr: { cassette_name: :pom_service_get_poms_filtered } do
+      poms = described_class.get_poms('LEI').select { |pom|
+        pom.status == 'active'
+      }
+      expect(poms).to be_kind_of(Array)
+      expect(poms.count).to eq(13)
+    end
   end
 
-  it "can fetch a single POM for a prison",
-     vcr: { cassette_name: :pom_service_get_pom_ok } do
-    pom = described_class.get_pom('LEI', staff_id)
-    expect(pom).not_to be nil
+  describe '#get_pom_names' do
+    it "can get the names for POMs when given IDs",
+       vcr: { cassette_name: :pom_service_get_poms_by_ids } do
+      names = described_class.get_pom_names('LEI')
+      expect(names).to be_kind_of(Hash)
+      expect(names.count).to eq(13)
+    end
   end
 
-  it "can handle no poms for a prison when fetching a pom",
-     vcr: { cassette_name: :pom_service_get_pom_none } do
-    pom = described_class.get_pom('CFI', 1234)
-    expect(pom).to be nil
-  end
+  describe '#get_pom' do
+    it "can fetch a single POM for a prison",
+       vcr: { cassette_name: :pom_service_get_pom_ok } do
+      pom = described_class.get_pom('LEI', staff_id)
+      expect(pom).not_to be nil
+    end
 
-  it "can handle a pom not existing at a prison",
-     vcr: { cassette_name: :pom_service_get_pom_fail } do
-    pom = described_class.get_pom('LEI', 1234)
-    expect(pom).to be nil
+    it "can handle no poms for a prison when fetching a pom",
+       vcr: { cassette_name: :pom_service_get_pom_none } do
+      pom = described_class.get_pom('CFI', 1234)
+      expect(pom).to be nil
+    end
+
+    it "can handle a pom not existing at a prison",
+       vcr: { cassette_name: :pom_service_get_pom_fail } do
+      pom = described_class.get_pom('LEI', 1234)
+      expect(pom).to be nil
+    end
   end
 end


### PR DESCRIPTION
Display secondary allocations on caseload (and allocation) pages with a status of 'Co-Working'