### PR TITLE
Coworking refactor

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -22,7 +22,7 @@ class AllocationVersion < ApplicationRecord
     allocate_primary_pom: ALLOCATE_PRIMARY_POM,
     reallocate_primary_pom: REALLOCATE_PRIMARY_POM,
     allocate_secondary_pom: ALLOCATE_SECONDARY_POM,
-    reallocate_seondary_pom: REALLOCATE_SECONDARY_POM,
+    reallocate_secondary_pom: REALLOCATE_SECONDARY_POM,
     deallocate_primary_pom: DEALLOCATE_PRIMARY_POM,
     deallocate_secondary_pom: DEALLOCATE_SECONDARY_POM
   }
@@ -76,7 +76,21 @@ class AllocationVersion < ApplicationRecord
 
   def self.last_event(nomis_offender_id)
     allocation = find_by(nomis_offender_id: nomis_offender_id)
-    allocation.event.to_s.humanize + ' - ' + allocation.updated_at.strftime('%d/%m/%Y')
+
+    event = event_type(allocation.event)
+    event + ' - ' + allocation.updated_at.strftime('%d/%m/%Y')
+  end
+
+  def self.event_type(event)
+    type = (event.include? 'primary_pom') ? 'POM ' : 'Co-working POM '
+
+    if event.include? 'reallocate'
+      type + 're-allocated'
+    elsif event.include? 'deallocate'
+      type + 'removed'
+    elsif event.include? 'allocate'
+      type + 'allocated'
+    end
   end
 
   def self.active?(nomis_offender_id)

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -141,7 +141,7 @@
           <%= link_to 'Allocate', new_prison_coworking_path(@prison, @prisoner.offender_no), class: "govuk-link pull-right" %>
         <% else %>
           <%= link_to @coworker.full_name, prison_pom_path(@prison, @coworker.staff_id), class: "govuk-link" %>
-          <%= link_to 'Deallocate', prison_coworking_path(@prison, @prisoner.offender_no), method: :delete, class: "govuk-link pull-right" %>
+          <%= link_to 'Remove', prison_coworking_path(@prison, @prisoner.offender_no), method: :delete, class: "govuk-link pull-right" %>
         <% end %>
       </td>
     </tr>

--- a/app/views/coworking/confirm.html.erb
+++ b/app/views/coworking/confirm.html.erb
@@ -4,7 +4,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag(prison_coworking_index_path(@prison), method: :post, id: "confirm_coworking_allocation_form") do %>
       <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Confirm co-working allocation</h1>
-      <p class="govuk-body">You are allocating <%= "#{@secondary_pom.first_name} #{@secondary_pom.last_name}".titleize %> to work with <%= "#{@primary_pom.first_name} #{@primary_pom.last_name}".titleize %> on <%= "#{@prisoner.first_name} #{@prisoner.last_name}".titleize %></p>
+      <p class="govuk-body">You are allocating co-working POM <%= "#{@secondary_pom.first_name} #{@secondary_pom.last_name}".titleize %> to <%= "#{@prisoner.first_name} #{@prisoner.last_name}".titleize %>.
+        The responsible POM is <%= "#{@primary_pom.first_name} #{@primary_pom.last_name}".titleize %>.</p>
       <% if @secondary_pom.emails.empty? %>
         <p class="govuk-body">No notification email will be sent to <%= "#{@secondary_pom.first_name} #{@secondary_pom.last_name}".titleize %> as they have no registered email address in NOMIS.</p>
       <% else %>

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -110,13 +110,31 @@ feature "view an offender's allocation information" do
 
       visit prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id_with_keyworker)
 
-      table_row = page.find(:css, 'tr.govuk-table__row', text: 'Co-working POM')
+      table_row = page.find(:css, 'tr.govuk-table__row#co-working-pom', text: 'Co-working POM')
 
       within table_row do
-        # expect(page).to have_link('Deallocate',
-        #                           href: prison_remove_coworking_path('LEI', nomis_offender_id_with_keyworker))
-        expect(page).to have_link('Deallocate')
+        expect(page).to have_link('Remove')
         expect(page).to have_content('Co-working POM Jones, Ross')
+      end
+    end
+  end
+
+  describe 'Allocation history link' do
+    before do
+      create_case_information_for(nomis_offender_id_with_keyworker)
+      create_allocation(nomis_offender_id_with_keyworker)
+    end
+
+    it 'displays a link to the allocation history', vcr: { cassette_name: :show_allocation_information_history_link } do
+      signin_user
+
+      visit prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id_with_keyworker)
+
+      table_row = page.find(:css, 'tr.govuk-table__row', text: 'Allocation history')
+
+      within table_row do
+        expect(page).to have_link('View')
+        expect(page).to have_content("POM allocated - #{Time.zone.now.strftime('%d/%m/%Y')}")
       end
     end
   end

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -97,7 +97,7 @@ feature 'Co-working' do
 
     visit prison_allocation_path('LEI', nomis_offender_id)
     within '#co-working-pom' do
-      click_link 'Deallocate'
+      click_link 'Remove'
     end
 
     expect(page).to have_link 'Allocate'

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -81,7 +81,7 @@ feature 'Co-working' do
           )
 
     expect(page).to have_content("Confirm co-working allocation")
-    expect(page).to have_content("You are allocating #{secondary_pom[:pom_name]} to work with #{probation_pom[:pom_name]} on Ozullirn Abbella")
+    expect(page).to have_content("You are allocating co-working POM #{secondary_pom[:pom_name]} to Ozullirn Abbella. The responsible POM is #{probation_pom[:pom_name]}.")
     expect(page).to have_content("We will send a confirmation email to #{secondary_pom[:email]}")
     expect(page).to have_button('Complete allocation')
     expect(page).to have_link('Cancel')

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe AllocationVersion, type: :model do
     end
   end
 
+  describe '#event_type' do
+    it 'returns the event in a more readable format' do
+      events = [
+          ['allocate_primary_pom', 'POM allocated'],
+          ['allocate_secondary_pom', 'Co-working POM allocated'],
+          ['reallocate_primary_pom', 'POM re-allocated'],
+          ['reallocate_secondary_pom', 'Co-working POM re-allocated'],
+          ['deallocate_primary_pom', 'POM removed'],
+          ['deallocate_secondary_pom', 'Co-working POM removed']
+      ]
+
+      events.each do |key, val|
+        expect(AllocationVersion.event_type(key)).to eq(val)
+      end
+    end
+  end
+
   describe '#override_reasons' do
     let!(:allocation_no_overrides) {
       create(


### PR DESCRIPTION
**Co-working confirmation page content changed**
<img width="537" alt="Screen Shot 2019-07-24 at 19 36 15" src="https://user-images.githubusercontent.com/10685841/61819197-6bbef380-ae4a-11e9-9e7e-eaf7b1d53f33.png">

**Allocation Information page changed** on rows 'Co-working POM' - replace 'Deallocate' link with the word 'Remove' and 'Allocation history' displays the last event in a more readable way
<img width="781" alt="Screen Shot 2019-07-24 at 19 34 35" src="https://user-images.githubusercontent.com/10685841/61819203-6e214d80-ae4a-11e9-92e6-b4160d3f9243.png">
