### PR TITLE
fix problem with building docker image 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'plissken'
 gem 'fast_underscore', require: false
 gem 'flipflop'
 gem 'hashdiff', ['>= 1.0.0.beta1', '< 2.0.0']
+gem 'rubyzip'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,6 +358,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubyzip
   sass-rails (~> 5.0)
   selenium-webdriver
   sentry-raven

--- a/lib/delius/processor.rb
+++ b/lib/delius/processor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
-require 'zip'
 
 require_relative 'sheet'
 require_relative 'string_collector'


### PR DESCRIPTION
- we now need to depend on rubyzip explictly

in production as we unzip a spreadsheet in a rake task