### PR TITLE
Add manual entry flag to caseinfo

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -22,7 +22,8 @@ class CaseInformationController < PrisonsApplicationController
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
       omicable: case_information_params[:omicable],
-      case_allocation: case_information_params[:case_allocation]
+      case_allocation: case_information_params[:case_allocation],
+      manual_entry: true
     )
 
     return redirect_to prison_summary_pending_path(active_prison) if @case_info.valid?
@@ -38,6 +39,7 @@ class CaseInformationController < PrisonsApplicationController
     case_info.tier = case_information_params[:tier]
     case_info.case_allocation = case_information_params[:case_allocation]
     case_info.omicable = case_information_params[:omicable]
+    case_info.manual_entry = true
     case_info.save
 
     redirect_to new_prison_allocation_path(active_prison, case_info.nomis_offender_id)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -2,7 +2,7 @@
 
 class CaseInformation < ApplicationRecord
   self.table_name = 'case_information'
-  validates :manual_entry, presence: true
+  validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }
   validates :nomis_offender_id, presence: true
   validates :omicable, presence: {
     message: 'Select yes if the prisoner’s last known address was in Wales'

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -2,6 +2,7 @@
 
 class CaseInformation < ApplicationRecord
   self.table_name = 'case_information'
+  validates :manual_entry, presence: true
   validates :nomis_offender_id, presence: true
   validates :omicable, presence: {
     message: 'Select yes if the prisoner’s last known address was in Wales'

--- a/db/migrate/20190726135613_add_case_info_manual_entry_flag.rb
+++ b/db/migrate/20190726135613_add_case_info_manual_entry_flag.rb
@@ -1,0 +1,8 @@
+class AddCaseInfoManualEntryFlag < ActiveRecord::Migration[5.2]
+  def change
+    change_table :case_information do |t|
+      t.boolean :manual_entry, null: false, default: true
+    end
+    change_column_default :case_information, :manual_entry, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_064658) do
+ActiveRecord::Schema.define(version: 2019_07_26_135613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_07_17_064658) do
     t.text "omicable"
     t.string "crn"
     t.integer "mappa_level"
+    t.boolean "manual_entry", null: false
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id"
   end
 

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -25,6 +25,7 @@ class OnboardPrison
         omicable: record[:omicable] ? 'Yes' : 'No',
         tier: record[:tier],
         case_allocation: record[:provider_cd],
+        manual_entry: false,
         crn: record[:crn]
       )
 

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       'NPS'
     end
 
+    manual_entry do
+      true
+    end
+
     nomis_offender_id { 'G12345' }
   end
 end

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
       true
     end
 
-    nomis_offender_id { 'G12345' }
+    nomis_offender_id do
+      'G12345'
+    end
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -15,7 +15,7 @@ feature 'Allocation' do
   }
 
   let!(:case_information) {
-    CaseInformation.create!(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'No')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'No')
   }
 
   scenario 'accepting a recommended allocation', versioning: true, vcr: { cassette_name: :create_new_allocation_feature } do

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -140,11 +140,11 @@ feature "view an offender's allocation information" do
   end
 
   def create_case_information_for(offender_no)
-    CaseInformation.create!(
-      nomis_offender_id: offender_no,
-      tier: 'A',
-      case_allocation: 'NPS',
-      omicable: 'No'
+    create(:case_information,
+           nomis_offender_id: offender_no,
+           tier: 'A',
+           case_allocation: 'NPS',
+           omicable: 'No'
     )
   end
 

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -6,7 +6,7 @@ feature "edit a POM's details" do
   let(:nomis_offender_id) { 'G4273GI' }
 
   before do
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPC', omicable: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id)
   end
 
   it "setting unavailable shows selected on re-edit", vcr: { cassette_name: :edit_poms_unavailable_check } do

--- a/spec/lib/onboard_prison_spec.rb
+++ b/spec/lib/onboard_prison_spec.rb
@@ -13,17 +13,17 @@ describe OnboardPrison do
     }
 
     it 'prepares the offender list by removing existing records' do
-      CaseInformation.find_or_create_by!(
-        nomis_offender_id: 'G5054VN',
-        tier: 'A',
-        case_allocation: 'NPS',
-        omicable: 'Yes'
+      create(:case_information,
+             nomis_offender_id: 'G5054VN',
+             tier: 'A',
+             case_allocation: 'NPS',
+             omicable: 'Yes'
       )
-      CaseInformation.find_or_create_by!(
-        nomis_offender_id: 'G9468UN',
-        tier: 'C',
-        case_allocation: 'CRC',
-        omicable: 'Yes'
+      create(:case_information,
+             nomis_offender_id: 'G9468UN',
+             tier: 'C',
+             case_allocation: 'CRC',
+             omicable: 'Yes'
       )
 
       op = described_class.new('PVI', offender_ids, nil)

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -16,4 +16,22 @@ RSpec.describe CaseInformation, type: :model do
       expect(subject).not_to be_valid
     end
   end
+
+  context 'with manual flag' do
+    it 'can be true' do
+      expect(build(:case_information, manual_entry: true)).to be_valid
+    end
+  end
+
+  context 'without manual flag' do
+    it 'can be false' do
+      expect(build(:case_information, manual_entry: false)).to be_valid
+    end
+  end
+
+  context 'with null manual flag' do
+    it 'cannot be nil' do
+      expect(build(:case_information, manual_entry: nil)).not_to be_valid
+    end
+  end
 end

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 describe CaseInformationService do
   let(:caseinfo) {
-    CaseInformation.find_or_create_by!(
-      nomis_offender_id: 'X1000XX',
-      tier: 'A',
-      case_allocation: 'NPS',
-      omicable: 'Yes'
+    create(:case_information,
+           nomis_offender_id: 'X1000XX',
+           tier: 'A',
+           case_allocation: 'NPS',
+           omicable: 'Yes'
     )
   }
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -21,7 +21,7 @@ describe OffenderService do
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     nomis_offender_id = 'G4273GI'
 
-    CaseInformation.create(nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', omicable: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', omicable: 'Yes')
     offender = described_class.get_offender(nomis_offender_id)
 
     expect(offender).to be_kind_of(Nomis::Models::Offender)


### PR DESCRIPTION
This PR is to help support the gradual introduction of nDelius imported Case Information. By having a 'manual' flag we can know whether to validate the presence of Team and LDU.