### PR TITLE
Add content to Allocation History deallocation events

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,4 +70,12 @@ module ApplicationHelper
   def humanized_bool(bool_value)
     bool_value ? 'Yes' : 'No'
   end
+
+  def format_email(email)
+    if email.nil?
+      '(email address not found)'
+    else
+      mail_to(email)
+    end
+  end
 end

--- a/app/views/allocations/_allocate_pom.html.erb
+++ b/app/views/allocations/_allocate_pom.html.erb
@@ -1,9 +1,7 @@
 <li class="action_needed">
   <h2 class="govuk-heading-s"><%= allocation_type %> allocation</h2>
 <p>Prisoner allocated to <%= pom_name.titleize %>
-  <% unless @pom_emails[pom_nomis_id].nil? %>
-    - <%= mail_to(@pom_emails[pom_nomis_id]) %>
-  <% end %>
+  - <%= format_email(@pom_emails[pom_nomis_id]) %>
   <br/>
   Tier: <%= allocation.allocated_at_tier %></p>
   <% if allocation.override_reasons.present? %>

--- a/app/views/allocations/_deallocate_pom.html.erb
+++ b/app/views/allocations/_deallocate_pom.html.erb
@@ -5,7 +5,11 @@
     <% end %>
   </h2>
   <p>
-  &nbsp;
+    <% unless allocation.event_trigger == 'offender_transferred' %>
+      Prisoner unallocated <%= allocation_type == 'Co-working' ? 'co-working POM ' : 'POM ' %>
+    <%= pom_name.titleize %> - <%= format_email(@pom_emails[pom_id]) %>
+    <% end %>
+  </p>
   <br/>
 &nbsp;
   <p class="time"><%= format_date_long(allocation.updated_at) %></p>

--- a/app/views/allocations/_reallocate_primary_pom.html.erb
+++ b/app/views/allocations/_reallocate_primary_pom.html.erb
@@ -1,9 +1,7 @@
 <li class="action_needed">
   <h2 class="govuk-heading-s">Prisoner reallocated</h2>
   <p>Prisoner reallocated to <%= pom_name.titleize %>
-    <% unless @pom_emails[pom_nomis_id].nil? %>
-      - <%= mail_to(@pom_emails[pom_nomis_id]) %>
-    <% end %>
+      - <%= format_email(@pom_emails[pom_nomis_id]) %>
     <br/>
     Tier: <%= allocation.allocated_at_tier %>
   <p class="time"><%= format_date_long(allocation.updated_at) %>

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -8,7 +8,7 @@
       <div class="timeline">
         <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
         <ul>
-          <% allocations.each do |allocation| %>
+          <% allocations.each_with_index do |allocation, i| %>
             <% if allocation.event == 'allocate_primary_pom' %>
               <%= render :partial => "allocate_pom",
                          :locals => { allocation: allocation, allocation_type: 'Prisoner',
@@ -25,10 +25,16 @@
                                       pom_nomis_id: allocation.secondary_pom_nomis_id} %>
             <% elsif allocation.event == 'deallocate_primary_pom' %>
               <%= render :partial => "deallocate_pom",
-                         :locals => { allocation: allocation, allocation_type: 'Prisoner' } %>
+                         :locals => { allocation: allocation,
+                                      allocation_type: 'Prisoner',
+                                      pom_name: allocations[i + 1].primary_pom_name,
+                                      pom_id: allocations[i + 1].primary_pom_nomis_id }%>
             <% elsif allocation.event == 'deallocate_secondary_pom' %>
               <%= render :partial => "deallocate_pom",
-                         :locals => { allocation: allocation, allocation_type: 'Co-working' } %>
+                         :locals => { allocation: allocation,
+                                      allocation_type: 'Co-working',
+                                      pom_name: allocations[i + 1].secondary_pom_name,
+                                      pom_id: allocations[i + 1].secondary_pom_nomis_id } %>
             <% end %>
           <% end %>
         </ul>

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -96,6 +96,8 @@ feature 'Allocation History' do
                        event_trigger: AllocationVersion::OFFENDER_TRANSFERRED,
                        primary_pom_nomis_id: nil,
                        primary_pom_name: nil,
+                       secondary_pom_nomis_id: nil,
+                       secondary_pom_name: nil,
                        recommended_pom_type: nil,
                        updated_at: Time.zone.now - 1.day,
                        primary_pom_allocated_at: nil)
@@ -117,7 +119,7 @@ feature 'Allocation History' do
         ['.govuk-heading-s', "Prisoner unallocated (transfer)"],
         ['.time', transfer_date.to_s],
         ['.govuk-heading-s', "Prisoner reallocated"],
-        ['p', "Prisoner reallocated to #{history1.primary_pom_name} Tier: #{history1.allocated_at_tier}"],
+        ['p', "Prisoner reallocated to #{history1.primary_pom_name} - (email address not found) Tier: #{history1.allocated_at_tier}"],
         ['.time', "#{formatted_date_for(history1)} by #{history1.created_by_name.titleize}"],
         ['.govuk-heading-s', "Prisoner allocation"],
         ['p', "Prisoner allocated to #{history2.primary_pom_name.titleize} - #{prison_pom[:email]} Tier: #{history2.allocated_at_tier}"],

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -84,13 +84,13 @@ feature 'Allocation History' do
                        primary_pom_nomis_id: prison_pom[:primary_pom_nomis_id],
                        primary_pom_name: prison_pom[:primary_pom_name],
                        recommended_pom_type: 'prison',
+                       created_by_name: nil,
                        updated_at: Time.zone.now - 4.days)
 
     allocation.update!(event: AllocationVersion::REALLOCATE_PRIMARY_POM,
                        primary_pom_nomis_id: pom_without_email[:primary_pom_nomis_id],
                        primary_pom_name: pom_without_email[:primary_pom_name],
                        recommended_pom_type: 'probation',
-                       created_by_name: nil,
                        updated_at: Time.zone.now - 2.days)
 
     allocation.update!(event: AllocationVersion::DEALLOCATE_PRIMARY_POM,
@@ -121,10 +121,10 @@ feature 'Allocation History' do
         ['.time', transfer_date.to_s],
         ['.govuk-heading-s', "Prisoner reallocated"],
         ['p', "Prisoner reallocated to #{history1.primary_pom_name} - (email address not found) Tier: #{history1.allocated_at_tier}"],
-        ['.time', "#{formatted_date_for(history1)} by #{history1.created_by_name.titleize}"],
+        ['.time', formatted_date_for(history1).to_s],
         ['.govuk-heading-s', "Prisoner allocation"],
         ['p', "Prisoner allocated to #{history2.primary_pom_name.titleize} - #{prison_pom[:email]} Tier: #{history2.allocated_at_tier}"],
-        ['.time', "#{formatted_date_for(history2)} by #{history2.created_by_name.titleize}"],
+        ['.time', formatted_date_for(history2).to_s],
         ['p', "Prisoner allocated to #{hist_allocate_secondary.secondary_pom_name.titleize} - #{probation_pom[:email]} Tier: #{hist_allocate_secondary.allocated_at_tier}"],
         ['.time', "#{formatted_date_for(hist_allocate_secondary)} by #{hist_allocate_secondary.created_by_name.titleize}"],
         ['.govuk-heading-m', "HMP Leeds"],

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,4 +38,18 @@ RSpec.describe ApplicationHelper do
       expect(case_owner_label(off)).to eq('Community')
     end
   end
+
+  describe 'displays mail_to link of a given email' do
+    it 'displays alternative text if email not present' do
+      email = nil
+
+      expect(format_email(email)).to eq('(email address not found)')
+    end
+
+    it 'displays email address as mail_to link' do
+      email = 'john.doe@example.com'
+
+      expect(format_email(email)).to eq("<a href=\"mailto:john.doe@example.com\">john.doe@example.com</a>")
+    end
+  end
 end


### PR DESCRIPTION

<img width="780" alt="Screen Shot 2019-07-26 at 15 33 22" src="https://user-images.githubusercontent.com/10685841/61960337-2b33b700-afbd-11e9-8caf-d469a13319af.png">


When a POM or a co-worker has been deallocated (this does
not include when a prisoner has been transferred), add
content detailing the name and email address (if present)
of the POM or co-worker.

Move the functionality of determining whether the POMs
email address is present or not from the views into a
helper method.