### PR TITLE
Fix Allocation History view

### DIFF
--- a/app/views/allocations/_allocate_pom.html.erb
+++ b/app/views/allocations/_allocate_pom.html.erb
@@ -15,5 +15,7 @@
     <% end %>
   <% end %>
 <p class="time"><%= format_date_long(allocation.updated_at) %>
-  by <%= allocation.created_by_name.titleize %></p>
+  <% if allocation.created_by_name.present? %>
+    by <%= allocation.created_by_name.titleize %></p>
+  <% end %>
 </li>

--- a/app/views/allocations/_reallocate_primary_pom.html.erb
+++ b/app/views/allocations/_reallocate_primary_pom.html.erb
@@ -7,5 +7,7 @@
     <br/>
     Tier: <%= allocation.allocated_at_tier %>
   <p class="time"><%= format_date_long(allocation.updated_at) %>
-    by <%= allocation.created_by_name.titleize %></p>
+    <% if allocation.created_by_name.present? %>
+      by <%= allocation.created_by_name.titleize %></p>
+    <% end %>
 </li>

--- a/app/views/shared/_allocation_history.html.erb
+++ b/app/views/shared/_allocation_history.html.erb
@@ -13,7 +13,9 @@
                 Tier: <%= allocation.allocated_at_tier %>
               </p>
               <p class="time"><%= format_date_long(allocation.primary_pom_allocated_at) %>
-                by <%= allocation.created_by_name.titleize %></p>
+                <% if allocation.created_by_name.present? %>
+                  by <%= allocation.created_by_name.titleize %></p>
+                <% end %>
             </li>
           <% end %>
         </ul>

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -119,7 +119,7 @@ feature 'Allocation History' do
           ['.time', transfer_date.to_s],
           ['.govuk-heading-s', "Prisoner reallocated"],
           ['p', "Prisoner reallocated to #{history1.primary_pom_name} Tier: #{history1.allocated_at_tier}"],
-          ['.time', "#{formatted_date_for(history1)}"],
+          ['.time', formatted_date_for(history1).to_s],
           ['.govuk-heading-s', "Prisoner allocation"],
           ['p', "Prisoner allocated to #{history2.primary_pom_name.titleize} - #{prison_pom[:email]} Tier: #{history2.allocated_at_tier}"],
           ['.time', "#{formatted_date_for(history2)} by #{history2.created_by_name.titleize}"],

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -90,6 +90,7 @@ feature 'Allocation History' do
                        primary_pom_nomis_id: pom_without_email[:primary_pom_nomis_id],
                        primary_pom_name: pom_without_email[:primary_pom_name],
                        recommended_pom_type: 'probation',
+                       created_by_name: nil,
                        updated_at: Time.zone.now - 2.days)
 
     allocation.update!(event: AllocationVersion::DEALLOCATE_PRIMARY_POM,
@@ -118,7 +119,7 @@ feature 'Allocation History' do
           ['.time', transfer_date.to_s],
           ['.govuk-heading-s', "Prisoner reallocated"],
           ['p', "Prisoner reallocated to #{history1.primary_pom_name} Tier: #{history1.allocated_at_tier}"],
-          ['.time', "#{formatted_date_for(history1)} by #{history1.created_by_name.titleize}"],
+          ['.time', "#{formatted_date_for(history1)}"],
           ['.govuk-heading-s', "Prisoner allocation"],
           ['p', "Prisoner allocated to #{history2.primary_pom_name.titleize} - #{prison_pom[:email]} Tier: #{history2.allocated_at_tier}"],
           ['.time', "#{formatted_date_for(history2)} by #{history2.created_by_name.titleize}"],


### PR DESCRIPTION
We have a small bug where if the "created_by_name" field is nil then the
allocation history page crashes.  There are a number of allocations that
were made before this field was implemented, so to ensure the page
doesn't crash we are only displaying the name if it exists.