### PR TITLE
look at version history to decide if we are a new case

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,9 @@ Layout/DotPosition:
 Style/FormatString:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 # It's not really clearer to replace every if with a return if.
 Style/GuardClause:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'timecop'
   gem 'capybara'
   gem 'database_cleaner'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -368,6 +369,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   stackprof
+  timecop
   turbolinks (~> 5)
   typhoeus
   tzinfo-data

--- a/app/models/allocation_with_sentence.rb
+++ b/app/models/allocation_with_sentence.rb
@@ -10,13 +10,21 @@ class AllocationWithSentence
 
   attr_reader :responsibility
 
-  def initialize(allocation, sentence, responsibility)
+  def initialize(staff_id, allocation, sentence, responsibility)
+    @staff_id = staff_id
     @allocation = allocation
     @sentence = sentence
     @responsibility = responsibility
   end
 
+  # check for changes in the last week where the target value
+  # (item[1] in the array) is our staff_id
   def new_case?
-    @allocation.updated_at >= 7.days.ago
+    @allocation.versions.where('created_at >= ?', 7.days.ago).map { |c|
+      YAML.load(c.object_changes)
+    }.select { |c|
+      c.key?('primary_pom_nomis_id') && c['primary_pom_nomis_id'][1] == @staff_id ||
+      c.key?('secondary_pom_nomis_id') && c['secondary_pom_nomis_id'][1] == @staff_id
+    }.any?
   end
 end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -81,6 +81,7 @@ class PrisonOffenderManagerService
         responsibility = 'Co-Working'
       end
       AllocationWithSentence.new(
+        nomis_staff_id,
         alloc,
         offender_map[alloc.nomis_booking_id],
         responsibility

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -109,7 +109,7 @@ feature "view POM's caseload" do
     expect(cat_code).to eq('C')
   end
 
-  it 'displays all cases that have been allocated to a specific POM in the last week', vcr: { cassette_name: :show_new_cases } do
+  it 'displays all cases that have been allocated to a specific POM in the last week', :versioning, vcr: { cassette_name: :show_new_cases } do
     signin_user('PK000223')
 
     visit prison_confirm_allocation_path('LEI', nomis_offender_id, nomis_staff_id)


### PR DESCRIPTION
Current co-working code gets the new_case? logic wrong because it uses AllocationVersion.updated_at <= 7.days.ago - this introduces spurious new cases for primary POMs  when the co-worker is allocated. 
This PR changes the logic to look at the paper trail history records, to see if we were the target of a primary or secondary change in the last 7 days.