### PR TITLE
Change username to user id in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ RUN mkdir -p /home/appuser && \
   chown -R appuser:appuser /app && \
   chown -R appuser:appuser /home/appuser
 
-USER appuser
+USER 1001
 
 RUN RAILS_ENV=production rails assets:precompile


### PR DESCRIPTION
Currently we can't deploy to preprod because it complains about
non-numeric user ids and not being able to determine if non-root. This
PR just changes the USER setting to be the ID rather than the name.