### PR TITLE
Spike custom stats logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'jbuilder', '~> 2.9'
 gem 'jwt'
 gem 'lograge'
 gem 'logstash-event'
+# to enable custom log stats by writing logs directly
+gem 'logstash-logger'
 gem 'omniauth-oauth2'
 gem 'paper_trail'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
+    logstash-logger (0.26.1)
+      logstash-event (~> 1.2)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -344,6 +346,7 @@ DEPENDENCIES
   loaf
   lograge
   logstash-event
+  logstash-logger
   memory_profiler
   omniauth-oauth2
   paper_trail

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/custom_stats_logging_job.rb
+++ b/app/jobs/custom_stats_logging_job.rb
@@ -1,0 +1,9 @@
+class CustomStatsLoggingJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    logger = LogStashLogger.new(type: :stdout)
+    case_info_count = CaseInformation.count
+    logger.info case_information_count: case_info_count
+  end
+end

--- a/deploy/staging/cronjob.yaml
+++ b/deploy/staging/cronjob.yaml
@@ -95,3 +95,53 @@ spec:
                     name: allocation-rds-instance-output
                     key: postgres_user
           restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: offender-manager-custom-stats
+spec:
+#  Run every 15 minutes on staging - see if it works with perform_now but could be deferred with perform_later
+  schedule: "15 * * * *"
+  startingDeadlineSeconds: 10
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: custom-stats-logging
+              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
+              imagePullPolicy: Always
+              command: ['sh', '-c', "bundle exec rails r CustomStatsLoggingJob.perform_now"]
+              envFrom:
+                - configMapRef:
+                    name: shared-environment
+                - secretRef:
+                    name: allocation-manager-secrets
+              env:
+                - name: PROMETHEUS_METRICS
+                  value: "off"
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: rds_instance_address
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_password
+                - name: POSTGRES_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_name
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_user
+          restartPolicy: OnFailure

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -13,5 +13,8 @@ FactoryBot.define do
     case_allocation do
       'NPS'
     end
+
+    nomis_offender_id { 'G12345' }
+
   end
 end

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -15,6 +15,5 @@ FactoryBot.define do
     end
 
     nomis_offender_id { 'G12345' }
-
   end
 end

--- a/spec/jobs/custom_stats_logging_job_job_spec.rb
+++ b/spec/jobs/custom_stats_logging_job_job_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe CustomStatsLoggingJob, type: :job do
+  before do
+    create(:case_information)
+  end
+
+  it 'does not crash' do
+    CustomStatsLoggingJob.perform_now
+  end
+end

--- a/spec/jobs/custom_stats_logging_job_job_spec.rb
+++ b/spec/jobs/custom_stats_logging_job_job_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe CustomStatsLoggingJob, type: :job do
   end
 
   it 'does not crash' do
-    CustomStatsLoggingJob.perform_now
+    described_class.perform_now
   end
 end


### PR DESCRIPTION
This is a spike to create custom stats in Kibana that we can graph. 
It logs the number of CaseInformation records every 15 minutes, so by filling in manually we should be able to see the numbers go up over time.