### PR TITLE
convert Movement rake task to 2 jobs 

### DIFF
--- a/app/jobs/movement_job.rb
+++ b/app/jobs/movement_job.rb
@@ -1,0 +1,7 @@
+class MovementJob < ApplicationJob
+  queue_as :default
+
+  def perform(movement)
+    MovementService.process_movement(Nomis::Models::Movement.new(JSON.parse(movement)))
+  end
+end

--- a/app/jobs/movements_on_date_job.rb
+++ b/app/jobs/movements_on_date_job.rb
@@ -1,0 +1,21 @@
+class MovementsOnDateJob < ApplicationJob
+  queue_as :default
+
+  def perform(date_string)
+    yesterday = Date.parse(date_string) - 1.day
+
+    movements = MovementService.movements_on(
+      yesterday,
+      type_filters: [
+        Nomis::Models::MovementType::ADMISSION,
+        Nomis::Models::MovementType::RELEASE
+      ]
+    )
+
+    # Ensure that 1 movement failure doesn't prevent all the others from running
+    # If we were to catch the exception here, then Sentry wouldn't report it :-(
+    movements.each { |movement|
+      MovementJob.perform_later(movement.to_json)
+    }
+  end
+end

--- a/lib/tasks/movements.rake
+++ b/lib/tasks/movements.rake
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'rake'
+require_relative '../../app//models/concerns/memory_model.rb'
+require_relative '../../app/services/nomis/models/movement.rb'
 
 namespace :movements do
   desc 'Process the movement events in the previous 24 hours'

--- a/lib/tasks/movements.rake
+++ b/lib/tasks/movements.rake
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'rake'
-require_relative '../../app//models/concerns/memory_model.rb'
-require_relative '../../app/services/nomis/models/movement.rb'
 
 namespace :movements do
   desc 'Process the movement events in the previous 24 hours'
@@ -11,18 +9,6 @@ namespace :movements do
       Rails.logger = Logger.new(STDOUT)
     end
 
-    yesterday = Time.zone.today - 1.day
-
-    movements = MovementService.movements_on(
-      yesterday,
-      type_filters: [
-        Nomis::Models::MovementType::ADMISSION,
-        Nomis::Models::MovementType::RELEASE
-      ]
-    )
-
-    movements.each { |movement|
-      MovementService.process_movement(movement)
-    }
+    MovementsOnDateJob.perform_now(Time.zone.today.to_s)
   end
 end

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe MovementsOnDateJob, type: :job do
+  let(:nomis_offender_id) { 'G1916EU' }
+  let!(:alloc) { create(:allocation_version, nomis_offender_id: nomis_offender_id, secondary_pom_nomis_id: 123_435, prison: 'MDI') }
+  let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
+
+  before do
+    stub_auth_token
+  end
+
+  it 'deallocates' do
+    stub_request(:get, "#{elite2api}/movements?fromDateTime=2019-06-29T00:00&movementDate=2019-06-30").
+      to_return(status: 200, body: [
+        { offenderNo: nomis_offender_id,
+          fromAgency: "MDI",
+          toAgency: "WEI",
+          movementType: "ADM",
+          directionCode: "IN"
+        }].to_json, headers: {})
+
+    expect(alloc.primary_pom_nomis_id).not_to be_nil
+    expect(alloc.secondary_pom_nomis_id).not_to be_nil
+
+    described_class.perform_now(Date.new(2019, 07, 1).to_s)
+
+    alloc.reload
+
+    expect(alloc.primary_pom_nomis_id).to be_nil
+    expect(alloc.secondary_pom_nomis_id).to be_nil
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'rspec/rails'
 require 'spec_helper'
 require 'support/helpers/jwt_helper'
 require 'support/helpers/features_helper'
+require 'support/helpers/auth_helper'
 require 'capybara/rspec'
 require 'webmock/rspec'
 require 'paper_trail/frameworks/rspec'
@@ -48,6 +49,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include JWTHelper
   config.include FeaturesHelper
+  config.include AuthHelper
 
   config.after(:each, :raven_intercept_exception) do
     Rails.configuration.sentry_dsn = nil

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -131,24 +131,14 @@ describe PrisonOffenderManagerService do
     end
 
     context 'when pom not existing at a prison' do
-      let(:t3) { 'https://gateway.t3.nomis-api.hmpps.dsd.io' }
       let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
-      let(:access_token) { 'an access token' }
 
       before do
-        allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(OpenStruct.new(access_token: access_token))
+        stub_auth_token
 
-        stub_request(:post, "#{t3}/auth/oauth/token?grant_type=client_credentials").
-          to_return(status: 200, body: {
-            "access_token": access_token,
-            "token_type": "bearer",
-            "expires_in": 1199,
-            "scope": "readwrite"
-          }.to_json, headers: {})
         stub_request(:get, "#{elite2api}/staff/roles/LEI/role/POM").
           with(
             headers: {
-              'Authorization' => "Bearer #{access_token}",
               'Page-Limit' => '100',
               'Page-Offset' => '0'
             }).

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -1,0 +1,16 @@
+module AuthHelper
+  T3 = 'https://gateway.t3.nomis-api.hmpps.dsd.io'
+  ACCESS_TOKEN = 'an access token'
+
+  def stub_auth_token
+    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(OpenStruct.new(access_token: ACCESS_TOKEN))
+
+    stub_request(:post, "#{T3}/auth/oauth/token?grant_type=client_credentials").
+      to_return(status: 200, body: {
+        "access_token": ACCESS_TOKEN,
+        "token_type": "bearer",
+        "expires_in": 1199,
+        "scope": "readwrite"
+      }.to_json, headers: {})
+  end
+end


### PR DESCRIPTION
-one to kick-off the day, and one to do each movement so that 1 failed movement record doesn't prevent the rest of the movements from being processed. 
The desired behaviour is that a failed movement still creates a Sentry alert.