### PR TITLE
Handle POMs without emails

### DIFF
--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -17,7 +17,7 @@ class EmailService
   end
 
   def send_email
-    return if @pom.emails.empty?
+    return if @pom.emails.blank?
 
     if @allocation.event == 'reallocate_primary_pom' && previous_pom.present?
       send_deallocation_email

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe EmailService, :queueing do
     }.to change(enqueued_jobs, :size).by(1)
   end
 
+  it "Can not crash when a pom has no email", vcr: { cassette_name: :email_service_send_allocation_email }, versioning: true  do
+    allow(PrisonOffenderManagerService).to receive(:get_pom_emails).and_return(nil)
+
+    expect {
+      described_class.instance(allocation: allocation, message: "", pom_nomis_id: allocation.primary_pom_nomis_id).send_email
+    }.to change(enqueued_jobs, :size).by(0)
+  end
+
   it "Can send a reallocation email", vcr: { cassette_name: :email_service_send_deallocation_email }, versioning: true  do
     allow(AllocationService).to receive(:get_versions_for).and_return([original_allocation])
 


### PR DESCRIPTION
When a POM has no email the send_email function crashes because it is
checking for what it believes is an empty list with `.empty?`. When this
is nil it crashes as `.empty?` is not a message nil understands.

Changed the call to `.blank?` which works with both nil and empty lists.

This fixes https://sentry.service.dsd.io/mojds/live1-allocation-manager-produ/issues/37052/