### PR TITLE
New API call to get all movements for a specific offender

### DIFF
--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -17,6 +17,17 @@ module Nomis
           api_deserialiser.deserialise(Nomis::Models::Movement, movement)
         }
       end
+
+      def self.movements_for(offender_no)
+        route = '/elite2api/api/movements/offenders'
+
+        data = e2_client.post(route, [offender_no])
+        data.sort_by { |k| k['movementTime'] }.map{ |movement|
+          if Nomis::Models::Movement.movement_types.include? movement['movementType']
+            api_deserialiser.deserialise(Nomis::Models::Movement, movement)
+          end
+        }.compact
+      end
     end
   end
 end

--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -18,16 +18,16 @@ module Nomis
         }
       end
 
+      # rubocop:disable Metrics/LineLength
       def self.movements_for(offender_no)
-        route = '/elite2api/api/movements/offenders'
+        route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL'
 
         data = e2_client.post(route, [offender_no])
         data.sort_by { |k| k['movementTime'] }.map{ |movement|
-          if Nomis::Models::Movement.movement_types.include? movement['movementType']
-            api_deserialiser.deserialise(Nomis::Models::Movement, movement)
-          end
-        }.compact
+          api_deserialiser.deserialise(Nomis::Models::Movement, movement)
+        }
       end
+      # rubocop:enable Metrics/LineLength
     end
   end
 end

--- a/app/services/nomis/models/movement.rb
+++ b/app/services/nomis/models/movement.rb
@@ -30,10 +30,6 @@ module Nomis
       attribute :movement_time
       attribute :movement_reason
       attribute :comment_text
-
-      def self.movement_types
-        [MovementType::RELEASE, MovementType::ADMISSION, MovementType::TRANSFER]
-      end
     end
   end
 end

--- a/app/services/nomis/models/movement.rb
+++ b/app/services/nomis/models/movement.rb
@@ -30,6 +30,10 @@ module Nomis
       attribute :movement_time
       attribute :movement_reason
       attribute :comment_text
+
+      def self.movement_types
+        [MovementType::RELEASE, MovementType::ADMISSION, MovementType::TRANSFER]
+      end
     end
   end
 end

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -26,13 +26,11 @@ describe Nomis::Elite2::MovementApi do
       allow_any_instance_of(Nomis::Client).to receive(:post).and_return([
         {
           'offender_no' => '2',
-          'movementTime' => '2017-03-09T15:50:52.676892',
-          'movementType' => 'REL'
+          'movementTime' => '2017-03-09T15:50:52.676892'
         },
         {
           'offender_no' => '1',
-          'movementTime' => '2015-01-01T15:50:52.676892',
-          'movementType' => 'ADM'
+          'movementTime' => '2015-01-01T15:50:52.676892'
         }
       ])
 

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -5,9 +5,42 @@ describe Nomis::Elite2::MovementApi do
     it 'can get movements on a specific date',
        vcr: { cassette_name: :movement_api_on_date } do
       movements = described_class.movements_on_date(Date.iso8601('2019-02-20'))
+
       expect(movements).to be_kind_of(Array)
       expect(movements.length).to eq(2)
       expect(movements.first).to be_kind_of(Nomis::Models::Movement)
+    end
+  end
+
+  describe 'Movements for single offenders' do
+    it 'can get movements for a specific_offender',
+       vcr: { cassette_name: :movement_api_for_offender } do
+      movements = described_class.movements_for('A5019DY')
+
+      expect(movements).to be_kind_of(Array)
+      expect(movements.length).to eq(1)
+      expect(movements.first).to be_kind_of(Nomis::Models::Movement)
+    end
+
+    it 'sort movements (oldest first) for a specific_offender' do
+      allow_any_instance_of(Nomis::Client).to receive(:post).and_return([
+        {
+          'offender_no' => '2',
+          'movementTime' => '2017-03-09T15:50:52.676892',
+          'movementType' => 'REL'
+        },
+        {
+          'offender_no' => '1',
+          'movementTime' => '2015-01-01T15:50:52.676892',
+          'movementType' => 'ADM'
+        }
+      ])
+
+      movements = described_class.movements_for('A5019DY')
+
+      expect(movements).to be_kind_of(Array)
+      expect(movements.length).to eq(2)
+      expect(movements.first.offender_no).to eq('1')
     end
   end
 end


### PR DESCRIPTION
As we need to clean up from the movement service not doing the correct
thing with some offenders, it is helpful to be able to get the entire
movement history (ADMissions, TRaNsfers and RELeases) for a single
offender.

The movements for this offender will be returned as `Movement` objects
in date order (oldest first).