### PR TITLE
Update the resources available to the pods

### DIFF
--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -41,6 +41,13 @@ spec:
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
+          resources:
+            limits:
+              memory: "1Gi"
+              cpu: "100m"
+            requests:
+              memory: "500Mi"
+              cpu: "50m"
           envFrom:
             - configMapRef:
                 name: shared-environment

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -41,6 +41,13 @@ spec:
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
+          resources:
+            limits:
+              memory: "1Gi"
+              cpu: "100m"
+            requests:
+              memory: "500Mi"
+              cpu: "50m"
           envFrom:
             - configMapRef:
                 name: shared-environment

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -41,6 +41,13 @@ spec:
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
+          resources:
+            limits:
+              memory: "1Gi"
+              cpu: "100m"
+            requests:
+              memory: "500Mi"
+              cpu: "50m"
           envFrom:
             - configMapRef:
                 name: shared-environment


### PR DESCRIPTION
Our pods are using more resources (CPU) than they have available, so
this PR increases the CPU share available to each pod to match roughly
what the current usage is, as determined by `top pods`