### PR TITLE
Update manual delius onboard process

### DIFF
--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -20,7 +20,7 @@ class OnboardPrison
       end
 
       # Create a CaseInformation .....
-      CaseInformation.find_or_create_by!(
+      CaseInformation.find_or_create_by(
         nomis_offender_id: offender_id,
         omicable: record[:omicable] ? 'Yes' : 'No',
         tier: record[:tier],


### PR DESCRIPTION
The validations on the CaseInformation model have been tightened and as
a result if you are running the manual onboarding task and the Tier
field contains invalid data it will crash, preventing the rest of the
job from being run.  By removing the bang we are going to allow it to
just skip that record and carry on.