### PR TITLE
Use blank? for checking if a POM has emails

### DIFF
--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -26,7 +26,7 @@ class EmailService
   end
 
   def send_coworking_primary_email(pom_firstname, coworking_pom_name)
-    unless @pom.emails.blank?
+    if @pom.emails.present?
       PomMailer.allocate_coworking_pom(
         message: @message,
         pom_name: pom_firstname.capitalize,
@@ -40,7 +40,7 @@ class EmailService
   end
 
   def send_secondary_email(pom_firstname)
-    unless @pom.emails.blank?
+    if @pom.emails.present?
       PomMailer.secondary_allocation_email(
         message: @message,
         pom_name: pom_firstname.capitalize,

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -26,7 +26,7 @@ class EmailService
   end
 
   def send_coworking_primary_email(pom_firstname, coworking_pom_name)
-    unless @pom.emails.empty?
+    unless @pom.emails.blank?
       PomMailer.allocate_coworking_pom(
         message: @message,
         pom_name: pom_firstname.capitalize,
@@ -40,7 +40,7 @@ class EmailService
   end
 
   def send_secondary_email(pom_firstname)
-    unless @pom.emails.empty?
+    unless @pom.emails.blank?
       PomMailer.secondary_allocation_email(
         message: @message,
         pom_name: pom_firstname.capitalize,

--- a/app/views/allocations/confirm.html.erb
+++ b/app/views/allocations/confirm.html.erb
@@ -6,7 +6,7 @@
     <%= form_tag(prison_allocations_path(@prison), method: :post, id: "confirm_allocation_form") do %>
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">Confirm allocation</h1>
       <p class="govuk-body">You are allocating <%= "#{@prisoner.first_name} #{@prisoner.last_name}".titleize %> to <%= "#{@pom.first_name} #{@pom.last_name}".titleize %>.</p>
-      <% if @pom.emails.empty? %>
+      <% if @pom.emails.blank? %>
         <p class="govuk-body">No notification email will be sent to <%= "#{@pom.first_name} #{@pom.last_name}".titleize %> as they have no registered email address in NOMIS.</p>
       <% else %>
         <p class="govuk-body">We will send a confirmation email to <%= @pom.emails.first %>.</p>

--- a/app/views/allocations/confirm_reallocation.html.erb
+++ b/app/views/allocations/confirm_reallocation.html.erb
@@ -6,7 +6,7 @@
     <%= form_tag(prison_allocations_path(@prison), id: "confirm_allocation_form") do %>
       <h1 class="govuk-heading-xl govuk-!-margin-top-4">Confirm allocation</h1>
       <p class="govuk-body">You are allocating <%= "#{@prisoner.first_name} #{@prisoner.last_name}".titleize %> to <%= "#{@pom.first_name} #{@pom.last_name}".titleize %>.</p>
-      <% if @pom.emails.empty? %>
+      <% if @pom.emails.blank? %>
         <p class="govuk-body">No notification email will be sent to <%= "#{@pom.first_name} #{@pom.last_name}".titleize %> as they have no registered email address in NOMIS.</p>
       <% else %>
         <p class="govuk-body">We will send a confirmation email to <%= @pom.emails.first %>.</p>

--- a/app/views/coworking/confirm.html.erb
+++ b/app/views/coworking/confirm.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Confirm co-working allocation</h1>
       <p class="govuk-body">You are allocating co-working POM <%= "#{@secondary_pom.first_name} #{@secondary_pom.last_name}".titleize %> to <%= "#{@prisoner.first_name} #{@prisoner.last_name}".titleize %>.
         The responsible POM is <%= "#{@primary_pom.first_name} #{@primary_pom.last_name}".titleize %>.</p>
-      <% if @secondary_pom.emails.empty? %>
+      <% if @secondary_pom.emails.blank? %>
         <p class="govuk-body">No notification email will be sent to <%= "#{@secondary_pom.first_name} #{@secondary_pom.last_name}".titleize %> as they have no registered email address in NOMIS.</p>
       <% else %>
         <p class="govuk-body">We will send a confirmation email to <%= @secondary_pom.emails.first %></p>


### PR DESCRIPTION
Multiple uses of empty? will break if the POM has no emails, empty? only
works on lists, but it might be nil.

Should resolve
https://sentry.service.dsd.io/mojds/live1-allocation-manager-produ/issues/37045/