### PR TITLE
Don't process movements for people on remand

### DIFF
--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -41,9 +41,10 @@ private
   def self.process_transfer(transfer)
     Rails.logger.info("Processing transfer for #{transfer.offender_no}")
 
+    return false unless should_process?(transfer.offender_no)
+
     AllocationVersion.deallocate_offender(transfer.offender_no,
                                           AllocationVersion::OFFENDER_TRANSFERRED)
-
     true
   end
 
@@ -57,5 +58,9 @@ private
                                           AllocationVersion::OFFENDER_RELEASED)
 
     true
+  end
+
+  def self.should_process?(offender_no)
+    OffenderService.get_offender(offender_no).convicted?
   end
 end

--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -22,6 +22,10 @@ module Nomis
       attribute :ldu, :string
       attribute :team, :string
 
+      def convicted?
+        convicted_status == 'Convicted'
+      end
+
       def sentenced?
         # A prisoner will have had a sentence calculation and for our purposes
         # this means that they will either have a:

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe MovementsOnDateJob, type: :job do
-  let(:nomis_offender_id) { 'G1916EU' }
+  let(:nomis_offender_id) { 'G3462VT' }
   let!(:alloc) { create(:allocation_version, nomis_offender_id: nomis_offender_id, secondary_pom_nomis_id: 123_435, prison: 'MDI') }
   let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
 
@@ -10,6 +10,10 @@ RSpec.describe MovementsOnDateJob, type: :job do
   end
 
   it 'deallocates' do
+    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Models::Offender.new.tap{ |o|
+      o.convicted_status = "Convicted"
+    })
+
     stub_request(:get, "#{elite2api}/movements?fromDateTime=2019-06-29T00:00&movementDate=2019-06-30").
       to_return(status: 200, body: [
         { offenderNo: nomis_offender_id,


### PR DESCRIPTION
Following an investigation into the MovementService we found that we
were processing movements for offenders on remand.  If they have
previously been in prison then we have old allocation records attributed
to them and this was causing issues where the offender is being
deallocated.  However, as they are on remand we shouldn't be processing
any movements.