### PR TITLE
Speed up reallocation page (and get_poms).

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -30,7 +30,9 @@ class AllocationsController < PrisonsApplicationController
   end
 
   def edit
-    unless AllocationVersion.active?(nomis_offender_id_from_url)
+    allocation = AllocationService.current_allocation_for(nomis_offender_id_from_url)
+
+    unless allocation.present? && allocation.active?
       redirect_to new_prison_allocation_path(active_prison, nomis_offender_id_from_url)
       return
     end

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -93,9 +93,8 @@ class AllocationVersion < ApplicationRecord
     end
   end
 
-  def self.active?(nomis_offender_id)
-    allocation = find_by(nomis_offender_id: nomis_offender_id)
-    !allocation.nil? && !allocation.primary_pom_nomis_id.nil?
+  def active?
+    primary_pom_nomis_id.present?
   end
 
   def override_reasons

--- a/app/services/nomis/models/prison_offender_manager.rb
+++ b/app/services/nomis/models/prison_offender_manager.rb
@@ -42,14 +42,13 @@ module Nomis
       end
 
       def add_detail(pom_detail, prison)
-        allocations = AllocationVersion.active_primary_pom_allocations(
-          pom_detail.nomis_staff_id, prison)
-        allocation_counts = allocations.group_by(&:allocated_at_tier)
+        allocation_counts = AllocationVersion.active_primary_pom_allocations(
+          pom_detail.nomis_staff_id, prison).group(:allocated_at_tier).count
 
-        self.tier_a = allocation_counts.fetch('A', []).count
-        self.tier_b = allocation_counts.fetch('B', []).count
-        self.tier_c = allocation_counts.fetch('C', []).count
-        self.tier_d = allocation_counts.fetch('D', []).count
+        self.tier_a = allocation_counts.fetch('A', 0)
+        self.tier_b = allocation_counts.fetch('B', 0)
+        self.tier_c = allocation_counts.fetch('C', 0)
+        self.tier_d = allocation_counts.fetch('D', 0)
         self.total_cases = [tier_a, tier_b, tier_c, tier_d].sum
         self.status = pom_detail.status
         self.working_pattern = pom_detail.working_pattern

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -4,9 +4,10 @@ class PrisonOffenderManagerService
   # Note - get_poms and get_pom return different data...
   def self.get_poms(prison)
     poms = Nomis::Elite2::PrisonOffenderManagerApi.list(prison)
+    pom_details = PomDetail.where(nomis_staff_id: poms.map(&:staff_id).map(&:to_i))
 
     poms = poms.map { |pom|
-      detail = get_pom_detail(pom.staff_id)
+      detail = get_pom_detail(pom_details, pom.staff_id.to_i)
       pom.add_detail(detail, prison)
       pom
     }.compact
@@ -119,10 +120,10 @@ class PrisonOffenderManagerService
 
 private
 
-  def self.get_pom_detail(nomis_staff_id)
-    PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id.to_i) { |s|
-      s.working_pattern = s.working_pattern || 0.0
-      s.status = s.status || 'active'
-    }
+  def self.get_pom_detail(pom_details, nomis_staff_id)
+    pom_details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
+      PomDetail.create!(nomis_staff_id: nomis_staff_id,
+                        working_pattern: 0.0,
+                        status: 'active')
   end
 end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -108,13 +108,15 @@ RSpec.describe AllocationVersion, type: :model do
 
   describe '#active?' do
     it 'return true if an Allocation has been assigned a Primary POM' do
-      expect(described_class.active?(nomis_offender_id)).to be(true)
+      alloc = AllocationService.current_allocation_for(nomis_offender_id)
+      expect(alloc.active?).to be(true)
     end
 
     it 'return false if an Allocation has not been assigned a Primary POM' do
       described_class.deallocate_primary_pom(nomis_staff_id)
+      alloc = AllocationService.current_allocation_for(nomis_offender_id)
 
-      expect(described_class.active?(nomis_offender_id)).to be(false)
+      expect(alloc.active?).to be(false)
     end
   end
 


### PR DESCRIPTION
Have re-instated the nplus one fix from Stephen, and also changed
add_detail so that it does less work.

Currently add_detail would fetch all the allocations for a POM, then
group them by allocated_at_tier, before then counting the size of the
list.  This would be slow (essentially fetching all the allocations for
a prison) and also memory intensive as we would be storing all those
allocations in RAM unnecessarily.

This PR changes the call to have the server group the response and just
return the counts.  This means the call should be a lot less variable
than previously and that we move a lot less data around.