### PR TITLE
Add search bar to summary pages

### DIFF
--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -4,6 +4,9 @@
 
 <h1 class="govuk-heading-xl">Allocations</h1>
 
+<div class="govuk-!-margin-bottom-6 govuk-!-margin-top-6">
+  <%= render "search/search_box" %>
+</div>
 <%= render(:partial => 'tabs_start', :locals => {:active => :allocated}) %>
 
 <section class="govuk-tabs__panel" id="allocated">

--- a/app/views/summary/pending.html.erb
+++ b/app/views/summary/pending.html.erb
@@ -4,6 +4,9 @@
 
 <h1 class="govuk-heading-xl">Allocations</h1>
 
+<div class="govuk-!-margin-bottom-6 govuk-!-margin-top-6">
+  <%= render "search/search_box" %>
+</div>
 <%= render(:partial => 'tabs_start', :locals => {:active => :pending}) %>
 
 <section class="govuk-tabs__panel" id="awaiting-information">

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -16,6 +16,9 @@
 
 <h1 class="govuk-heading-xl">Allocations</h1>
 
+<div class="govuk-!-margin-bottom-6 govuk-!-margin-top-6">
+  <%= render "search/search_box" %>
+</div>
 <%= render(:partial => 'tabs_start', :locals => {:active => :unallocated}) %>
 
 <section class="govuk-tabs__panel" id="awaiting-allocation">

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Search for offenders' do
-  it 'Can search from the dashboard', vcr: { cassette_name: :search_feature } do
+  it 'Can search from the dashboard', vcr: { cassette_name: :dashboard_search_feature } do
     signin_user
     visit root_path
 
@@ -11,5 +11,41 @@ feature 'Search for offenders' do
 
     expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
     expect(page).to have_css('tbody tr', count: 6)
+  end
+
+  it 'Can search from the Allocations summary page', vcr: { cassette_name: :allocated_search_feature } do
+    signin_user
+    visit prison_summary_allocated_path('LEI')
+
+    expect(page).to have_text('See allocations')
+    fill_in 'q', with: 'Fra'
+    click_on('search-button')
+
+    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_css('tbody tr', count: 9)
+  end
+
+  it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: :waiting_allocation_search_feature } do
+    signin_user
+    visit prison_summary_unallocated_path('LEI')
+
+    expect(page).to have_text('Make allocations')
+    fill_in 'q', with: 'Tre'
+    click_on('search-button')
+
+    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_css('tbody tr', count: 1)
+  end
+
+  it 'Can search from the Missing Information summary page', vcr: { cassette_name: :missing_info_search_feature } do
+    signin_user
+    visit  prison_summary_pending_path('LEI')
+
+    expect(page).to have_text('Make allocations')
+    fill_in 'q', with: 'Ste'
+    click_on('search-button')
+
+    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_css('tbody tr', count: 4)
   end
 end


### PR DESCRIPTION
We have received feedback from users that they would like to have
better search functionality.  We have an establishment-wide search bar
in the main dashboard, but this can be laborious/easy to forget about if
users are spending a lot of time allocating/reallocation.  Therefore a
decision has been made to add the search bar to the allocated,
unallocated and pending summary pages to makes searching simpler, and
easier to access for staff.