### PR TITLE
Don't create caseinfo for remand offenders in delius import

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -21,6 +21,8 @@ private
   def import(delius_record)
     offender = OffenderService.get_offender(delius_record.noms_no)
 
+    return unless offender.present? && offender.convicted?
+
     if auto_delius_import_enabled?(offender.latest_location_id)
       if dob_matches?(offender, delius_record)
         process_record(delius_record)

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }, type: :job do
   let(:nomis_offender_id) { 'G4281GV' }
+  let(:remand_nomis_offender_id) { 'G3716UD' }
 
   context 'with auto_delius_import enabled' do
     let(:test_strategy) { Flipflop::FeatureSet.current.test! }
@@ -37,6 +38,16 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
         expect {
           described_class.perform_now d1.noms_no
         }.to change(CaseInformation, :count).by(1)
+      end
+    end
+
+    context 'when offender is not convicted' do
+      let!(:d1) { create(:delius_data, noms_no: remand_nomis_offender_id) }
+
+      it 'does not case information' do
+        expect {
+          described_class.perform_now d1.noms_no
+        }.to change(CaseInformation, :count).by(0)
       end
     end
 


### PR DESCRIPTION
We don't want to create caseinfo for remand offenders (as our API call
to get offenders for prison only shows Convicted) but it confuses
things elsewhere.