### PR TITLE
Manually update rails-html-sanitizer gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.1.0)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.3)
       actionpack (= 5.2.3)


### PR DESCRIPTION
We have started to see deprecation warnings whilst running specs,
specifically "DEPRECATION WARNING: warning: white_list_sanitizer
isdeprecated, please use safe_list_sanitizer instead."  An issue was
opened on the Rails Github account
(https://github.com/rails/rails/issues/36858) and basically the fix is
to update to the latest version of the gem.

However, we have reduced the frequency we are getting Dependabot updates
and it could be another couple of weeks before this particular update
comes through, and therefore thought it would be a good idea to just
update it manually so we can stop seeing the deprecation warning.