### PR TITLE
Switch off auto Delius import for Cardiff

### DIFF
--- a/deploy/production/shared-environment.yaml
+++ b/deploy/production/shared-environment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: shared-environment
 data:
   PROMETHEUS_METRICS: "on"
-  AUTO_DELIUS_IMPORT: "CFI,UKI"
+  AUTO_DELIUS_IMPORT: "UKI"
   DELIUS_EMAIL_FOLDER: "Data/prod"
   RAILS_ENV: "production"
   RAILS_SERVE_STATIC_FILES: "true"


### PR DESCRIPTION
The SPO at Cardiff has been in contact to request to have the manual
option back for updating Case Information.  At present they are unable
to complete the process of updating the information in Delius and this
is causing a backlog to develop in their 'missing info' tab.  As Cardiff
can have up to 40 new offenders arrive each day then this will quickly
cause them issues.  Therefore it has been agreed that we'll remove the
auto import until we can better understand how to assist Cardiff in
fixing data in Delius.