### PR TITLE
[POM-298] Add debugging page

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -5,7 +5,7 @@ class DebuggingController < PrisonsApplicationController
     nomis_offender_id = id
 
     @offender = offender(nomis_offender_id)
-    unless @offender.blank?
+    if @offender.present?
       @allocation = AllocationVersion.where(nomis_offender_id: @offender.offender_no)
       @movements = Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).first
     end

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
 class DebuggingController < PrisonsApplicationController
-
   def debugging
     nomis_offender_id = id
 
     @offender = offender(nomis_offender_id)
-    unless @offender.blank?
+    if @offender.present?
       @allocation = AllocationVersion.where(nomis_offender_id: @offender.offender_no)
       @movements = Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).first
     end
   end
 
-  private
+private
 
   def id
     params[:offender_no]
@@ -20,6 +19,7 @@ class DebuggingController < PrisonsApplicationController
 
   def offender(offender_no)
     return [] if offender_no.blank?
+
     OffenderService.get_offender(offender_no)
   end
 end

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -18,7 +18,7 @@ private
   end
 
   def offender(offender_no)
-    return [] if offender_no.blank?
+    return nil if offender_no.blank?
 
     OffenderService.get_offender(offender_no)
   end

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DebuggingController < PrisonsApplicationController
+
+  def debugging
+    nomis_offender_id = id
+
+    @offender = offender(nomis_offender_id)
+    unless @offender.blank?
+      @allocation = AllocationVersion.where(nomis_offender_id: @offender.offender_no)
+      @movements = Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).first
+    end
+  end
+
+  private
+
+  def id
+    params[:offender_no]
+  end
+
+  def offender(offender_no)
+    return [] if offender_no.blank?
+    OffenderService.get_offender(offender_no)
+  end
+end

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -5,7 +5,7 @@ class DebuggingController < PrisonsApplicationController
     nomis_offender_id = id
 
     @offender = offender(nomis_offender_id)
-    if @offender.present?
+    unless @offender.blank?
       @allocation = AllocationVersion.where(nomis_offender_id: @offender.offender_no)
       @movements = Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).first
     end

--- a/app/helpers/debugging_helper.rb
+++ b/app/helpers/debugging_helper.rb
@@ -3,7 +3,7 @@ module DebuggingHelper
     if PrisonService::PRISONS.include?(code)
       PrisonService.name_for(code)
     else
-      "Location outside the prison estate"
+      'Location outside the prison estate'
     end
   end
 end

--- a/app/helpers/debugging_helper.rb
+++ b/app/helpers/debugging_helper.rb
@@ -1,0 +1,9 @@
+module DebuggingHelper
+  def agency(code)
+    if PrisonService::PRISONS.include?(code)
+      PrisonService.name_for(code)
+    else
+      "Location outside the prison estate"
+    end
+  end
+end

--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -44,6 +44,10 @@ module Nomis
         SentenceTypeService.indeterminate_sentence?(imprisonment_status)
       end
 
+      def over_18?
+        age > 18
+      end
+
       def awaiting_allocation_for
         omic_start_date = Date.new(2019, 2, 4)
 

--- a/app/services/nomis/models/offender_base.rb
+++ b/app/services/nomis/models/offender_base.rb
@@ -45,7 +45,7 @@ module Nomis
       end
 
       def over_18?
-        age > 18
+        age >= 18
       end
 
       def awaiting_allocation_for

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -1,0 +1,243 @@
+<% content_for :switcher do %>
+  <%= render '/layouts/prison_switcher' %>
+<% end %>
+
+<h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Debugging</h1>
+
+<div class="search-box govuk-grid-row">
+  <%= form_tag(prison_debugging_path(@prison), method: :get, id: "debugging_form") do %>
+    <div class="govuk-form-group" style="display: inline;" >
+      <label class="govuk-label" for="offender_no">
+        Enter a prisoner number
+      </label>
+      <input class="govuk-input" id="offender_no" name="offender_no" type="text" value="<%= @offender_no %>" autofocus="true">
+
+      <input id="search-button" type="submit" class="govuk-button" value="    Search    "/>
+    </div>
+  <% end %>
+</div>
+
+<% if @offender.blank? %>
+  <p>
+    No offender was found, please check the offender number and try again
+  </p>
+  <% else %>
+
+<div class="govuk-!-margin-top-1">
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header" scope="row">Prisoner information</td>
+      <td class="govuk-table__cell"></td>
+    </tr>
+    <tr class="govuk-table__row" id="name">
+      <td class="govuk-table__cell govuk-!-width-one-half">Name</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @offender.full_name %></td>
+    </tr>
+    <tr class="govuk-table__row" id="dob">
+      <td class="govuk-table__cell govuk-!-width-one-half">DOB</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= format_date(@offender.date_of_birth) %></td>
+    </tr>
+    <tr class="govuk-table__row" id="convicted">
+      <td class="govuk-table__cell">Convicted?</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= humanized_bool(@offender.convicted?) %>
+    </tr>
+    <tr class="govuk-table__row" id="sentenced"">
+      <td class="govuk-table__cell">Sentenced?</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= humanized_bool(@offender.sentenced?) %>
+    </tr>
+    <tr class="govuk-table__row" id="over-18">
+      <td class="govuk-table__cell govuk-!-width-one-half">Over 18?</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= humanized_bool(@offender.over_18?) %></td>
+    </tr>
+    <tr class="govuk-table__row" id="tier">
+      <td class="govuk-table__cell">Tiering calculation</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <% if @offender.tier %>
+          <%= @offender.tier %>
+        <% else %>
+          Not provided
+        <% end %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id=service-provider">
+      <td class="govuk-table__cell">Service provider</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <% if @offender.case_allocation %>
+          <%= service_provider_label(@offender.case_allocation) %>
+        <% else %>
+          Not provided
+        <% end %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="omicable">
+      <td class="govuk-table__cell">Last known address in Wales</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= humanized_bool(@offender.omicable) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="responsibility"">
+      <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= case_owner_label(@offender) %>
+      </td>
+
+    </tbody>
+  </table>
+
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Sentence information</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    </tr>
+    <tr class="govuk-table__row" id="offence">
+      <td class="govuk-table__cell govuk-!-width-one-half">Main offence</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @offender.main_offence %></td>
+    </tr>
+    <tr class="govuk-table__row" id="category">
+      <td class="govuk-table__cell govuk-!-width-one-half">Category</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">Cat <%= @offender.category_code %></td>
+    </tr>
+    <tr class="govuk-table__row" id="imprisonment-status">
+      <td class="govuk-table__cell govuk-!-width-one-half">Imprisonment status</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @offender.imprisonment_status %></td>
+    </tr>
+    <tr class="govuk-table__row" id="sentence-type">
+      <td class="govuk-table__cell">Sentence type</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= sentence_type_label(@offender) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="earliest-release-date">
+      <td class="govuk-table__cell">Earliest release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.earliest_release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="release-date">
+      <td class="govuk-table__cell">Release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="conditional-release-date">
+      <td class="govuk-table__cell">Conditional release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.conditional_release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="automatic-release-date">
+      <td class="govuk-table__cell">Automatic release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.automatic_release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="parole=eligibility-date">
+      <td class="govuk-table__cell">Parole eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.parole_eligibility_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="hdc-date">
+      <td class="govuk-table__cell">Home detention curfew eligibility</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.home_detention_curfew_eligibility_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="tariff-date">
+      <td class="govuk-table__cell">Tariff date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.tariff_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+
+<% if @allocation.blank? %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-4">Not currently allocated</h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<% else %>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Prison allocation</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    <tr class="govuk-table__row" id="pom-role">
+      <td class="govuk-table__cell">POM role</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= pom_responsibility_label(@offender) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="pom">
+      <td class="govuk-table__cell govuk-!-width-one-half">POM</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= @allocation.first.primary_pom_name.titleize%>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="co-working-pom">
+      <td class="govuk-table__cell govuk-!-width-one-half">Co-working POM</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <% if @coworker.nil? %>
+          N/A
+        <% else %>
+          <%= @allocation.first.secondary_pom_name %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="allocation-event">
+      <td class="govuk-table__cell govuk-!-width-one-half">Last allocation event</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= @allocation.last_event(@offender.offender_no) %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<% end %>
+
+<% unless @movements.blank? %>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Last recorded movement</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Movement date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@movements.create_date_time) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="from-agency">
+      <td class="govuk-table__cell">Starting point</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= agency(@movements.from_agency) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="to-agency">
+      <td class="govuk-table__cell govuk-!-width-one-half">Destination</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= agency(@movements.to_agency) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="movement-direction">
+      <td class="govuk-table__cell govuk-!-width-one-half">Movement direction</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= @movements.direction_code.titleize %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="movement-type">
+      <td class="govuk-table__cell govuk-!-width-one-half">Movement type</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <%= @movements.movement_type %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<% end %>
+
+
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     resource :overrides,  only: %i[ new create ], path_names: { new: 'new/:nomis_offender_id/:nomis_staff_id'}
     resources :poms, only: %i[ index show edit update ], param: :nomis_staff_id
 
+    get('/debugging' => 'debugging#debugging')
     get('/search' => 'search#search')
 
     get('/summary' => 'summary#index')

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+feature 'Provide debugging information for an offender' do
+  let(:nomis_offender_id) { "G7806VO" }
+
+  it 'returns information for an unallocated offender', vcr: { cassette_name: :debugging_feature } do
+    signin_user
+    visit prison_debugging_path('LEI')
+
+    expect(page).to have_text('Debugging')
+    fill_in 'offender_no', with: nomis_offender_id
+    click_on('search-button')
+
+    expect(page).to have_css('tbody tr', count: 28)
+    expect(page).to have_content("Not currently allocated")
+
+    table_row = page.find(:css, 'tr.govuk-table__row#convicted', text: 'Convicted?')
+
+    within table_row do
+      expect(page).to have_content('Yes')
+    end
+  end
+
+  it 'returns information for an allocated offender', vcr: { cassette_name: :debugging_allocated_offender_feature } do
+    create(:allocation_version,
+           nomis_offender_id: nomis_offender_id,
+           primary_pom_name: "Rossana Spinka"
+           )
+    signin_user
+    visit prison_debugging_path('LEI')
+
+    expect(page).to have_text('Debugging')
+    fill_in 'offender_no', with: nomis_offender_id
+    click_on('search-button')
+
+    expect(page).to have_css('tbody tr', count: 33)
+
+    table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
+
+    within table_row do
+      expect(page).to have_content('POM Rossana Spinka')
+    end
+  end
+
+  it 'can handle an incorrect offender number', vcr: { cassette_name: :debugging_incorrect_offender_feature } do
+    signin_user
+    visit prison_debugging_path('LEI')
+
+    expect(page).to have_text('Debugging')
+    fill_in 'offender_no', with: "A1234BC"
+    click_on('search-button')
+
+    expect(page).to have_content("No offender was found, please check the offender number and try again")
+  end
+
+  it 'can handle no offender number being entered', vcr: { cassette_name: :debugging_no_offender_feature } do
+    signin_user
+    visit prison_debugging_path('LEI')
+
+    expect(page).to have_text('Debugging')
+    fill_in 'offender_no', with: ""
+    click_on('search-button')
+
+    expect(page).to have_content("No offender was found, please check the offender number and try again")
+  end
+end

--- a/spec/helpers/debugging_helper_spec.rb
+++ b/spec/helpers/debugging_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DebuggingHelper do
   describe '#agency' do
-    context 'it takes the agency code from a movement and returns the appropriate string' do
+    context 'when parsing an agency code from a movement it returns the appropriate string' do
       it 'displays the full prison name if the agency is within the prison estate' do
         expect(agency("LEI")).to eq "HMP Leeds"
       end

--- a/spec/helpers/debugging_helper_spec.rb
+++ b/spec/helpers/debugging_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DebuggingHelper do
+  describe '#agency' do
+    context 'it takes the agency code from a movement and returns the appropriate string' do
+      it 'displays the full prison name if the agency is within the prison estate' do
+        expect(agency("LEI")).to eq "HMP Leeds"
+      end
+
+      it "returns 'Location outside the prison estate' if the code is not for a prison" do
+        expect(agency("ERGERH")).to eq "Location outside the prison estate"
+      end
+    end
+  end
+end


### PR DESCRIPTION
During the onboarding process we have received a number of queries from
users in regards to missing offenders, offenders with incorrect
information and so forth.  For example: for an offender to show up in
our service they need to be over 18, convicted, sentenced, etc.  At the
moment a dev needs to go and run a number of commands to try and find
out the various pieces of information and pass it along to whoever is on
duty.  Therefore, it was agreed that we should add a debugging page,
that anyone in the team can access, that provides a breakdown of the
individual offender to help us answer these types of queries.