### PR TITLE
[POM-303] Update OffenderApi

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -21,6 +21,10 @@ private
   def import(delius_record)
     offender = OffenderService.get_offender(delius_record.noms_no)
 
+    if offender.blank?
+      return logger.error("Failed to retrieve NOMIS record #{delius_record.noms_no}")
+    end
+
     if auto_delius_import_enabled?(offender.latest_location_id)
       if dob_matches?(offender, delius_record)
         process_record(delius_record)
@@ -29,8 +33,6 @@ private
                                   error_type: DeliusImportError::MISMATCHED_DOB
       end
     end
-  rescue Nomis::Client::APIError
-    logger.error("Failed to retrieve NOMIS record #{delius_record.noms_no}")
   end
 
   def dob_matches?(offender, delius_record)

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -21,9 +21,11 @@ private
   def import(delius_record)
     offender = OffenderService.get_offender(delius_record.noms_no)
 
-    if offender.blank?
+    if offender.nil?
       return logger.error("Failed to retrieve NOMIS record #{delius_record.noms_no}")
     end
+
+    return unless offender.convicted?
 
     if auto_delius_import_enabled?(offender.latest_location_id)
       if dob_matches?(offender, delius_record)

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -42,14 +42,10 @@ module Nomis
 
       def self.get_offender(offender_no)
         route = "/elite2api/api/prisoners/#{URI.encode_www_form_component(offender_no)}"
-        response = e2_client.get(route) { |data|
-          raise Nomis::Client::APIError, 'No data was returned' if data.empty?
-        }
+        response = e2_client.get(route)
+        return '' if response.empty?
 
         api_deserialiser.deserialise(Nomis::Models::Offender, response.first)
-      rescue Nomis::Client::APIError => e
-        AllocationManager::ExceptionHandler.capture_exception(e)
-        Nomis::Models::NullOffender.new
       end
 
       def self.get_offence(booking_id)

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -43,7 +43,7 @@ module Nomis
       def self.get_offender(offender_no)
         route = "/elite2api/api/prisoners/#{URI.encode_www_form_component(offender_no)}"
         response = e2_client.get(route)
-        return '' if response.empty?
+        return nil if response.empty?
 
         api_deserialiser.deserialise(Nomis::Models::Offender, response.first)
       end

--- a/app/services/nomis/models/null_offender.rb
+++ b/app/services/nomis/models/null_offender.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Nomis
-  module Models
-    class NullOffender < Offender; end
-  end
-end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -3,6 +3,8 @@
 class OffenderService
   def self.get_offender(offender_no)
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
+      next false if o.blank?
+
       record = CaseInformation.find_by(nomis_offender_id: offender_no)
 
       if record.present?

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -3,7 +3,7 @@
 class OffenderService
   def self.get_offender(offender_no)
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
-      next false if o.blank?
+      next false if o.nil?
 
       record = CaseInformation.find_by(nomis_offender_id: offender_no)
 

--- a/spec/services/nomis/elite2/offender_api_spec.rb
+++ b/spec/services/nomis/elite2/offender_api_spec.rb
@@ -65,7 +65,7 @@ describe Nomis::Elite2::OffenderApi do
 
       response = described_class.get_offender(noms_id)
 
-      expect(response).to eq ""
+      expect(response).to be_nil
     end
   end
 end

--- a/spec/services/nomis/elite2/offender_api_spec.rb
+++ b/spec/services/nomis/elite2/offender_api_spec.rb
@@ -59,13 +59,13 @@ describe Nomis::Elite2::OffenderApi do
       expect(response).to eq('C')
     end
 
-    it 'returns null if unable to find prisoner', :raven_intercept_exception,
+    it 'returns if unable to find prisoner',
        vcr: { cassette_name: :offender_api_null_offender_spec  } do
       noms_id = 'AAA22D'
 
       response = described_class.get_offender(noms_id)
 
-      expect(response).to be_instance_of(Nomis::Models::NullOffender)
+      expect(response).to eq ""
     end
   end
 end

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -31,7 +31,7 @@ describe OffenderService do
     expect(offender.case_allocation).to eq 'CRC'
   end
 
-  it "can handle an offender record not being found", vcr: { cassette_name: :offender_service_single_offender_not_found_spec } do
+  it "returns nil if offender record not found", vcr: { cassette_name: :offender_service_single_offender_not_found_spec } do
     nomis_offender_id = 'AAA121212CV4G4GGVV'
 
     offender = described_class.get_offender(nomis_offender_id)

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -31,6 +31,13 @@ describe OffenderService do
     expect(offender.case_allocation).to eq 'CRC'
   end
 
+  it "can handle an offender record not being found", vcr: { cassette_name: :offender_service_single_offender_not_found_spec } do
+    nomis_offender_id = 'AAA121212CV4G4GGVV'
+
+    offender = described_class.get_offender(nomis_offender_id)
+    expect(offender).to be_nil
+  end
+
   it "gets the POM names for allocated offenders",
      vcr: { cassette_name: :offender_service_pom_names_spec } do
     offenders = described_class.get_offenders_for_prison('LEI').first(3)


### PR DESCRIPTION
Whilst working on ticket POM-298 we found out that the endpoint to fetch
a single offender on Elite2 ("/elite2api/api/prisoners/OFFENDER_NO") now
returns 200 with an empty array/list, whereas it previously returned a
500 if the offender number was malformed, or the offender didn't exist.
This means that we can remove the NullOffender object and handle not
finding offenders differently.