### PR TITLE
Change the way get the allocated POM's name for an offender in SummaryService

### DIFF
--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -20,7 +20,7 @@ class AllocationService
       PrisonOffenderManagerService.get_user_name(created_by_username)
 
     alloc_version.update!(
-      secondary_pom_name: "#{coworking_pom_firstname} #{coworking_pom_secondname}",
+      secondary_pom_name: "#{coworking_pom_secondname}, #{coworking_pom_firstname}",
       created_by_name: "#{user_firstname} #{user_secondname}",
       created_by_username: created_by_username,
       secondary_pom_nomis_id: secondary_pom_nomis_id,
@@ -46,7 +46,7 @@ class AllocationService
       PrisonOffenderManagerService.get_user_name(params[:created_by_username])
 
     params_copy = params.merge(
-      primary_pom_name: "#{pom_firstname} #{pom_secondname}",
+      primary_pom_name: "#{pom_secondname}, #{pom_firstname}",
       created_by_name: "#{user_firstname} #{user_secondname}",
       primary_pom_allocated_at: DateTime.now.utc
     )

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -103,7 +103,8 @@ class OffenderService
   end
 
   # Takes a list of OffenderSummary or Offender objects, and returns them with their
-  # allocated POM name set in :allocated_pom_name
+  # allocated POM name set in :allocated_pom_name.
+  # This is now only used by the SearchController.
   # rubocop:disable Metrics/LineLength
   def self.set_allocated_pom_name(offenders, caseload)
     pom_names = PrisonOffenderManagerService.get_pom_names(caseload)

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -64,13 +64,14 @@ class SummaryService
 
     # For the allocated offenders, we need to provide the allocated POM's
     # name
+    offender_items = bucket.take(wanted_items, from) || []
+
     if summary_type == :allocated
-      offender_items = OffenderService.set_allocated_pom_name(
-        bucket.take(wanted_items, from) || [],
-        prison
-      )
-    else
-      offender_items = bucket.take(wanted_items, from) || []
+      offender_items.each { |offender|
+        alloc = active_allocations_hash[offender.offender_no]
+        offender.allocated_pom_name = alloc.primary_pom_name.titleize
+        offender.allocation_date = alloc.primary_pom_allocated_at
+      }
     end
 
     Summary.new(summary_type).tap { |summary|

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -69,7 +69,7 @@ class SummaryService
     if summary_type == :allocated
       offender_items.each { |offender|
         alloc = active_allocations_hash[offender.offender_no]
-        offender.allocated_pom_name = alloc.primary_pom_name.titleize
+        offender.allocated_pom_name = restructure_pom_name(alloc.primary_pom_name)
         offender.allocation_date = alloc.primary_pom_allocated_at
       }
     end
@@ -90,6 +90,14 @@ class SummaryService
 # rubocop:enable Metrics/PerceivedComplexity
 
 private
+
+  def self.restructure_pom_name(pom_name)
+    name = pom_name.titleize
+    return name if name.include? ','
+
+    parts = name.split(' ')
+    "#{parts[1]}, #{parts[0]}"
+  end
 
   def self.number_items_wanted(is_last_page, last_digit_of_count)
     if is_last_page && last_digit_of_count != 0

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -4,7 +4,7 @@ feature 'Allocation History' do
   let!(:probation_pom) do
     {
       primary_pom_nomis_id: 485_752,
-      primary_pom_name: 'Ross Jones',
+      primary_pom_name: 'Jones, Ross',
       email: 'Ross.jonessss@digital.justice.gov.uk'
     }
   end
@@ -12,7 +12,7 @@ feature 'Allocation History' do
   let!(:prison_pom) do
     {
       primary_pom_nomis_id: 485_737,
-      primary_pom_name: 'Jay Heal',
+      primary_pom_name: 'Heal, Jay',
       email: 'jay.heal@digital.justice.gov.uk'
     }
   end
@@ -20,7 +20,7 @@ feature 'Allocation History' do
   let!(:probation_pom_2) do
     {
       primary_pom_nomis_id: 485_637,
-      primary_pom_name: 'Kath Pobee-Norris',
+      primary_pom_name: 'Pobee-Norris, Kath',
       email: 'kath.pobee-norris@digital.justice.gov.uk'
     }
   end
@@ -28,7 +28,7 @@ feature 'Allocation History' do
   let!(:pom_without_email) do
     {
       primary_pom_nomis_id: 485_636,
-      primary_pom_name: "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+      primary_pom_name: "#{Faker::Name.last_name}, #{Faker::Name.first_name}"
     }
   end
 

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -81,7 +81,7 @@ feature "view an offender's allocation information" do
 
       allocation.update!(event: AllocationVersion::ALLOCATE_SECONDARY_POM,
                          secondary_pom_nomis_id: 485_752,
-                         secondary_pom_name: "Ross Jones")
+                         secondary_pom_name: "Jones, Ross")
 
       visit prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id_with_keyworker)
 

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -95,7 +95,7 @@ feature 'Co-working' do
 
       allocation.reload
       expect(allocation.secondary_pom_nomis_id).to eq(secondary_pom[:staff_id])
-      expect(allocation.secondary_pom_name).to eq(secondary_pom[:pom_name].upcase)
+      expect(allocation.secondary_pom_name).to eq("POBEE-NORRIS, KATH")
 
       visit prison_allocation_path('LEI', nomis_offender_id)
       within '#co-working-pom' do

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -20,7 +20,7 @@ describe AllocationService do
       create(:allocation_version,
              nomis_offender_id: nomis_offender_id,
              primary_pom_nomis_id: primary_pom_id,
-             primary_pom_name: 'ROSS JONES')
+             primary_pom_name: 'JONES, ROSS')
     }
 
     it 'sends an email to both primary and secondary POMS', vcr: { cassette_name: :allocation_service_allocate_secondary } do
@@ -31,7 +31,7 @@ describe AllocationService do
                                            message: message
         )
         expect(allocation.reload.secondary_pom_nomis_id).to eq(secondary_pom_id)
-        expect(allocation.reload.secondary_pom_name).to eq('KATH POBEE-NORRIS')
+        expect(allocation.reload.secondary_pom_name).to eq('POBEE-NORRIS, KATH')
       }.to change(enqueued_jobs, :count).by(2)
 
       primary_email_job, secondary_email_job = enqueued_jobs.last(2)
@@ -44,7 +44,7 @@ describe AllocationService do
             "pom_name" => "Ross",
             "offender_name" => "Abdoria, Ongmetain",
             "nomis_offender_id" => "G7806VO",
-            "coworking_pom_name" => "KATH POBEE-NORRIS",
+            "coworking_pom_name" => "POBEE-NORRIS, KATH",
             "pom_email" => "Ross.jonessss@digital.justice.gov.uk",
             "url" => "http://localhost:3000/prisons/LEI/caseload"
           ))
@@ -58,7 +58,7 @@ describe AllocationService do
             "offender_name" => "Abdoria, Ongmetain",
             "nomis_offender_id" => "G7806VO",
             "responsibility" => "supporting",
-            "responsible_pom_name" => 'ROSS JONES',
+            "responsible_pom_name" => 'JONES, ROSS',
             "pom_email" => "kath.pobee-norris@digital.justice.gov.uk",
             "url" => "http://localhost:3000/prisons/LEI/caseload"
           ))


### PR DESCRIPTION
We were using the method `set_allocated_pom_name` in OffenderService but this is a painfully slow function call as it re-fetches the allocation for each offender being shown in the allocated tab to work out the name of the POM.

This commit removes the call to `set_allocated_pom_name` and grabs the primary_pom_name and primary_pom_allocated_at date from the allocations we have already obtained.

`OffenderService.set_allocated_pom_name` is used in SearchController so it has been left untouched for now.