### PR TITLE
Add transfer check in MovementService

### DIFF
--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -24,11 +24,13 @@ class MovementService
       return process_release(movement)
     end
 
-    # We think that an ADM without a fromAgency is from court so there
-    # will be nothing to delete/change.
+    # We need to check whether the from_agency is from without the prison estate
+    # to know whether it is a transfer.  If it isn't then we want to bail and
+    # not process the new admission.
     if movement.movement_type == Nomis::Models::MovementType::ADMISSION &&
       movement.direction_code == Nomis::Models::MovementDirection::IN &&
       movement.from_agency.present? &&
+      is_transfer?(movement.from_agency) &&
       movement.to_agency.present?
       return process_transfer(movement)
     end
@@ -58,6 +60,10 @@ private
                                           AllocationVersion::OFFENDER_RELEASED)
 
     true
+  end
+
+  def self.is_transfer?(from_agency_code)
+    PrisonService::PRISONS.include?(from_agency_code)
   end
 
   def self.should_process?(offender_no)

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -19,6 +19,7 @@ class MovementService
     movements
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def self.process_movement(movement)
     if movement.movement_type == Nomis::Models::MovementType::RELEASE
       return process_release(movement)
@@ -30,13 +31,14 @@ class MovementService
     if movement.movement_type == Nomis::Models::MovementType::ADMISSION &&
       movement.direction_code == Nomis::Models::MovementDirection::IN &&
       movement.from_agency.present? &&
-      is_transfer?(movement.from_agency) &&
+      a_transfer?(movement.from_agency) &&
       movement.to_agency.present?
       return process_transfer(movement)
     end
 
     false
   end
+# rubocop:enable Metrics/CyclomaticComplexity
 
 private
 
@@ -62,7 +64,7 @@ private
     true
   end
 
-  def self.is_transfer?(from_agency_code)
+  def self.a_transfer?(from_agency_code)
     PrisonService::PRISONS.include?(from_agency_code)
   end
 

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../app/services/nomis/models/movement'
 
 describe MovementService do
   let!(:new_offender_court) { create(:movement, offender_no: 'G4273GI', from_agency: 'COURT')   }
-  let!(:new_offender_nil) { create(:movement, offender_no: 'G4273GI', from_agency: nil )   }
+  let!(:new_offender_nil) { create(:movement, offender_no: 'G4273GI', from_agency: nil)   }
   let!(:transfer_out) { create(:movement, offender_no: 'G4273GI', direction_code: 'OUT', movement_type: 'TRN')   }
 
   it "can get recent movements",

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 require_relative '../../app/services/nomis/models/movement'
 
 describe MovementService do
-  let!(:new_offender) { create(:movement, offender_no: 'G4273GI', from_agency: nil)   }
+  let!(:new_offender_court) { create(:movement, offender_no: 'G4273GI', from_agency: 'COURT')   }
+  let!(:new_offender_nil) { create(:movement, offender_no: 'G4273GI', from_agency: nil )   }
   let!(:transfer_out) { create(:movement, offender_no: 'G4273GI', direction_code: 'OUT', movement_type: 'TRN')   }
 
   it "can get recent movements",
@@ -77,9 +78,15 @@ describe MovementService do
     expect(processed).to be false
   end
 
-  it "can ignore new offenders arriving at prison",
-     vcr: { cassette_name: :movement_service_ignore_new_spec }  do
-    processed = described_class.process_movement(new_offender)
+  it "can ignore new offenders arriving at prison when from_agency is outside the prison estate",
+     vcr: { cassette_name: :movement_service_ignore_new__from_court_spec }  do
+    processed = described_class.process_movement(new_offender_court)
+    expect(processed).to be false
+  end
+
+  it "can ignore new offenders arriving at prison when from_agency is nil",
+     vcr: { cassette_name: :movement_service_ignore_new_from_nil_spec }  do
+    processed = described_class.process_movement(new_offender_nil)
     expect(processed).to be false
   end
 


### PR DESCRIPTION
We are continuing to see a few cases failing the prison validation when
running the MovementService. The issue appears to be when an offender is
being brought into prison (movement_type: ADM & direction_code: IN), but
they were previously in prison and have a historical allocation. If it
is a new case then we want to bail out and not process any records.

Our initial assumption was that if the “from_agency” code was missing
then this would indicate it was an admission rather than a transfer,
and we wouldn’t process the admissions.  However, we are now seeing this
isn’t the case and we need to explicitly check if the “from_agency” is
from outside the prison estate.