### PR TITLE
[POM-287] Increase offenders displayed per page

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -7,7 +7,7 @@ class CaseloadController < PrisonsApplicationController
   breadcrumb -> { 'New cases' },
              -> { new_prison_caseload_path(active_prison) }, only: [:new]
 
-  PAGE_SIZE = 10
+  PAGE_SIZE = 20
 
   def index
     allocations = PrisonOffenderManagerService.get_allocated_offenders(

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,7 +3,7 @@
 class SearchController < PrisonsApplicationController
   breadcrumb 'Search', -> { prison_search_path(active_prison) }, only: [:search]
 
-  PAGE_SIZE = 10
+  PAGE_SIZE = 20
 
   def search
     @q = search_term

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -28,7 +28,7 @@ private
 
   def new_page_meta(current_page)
     PageMeta.new.tap{ |p|
-      p.size = 10
+      p.size = 20
       p.number = current_page
     }
   end

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -6,7 +6,7 @@ module Nomis
       extend Elite2Api
 
       # rubocop:disable Metrics/MethodLength
-      def self.list(prison, page = 0, page_size: 10)
+      def self.list(prison, page = 0, page_size: 20)
         route = "/elite2api/api/locations/description/#{prison}/inmates"
 
         queryparams = { 'convictedStatus' => 'Convicted', 'returnCategory' => true }

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SummaryService
-  PAGE_SIZE = 10 # The number of items to show in the view
+  PAGE_SIZE = 20 # The number of items to show in the view
 
   class SummaryParams
     attr_reader :sort_field, :sort_direction

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -53,7 +53,7 @@ class SummaryService
     # we just want the last digit, so if there are 138 items, the last page should
     # show 8.
     wanted_items = number_items_wanted(
-      page_count == page,
+      page_count == page && page_count > 1,
       counts[summary_type].digits[0]
     )
     if params.sort_field.present?

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe SearchController, type: :controller do
     expect(assigns(:offenders).size).to eq(0)
 
     actual = assigns(:page_meta)
-    expect(actual.size).to eq(10)
+    expect(actual.size).to eq(20)
     expect(actual.total_pages).to eq(0)
     expect(actual.total_elements).to eq(0)
     expect(actual.number).to eq(1)

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -4,7 +4,17 @@ feature "view POM's caseload" do
   let(:nomis_staff_id) { 485_637 }
   let(:nomis_offender_id) { 'G4273GI' }
 
-  # create 11 allocations for prisoners named A-K so that we can verify that default sorted paging works
+  # create 21 allocations for prisoners named A-K so that we can verify that default sorted paging works
+  let!(:offender21_case_info) { create(:case_information, nomis_offender_id: 'G7266VD') }
+  let!(:offender20_case_info) { create(:case_information, nomis_offender_id: 'G8563UA') }
+  let!(:offender19_case_info) { create(:case_information, nomis_offender_id: 'G6068GV') }
+  let!(:offender18_case_info) { create(:case_information, nomis_offender_id: 'G0572VU') }
+  let!(:offender17_case_info) { create(:case_information, nomis_offender_id: 'G8668GF') }
+  let!(:offender16_case_info) { create(:case_information, nomis_offender_id: 'G9465UP') }
+  let!(:offender15_case_info) { create(:case_information, nomis_offender_id: 'G9372GQ') }
+  let!(:offender14_case_info) { create(:case_information, nomis_offender_id: 'G1618UI') }
+  let!(:offender13_case_info) { create(:case_information, nomis_offender_id: 'G4328GK') }
+  let!(:offender12_case_info) { create(:case_information, nomis_offender_id: 'G4143VX') }
   let!(:offender11_case_info) { create(:case_information, nomis_offender_id: 'G8180UO') }
   let!(:offender10_case_info) { create(:case_information, nomis_offender_id: 'G8909GV') }
   let!(:offender9_case_info) { create(:case_information, nomis_offender_id: 'G8339GD') }
@@ -21,14 +31,22 @@ feature "view POM's caseload" do
 
   context 'when paginating', vcr: { cassette_name: :show_poms_caseload } do
     before do
-      stub_const("NAMES", ["Abbella, Ozullirn", "Bennany, Yruicafar", "Cadary, Avncent", "Daijedo, Egvaning",
+      stub_const("NAMES", ["Abbella, Ozullirn", 'Allix, Aobmethani',
+                           'Almesa, Akoresjan', 'Amabeth, Eeonyan', 'Anasterie, Aobmethani', 'Andexia, Obinins',
+                           'Andoy, Demolarichard', 'Androne, Alblisdavid', 'Anikariah, Aeticake',
+                           'Annole, Omistius', 'Anslana, Diydonopher',
+                           "Bennany, Yruicafar", "Cadary, Avncent", "Daijedo, Egvaning",
                            'Ebonuardo, Omimchi', 'Felitha, Asjmonzo', 'Gabrijah, Eastzo', 'Hah, Dyfastoaul',
-                           'Ibriyah, Aiamce', 'Jabexia, Elnuunbo', 'Kaceria, Omaertain'])
+                           'Ibriyah, Aiamce', 'Jabexia, Elnuunbo', 'Kaceria, Omaertain'
+      ])
       signin_user('PK000223')
 
       [offender1_case_info, offender2_case_info, offender3_case_info, offender4_case_info,
        offender5_case_info, offender6_case_info, offender7_case_info, offender8_case_info,
-       offender9_case_info, offender10_case_info, offender11_case_info].each do |case_info|
+       offender9_case_info, offender10_case_info, offender11_case_info, offender12_case_info,
+       offender13_case_info, offender14_case_info, offender15_case_info, offender16_case_info,
+       offender17_case_info, offender18_case_info, offender19_case_info, offender20_case_info,
+       offender21_case_info].each do |case_info|
         visit prison_confirm_allocation_path('LEI', case_info.nomis_offender_id, nomis_staff_id)
         click_button 'Complete allocation'
       end
@@ -36,21 +54,21 @@ feature "view POM's caseload" do
     end
 
     it 'displays paginated cases for a specific POM' do
-      expect(page).to have_content("Showing 1 - 10 of 11 results")
+      expect(page).to have_content("Showing 1 - 20 of 21 results")
       expect(page).to have_content("Your caseload")
-      NAMES.first(10).each_with_index do |name, index|
+      NAMES.first(20).each_with_index do |name, index|
         within ".offender_row_#{index}" do
           expect(page).to have_content(name)
         end
       end
       click_link 'Next »'
-      expect(page).to have_content("Showing 11 - 11 of 11 results")
+      expect(page).to have_content("Showing 21 - 21 of 21 results")
       expect(page).to have_content(NAMES.last)
     end
 
     it 'can be reverse sorted by name' do
       click_link 'Prisoner name'
-      NAMES.last(10).reverse.each_with_index do |name, index|
+      NAMES.last(20).reverse.each_with_index do |name, index|
         within ".offender_row_#{index}" do
           expect(page).to have_content(name)
         end
@@ -59,11 +77,12 @@ feature "view POM's caseload" do
 
     it 'can be sorted by release date' do
       page.all('th')[2].find('a').click
+      save_and_open_page
       within '.offender_row_2' do
         expect(page).to have_content('Kaceria, Omaertain')
       end
       within '.offender_row_3' do
-        expect(page).to have_content('Gabrijah, Eastzo')
+        expect(page).to have_content('Anikariah, Aeticake')
       end
     end
 
@@ -85,7 +104,7 @@ feature "view POM's caseload" do
     it 'can be searched by role' do
       select 'Supporting', from: 'role'
       click_on 'Search'
-      expect(page).to have_content('Showing 1 - 7 of 7 results')
+      expect(page).to have_content('Showing 1 - 14 of 14 results')
     end
   end
 

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -108,11 +108,11 @@ feature "view POM's caseload" do
 
     it 'can be sorted by release date' do
       page.all('th')[2].find('a').click
-      within '.offender_row_2' do
-        expect(page).to have_content('Anikariah, Aeticake')
+      within '.offender_row_4' do
+        expect(page).to have_content('Allix, Aobmethani')
       end
-      within '.offender_row_3' do
-        expect(page).to have_content('Kaceria, Omaertain')
+      within '.offender_row_5' do
+        expect(page).to have_content('Andoy, Demolarichard')
       end
     end
 

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -77,7 +77,6 @@ feature "view POM's caseload" do
 
     it 'can be sorted by release date' do
       page.all('th')[2].find('a').click
-      save_and_open_page
       within '.offender_row_2' do
         expect(page).to have_content('Kaceria, Omaertain')
       end

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -29,6 +29,43 @@ feature "view POM's caseload" do
     create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'Yes')
   end
 
+  let!(:case_infos) {
+    [
+   offender1_case_info, offender2_case_info, offender3_case_info, offender4_case_info,
+   offender5_case_info, offender6_case_info, offender7_case_info, offender8_case_info,
+   offender9_case_info, offender10_case_info, offender11_case_info, offender12_case_info,
+   offender13_case_info, offender14_case_info, offender15_case_info, offender16_case_info,
+   offender17_case_info, offender18_case_info, offender19_case_info, offender20_case_info,
+   offender21_case_info
+    ]
+  }
+
+  let!(:allocations) {
+    [
+    create(:allocation_version, nomis_offender_id: 'G7266VD', primary_pom_nomis_id: '485637', nomis_booking_id: '1073602'),
+    create(:allocation_version, nomis_offender_id: 'G8563UA', primary_pom_nomis_id: '485637', nomis_booking_id: '1020605'),
+    create(:allocation_version, nomis_offender_id: 'G6068GV', primary_pom_nomis_id: '485637', nomis_booking_id: '1030841'),
+    create(:allocation_version, nomis_offender_id: 'G0572VU', primary_pom_nomis_id: '485637', nomis_booking_id: '861029'),
+    create(:allocation_version, nomis_offender_id: 'G8668GF', primary_pom_nomis_id: '485637', nomis_booking_id: '1106348'),
+    create(:allocation_version, nomis_offender_id: 'G9465UP', primary_pom_nomis_id: '485637', nomis_booking_id: '1186259'),
+    create(:allocation_version, nomis_offender_id: 'G9372GQ', primary_pom_nomis_id: '485637', nomis_booking_id: '752833'),
+    create(:allocation_version, nomis_offender_id: 'G1618UI', primary_pom_nomis_id: '485637', nomis_booking_id: '1161236'),
+    create(:allocation_version, nomis_offender_id: 'G4328GK', primary_pom_nomis_id: '485637', nomis_booking_id: '1055341'),
+    create(:allocation_version, nomis_offender_id: 'G4143VX', primary_pom_nomis_id: '485637', nomis_booking_id: '1083858'),
+    create(:allocation_version, nomis_offender_id: 'G8180UO', primary_pom_nomis_id: '485637', nomis_booking_id: '1172076'),
+    create(:allocation_version, nomis_offender_id: 'G8909GV', primary_pom_nomis_id: '485637', nomis_booking_id: '877782'),
+    create(:allocation_version, nomis_offender_id: 'G8339GD', primary_pom_nomis_id: '485637', nomis_booking_id: '260708'),
+    create(:allocation_version, nomis_offender_id: 'G1992GH', primary_pom_nomis_id: '485637', nomis_booking_id: '1179167'),
+    create(:allocation_version, nomis_offender_id: 'G1986GG', primary_pom_nomis_id: '485637', nomis_booking_id: '1165890'),
+    create(:allocation_version, nomis_offender_id: 'G6262GI', primary_pom_nomis_id: '485637', nomis_booking_id: '961997'),
+    create(:allocation_version, nomis_offender_id: 'G6653UC', primary_pom_nomis_id: '485637', nomis_booking_id: '1009990'),
+    create(:allocation_version, nomis_offender_id: 'G1718GG', primary_pom_nomis_id: '485637', nomis_booking_id: '928042'),
+    create(:allocation_version, nomis_offender_id: 'G4706UP', primary_pom_nomis_id: '485637', nomis_booking_id: '1180800'),
+    create(:allocation_version, nomis_offender_id: 'G9344UG', primary_pom_nomis_id: '485637', nomis_booking_id: '841994'),
+    create(:allocation_version, nomis_offender_id: 'G4273GI', primary_pom_nomis_id: '485637', nomis_booking_id: '1153753')
+  ]
+  }
+
   context 'when paginating', vcr: { cassette_name: :show_poms_caseload } do
     before do
       stub_const("NAMES", ["Abbella, Ozullirn", 'Allix, Aobmethani',
@@ -41,15 +78,9 @@ feature "view POM's caseload" do
       ])
       signin_user('PK000223')
 
-      [offender1_case_info, offender2_case_info, offender3_case_info, offender4_case_info,
-       offender5_case_info, offender6_case_info, offender7_case_info, offender8_case_info,
-       offender9_case_info, offender10_case_info, offender11_case_info, offender12_case_info,
-       offender13_case_info, offender14_case_info, offender15_case_info, offender16_case_info,
-       offender17_case_info, offender18_case_info, offender19_case_info, offender20_case_info,
-       offender21_case_info].each do |case_info|
-        visit prison_confirm_allocation_path('LEI', case_info.nomis_offender_id, nomis_staff_id)
-        click_button 'Complete allocation'
-      end
+      case_infos
+      allocations
+
       visit prison_caseload_index_path('LEI')
     end
 
@@ -78,10 +109,10 @@ feature "view POM's caseload" do
     it 'can be sorted by release date' do
       page.all('th')[2].find('a').click
       within '.offender_row_2' do
-        expect(page).to have_content('Kaceria, Omaertain')
+        expect(page).to have_content('Anikariah, Aeticake')
       end
       within '.offender_row_3' do
-        expect(page).to have_content('Anikariah, Aeticake')
+        expect(page).to have_content('Kaceria, Omaertain')
       end
     end
 

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -5,8 +5,8 @@ describe SummaryService do
   it "will generate a summary", vcr: { cassette_name: :allocation_summary_service_summary } do
     summary = described_class.summary(:pending, 'LEI', 15, SummaryService::SummaryParams.new)
 
-    expect(summary.offenders.count).to eq(10)
-    expect(summary.page_count).to eq(83)
+    expect(summary.offenders.count).to eq(20)
+    expect(summary.page_count).to eq(42)
   end
 
   it "will sort a summary", vcr: { cassette_name: :allocation_summary_service_summary_sort } do


### PR DESCRIPTION
We discussed the option of increasing the number of offenders we display on a page, upping it from 10 to 20.  This is a temporary solution whilst further research is done into how we can improve the pagination situation. 