### PR TITLE
Waiting to allocate date

### DIFF
--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -21,11 +21,13 @@ class SummaryController < PrisonsApplicationController
   def unallocated
     @summary = create_summary(:unallocated)
     @page_meta = @summary.page_meta(page)
+    @prison_dates = SummaryService.entered_prison_dates(@summary.offenders)
   end
 
   def pending
     @summary = create_summary(:pending)
     @page_meta = @summary.page_meta(page)
+    @prison_dates = SummaryService.entered_prison_dates(@summary.offenders)
   end
 
 private

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -3,6 +3,6 @@
 module SummaryHelper
   def start_date(prison_dates, offender_no)
     prison_date = prison_dates.detect{ |f| f[:offender_no] == offender_no }
-    prison_date.nil? ? '-' : prison_date[:days_count]
+    prison_date.nil? ? '-1' : prison_date[:days_count]
   end
 end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SummaryHelper
+  def start_date(prison_dates, offender_no)
+    prison_date = prison_dates.detect{ |f| f[:offender_no] == offender_no }
+    prison_date.nil? ? '-' : prison_date[:days_count]
+  end
+end

--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -21,7 +21,12 @@ module Nomis
       def self.movements_for(offender_no)
         route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false'
 
-        data = e2_client.post(route, [offender_no])
+        if offender_no.is_a?(Array)
+          data = e2_client.post(route, offender_no)
+        else
+          data = e2_client.post(route, [offender_no])
+        end
+
         data.sort_by { |k| k['createDateTime'] }.map{ |movement|
           api_deserialiser.deserialise(Nomis::Movement, movement)
         }

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -85,7 +85,7 @@ class SummaryService
 
     offenders = offender_list.map(&:offender_no)
 
-    return if offenders.nil?
+    return if offenders.empty?
 
     omic_start_date = Date.new(2019, 2, 4)
     movements = Nomis::Elite2::MovementApi.movements_for(offenders)

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -75,10 +75,34 @@ class SummaryService
       summary.page_count = page_count
     }
   end
-# rubocop:enable Metrics/CyclomaticComplexity
-# rubocop:enable Metrics/LineLength
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
+
+  def self.entered_prison_dates(offender_list)
+    return if offender_list.empty?
+
+    offenders = offender_list.map(&:offender_no)
+    prison_dates = []
+
+    unless offenders.nil?
+      omic_start_date = Date.new(2019, 2, 4)
+      movements = Nomis::Elite2::MovementApi.movements_for(offenders)
+
+      prison_dates = movements.map { |movement|
+        if movement.create_date_time.nil? ||
+            movement.create_date_time < omic_start_date
+          start_date = (Time.zone.today - omic_start_date).to_i
+        else
+          start_date = (Time.zone.today - movement.create_date_time).to_i
+        end
+        { offender_no: movement.offender_no, days_count: start_date }
+      }
+    end
+
+    prison_dates
+  end
 
 private
 

--- a/app/views/summary/pending.html.erb
+++ b/app/views/summary/pending.html.erb
@@ -52,7 +52,7 @@
             Not provided
           <% end %>
         </td>
-        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %> days</td>
+        <td aria-label="Waiting" class="govuk-table__cell"><%=  start_date(@prison_dates, offender.offender_no) %> days</td>
         <td aria-label="Action" class="govuk-table__cell" id="<%= "edit_#{offender.offender_no}" %>">
           <% if auto_delius_import_enabled?(@prison) %>
             <%= link_to "Update", prison_case_information_path(@prison, offender.offender_no) %>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -61,7 +61,7 @@
           <%= case_owner_label(offender) %>
         </td>
         <td aria-label="Awaiting allocation for" class="govuk-table__cell">
-          <%= offender.awaiting_allocation_for %> days
+          <%= start_date(@prison_dates, offender.offender_no) %> days
         </td>
         <td aria-label="Action" class="govuk-table__cell ">
           <a href="<%= new_prison_allocation_path(@prison, offender.offender_no) %>">Allocate</a>

--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SummaryHelper do
+  describe 'start_date' do
+    let(:prison_dates) do
+      [
+          { offender_no: "A1120GH", days_count: 199 },
+          { offender_no: "G9765JZ", days_count: 50 }
+      ]
+    end
+
+    it "formats an offender's prison start date if offender exists" do
+      expect(start_date(prison_dates, "A1120GH")).to eq(199)
+    end
+
+    it "formats an offender's prison start date if offender does not exist" do
+      expect(start_date(prison_dates, "Z1234WQ")).to eq('-')
+    end
+  end
+end

--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SummaryHelper do
     end
 
     it "formats an offender's prison start date if offender does not exist" do
-      expect(start_date(prison_dates, "Z1234WQ")).to eq('-')
+      expect(start_date(prison_dates, "Z1234WQ")).to eq('-1')
     end
   end
 end

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -56,8 +56,8 @@ describe Nomis::Elite2::MovementApi do
       movements = described_class.movements_for(%w[A5019DY G7806VO])
 
       expect(movements).to be_kind_of(Array)
-      expect(movements.length).to eq(2)
-      expect(movements.first).to be_kind_of(Nomis::Models::Movement)
+      expect(movements.length).to eq(7)
+      expect(movements.first).to be_kind_of(Nomis::Movement)
     end
   end
 end

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -50,4 +50,14 @@ describe Nomis::Elite2::MovementApi do
       expect(movements.first).to be_kind_of(Nomis::Movement)
     end
   end
+
+  describe 'Movements for multiple offenders' do
+    it 'can get movements for multiple offenders', vcr: { cassette_name: :movement_api_for_multiple_offenders } do
+      movements = described_class.movements_for(%w[A5019DY G7806VO])
+
+      expect(movements).to be_kind_of(Array)
+      expect(movements.length).to eq(2)
+      expect(movements.first).to be_kind_of(Nomis::Models::Movement)
+    end
+  end
 end

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -28,4 +28,19 @@ describe SummaryService do
 
     expect(asc_cells).not_to match_array(desc_cells)
   end
+
+  describe 'entered_prison_dates', vcr: { cassette_name: :allocation_summary_service_entered_prison_dates } do
+    asc_summary = described_class.summary(
+      :pending,
+      'LEI',
+      1,
+      SummaryService::SummaryParams.new(sort_field: :last_name)
+    )
+
+    it 'gets the prison dates for list of offenders' do
+      prison_dates = described_class.entered_prison_dates(asc_summary.offenders)
+      expect(prison_dates).to be_an(Array)
+      expect(prison_dates.first).to include(:offender_no, :days_count)
+    end
+  end
 end

--- a/spec/services/summary_service_spec.rb
+++ b/spec/services/summary_service_spec.rb
@@ -29,7 +29,7 @@ describe SummaryService do
     expect(asc_cells).not_to match_array(desc_cells)
   end
 
-  describe 'entered_prison_dates', vcr: { cassette_name: :allocation_summary_service_entered_prison_dates } do
+  describe 'entered_prison_dates' do
     asc_summary = described_class.summary(
       :pending,
       'LEI',
@@ -37,10 +37,15 @@ describe SummaryService do
       SummaryService::SummaryParams.new(sort_field: :last_name)
     )
 
-    it 'gets the prison dates for list of offenders' do
+    it 'gets the prison dates for list of offenders', vcr: { cassette_name: :allocation_summary_service_entered_prison_dates } do
       prison_dates = described_class.entered_prison_dates(asc_summary.offenders)
       expect(prison_dates).to be_an(Array)
       expect(prison_dates.first).to include(:offender_no, :days_count)
+    end
+
+    it 'returns nil if there are no offenders', vcr: { cassette_name: :allocation_summary_service_entered_prison_dates_blank } do
+      prison_dates = described_class.entered_prison_dates([])
+      expect(prison_dates).to be(nil)
     end
   end
 end


### PR DESCRIPTION
Currently the "Waiting to Allocate" date shows the date the offender was sentenced, this PR is to provide a more accurate reflection of the actual time the offender entered the current prison as offenders are often transferred to other prisons during their stay.

This PR amends the MovementAPI movement_for method to accept an array of offenders to obtain the prison the offender is currently located at. This information is used to determine when the waiting to allocate date occurs at either from the omic start date or the date the offender entered the prison.