### PR TITLE
In search results, show View link when viewing allocated results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -19,8 +19,8 @@ module SearchHelper
     end
 
     link_to(
-      'Reallocate',
-      new_prison_allocation_path(prison, nomis_offender_id: offender_id)
+      'View',
+      prison_allocation_path(prison, nomis_offender_id: offender_id)
     )
   end
 end

--- a/spec/factories/allocation_versions.rb
+++ b/spec/factories/allocation_versions.rb
@@ -23,15 +23,15 @@ FactoryBot.define do
     end
 
     nomis_booking_id do
-      Faker::Number.number(7)
+      Faker::Number.number(digits: 7)
     end
 
     nomis_offender_id do
-      Faker::Alphanumeric.alpha(10)
+      Faker::Alphanumeric.alpha(number: 10)
     end
 
     primary_pom_nomis_id do
-      Faker::Number.number(7)
+      Faker::Number.number(digits: 7)
     end
 
     primary_pom_name do

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -19,13 +19,13 @@ FactoryBot.define do
     end
 
     nomis_offender_id do
-      Faker::Alphanumeric.alpha(10)
+      Faker::Alphanumeric.alpha(number: 10)
     end
 
     association :team, code: '1234', name: 'A nice team'
 
     association :local_divisional_unit, code: '123', name: "LDU Name"
 
-    crn { Faker::Alphanumeric.alpha(10) }
+    crn { Faker::Alphanumeric.alpha(number: 10) }
   end
 end

--- a/spec/factories/delius_datums.rb
+++ b/spec/factories/delius_datums.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       'G4281GV'
     end
     crn do
-      Faker::Number.number(8)
+      Faker::Number.number(digits: 8)
     end
     # This has to match the T3 record for G4281GV above
     date_of_birth do '11/11/1964' end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe SearchHelper do
       expect(text).to eq('<a href="/prisons/LEI/allocations/A/new">Allocate</a>')
     end
 
-    it "will change to reallocate if there is an allocation" do
+    it "will change to view if there is an allocation" do
       offender = Nomis::Models::Offender.new(
         offender_no: 'A',
         tier: 'A',
         allocated_pom_name: 'Bob'
       )
       text, _link = cta_for_offender('LEI', offender)
-      expect(text).to eq('<a href="/prisons/LEI/allocations/A/new">Reallocate</a>')
+      expect(text).to eq('<a href="/prisons/LEI/allocations/A">View</a>')
     end
   end
 end

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -112,9 +112,9 @@ describe MovementService do
       processed = described_class.process_movement(transfer_adm)
       updated_allocation = AllocationVersion.find_by(nomis_offender_id: transfer_adm.offender_no)
 
-      expect(updated_allocation.primary_pom_name).to be_nil
       expect(updated_allocation.event).to eq 'deallocate_primary_pom'
       expect(updated_allocation.event_trigger).to eq 'offender_transferred'
+      expect(updated_allocation.primary_pom_name).to be_nil
       expect(processed).to be true
     end
 


### PR DESCRIPTION
When viewing the search results, and seeing an allocated offender, the
link should say View and go to the Allocation Info page, rather than
directly to re-allocate.

Also fixed required faker updates.