### PR TITLE
Only active allocations when grouping in summary

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -136,7 +136,7 @@ private
   end
 
   def current_pom_for(nomis_offender_id)
-    current_allocation = AllocationService.allocations(nomis_offender_id, active_prison)
+    current_allocation = AllocationService.active_allocations(nomis_offender_id, active_prison)
     nomis_staff_id = current_allocation[nomis_offender_id]['primary_pom_nomis_id']
 
     PrisonOffenderManagerService.get_pom(active_prison, nomis_staff_id)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -89,7 +89,7 @@ class AllocationService
 
   def self.active_allocations(nomis_offender_ids, prison)
     AllocationVersion.where.not(
-      primary_pom_nomis_id:nil
+      primary_pom_nomis_id: nil
     ).where(
       nomis_offender_id: nomis_offender_ids, prison: prison
     ).map { |a|

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -87,11 +87,12 @@ class AllocationService
     }.to_h
   end
 
-  def self.allocations(nomis_offender_ids, prison)
-    AllocationVersion.where(
-      nomis_offender_id: nomis_offender_ids,
-      prison: prison).
-      map { |a|
+  def self.active_allocations(nomis_offender_ids, prison)
+    AllocationVersion.where.not(
+      primary_pom_nomis_id:nil
+    ).where(
+      nomis_offender_id: nomis_offender_ids, prison: prison
+    ).map { |a|
       [
         a[:nomis_offender_id],
         a
@@ -148,7 +149,7 @@ class AllocationService
   end
 
   def self.current_pom_for(nomis_offender_id, prison_id)
-    current_allocation = allocations(nomis_offender_id, prison_id)
+    current_allocation = active_allocations(nomis_offender_id, prison_id)
     nomis_staff_id = current_allocation[nomis_offender_id]['primary_pom_nomis_id']
 
     PrisonOffenderManagerService.get_pom(prison_id, nomis_staff_id)

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -26,14 +26,12 @@ class SummaryService
     counts = { allocated: 0, unallocated: 0, pending: 0, all: 0 }
 
     offenders = OffenderService.get_offenders_for_prison(prison)
-    active_allocations_hash = AllocationService.allocations(offenders.map(&:offender_no), prison)
+    active_allocations_hash = AllocationService.active_allocations(offenders.map(&:offender_no), prison)
 
     offenders.each do |offender|
       if offender.tier.present?
-        # When trying to determine if this offender has a current allocation, we want to know
-        # if it is for this prison.  If the offender was recently transferred here their prison
-        # field should be nil, which means they will be pending allocation.  Once they are allocated
-        # the prison will be set on their existing allocation.
+        # When trying to determine if this offender has a current active allocation, we want to know
+        # if it is for this prison.
         if active_allocations_hash.key?(offender.offender_no)
           bucket.items << offender if summary_type == :allocated
           counts[:allocated] += 1

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -132,7 +132,7 @@ describe AllocationService do
         prison: 'USK'
       )
 
-      allocations = described_class.allocations([first_offender_id, second_offender_id], leeds_prison)
+      allocations = described_class.active_allocations([first_offender_id, second_offender_id], leeds_prison)
 
       expect(allocations.keys.count).to be(1)
       expect(allocations.keys.first).to eq(first_offender_id)


### PR DESCRIPTION
When grouping offenders into the correct bucket in summary, ensure we
ignore inactive previous allocations.