### PR TITLE
A simple rake task to fix up incorrect allocations

### DIFF
--- a/lib/allocation_validation.rb
+++ b/lib/allocation_validation.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class AllocationValidation
+  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Rails/Output
+  def fixup(prison)
+    # Looks for offenders who have an allocation at this prison
+    # who are allocated incorrectly because of a release or a transfer.
+    #
+    # Specifically it handles
+    #
+    # * Offender is currently allocated at this prison but was released
+    # * Offender is currently allocated at this prison but was transferred
+    #   This means that they will be available for allocation at their new
+    #   prison until we deactivate the allocation at the old prison
+    #
+
+    # Get all active allocations for this prison
+    allocations = active_allocations_for_prison(prison)
+
+    puts "Processing #{allocations.count} items"
+
+    allocations.each { |allocation|
+      # Get the offender from NOMIS
+      offender = OffenderService.get_offender(allocation.nomis_offender_id)
+
+      # If the offender is at this prison, we're good .
+      next if offender.latest_location_id == prison
+
+      # If the offender is out, deallocate as a release
+      if offender.latest_location_id == 'OUT'
+        puts "#{offender.offender_no} appears to have been released"
+        # AllocationVersion.deallocate_offender(offender.offender_no, 'offender_released')
+        next
+      end
+
+      # The offender is at a different prison so deallocate as a transfer
+      puts "#{offender.offender_no} (allocated) appears to have been transferred to #{offender.latest_location_id}"
+      # AllocationVersion.deallocate_offender(offender.offender_no, 'offender_transferred')
+    }
+  end
+  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Rails/Output
+
+  def active_allocations_for_prison(prison)
+    AllocationVersion.where.not(primary_pom_nomis_id: nil).where(prison: prison)
+  end
+end

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OnboardPrison
   attr_reader :offender_ids, :delius_records
   attr_accessor :delius_missing, :additions

--- a/lib/tasks/fix_data.rake
+++ b/lib/tasks/fix_data.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../allocation_validation'
+
+namespace :fix_data do
+  desc 'Fixes data for incorrect transfer/releases/allocations'
+  task :for_prison, [:prison] => [:environment] do |_task, args|
+    prison = args[:prison]
+
+    if PrisonService.name_for(prison).nil?
+      puts "Unable to find prison #{prison}"
+      next
+    end
+
+    AllocationValidation.new.fixup(prison)
+  end
+end


### PR DESCRIPTION
As we currently have allocations that are incorrect, because of releases
and transfers that the movement_service has missed, we need to clean
them up.

This version of a rake task will, for a single prison at a time, fix up
all allocations for that prison to ensure offenders no longer there are
deallocated (and then should be available for allocation in their new
prison, if they have one).

Initially we will simply print out what we would have done as we don't
want to risk breaking a production database.