### PR TITLE
Allow client to not log 404s

### DIFF
--- a/app/services/nomis/keyworker/keyworker_api.rb
+++ b/app/services/nomis/keyworker/keyworker_api.rb
@@ -18,7 +18,7 @@ module Nomis
 
       def self.client
         host = Rails.configuration.keyworker_api_host
-        Nomis::Client.new(host)
+        Nomis::Client.new(host, false)
       end
     end
   end

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -49,6 +49,13 @@ describe Nomis::Client do
       expect(AllocationManager::ExceptionHandler).to receive(:capture_exception).with(error)
       expect { client.get(route) }.to raise_error(Nomis::Client::APIError)
     end
+
+    it 'does not send the error to sentry if told not to' do
+      non_logging_client = described_class.new(api_host, false)
+
+      expect(AllocationManager::ExceptionHandler).not_to receive(:capture_exception).with(error)
+      expect { non_logging_client.get(route) }.to raise_error(Nomis::Client::APIError)
+    end
   end
 
   describe 'when there is an 500 (server broken) error' do
@@ -64,7 +71,7 @@ describe Nomis::Client do
 
     it 'raises an APIError', :raven_intercept_exception do
       expect { client.get(route) }.
-        to raise_error(Nomis::Client::APIError, 'Unexpected status 500')
+        to raise_error(Nomis::Client::APIError, 'Client error: 500')
     end
 
     it 'sends the error to sentry' do

--- a/spec/services/nomis/keyworker/keyworker_api_spec.rb
+++ b/spec/services/nomis/keyworker/keyworker_api_spec.rb
@@ -13,7 +13,7 @@ describe Nomis::Keyworker::KeyworkerApi do
       expect(response.first_name).to eq('DOM')
     end
 
-    it 'returns null if unable find a Keyworker', :raven_intercept_exception,
+    it 'returns nullkeyworker if unable find a Keyworker', :raven_intercept_exception,
        vcr: { cassette_name: :keyworker_api_details_not_found_spec } do
       unknown_offender_no = 'GGGGGGG'
       response = described_class.get_keyworker(location, unknown_offender_no)


### PR DESCRIPTION
Now when creating a client, you can ask it to not log 404s if it doesn't
make sense. In particular, things like the keyworker api.

See POM-317