### PR TITLE
Fix MovementApi spec test

### DIFF
--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -18,7 +18,7 @@ describe Nomis::Elite2::MovementApi do
       movements = described_class.movements_for('A5019DY')
 
       expect(movements).to be_kind_of(Array)
-      expect(movements.length).to eq(1)
+      expect(movements.length).to eq(2)
       expect(movements.first).to be_kind_of(Nomis::Models::Movement)
     end
 


### PR DESCRIPTION
Test returns 2 records for the offender's movement instead of 1