### PR TITLE
Fix allocation date exceptions

### DIFF
--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -118,7 +118,7 @@ class OffenderService
           a.nomis_offender_id,
           {
             pom_name: pom_names[a.primary_pom_nomis_id],
-            allocation_date: a.primary_pom_allocated_at.to_date
+            allocation_date: (a.primary_pom_allocated_at || a.updated_at)&.to_date
           }
         ]
       }.to_h

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -61,7 +61,7 @@ class SummaryService
       offender_items.each { |offender|
         alloc = active_allocations_hash[offender.offender_no]
         offender.allocated_pom_name = restructure_pom_name(alloc.primary_pom_name)
-        offender.allocation_date = alloc.primary_pom_allocated_at.to_date
+        offender.allocation_date = (alloc.primary_pom_allocated_at || alloc.updated_at)&.to_date
       }
     end
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -38,13 +38,37 @@ describe OffenderService do
     expect(offender).to be_nil
   end
 
-  it "gets the POM names for allocated offenders",
-     vcr: { cassette_name: :offender_service_pom_names_spec } do
-    offenders = described_class.get_offenders_for_prison('LEI').first(3)
-    nomis_staff_id = 485_752
+  describe "#set_allocated_pom_name" do
+    let(:offenders) { described_class.get_offenders_for_prison('LEI').first(3) }
+    let(:nomis_staff_id) { 485_752 }
 
-    PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
+    before do
+      PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
+    end
 
+    it "gets the POM names for allocated offenders",
+       vcr: { cassette_name: :offender_service_pom_names_spec } do
+      allocate_offender(DateTime.now.utc)
+
+      updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
+      expect(updated_offenders).to be_kind_of(Array)
+      expect(updated_offenders.first).to be_kind_of(Nomis::Models::OffenderSummary)
+      expect(updated_offenders.count).to eq(offenders.count)
+      expect(updated_offenders.first.allocated_pom_name).to eq('Jones, Ross')
+      expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
+    end
+
+    it "uses 'updated_at' date when 'primary_pom_allocated_at' date is nil",
+       vcr: { cassette_name: :offender_service_set_allocated_pom_when_primary_pom_date_nil } do
+      allocate_offender(nil)
+
+      updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
+      expect(updated_offenders.first.allocated_pom_name).to eq('Jones, Ross')
+      expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
+    end
+  end
+
+  def allocate_offender(allocated_date)
     AllocationVersion.create!(
       nomis_offender_id: offenders.first.offender_no,
       nomis_booking_id: 1_153_753,
@@ -52,17 +76,10 @@ describe OffenderService do
       allocated_at_tier: 'C',
       created_by_username: 'PK000223',
       primary_pom_nomis_id: nomis_staff_id,
-      primary_pom_allocated_at: DateTime.now.utc,
+      primary_pom_allocated_at: allocated_date,
       recommended_pom_type: 'prison',
       event: AllocationVersion::ALLOCATE_PRIMARY_POM,
       event_trigger: AllocationVersion::USER
     )
-
-    updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
-    expect(updated_offenders).to be_kind_of(Array)
-    expect(updated_offenders.first).to be_kind_of(Nomis::Models::OffenderSummary)
-    expect(updated_offenders.count).to eq(offenders.count)
-    expect(updated_offenders.first.allocated_pom_name).to eq('Jones, Ross')
-    expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
   end
 end


### PR DESCRIPTION
Allocation dates are occasionally raising exceptions. This is due the
`primary_pom_allocated_at` date being nil and calling the method
`.to_date` on it.

This PR fixes this issue by checking whether `primary_pom_allocated_at`
date for an allocated offender is nil, if so we use the `updated_at`
date instead and only call. The `.to_date` method is only called if
the date is not nil.