### PR TITLE
Do not try and email poms with no email address

### DIFF
--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -85,6 +85,10 @@ private
   end
 
   def send_deallocation_email
+    # If the previous pom does not have email configured, do not
+    # try and email them.
+    return if previous_pom.emails.blank?
+
     PomMailer.deallocation_email(
       previous_pom_name: previous_pom.first_name.capitalize,
       responsibility: current_responsibility,


### PR DESCRIPTION
When reallocating an offender the system tries to email the previous pom to tell them that the offender has been reallocated.

It appears we still have some POMs who do not have email addresses configured in NOMIS - in these cases, do not try and send an email.