### PR TITLE
Update POMs in specs

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # Jay Heal
 PomDetail.find_or_create_by!(
-  nomis_staff_id: 485_737,
+  nomis_staff_id: 485_833,
   status: 'active',
   working_pattern: 1
 )

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -40,7 +40,7 @@ feature 'Allocation' do
   end
 
   scenario 'overriding an allocation', vcr: { cassette_name: :override_allocation_feature_ok } do
-    override_nomis_staff_id = 485_737
+    override_nomis_staff_id = 485_758
 
     signin_user
 
@@ -63,7 +63,12 @@ feature 'Allocation' do
     click_button 'Complete allocation'
 
     expect(page).to have_current_path prison_summary_unallocated_path('LEI')
-    expect(page).to have_css('.notification', text: 'Ozullirn Abbella has been allocated to Jay Heal (Prison POM)')
+
+    # Note: after removing an old team member as a POM the MOIC integration test user is now top of the list of POMS.
+    # This user is both a probation and prison POM in the system and therefore whilst it says 'Probation POM' in this
+    # test it is actually going through the test and passing as we'd expect, just that it say Probation and not Prison POM
+
+    expect(page).to have_css('.notification', text: 'Ozullirn Abbella has been allocated to Moic Integration-Tests (Probation POM)')
     expect(Override.count).to eq(0)
   end
 

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -11,9 +11,9 @@ feature 'Allocation History' do
 
   let!(:prison_pom) do
     {
-      primary_pom_nomis_id: 485_737,
+      primary_pom_nomis_id: 485_833,
       primary_pom_name: 'Heal, Jay',
-      email: 'jay.heal@digital.justice.gov.uk'
+      email: 'andrien.ricketts@digital.justice.gov.uk'
     }
   end
 

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -60,7 +60,7 @@ feature 'Co-working' do
     end
 
     scenario 'show correct unavailable message', vcr: { cassette_name: :show_coworking_unavailable } do
-      inactive_poms = [485_734, 485_833]
+      inactive_poms = [485_637, 485_833]
       inactive_texts = ['There is 1 unavailable POM for new allocation',
                         'There are 2 unavailable POMs for new allocation']
 

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "edit a POM's details" do
   let(:nomis_staff_id) { 485_637 }
-  let(:fulltime_pom_id) { 485_737 }
+  let(:fulltime_pom_id) { 485_833 }
   let(:nomis_offender_id) { 'G4273GI' }
 
   before do

--- a/spec/helpers/override_helper_spec.rb
+++ b/spec/helpers/override_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe OverrideHelper do
   let(:allocation_one) {
     build(:allocation_version,
-          primary_pom_nomis_id: 485_737,
+          primary_pom_nomis_id: 485_833,
           nomis_offender_id: 'G2911GD',
           recommended_pom_type: 'prison',
           suitability_detail: "Prisoner too high risk",
@@ -13,7 +13,7 @@ RSpec.describe OverrideHelper do
 
   let(:allocation_two) {
     build(:allocation_version,
-          primary_pom_nomis_id: 485_737,
+          primary_pom_nomis_id: 485_833,
           nomis_offender_id: 'G2911GD',
           recommended_pom_type: nil
     )

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -186,7 +186,7 @@ describe AllocationService do
       described_class.create_or_update(
         nomis_offender_id: nomis_offender_id,
         nomis_booking_id: 1,
-        primary_pom_nomis_id: 485_737,
+        primary_pom_nomis_id: 485_833,
         allocated_at_tier: 'A',
         prison: 'LEI',
         recommended_pom_type: 'probation',

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe EmailService, :queueing do
 
   let(:allocation) {
     AllocationVersion.new.tap do |a|
-      a.primary_pom_nomis_id = 485_737
+      a.primary_pom_nomis_id = 485_833
       a.nomis_offender_id = 'G2911GD'
       a.created_by_username = 'PK000223'
       a.nomis_booking_id = 0
@@ -30,7 +30,7 @@ RSpec.describe EmailService, :queueing do
   let(:original_allocation) {
     # The original allocation before the reallocation
     AllocationVersion.new.tap { |a|
-      a.primary_pom_nomis_id = 485_737
+      a.primary_pom_nomis_id = 485_833
       a.nomis_offender_id = 'G2911GD'
       a.created_by_username = 'PK000223'
       a.nomis_booking_id = 0

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe PrisonOffenderManagerService do
   let(:other_staff_id) { 485_637 }
-  let(:staff_id) { 485_737 }
+  let(:staff_id) { 485_833 }
 
   before(:each) {
     PomDetail.create(nomis_staff_id: 485_637, working_pattern: 1.0, status: 'inactive')
@@ -12,8 +12,8 @@ describe PrisonOffenderManagerService do
     it "can get staff names",
        vcr: { cassette_name: :pom_service_staff_name } do
       fname, lname = described_class.get_pom_name(staff_id)
-      expect(fname).to eq('JAY')
-      expect(lname).to eq('HEAL')
+      expect(fname).to eq('ANDRIEN')
+      expect(lname).to eq('RICKETTS')
     end
   end
 


### PR DESCRIPTION
We have had a couple of changes to team members and so two were removed
as POMs whilst another two were added.  This means updating the various
specs and seeds to ensure we no longer reference/use the old team
members and instead use Andrien