### PR TITLE
Fix the submit button in the contact form.

### DIFF
--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -78,7 +78,6 @@
           <% end %>
           <%= text_area_tag("message", nil, rows: 10, id: "message", class: "govuk-textarea") %>
         </div>
-        </div>
         <button class="govuk-button" type="submit">Submit</button>
       <% end %>
       </div>


### PR DESCRIPTION
The contact form was not doing a submit when the help link was used to
navigate to the page, although it worked if the page was accessed
directly.  This was tracked down to a closing div tag, now removed.