### PR TITLE
Get movement history for an offender

### DIFF
--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -19,7 +19,7 @@ module Nomis
 
       # rubocop:disable Metrics/LineLength
       def self.movements_for(offender_no)
-        route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL'
+        route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false'
 
         data = e2_client.post(route, [offender_no])
         data.sort_by { |k| k['movementTime'] }.map{ |movement|

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -18,7 +18,7 @@ describe Nomis::Elite2::MovementApi do
       movements = described_class.movements_for('A5019DY')
 
       expect(movements).to be_kind_of(Array)
-      expect(movements.length).to eq(1)
+      expect(movements.length).to eq(2)
       expect(movements.first).to be_kind_of(Nomis::Movement)
     end
 
@@ -39,6 +39,15 @@ describe Nomis::Elite2::MovementApi do
       expect(movements).to be_kind_of(Array)
       expect(movements.length).to eq(2)
       expect(movements.first.offender_no).to eq('1')
+    end
+
+    it 'can return multiple movements for a specific offender',
+       vcr: { cassette_name: :movement_api_multiple_movements } do
+      movements = described_class.movements_for('G1670VU')
+
+      expect(movements).to be_kind_of(Array)
+      expect(movements.length).to eq(5)
+      expect(movements.first).to be_kind_of(Nomis::Movement)
     end
   end
 end


### PR DESCRIPTION
Currently we only receive the latest movement for an offender.

The Movement API has recently changed allowing us to obtain the
full history of movements for a specific offender. This commit
updates the api call to get this information.