### PR TITLE
Fix Zendesk tag issue

### DIFF
--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -5,6 +5,8 @@ class ZendeskTicketsJob < ActiveJob::Base
   URL_FIELD = '23730083'.freeze
   BROWSER_FIELD = '23791776'.freeze
   PRISON_FIELD = '23984153'.freeze
+  JOB_TYPE_FIELD = '360003119357'.freeze
+  SERVICE_FIELD = '23757677'.freeze
 
   def perform(contact)
     contact.destroy! if ticket_raised!(contact)
@@ -21,10 +23,9 @@ private
     {
       description: contact.message,
       requester: { email: contact.email_address,
-                   name: contact.name,
-                   job_type: contact.job_type,
-                   tags: ['moic'],
-                   custom_fields: custom_fields(contact) }
+                   name: contact.name },
+      tags: ['moic'],
+      custom_fields: custom_fields(contact)
     }
   end
 
@@ -32,7 +33,9 @@ private
     attrs = [
         as_hash(URL_FIELD, contact.referrer),
         as_hash(BROWSER_FIELD, contact.user_agent),
-        as_hash(PRISON_FIELD, contact.prison)
+        as_hash(PRISON_FIELD, contact.prison),
+        as_hash(JOB_TYPE_FIELD, contact.job_type),
+        as_hash(SERVICE_FIELD, 'MOIC')
     ]
     attrs
   end

--- a/spec/jobs/zendesk_tickets_job_spec.rb
+++ b/spec/jobs/zendesk_tickets_job_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe ZendeskTicketsJob, type: :job do
     { id: ZendeskTicketsJob::PRISON_FIELD, value: contact.prison }
   end
 
+  let(:service_custom_field) do
+    { id: ZendeskTicketsJob::SERVICE_FIELD, value: 'MOIC' }
+  end
+
+  let(:job_type_custom_field) do
+    { id: ZendeskTicketsJob::JOB_TYPE_FIELD, value: contact.job_type }
+  end
+
   before do
     allow(Rails.application.config).to receive(:zendesk_url).and_return('https://zendesk_api.com')
     allow(Zendesk::MOICApi).to receive(:new).and_return(zendesk_moic_api)
@@ -43,14 +51,15 @@ RSpec.describe ZendeskTicketsJob, type: :job do
               with(
                 description: 'text',
                 requester: { email: 'email@example.com',
-                             name: 'Frank',
-                             job_type: 'SPO',
-                             tags: ['moic'],
-                             custom_fields: [
-                                 url_custom_field,
-                                 browser_custom_field,
-                                 prison_custom_field
-                             ] }
+                             name: 'Frank' },
+                tags: ['moic'],
+                custom_fields: [
+                   url_custom_field,
+                   browser_custom_field,
+                   prison_custom_field,
+                   job_type_custom_field,
+                   service_custom_field
+                ]
               ).and_return(true)
 
       subject.perform_now(contact)
@@ -64,14 +73,15 @@ RSpec.describe ZendeskTicketsJob, type: :job do
               with(
                 description: 'text',
                 requester: { email: 'email@example.com',
-                             name: 'Frank',
-                             job_type: 'SPO',
-                             tags: ['moic'],
-                             custom_fields: [
-                                 url_custom_field,
-                                 browser_custom_field,
-                                 prison_custom_field
-                             ] }
+                             name: 'Frank' },
+                tags: ['moic'],
+                custom_fields: [
+                    url_custom_field,
+                    browser_custom_field,
+                    prison_custom_field,
+                    job_type_custom_field,
+                    service_custom_field
+                ]
               ).and_return(true)
 
       subject.perform_now(contact)
@@ -87,14 +97,15 @@ RSpec.describe ZendeskTicketsJob, type: :job do
               with(
                 description: 'text',
                 requester: { email: 'email@example.com',
-                             name: 'Frank',
-                             job_type: 'SPO',
-                             tags: ['moic'],
-                             custom_fields: [
-                                 url_custom_field,
-                                 browser_custom_field,
-                                 prison_custom_field
-                             ] }
+                             name: 'Frank' },
+                tags: ['moic'],
+                custom_fields: [
+                    url_custom_field,
+                    browser_custom_field,
+                    prison_custom_field,
+                    job_type_custom_field,
+                    service_custom_field
+                ]
               ).and_raise(ZendeskAPI::Error::ClientError.new('Error'))
 
       expect { subject.perform_now(contact) }.to raise_error(ZendeskAPI::Error::ClientError)


### PR DESCRIPTION
Whilst testing the new Zendesk feature on staging we found an issue
where the tag for 'moic' wasn't always being set, which caused a problem
when trying to find relevant tickets.  In addition to this, the custom
fields weren't set up correctly and so the crucial information we were
collecting in the form wasn't then being translated to the Zendesk app.