### PR TITLE
Update MovementService

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -118,7 +118,7 @@ class AllocationVersion < ApplicationRecord
     alloc.secondary_pom_nomis_id = nil
     alloc.secondary_pom_name = nil
     alloc.recommended_pom_type = nil
-    if movement_type == 'offender_released'
+    if movement_type == AllocationVersion::OFFENDER_RELEASED
       alloc.event = DEALLOCATE_RELEASED_OFFENDER
     else
       alloc.event = DEALLOCATE_PRIMARY_POM
@@ -155,13 +155,13 @@ class AllocationVersion < ApplicationRecord
     # and this causes an issue should those offenders move or be released.
     # To handle this we will attempt to set the prison to a valid code
     # based on the event that has happened.
-    if movement_type == 'offender_released'
+    if movement_type == AllocationVersion::OFFENDER_RELEASED
       movements = Nomis::Elite2::MovementApi.movements_for(allocation.nomis_offender_id)
       if movements.present?
         movement = movements.first
         return movement.from_agency if movement.from_prison?
       end
-    elsif movement_type == 'offender_transferred'
+    elsif movement_type == AllocationVersion::OFFENDER_TRANSFERRED
       offender = OffenderService.get_offender(allocation.nomis_offender_id)
       offender.latest_location_id
     end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe AllocationVersion, type: :model do
     it 'will set the prison when released' do
       allow(Nomis::Elite2::MovementApi).to receive(:movements_for).and_return([movement])
 
-      described_class.deallocate_offender(offender_no, 'offender_released')
+      described_class.deallocate_offender(offender_no, AllocationVersion::OFFENDER_RELEASED)
 
       updated_allocation = described_class.find_by(nomis_offender_id: offender_no)
       expect(updated_allocation.prison).not_to be_nil
@@ -141,7 +141,7 @@ RSpec.describe AllocationVersion, type: :model do
 
     it 'will set the prison when transferred',
        vcr: { cassette_name: :allocation_version_transfer_prison_fix } do
-      described_class.deallocate_offender(offender_no, 'offender_transferred')
+      described_class.deallocate_offender(offender_no, AllocationVersion::OFFENDER_TRANSFERRED)
 
       updated_allocation = described_class.find_by(nomis_offender_id: offender_no)
       expect(updated_allocation.prison).not_to be_nil


### PR DESCRIPTION
We have continued to see validation errors for 'prison can't be blank'
when running the movementService.  Another look at this showed that the
recently added method 'prison_fix' was in fact returning nil as the
movement_type check was against the string
'offender_released/transferred' rather than the constant which is being
sent by the movement service.