### PR TITLE
Fix tabs after govuk frontend update

### DIFF
--- a/app/views/summary/_tabs_start.html.erb
+++ b/app/views/summary/_tabs_start.html.erb
@@ -4,18 +4,18 @@
       Allocations
   </h2>
   <ul class="govuk-tabs__list" role='tablist'>
-      <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab <%= 'govuk-tabs__tab--selected' if active == :allocated %>" href="<%= prison_summary_allocated_path(@prison) %>">
+      <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if active == :allocated %>">
+      <a class="govuk-tabs__tab" href="<%= prison_summary_allocated_path(@prison) %>">
           See allocations (<%= @summary.allocated_total %>)
       </a>
       </li>
-      <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab <%= 'govuk-tabs__tab--selected' if active == :unallocated %>" href="<%= prison_summary_unallocated_path(@prison) %>">
+      <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if active == :unallocated %>">
+      <a class="govuk-tabs__tab" href="<%= prison_summary_unallocated_path(@prison) %>">
           Make allocations (<%= @summary.unallocated_total %>)
       </a>
       </li>
-      <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab <%= 'govuk-tabs__tab--selected' if active == :pending %>" href="<%= prison_summary_pending_path(@prison) %>">
+      <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if active == :pending %>">
+      <a class="govuk-tabs__tab" href="<%= prison_summary_pending_path(@prison) %>">
           Update information (<%= @summary.pending_total %>)
       </a>
       </li>


### PR DESCRIPTION
The tabs markup changed in v3 and so we need to add a differnt class to
an enclosing element.