### PR TITLE
Unallocate anyone who is allocated but not sentenced

### DIFF
--- a/lib/allocation_validation.rb
+++ b/lib/allocation_validation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AllocationValidation
+  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/LineLength
   # rubocop:disable Rails/Output
   def fixup(prison)
@@ -53,6 +54,7 @@ class AllocationValidation
   end
   # rubocop:enable Metrics/LineLength
   # rubocop:enable Rails/Output
+  # rubocop:enable Metrics/MethodLength
 
   def active_allocations_for_prison(prison)
     AllocationVersion.where.not(primary_pom_nomis_id: nil).where(prison: prison)

--- a/lib/allocation_validation.rb
+++ b/lib/allocation_validation.rb
@@ -28,6 +28,14 @@ class AllocationValidation
         next
       end
 
+      if offender.sentenced? == false
+        # This offender should not have any case information, and should not
+        # be allocated to anybody We will de-allocate the offender so they can
+        # be re-allocated against a new offense.
+        puts "#{offender.offender_no} is not sentenced - deallocating"
+        AllocationVersion.deallocate_offender(offender.offender_no, 'offender_released')
+      end
+
       # If the offender is at this prison, we're good .
       next if offender.latest_location_id == prison
 

--- a/lib/tasks/fix_data.rake
+++ b/lib/tasks/fix_data.rake
@@ -5,13 +5,16 @@ require_relative '../allocation_validation'
 namespace :fix_data do
   desc 'Fixes data for incorrect transfer/releases/allocations'
   task :for_prison, [:prison] => [:environment] do |_task, args|
-    prison = args[:prison]
+    prisons = args[:prison].split
 
-    if PrisonService.name_for(prison).nil?
-      puts "Unable to find prison #{prison}"
-      next
-    end
+    prisons.each { |prison|
+      puts "Attempting to process #{prison}"
+      if PrisonService.name_for(prison).nil?
+        puts "Unable to find prison #{prison}"
+        next
+      end
 
-    AllocationValidation.new.fixup(prison)
+      AllocationValidation.new.fixup(prison)
+    }
   end
 end


### PR DESCRIPTION
If the offender is released (and maybe we missed it) it's possible
they'll come back on a different sentence, but will still be allocated
when they are not sentenced.

Also allows for the processing of multiple prisons, so 

`rails fix_data:for_prison['BAI LEI']`
