### PR TITLE
Update co-working de-allocation

### DIFF
--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -70,12 +70,20 @@ class CoworkingController < PrisonsApplicationController
       nomis_offender_id: nomis_offender_id_from_url
     )
 
+    secondary_pom_name = @allocation.secondary_pom_name
+
     @allocation.update!(
       secondary_pom_name: nil,
       secondary_pom_nomis_id: nil,
       event: AllocationVersion::DEALLOCATE_SECONDARY_POM,
       event_trigger: AllocationVersion::USER
     )
+
+    EmailService.instance(allocation: @allocation,
+                          message: '',
+                          pom_nomis_id: @allocation.primary_pom_nomis_id
+    ).send_cowork_deallocation_email(secondary_pom_name)
+
     redirect_to prison_allocation_path(active_prison, nomis_offender_id_from_url)
   end
 

--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -38,6 +38,23 @@ class PomMailer < GovukNotifyRails::Mailer
   # rubocop:enable Metrics/ParameterLists
 
   # rubocop:disable Metrics/ParameterLists
+  def deallocate_coworking_pom(email_address:, pom_name:,
+    secondary_pom_name:, nomis_offender_id:,
+    offender_name:, url:)
+    set_template('bbdd094b-037b-424d-8b9b-ee310e291c9e')
+
+    set_personalisation(pom_name: pom_name,
+                        email_address: email_address,
+                        secondary_pom_name: secondary_pom_name,
+                        nomis_offender_id: nomis_offender_id,
+                        offender_name: offender_name,
+                        url: url)
+
+    mail(to: email_address)
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  # rubocop:disable Metrics/ParameterLists
   def secondary_allocation_email(
     message:, pom_name:, offender_name:, nomis_offender_id:,
     responsible_pom_name:, pom_email:, url:, responsibility:

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -54,6 +54,19 @@ class EmailService
     end
   end
 
+  def send_cowork_deallocation_email(secondary_pom_name)
+    return if @pom.emails.blank?
+
+    PomMailer.deallocate_coworking_pom(
+      pom_name: @pom.first_name.capitalize,
+      email_address: @pom.emails.first,
+      secondary_pom_name: secondary_pom_name,
+      nomis_offender_id: @offender.offender_no,
+      offender_name: @offender.full_name,
+      url: url
+    ).deliver_later
+  end
+
 private
 
   # rubocop:disable Metrics/LineLength

--- a/app/views/coworking/confirm_removal.html.erb
+++ b/app/views/coworking/confirm_removal.html.erb
@@ -1,39 +1,16 @@
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Confirm removal of co-working Prison Offender Manager</h1>
 
-<% if @errors.count > 0 %>
-  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @errors } %>
-<% end %>
-
 <p class="govuk-body">
-You are removing <%= @allocation.secondary_pom_name %> from co-working POM <%= @allocation.primary_pom_name %>
+  You are removing co-working POM <%= @allocation.secondary_pom_name %> who was working with <%= @prisoner.full_name %>.
+  The <%= @responsibility_type %> POM is <%= @allocation.primary_pom_name %>.
 </p>
 
-<p class="govuk-body">
-We will send a confirmation email to <%= @primary_pom.emails.first %>
-</p>
-
-<p class="govuk-body">
-  <b>Do you want to allocate this prisoner to a new co-working POM?</b>
-</p>
+<p class="govuk-body">We will send a confirmation email to <%= @primary_pom.emails.first %></p>
 
 <%= form_tag(prison_coworking_path(@prison, @prisoner.offender_no), method: :delete) do %>
-  <div class='govuk-!-margin-top-6'>
-    <div class="govuk-form-group">
-      <div class="govuk-radios" data-module="govuk-radios">
-        <div class="govuk-radios__item">
-          <%= radio_button_tag("reallocate", true, false, class: "govuk-radios__input") %>
-          <%= label_tag "reallocate", "Yes", class: "govuk-label govuk-radios__label" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= radio_button_tag("reallocate", false, false, class: "govuk-radios__input") %>
-          <%= label_tag "reallocate", "No", class: "govuk-label govuk-radios__label" %>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="govuk-form-group">
-    <button type="submit" class="govuk-button">Continue</button>
-    <%= link_to 'Cancel',  prison_allocation_path(@prison, @prisoner.offender_no), class: 'govuk-link cancel-button' %>
+    <button type="submit" class="govuk-button">Confirm</button>
+    <%= link_to 'Cancel',  prison_allocation_path(@prison, @prisoner.offender_no),
+                class: 'govuk-link cancel-button' %>
   </div>
 <% end %>

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -126,45 +126,39 @@ feature 'Co-working' do
       end
 
       expect(page).to have_current_path('/prisons/LEI/coworking/G4273GI/confirm_coworking_removal')
-
-      expect(page).to have_content 'You are removing Kath Pobee-Norris from co-working POM Ross Jones'
-      expect(page).to have_content 'We will send a confirmation email to Ross.jonessss@digital.justice.gov.uk'
+      expect(page).to have_content "You are removing co-working POM #{secondary_pom[:pom_name]} who was working with Abbella, Ozullirn. The Supporting POM is #{probation_pom[:pom_name]}."
+      expect(page).to have_content "We will send a confirmation email to #{probation_pom[:email]}"
     end
 
-    scenario 'removing a co-working POM then changing our mind', vcr: { cassette_name: :coworking_remove_changed_mind } do
+    scenario 'cancel removal of a co-working POM', vcr: { cassette_name: :coworking_pom_cancel } do
+      visit prison_allocation_path('LEI', nomis_offender_id)
+
+      within '#co-working-pom' do
+        click_link 'Remove'
+      end
+
+      expect(page).to have_current_path('/prisons/LEI/coworking/G4273GI/confirm_coworking_removal')
       click_link 'Cancel'
+
       expect(page).to have_current_path(prison_allocation_path('LEI', nomis_offender_id))
-
-      allocation.reload
-      expect(allocation.secondary_pom_nomis_id).to eq(secondary_pom[:staff_id])
-      expect(allocation.secondary_pom_name).to eq(secondary_pom[:pom_name])
     end
 
-    scenario 'clicking continue without selecting Yes/No', vcr: { cassette_name: :coworking_hit_continue } do
-      click_button 'Continue'
-      expect(page).to have_current_path('/prisons/LEI/coworking/G4273GI')
-      expect(page).to have_content 'Please select Yes or No'
-    end
+    scenario 'removing a co-working POM', vcr: { cassette_name: :coworking_pom_remove } do
+      visit prison_allocation_path('LEI', nomis_offender_id)
 
-    scenario 'removing a co-working POM but not reallocating', vcr: { cassette_name: :coworking_realloc_no } do
-      page.find('#reallocate_false').click
-      click_button 'Continue'
+      within '#co-working-pom' do
+        click_link 'Remove'
+      end
+
+      expect(page).to have_current_path('/prisons/LEI/coworking/G4273GI/confirm_coworking_removal')
+
+      click_button 'Confirm'
       expect(page).to have_current_path('/prisons/LEI/allocations/G4273GI')
 
       expect(page).to have_link 'Allocate'
       within '#co-working-pom' do
         expect(page).to have_content('N/A')
       end
-    end
-
-    scenario 'removing a co-working POM then reallocating', vcr: { cassette_name: :coworking_realloc_yes } do
-      page.find('#reallocate_true').click
-      click_button 'Continue'
-      allocation.reload
-      expect(allocation.secondary_pom_nomis_id).to be_nil
-      expect(allocation.secondary_pom_name).to be_nil
-
-      expect(page).to have_current_path new_prison_coworking_path('LEI', nomis_offender_id)
     end
   end
 end

--- a/spec/mailers/pom_mailer_spec.rb
+++ b/spec/mailers/pom_mailer_spec.rb
@@ -94,4 +94,40 @@ RSpec.describe PomMailer, type: :mailer do
              )
     end
   end
+
+  describe 'deallocate_coworking_pom' do
+    let(:params) do
+      {
+        email_address: "something@example.com",
+        pom_name: "Pobee-Norris, Kath",
+        secondary_pom_name: "Jones, Ross",
+        nomis_offender_id: "GE4595D",
+        offender_name: "Marks, Simon",
+        url: "http:://example.com"
+      }
+    end
+
+    let(:mail) { described_class.deallocate_coworking_pom(params) }
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template).
+          to eq 'bbdd094b-037b-424d-8b9b-ee310e291c9e'
+    end
+
+    it 'sets the To address of the email using the provided user' do
+      expect(mail.to).to eq(["something@example.com"])
+    end
+
+    it 'personalises the email' do
+      expect(mail.govuk_notify_personalisation).
+          to eq(
+            email_address: params[:email_address],
+            pom_name: params[:pom_name],
+            secondary_pom_name: params[:secondary_pom_name],
+            offender_name: params[:offender_name],
+            nomis_offender_id: params[:nomis_offender_id],
+            url: params[:url]
+             )
+    end
+  end
 end


### PR DESCRIPTION
Currently when a co-worker is being de-allocated from an offender, the user can decide to replace the co-worker with another POM or simply de-allocate the current co-working pom from the `coworking#confirm_removal` view. In the content we also state that we will send an email to the primary pom, but this does not happen.

In this PR we are no longer allowing the user to re-allocate a co-working pom from the `coworking#confirm_removal` view. If the user wants to assign another co-working pom they will do this from the `allocations#show page`, which is the page that the user will navigate to after confirming the de-allocation. There are also content changes in this view.

In addition we now send an email to the primary pom confirming the de-allocation of the co-working pom.

**Confirming co-working de-allocation:**

### BEFORE:
<img width="991" alt="Screen Shot 2019-09-12 at 13 51 39" src="https://user-images.githubusercontent.com/10685841/64785631-b7497000-d564-11e9-904e-dc6590534b27.png">

### NOW:
<img width="993" alt="Screen Shot 2019-09-12 at 13 50 21" src="https://user-images.githubusercontent.com/10685841/64785658-c2040500-d564-11e9-8286-05ad4d0fcbe3.png">
