### PR TITLE
Fix POM working pattern bug

### DIFF
--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -2,7 +2,7 @@
 
 module PomHelper
   def format_working_pattern(pattern)
-    if pattern == '1.0'
+    if pattern == 1.0
       'Full time'
     else
       "Part time - #{pattern}"

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe PomHelper do
   describe 'format_working_pattern' do
     it "formats a POM's working pattern" do
-      expect(format_working_pattern('1.0')).to eq('Full time')
+      expect(format_working_pattern(1.0)).to eq('Full time')
     end
   end
 end


### PR DESCRIPTION
We have been receiving reports that the working pattern for POMs hasn't
been working properly.  Even if a POM was being added as working full
time the page would display 'Part time - 1.0', rather than 'Full time'.
It turns out that we're storing the working pattern as a float, but in
the helper we're comparing it to a string, and therefore it wasn't
working properly.  This PR updates the helper to compare against a float
and will now correctly display the working pattern.