### PR TITLE
Add LDU email

### DIFF
--- a/app/views/prisoners/_community_information.html.erb
+++ b/app/views/prisoners/_community_information.html.erb
@@ -5,20 +5,20 @@
       <td class="govuk-table__cell govuk-!-width-one-half"></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
-      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"></td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Service provider</td>
-      <td class="govuk-table__cell table_cell__left_align"></td>
-    </tr>
-    <tr class="govuk-table__row">
       <td class="govuk-table__cell">Local divisional unit (LDU)</td>
       <td class="govuk-table__cell table_cell__left_align"></td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Last known address in Wales</td>
+      <td class="govuk-table__cell">Local divisional unit (LDU) email address</td>
       <td class="govuk-table__cell table_cell__left_align"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Team</td>
+      <td class="govuk-table__cell table_cell__left_align"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"></td>
     </tr>
   </tbody>
 </table>

--- a/db/migrate/20190913113448_add_email_address_to_local_divisional_unit.rb
+++ b/db/migrate/20190913113448_add_email_address_to_local_divisional_unit.rb
@@ -1,0 +1,9 @@
+class AddEmailAddressToLocalDivisionalUnit < ActiveRecord::Migration[5.2]
+  def up
+    add_column :local_divisional_units, :email_address, :string
+  end
+
+  def down
+    remove_column :local_divisional_units, :email_address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_09_115431) do
+ActiveRecord::Schema.define(version: 2019_09_13_113448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2019_09_09_115431) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email_address"
     t.index ["code"], name: "index_local_divisional_units_on_code"
   end
 

--- a/spec/factories/local_divisional_units.rb
+++ b/spec/factories/local_divisional_units.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :local_divisional_unit do
     code do 'BG12345' end
-    name { 'Barnsley LDU' }
+    name do 'Barnsley LDU' end
+    email_address { 'joe.bloggs@example.com' }
   end
 end

--- a/spec/models/local_divisional_unit_spec.rb
+++ b/spec/models/local_divisional_unit_spec.rb
@@ -4,5 +4,6 @@ RSpec.describe LocalDivisionalUnit, type: :model do
   it {
     expect(subject).to validate_presence_of :name
     expect(subject).to validate_presence_of :code
+    expect(subject).not_to validate_presence_of :email_address
   }
 end


### PR DESCRIPTION
In this PR we:

- Add an email_address field to the Local_Divisional_Unit table

- Update the community information section to include the email_address, also re-order the rows to 
 reflect the current designs. Note: The community information section is not yet visible to the users.

- Update the tests to include email_address field