### PR TITLE
Fix debugging page

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -8,7 +8,7 @@ class DebuggingController < PrisonsApplicationController
     if @offender.present?
       @allocation = AllocationVersion.find_by(nomis_offender_id: @offender.offender_no)
       @movements =
-        Nomis::Elite2::MovementApi.latest_movement_for(@offender.offender_no).first
+        Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).last
     end
   end
 

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -7,7 +7,8 @@ class DebuggingController < PrisonsApplicationController
     @offender = offender(nomis_offender_id)
     if @offender.present?
       @allocation = AllocationVersion.find_by(nomis_offender_id: @offender.offender_no)
-      @movements = Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).first
+      @movements =
+        Nomis::Elite2::MovementApi.latest_movement_for(@offender.offender_no).first
     end
   end
 

--- a/app/models/concerns/deserialisable.rb
+++ b/app/models/concerns/deserialisable.rb
@@ -10,9 +10,19 @@ module Deserialisable
 
       Date.parse(payload[field])
     end
+
+    def base.deserialise_date_and_time(payload, field)
+      return nil unless payload.key? field
+
+      DateTime.parse(payload[field])
+    end
   end
 
   def deserialise_date(payload, field)
     self.class.deserialise_date(payload, field)
+  end
+
+  def deserialise_date_and_time(payload, field)
+    self.class.deserialise_date_and_time(payload, field)
   end
 end

--- a/app/models/nomis/movement.rb
+++ b/app/models/nomis/movement.rb
@@ -41,7 +41,7 @@ module Nomis
     def self.from_json(payload)
       Movement.new.tap { |obj|
         obj.offender_no = payload['offenderNo']
-        obj.create_date_time = deserialise_date(payload, 'createDateTime')
+        obj.create_date_time = deserialise_date_and_time(payload, 'createDateTime')
         obj.from_agency = payload['fromAgency']
         obj.from_agency_description = payload['fromAgencyDescription']
         obj.to_agency = payload['toAgency']

--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -26,6 +26,15 @@ module Nomis
           api_deserialiser.deserialise(Nomis::Movement, movement)
         }
       end
+
+      def self.latest_movement_for(offender_no)
+        route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL'
+
+        data = e2_client.post(route, [offender_no])
+        data.sort_by { |k| k['movementTime'] }.map{ |movement|
+          api_deserialiser.deserialise(Nomis::Movement, movement)
+        }
+      end
       # rubocop:enable Metrics/LineLength
     end
   end

--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -22,16 +22,7 @@ module Nomis
         route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false'
 
         data = e2_client.post(route, [offender_no])
-        data.sort_by { |k| k['movementTime'] }.map{ |movement|
-          api_deserialiser.deserialise(Nomis::Movement, movement)
-        }
-      end
-
-      def self.latest_movement_for(offender_no)
-        route = '/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL'
-
-        data = e2_client.post(route, [offender_no])
-        data.sort_by { |k| k['movementTime'] }.map{ |movement|
+        data.sort_by { |k| k['createDateTime'] }.map{ |movement|
           api_deserialiser.deserialise(Nomis::Movement, movement)
         }
       end

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -209,7 +209,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__header govuk-!-width-one-half" scope="row">Last recorded movement</td>
       <td class="govuk-table__cell govuk-!-width-one-half"></td>
-    <tr class="govuk-table__row">
+    <tr class="govuk-table__row" id="movement_date">
       <td class="govuk-table__cell">Movement date</td>
       <td class="govuk-table__cell table_cell__left_align">
         <%= format_date(@movements.create_date_time) %>

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Provide debugging information for an offender' do
-  let(:nomis_offender_id) { "G7806VO" }
+  let(:nomis_offender_id) { "G1670VU" }
 
   it 'returns information for an unallocated offender', vcr: { cassette_name: :debugging_feature } do
     signin_user
@@ -35,10 +35,16 @@ feature 'Provide debugging information for an offender' do
 
     expect(page).to have_css('tbody tr', count: 34)
 
-    table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
+    pom_table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
 
-    within table_row do
+    within pom_table_row do
       expect(page).to have_content('POM Rossana Spinka')
+    end
+
+    movement_table_row = page.find(:css, 'tr.govuk-table__row#movement_date', text: 'Movement date')
+
+    within movement_table_row do
+      expect(page).to have_content('Movement date 20/07/2018')
     end
   end
 

--- a/spec/services/nomis/elite2/movement_api_spec.rb
+++ b/spec/services/nomis/elite2/movement_api_spec.rb
@@ -26,11 +26,11 @@ describe Nomis::Elite2::MovementApi do
       allow_any_instance_of(Nomis::Client).to receive(:post).and_return([
         {
           'offenderNo' => '2',
-          'movementTime' => '2017-03-09T15:50:52.676892'
+          'createDateTime' => '2017-03-09T15:50:52.676892'
         },
         {
           'offenderNo' => '1',
-          'movementTime' => '2015-01-01T15:50:52.676892'
+          'createDateTime' => '2015-01-01T15:50:52.676892'
         }
       ])
 


### PR DESCRIPTION
A recent change to the MovementApi mean that we started getting all
movements for an offender, rather than just the latest.  The debugging
page displays the last movement, but as they're not returned in date
order it meant it could be showing an old movement.  Therefore this PR
adds the api call to get just the latest movement for an offender to
ensure the debugging page shows the right information.