### PR TITLE
[POM-344] Add allocation history link

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -26,7 +26,7 @@ class AllocationsController < PrisonsApplicationController
     @pom = PrisonOffenderManagerService.get_pom(active_prison, primary_pom_nomis_id)
     @coworker = PrisonOffenderManagerService.get_pom(active_prison, secondary_pom_nomis_id)
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_prison, @prisoner.offender_no)
-    @allocation = AllocationVersion.where(nomis_offender_id: @prisoner.offender_no).first
+    @allocation = AllocationVersion.find_by(nomis_offender_id: @prisoner.offender_no)
   end
 
   def edit

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -26,7 +26,7 @@ class AllocationsController < PrisonsApplicationController
     @pom = PrisonOffenderManagerService.get_pom(active_prison, primary_pom_nomis_id)
     @coworker = PrisonOffenderManagerService.get_pom(active_prison, secondary_pom_nomis_id)
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_prison, @prisoner.offender_no)
-    @allocation = AllocationVersion.where(nomis_offender_id: @prisoner.offender_no)
+    @allocation = AllocationVersion.where(nomis_offender_id: @prisoner.offender_no).first
   end
 
   def edit

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -8,7 +8,7 @@ class PrisonersController < PrisonsApplicationController
 
   def show
     @prisoner = offender
-    @allocation = AllocationVersion.where(nomis_offender_id: @prisoner.offender_no).first
+    @allocation = AllocationVersion.find_by(nomis_offender_id: @prisoner.offender_no)
     @pom_responsibility = ResponsibilityService.new.calculate_pom_responsibility(
       offender
     )

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -8,7 +8,7 @@ class PrisonersController < PrisonsApplicationController
 
   def show
     @prisoner = offender
-    @allocation = AllocationService.current_allocation_for(@prisoner.offender_no)
+    @allocation = AllocationVersion.where(nomis_offender_id: @prisoner.offender_no).first
     @pom_responsibility = ResponsibilityService.new.calculate_pom_responsibility(
       offender
     )

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -9,4 +9,21 @@ module OffenderHelper
   def pom_responsibility_label(offender)
     offender.pom_responsibility
   end
+
+  def last_event(allocation)
+    event = event_type(allocation.event)
+    event + ' - ' + allocation.updated_at.strftime('%d/%m/%Y')
+  end
+
+  def event_type(event)
+    type = (event.include? 'primary_pom') ? 'POM ' : 'Co-working POM '
+
+    if event.include? 'reallocate'
+      type + 're-allocated'
+    elsif event.include? 'deallocate'
+      type + 'removed'
+    elsif event.include? 'allocate'
+      type + 'allocated'
+    end
+  end
 end

--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -76,25 +76,6 @@ class AllocationVersion < ApplicationRecord
     end
   end
 
-  def self.last_event(nomis_offender_id)
-    allocation = find_by(nomis_offender_id: nomis_offender_id)
-
-    event = event_type(allocation.event)
-    event + ' - ' + allocation.updated_at.strftime('%d/%m/%Y')
-  end
-
-  def self.event_type(event)
-    type = (event.include? 'primary_pom') ? 'POM ' : 'Co-working POM '
-
-    if event.include? 'reallocate'
-      type + 're-allocated'
-    elsif event.include? 'deallocate'
-      type + 'removed'
-    elsif event.include? 'allocate'
-      type + 'allocated'
-    end
-  end
-
   def active?
     primary_pom_nomis_id.present?
   end

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => prison_allocation_path(@prison, @prisoner.offender_no) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <h1 class="govuk-heading-l"><%= @prisoner.full_name %></h1>
 

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -155,7 +155,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Allocation history</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%=@allocation.last_event(@prisoner.offender_no) %>
+        <%= last_event(@allocation) %>
         <%= link_to 'View', prison_allocation_history_path(@prison, @prisoner.offender_no), class: "govuk-link pull-right" %>
       </td>
     </tr>

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -192,7 +192,7 @@
     <tr class="govuk-table__row" id="allocation-event">
       <td class="govuk-table__cell govuk-!-width-one-half">Last allocation event</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-        <%= AllocationVersion.last_event(@offender.offender_no) %>
+        <%= last_event(@allocation) %>
       </td>
     </tr>
     </tbody>

--- a/app/views/prisoners/_prison_allocation.html.erb
+++ b/app/views/prisoners/_prison_allocation.html.erb
@@ -13,23 +13,30 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">POM</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <% if @allocation && @allocation.active? %>
+        <% if @allocation && @allocation.primary_pom_name.present? %>
           <%= @allocation.primary_pom_name.titleize %>
         <% end %>
       </td>
     </tr>
-  <!-- PENDING DATA
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Co-working POM</td>
-      <td class="govuk-table__cell table_cell__left_align"></td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <% if @allocation.secondary_pom_name.present? %>
+          <%= @allocation.secondary_pom_name.titleize %>
+        <% else %>
+          N/A
+        <% end %>
+      </td>
     </tr>
-  -->
-<!-- PENDING DATA
+
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Allocation history</td>
-      <td class="govuk-table__cell table_cell__left_align"></td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= last_event(@allocation) %>
+        <%= link_to 'View', prison_allocation_history_path(@allocation.prison, @allocation.nomis_offender_id), class: "govuk-link pull-right" %>
+      </td>
     </tr>
-  -->
+
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Keyworker</td>
       <td class="govuk-table__cell table_cell__left_align">

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 feature 'View a prisoner profile page' do
-    let!(:alloc) {
-      a = build(
-          :allocation_version,
-          nomis_offender_id: 'G7998GJ',
-          primary_pom_nomis_id: '485637'
-      )
-      a.save(validate: false)
-      a
-    }
+  let!(:alloc) {
+    a = build(
+      :allocation_version,
+      nomis_offender_id: 'G7998GJ',
+      primary_pom_nomis_id: '485637'
+    )
+    a.save(validate: false)
+    a
+  }
+
   it 'shows the prisoner information', :raven_intercept_exception, vcr: { cassette_name: :show_offender_spec } do
     signin_user
     visit prison_prisoner_show_path('LEI', 'G7998GJ')

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -1,9 +1,17 @@
 require 'rails_helper'
 
 feature 'View a prisoner profile page' do
+    let!(:alloc) {
+      a = build(
+          :allocation_version,
+          nomis_offender_id: 'G7998GJ',
+          primary_pom_nomis_id: '485637'
+      )
+      a.save(validate: false)
+      a
+    }
   it 'shows the prisoner information', :raven_intercept_exception, vcr: { cassette_name: :show_offender_spec } do
     signin_user
-
     visit prison_prisoner_show_path('LEI', 'G7998GJ')
 
     expect(page).to have_css('h2', text: 'Ahmonis, Okadonah')
@@ -17,5 +25,13 @@ feature 'View a prisoner profile page' do
 
     visit prison_prisoner_image_path('LEI', 'G7998GJ')
     expect(page.response_headers['Content-Type']).to eq('image/jpg')
+  end
+
+  it "has a link to the allocation history",
+     :raven_intercept_exception, vcr: { cassette_name: :link_to_allocation_history } do
+    signin_user
+    visit prison_prisoner_show_path('LEI', 'G7998GJ')
+    click_link "View"
+    expect(page).to have_content('Prisoner allocation')
   end
 end

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -6,4 +6,21 @@ RSpec.describe OffenderHelper do
       expect(digital_prison_service_profile_path('AB1234A')).to eq("#{Rails.configuration.digital_prison_service_host}/offenders/AB1234A/quick-look")
     end
   end
+
+  describe '#event_type' do
+    let(:nomis_staff_id) { 456_789 }
+    let(:nomis_offender_id) { 123_456 }
+
+    let!(:allocation) {
+      create(
+          :allocation_version,
+          nomis_offender_id: nomis_offender_id,
+          primary_pom_nomis_id: nomis_staff_id,
+          event: 'allocate_primary_pom'
+      )
+    }
+    it 'returns the event in a more readable format' do
+        expect(last_event(allocation)).to eq('POM allocated - 17/09/2019')
+    end
+  end
 end

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -13,14 +13,15 @@ RSpec.describe OffenderHelper do
 
     let!(:allocation) {
       create(
-          :allocation_version,
-          nomis_offender_id: nomis_offender_id,
-          primary_pom_nomis_id: nomis_staff_id,
-          event: 'allocate_primary_pom'
+        :allocation_version,
+        nomis_offender_id: nomis_offender_id,
+        primary_pom_nomis_id: nomis_staff_id,
+        event: 'allocate_primary_pom'
       )
     }
+
     it 'returns the event in a more readable format' do
-        expect(last_event(allocation)).to eq('POM allocated - 17/09/2019')
+      expect(last_event(allocation)).to eq('POM allocated - 17/09/2019')
     end
   end
 end

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OffenderHelper do
     }
 
     it 'returns the event in a more readable format' do
-      expect(last_event(allocation)).to eq('POM allocated - 17/09/2019')
+      expect(last_event(allocation)).to eq("POM allocated - #{allocation.updated_at.strftime('%d/%m/%Y')}")
     end
   end
 end

--- a/spec/models/allocation_version_spec.rb
+++ b/spec/models/allocation_version_spec.rb
@@ -163,23 +163,6 @@ RSpec.describe AllocationVersion, type: :model do
     end
   end
 
-  describe '#event_type' do
-    it 'returns the event in a more readable format' do
-      events = [
-          ['allocate_primary_pom', 'POM allocated'],
-          ['allocate_secondary_pom', 'Co-working POM allocated'],
-          ['reallocate_primary_pom', 'POM re-allocated'],
-          ['reallocate_secondary_pom', 'Co-working POM re-allocated'],
-          ['deallocate_primary_pom', 'POM removed'],
-          ['deallocate_secondary_pom', 'Co-working POM removed']
-      ]
-
-      events.each do |key, val|
-        expect(described_class.event_type(key)).to eq(val)
-      end
-    end
-  end
-
   describe '#override_reasons' do
     let!(:allocation_no_overrides) {
       create(


### PR DESCRIPTION
The prisoner information page that a POM accesses via their caseload
page needs to display a link to the allocation history page to reflect
the current service design.

As part of this PR I have also removed the last_event method from the
AllocationVersion model and added it to the OffenderHelper module as
really is a view helper.

I have also updated the "Back" link on the allocation history as it can
be accessed from two pages and it's important that the back link directs
the user back to the appropriate page.