### PR TITLE
Rename the omicable field to welsh_offender

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -49,7 +49,7 @@ class CaseInformationController < PrisonsApplicationController
     @case_info = CaseInformation.create(
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
-      omicable: case_information_params[:omicable],
+      welsh_offender: case_information_params[:welsh_offender],
       case_allocation: case_information_params[:case_allocation],
       manual_entry: true
     )
@@ -66,7 +66,7 @@ class CaseInformationController < PrisonsApplicationController
     )
     case_info.tier = case_information_params[:tier]
     case_info.case_allocation = case_information_params[:case_allocation]
-    case_info.omicable = case_information_params[:omicable]
+    case_info.welsh_offender = case_information_params[:welsh_offender]
     case_info.manual_entry = true
     case_info.save
 
@@ -85,6 +85,6 @@ private
 
   def case_information_params
     params.require(:case_information).
-      permit(:nomis_offender_id, :tier, :case_allocation, :omicable)
+      permit(:nomis_offender_id, :tier, :case_allocation, :welsh_offender)
   end
 end

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -68,7 +68,7 @@ private
         local_divisional_unit: make_ldu_record(delius_record),
         team: make_team_record(delius_record),
         case_allocation: delius_record.service_provider,
-        omicable: map_omicable(delius_record.omicable?),
+        welsh_offender: map_welsh_offender(delius_record.welsh_offender?),
         mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
       )
     end
@@ -108,8 +108,8 @@ private
     end
   end
 
-  def map_omicable(omicable)
-    omicable ? 'Yes' : 'No'
+  def map_welsh_offender(welsh_offender)
+    welsh_offender ? 'Yes' : 'No'
   end
 
   def map_tier(tier)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -11,7 +11,7 @@ class CaseInformation < ApplicationRecord
 
   validates :local_divisional_unit, :team, presence: true, unless: ->{ manual_entry }
 
-  validates :omicable, inclusion: {
+  validates :welsh_offender, inclusion: {
     in: %w[Yes No],
     allow_nil: false,
     message: 'Select yes if the prisoner’s last known address was in Wales'

--- a/app/models/delius_data.rb
+++ b/app/models/delius_data.rb
@@ -10,7 +10,7 @@ class DeliusData < ApplicationRecord
     end
   end
 
-  def omicable?
+  def welsh_offender?
     # WPT is the first 3 chars of the ldu_code for all Welsh LDU (Local Divisional Unit).
     ldu_code.present? && ldu_code.start_with?('WPT')
   end

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -11,7 +11,7 @@ module Nomis
     # Custom attributes
     attr_accessor :crn,
                   :allocated_pom_name, :case_allocation,
-                  :omicable, :tier,
+                  :welsh_offender, :tier,
                   :sentence, :mappa_level,
                   :ldu, :team
 

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -10,7 +10,7 @@ class OffenderService
       if record.present?
         o.tier = record.tier
         o.case_allocation = record.case_allocation
-        o.omicable = record.omicable == 'Yes'
+        o.welsh_offender = record.welsh_offender == 'Yes'
         o.crn = record.crn
         o.mappa_level = record.mappa_level
       end
@@ -85,7 +85,7 @@ class OffenderService
         if record
           offender.tier = record.tier
           offender.case_allocation = record.case_allocation
-          offender.omicable = record.omicable == 'Yes'
+          offender.welsh_offender = record.welsh_offender == 'Yes'
           offender.crn = record.crn
           offender.mappa_level = record.mappa_level
         end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -78,7 +78,7 @@ class PrisonOffenderManagerService
       if record.present?
         offender_stub.tier = record.tier
         offender_stub.case_allocation = record.case_allocation
-        offender_stub.omicable = record.omicable
+        offender_stub.welsh_offender = record.welsh_offender
       end
 
       if alloc.for_primary_only?

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -10,7 +10,7 @@ class ResponsibilityService
   # rubocop:disable Metrics/CyclomaticComplexity
   def self.calculate_pom_responsibility(offender)
     return RESPONSIBLE if offender.sentence.earliest_release_date.nil?
-    return SUPPORTING unless omicable?(offender)
+    return SUPPORTING unless welsh_offender?(offender)
 
     return RESPONSIBLE if nps_case?(offender) &&
       new_case?(offender) &&
@@ -40,8 +40,8 @@ class ResponsibilityService
 
 private
 
-  def self.omicable?(offender)
-    offender.omicable == true
+  def self.welsh_offender?(offender)
+    offender.welsh_offender == true
   end
 
   def self.nps_case?(offender)

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -19,7 +19,7 @@
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">Last known address in Wales</td>
     <td class="govuk-table__cell table_cell__left_align">
-      <%= humanized_bool(@prisoner.omicable) %>
+      <%= humanized_bool(@prisoner.welsh_offender) %>
       <a class="govuk-link pull-right" href="<%= edit_prison_case_information_path(@prison, @prisoner.offender_no) %>">Change</a>
     </td>
   </tr>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -54,7 +54,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Last known address in Wales</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= humanized_bool(@prisoner.omicable) %>
+        <%= humanized_bool(@prisoner.welsh_offender) %>
         <% unless auto_delius_import_enabled?(@prison) %>
           <a class="govuk-link pull-right" href="<%= edit_prison_case_information_path(@prison, @prisoner.offender_no) %>">Change</a>
         <% end %>

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -2,7 +2,7 @@
 <%= form_tag(action, method: method, id: "case_info_form") do %>
     <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
 
-    <div class="govuk-form-group <% if @case_info.errors[:omicable].present? %>govuk-form-group--error<% end %>">
+    <div class="govuk-form-group <% if @case_info.errors[:welsh_offender].present? %>govuk-form-group--error<% end %>">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-2">
           Was this prisoner's last known address in Wales?
@@ -11,20 +11,20 @@
           Only prisoners with a Welsh address will be allocated a responsible<br/> prison or probation POM.
         </p>
 
-        <% if @case_info.errors[:omicable].present? %>
+        <% if @case_info.errors[:welsh_offender].present? %>
           <span class="govuk-error-message">
-            <%= @case_info.errors[:omicable].first %>
+            <%= @case_info.errors[:welsh_offender].first %>
           </span>
         <% end %>
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[omicable]", 'Yes', @case_info.omicable == 'Yes', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[omicable]", 'Yes', class: "govuk-label govuk-radios__label" %>
+            <%= radio_button_tag("case_information[welsh_offender]", 'Yes', @case_info.welsh_offender == 'Yes', class: "govuk-radios__input") %>
+            <%= label_tag "case_information[welsh_offender]", 'Yes', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[omicable]", 'No', @case_info.omicable == 'No', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[omicable]", "No", class: "govuk-label govuk-radios__label" %>
+            <%= radio_button_tag("case_information[welsh_offender]", 'No', @case_info.welsh_offender == 'No', class: "govuk-radios__input") %>
+            <%= label_tag "case_information[welsh_offender]", "No", class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -77,10 +77,10 @@
         <% end %>
       </td>
     </tr>
-    <tr class="govuk-table__row" id="omicable">
+    <tr class="govuk-table__row" id="welsh_offender">
       <td class="govuk-table__cell">Last known address in Wales</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= humanized_bool(@offender.omicable) %>
+        <%= humanized_bool(@offender.welsh_offender) %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="responsibility"">

--- a/app/views/prisoners/_prisoner_information.html.erb
+++ b/app/views/prisoners/_prisoner_information.html.erb
@@ -43,7 +43,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Last known address in Wales</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= humanized_bool(@prisoner.omicable) %>
+        <%= humanized_bool(@prisoner.welsh_offender) %>
       </td>
     </tr>
     <tr class="govuk-table__row">

--- a/db/migrate/20190919074927_rename_omicable_field.rb
+++ b/db/migrate/20190919074927_rename_omicable_field.rb
@@ -1,0 +1,9 @@
+class RenameOmicableField < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :case_information, :omicable, :welsh_offender
+  end
+
+  def down
+    rename_column :case_information, :welsh_offender, :omicable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_113448) do
+ActiveRecord::Schema.define(version: 2019_09_19_074927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2019_09_13_113448) do
     t.string "tier"
     t.string "case_allocation"
     t.string "nomis_offender_id"
-    t.text "omicable"
+    t.text "welsh_offender"
     t.string "crn"
     t.integer "mappa_level"
     t.boolean "manual_entry", null: false

--- a/lib/delius/manual_extractor.rb
+++ b/lib/delius/manual_extractor.rb
@@ -33,7 +33,7 @@ module Delius
           noms_no: row[2],
           tier: row[4].present? ? row[4][0] : '',
           provider_cd: row[10][0] == 'C' ? 'CRC' : 'NPS',
-          omicable: row[12].start_with?('WPT'),
+          welsh_offender: row[12].start_with?('WPT'),
           crn: row[0]
         }
 

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -24,7 +24,7 @@ class OnboardPrison
       # Create a CaseInformation .....
       CaseInformation.find_or_create_by(
         nomis_offender_id: offender_id,
-        omicable: record[:omicable] ? 'Yes' : 'No',
+        welsh_offender: record[:welsh_offender] ? 'Yes' : 'No',
         tier: record[:tier],
         case_allocation: record[:provider_cd],
         crn: record[:crn],

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       'A'
     end
 
-    omicable do
+    welsh_offender do
       'Yes'
     end
 

--- a/spec/factories/delius_datums.rb
+++ b/spec/factories/delius_datums.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     # This has to match the T3 record for G4281GV above
     date_of_birth do '11/11/1964' end
 
-    # By default delius data is omicable
+    # By default delius data is welsh_offender
     ldu_code do 'WPT001' end
     ldu do 'Somewhere in Wales' end
     team_code do 'abcdefg' end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -15,7 +15,7 @@ feature 'Allocation' do
   }
 
   let!(:case_information) {
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'No')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'No')
   }
 
   scenario 'accepting a recommended allocation', versioning: true, vcr: { cassette_name: :create_new_allocation_feature } do

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -132,7 +132,7 @@ feature "view an offender's allocation information" do
            nomis_offender_id: offender_no,
            tier: 'A',
            case_allocation: 'NPS',
-           omicable: 'No'
+           welsh_offender: 'No'
     )
   end
 

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -14,7 +14,7 @@ feature 'case information feature' do
     end
     visit new_prison_case_information_path('LEI', nomis_offender_id)
 
-    choose('case_information_omicable_Yes')
+    choose('case_information_welsh_offender_Yes')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'
@@ -77,7 +77,7 @@ feature 'case information feature' do
 
     signin_user
     visit new_prison_case_information_path('LEI', nomis_offender_id)
-    choose('case_information_omicable_No')
+    choose('case_information_welsh_offender_No')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'
@@ -86,7 +86,7 @@ feature 'case information feature' do
 
     expect(page).to have_content('Case information')
     expect(page).to have_content('G1821VA')
-    choose('case_information_omicable_No')
+    choose('case_information_welsh_offender_No')
     choose('case_information_case_allocation_CRC')
     click_button 'Update'
 

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -26,7 +26,7 @@ feature "view POM's caseload" do
   let!(:offender3_case_info) { create(:case_information, nomis_offender_id: 'G4706UP') }
   let!(:offender2_case_info) { create(:case_information, nomis_offender_id: 'G9344UG') }
   let!(:offender1_case_info) do
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', omicable: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'Yes')
   end
 
   let!(:case_infos) {

--- a/spec/lib/onboard_prison_spec.rb
+++ b/spec/lib/onboard_prison_spec.rb
@@ -17,13 +17,13 @@ describe OnboardPrison do
              nomis_offender_id: 'G5054VN',
              tier: 'A',
              case_allocation: 'NPS',
-             omicable: 'Yes'
+             welsh_offender: 'Yes'
       )
       create(:case_information,
              nomis_offender_id: 'G9468UN',
              tier: 'C',
              case_allocation: 'CRC',
-             omicable: 'Yes'
+             welsh_offender: 'Yes'
       )
 
       op = described_class.new('PVI', offender_ids, nil)

--- a/spec/models/delius_data_spec.rb
+++ b/spec/models/delius_data_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DeliusData, type: :model do
     end
   end
 
-  describe '#omicable?' do
+  describe '#welsh_offender?' do
     context 'when a record is Welsh' do
       subject {
         described_class.new(
@@ -32,7 +32,7 @@ RSpec.describe DeliusData, type: :model do
         )
       }
 
-      it { should be_omicable }
+      it { should be_welsh_offender }
     end
 
     context 'when a record is not Welsh' do
@@ -44,7 +44,7 @@ RSpec.describe DeliusData, type: :model do
         )
       }
 
-      it { should_not be_omicable }
+      it { should_not be_welsh_offender }
     end
   end
 

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -6,7 +6,7 @@ describe CaseInformationService do
            nomis_offender_id: 'X1000XX',
            tier: 'A',
            case_allocation: 'NPS',
-           omicable: 'Yes'
+           welsh_offender: 'Yes'
     )
   }
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -21,7 +21,7 @@ describe OffenderService do
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     nomis_offender_id = 'G4273GI'
 
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', omicable: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_offender: 'Yes')
     offender = described_class.get_offender(nomis_offender_id)
 
     expect(offender).to be_kind_of(Nomis::Offender)

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -10,7 +10,7 @@ describe ResponsibilityService do
 
   let(:offender_not_welsh) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = false
+      o.welsh_offender = false
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.release_date = DateTime.now.utc.to_date + 6.months
     }
@@ -18,7 +18,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_crc_lt_12_wk) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'CRC'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.release_date = DateTime.now.utc.to_date + 2.weeks
@@ -27,7 +27,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_crc_gt_12_wk) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'CRC'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.release_date = DateTime.now.utc.to_date + 13.weeks
@@ -36,7 +36,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_gt_10_mths) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'NPS'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.release_date = DateTime.now.utc.to_date + 11.months
@@ -45,7 +45,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_lt_10_mths) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'NPS'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.release_date = DateTime.now.utc.to_date + 9.months
@@ -54,7 +54,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_old_case_gt_15_mths) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'NPS'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.sentence_start_date = DateTime.new(2019, 1, 19).utc
@@ -64,7 +64,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_old_case_lt_15_mths) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'NPS'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.sentence_start_date = DateTime.new(2019, 2, 20).utc
@@ -74,7 +74,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_new_case_gt_10_mths) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'NPS'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.sentence_start_date = DateTime.new(2019, 1, 19).utc
@@ -84,7 +84,7 @@ describe ResponsibilityService do
 
   let(:offender_welsh_nps_new_case_lt_10_mths) {
     Nomis::Offender.new.tap { |o|
-      o.omicable = true
+      o.welsh_offender = true
       o.case_allocation = 'NPS'
       o.sentence = Nomis::SentenceDetail.new
       o.sentence.sentence_start_date = DateTime.new(2019, 2, 20).utc


### PR DESCRIPTION
The field formerly known as `omicable` in CaseInformation was used to
differentiate offenders who should be subject to the OMIC policy.  As
the determination of omicability has changed (based on the 2 go-live
dates for the policy) this has been renamed to reflect what it actually
captures.