### PR TITLE
Allocations back links and redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem 'capybara'
   gem 'database_cleaner'
   gem 'faker'
+  gem 'geckodriver-helper'
   gem 'launchy'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    archive-zip (0.12.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.7.0)
@@ -102,6 +104,8 @@ GEM
     flamegraph (0.9.5)
     flipflop (2.6.0)
       activesupport (>= 4.0)
+    geckodriver-helper (0.24.0)
+      archive-zip (~> 0.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gov_uk_date_fields (4.1.0)
@@ -114,6 +118,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -376,6 +381,7 @@ DEPENDENCIES
   flamegraph
   flipflop
   gov_uk_date_fields
+  geckodriver-helper
   govuk_notify_rails
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
   jbuilder (~> 2.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,8 +380,8 @@ DEPENDENCIES
   fast_underscore
   flamegraph
   flipflop
-  gov_uk_date_fields
   geckodriver-helper
+  gov_uk_date_fields
   govuk_notify_rails
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
   jbuilder (~> 2.9)

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -82,7 +82,11 @@ class AllocationsController < PrisonsApplicationController
         "#{offender.full_name_ordered} has not been allocated  - please try again"
     end
 
-    redirect_to prison_summary_unallocated_path(active_prison)
+    if allocation[:event] == 'allocate_primary_pom'
+      redirect_to prison_summary_unallocated_path(active_prison)
+    else
+      redirect_to prison_summary_allocated_path(active_prison)
+    end
   end
 
   def history

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -83,9 +83,9 @@ class AllocationsController < PrisonsApplicationController
     end
 
     if allocation[:event] == 'allocate_primary_pom'
-      redirect_to prison_summary_unallocated_path(active_prison, page: params[:page])
+      redirect_to prison_summary_unallocated_path(active_prison, page: params[:page], sort: params[:sort])
     else
-      redirect_to prison_summary_allocated_path(active_prison, page: params[:page])
+      redirect_to prison_summary_allocated_path(active_prison, page: params[:page], sort: params[:sort])
     end
   end
 

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -83,9 +83,9 @@ class AllocationsController < PrisonsApplicationController
     end
 
     if allocation[:event] == 'allocate_primary_pom'
-      redirect_to prison_summary_unallocated_path(active_prison)
+      redirect_to prison_summary_unallocated_path(active_prison, page: params[:page])
     else
-      redirect_to prison_summary_allocated_path(active_prison)
+      redirect_to prison_summary_allocated_path(active_prison, page: params[:page])
     end
   end
 

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -46,7 +46,10 @@ class CaseInformationController < PrisonsApplicationController
     )
 
     if @case_info.valid?
-      return redirect_to prison_summary_pending_path(active_prison, page: params[:page])
+      return redirect_to prison_summary_pending_path(active_prison,
+                                                     sort: params[:sort],
+                                                     page: params[:page]
+                         )
     end
 
     @prisoner = prisoner(case_information_params[:nomis_offender_id])

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -46,11 +46,11 @@ class CaseInformationController < PrisonsApplicationController
     )
 
     if @case_info.valid?
-      redirect_to prison_summary_pending_path(active_prison)
-    else
-      @prisoner = prisoner(case_information_params[:nomis_offender_id])
-      render :new
+      return redirect_to prison_summary_pending_path(active_prison, page: params[:page])
     end
+
+    @prisoner = prisoner(case_information_params[:nomis_offender_id])
+    render :new
   end
 
   def update

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -54,6 +54,7 @@ private
         active_prison,
         override_params[:nomis_offender_id],
         override_params[:nomis_staff_id],
+        sort: params[:sort],
         page: params[:page]
       )
     else
@@ -61,6 +62,7 @@ private
         active_prison,
         override_params[:nomis_offender_id],
         override_params[:nomis_staff_id],
+        sort: params[:sort],
         page: params[:page]
       )
     end

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -45,11 +45,25 @@ private
   end
 
   def redirect_on_success
-    redirect_to prison_confirm_allocation_path(
-      active_prison,
-      override_params[:nomis_offender_id],
-      override_params[:nomis_staff_id]
+    previously_allocated = AllocationService.previously_allocated_poms(
+      override_params[:nomis_offender_id]
     )
+
+    if previously_allocated.empty?
+      redirect_to prison_confirm_allocation_path(
+        active_prison,
+        override_params[:nomis_offender_id],
+        override_params[:nomis_staff_id],
+        page: params[:page]
+      )
+    else
+      redirect_to prison_confirm_reallocation_path(
+        active_prison,
+        override_params[:nomis_offender_id],
+        override_params[:nomis_staff_id],
+        page: params[:page]
+      )
+    end
   end
 
   def override_params

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -34,7 +34,7 @@ time left to serve into account.</p>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
-      <%= link_to "Allocate", prison_confirm_allocation_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
+      <%= link_to "Allocate", prison_confirm_allocation_path(@prison, @prisoner.offender_no, pom.staff_id, sort: params[:sort], page: params[:page]), class: "govuk-link" %>
       </td>
     </tr>
   <% end %>
@@ -83,7 +83,7 @@ time left to serve into account.</p>
           <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
           <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
           <td aria-label="Action" class="govuk-table__cell table_cell__right_align">
-          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
+          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id, sort: params[:sort], page: params[:page]), class: "govuk-link" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/allocations/_pom_tables.html.erb
+++ b/app/views/allocations/_pom_tables.html.erb
@@ -34,7 +34,7 @@ time left to serve into account.</p>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
-      <%= link_to "Allocate", prison_confirm_allocation_path(@prison, @prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
+      <%= link_to "Allocate", prison_confirm_allocation_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
       </td>
     </tr>
   <% end %>
@@ -83,7 +83,7 @@ time left to serve into account.</p>
           <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
           <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
           <td aria-label="Action" class="govuk-table__cell table_cell__right_align">
-          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
+          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/allocations/_pom_tables_reallocate.html.erb
+++ b/app/views/allocations/_pom_tables_reallocate.html.erb
@@ -34,7 +34,7 @@ time left to serve into account.</p>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
-      <%= link_to "Allocate", prison_confirm_reallocation_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
+      <%= link_to "Allocate", prison_confirm_reallocation_path(@prison, @prisoner.offender_no, pom.staff_id, sort: params[:sort], page: params[:page]), class: "govuk-link" %>
       </td>
     </tr>
   <% end %>
@@ -83,7 +83,7 @@ time left to serve into account.</p>
           <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
           <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
           <td aria-label="Action" class="govuk-table__cell table_cell__right_align">
-          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
+          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id, sort: params[:sort], page: params[:page]), class: "govuk-link" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/allocations/_pom_tables_reallocate.html.erb
+++ b/app/views/allocations/_pom_tables_reallocate.html.erb
@@ -34,7 +34,7 @@ time left to serve into account.</p>
       <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
       <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
       <td aria-label="Action" class="govuk-table__cell table_cell__left_align">
-      <%= link_to "Allocate", prison_confirm_reallocation_path(@prison, @prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
+      <%= link_to "Allocate", prison_confirm_reallocation_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
       </td>
     </tr>
   <% end %>
@@ -83,7 +83,7 @@ time left to serve into account.</p>
           <td aria-label="Total" class="govuk-table__cell "><%= pom.total_cases %></td>
           <td aria-label="Working pattern" class="govuk-table__cell"><%= working_pattern_name(pom.working_pattern) %></td>
           <td aria-label="Action" class="govuk-table__cell table_cell__right_align">
-          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id), class: "govuk-link" %>
+          <%= link_to "Allocate", new_prison_overrides_path(@prison, @prisoner.offender_no, pom.staff_id, page: params[:page]), class: "govuk-link" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/allocations/confirm.html.erb
+++ b/app/views/allocations/confirm.html.erb
@@ -21,6 +21,7 @@
       <%= hidden_field_tag("allocations[nomis_staff_id]", @pom.staff_id) %>
       <%= hidden_field_tag("allocations[event]", @event) %>
       <%= hidden_field_tag("allocations[event_trigger]", @event_trigger) %>
+      <%= hidden_field_tag("page", params[:page]) %>
       <%= submit_tag "Complete allocation", role: "button", draggable: "false", class: "govuk-button" %>
       <a class="govuk-link cancel-button" href="<%= new_prison_allocation_path(@prison, @prisoner.offender_no) %>">Cancel</a>
     <% end %>

--- a/app/views/allocations/confirm.html.erb
+++ b/app/views/allocations/confirm.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_prison_allocation_path(@prison, @prisoner.offender_no) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/allocations/confirm.html.erb
+++ b/app/views/allocations/confirm.html.erb
@@ -21,6 +21,7 @@
       <%= hidden_field_tag("allocations[nomis_staff_id]", @pom.staff_id) %>
       <%= hidden_field_tag("allocations[event]", @event) %>
       <%= hidden_field_tag("allocations[event_trigger]", @event_trigger) %>
+      <%= hidden_field_tag("sort", params[:sort]) %>
       <%= hidden_field_tag("page", params[:page]) %>
       <%= submit_tag "Complete allocation", role: "button", draggable: "false", class: "govuk-button" %>
       <a class="govuk-link cancel-button" href="<%= new_prison_allocation_path(@prison, @prisoner.offender_no) %>">Cancel</a>

--- a/app/views/allocations/confirm_reallocation.html.erb
+++ b/app/views/allocations/confirm_reallocation.html.erb
@@ -21,6 +21,7 @@
       <%= hidden_field_tag("allocations[nomis_staff_id]", @pom.staff_id) %>
       <%= hidden_field_tag("allocations[event]", @event) %>
       <%= hidden_field_tag("allocations[event_trigger]", @event_trigger) %>
+      <%= hidden_field_tag("page", params[:page]) %>
       <%= submit_tag "Complete allocation", role: "button", draggable: "false", class: "govuk-button" %>
       <a class="govuk-link cancel-button" href="<%= new_prison_allocation_path(@prison, @prisoner.offender_no) %>">Cancel</a>
     <% end %>

--- a/app/views/allocations/confirm_reallocation.html.erb
+++ b/app/views/allocations/confirm_reallocation.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_prison_allocation_path(@prison, @prisoner.offender_no) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <div class="govuk-grid-row">
 

--- a/app/views/allocations/confirm_reallocation.html.erb
+++ b/app/views/allocations/confirm_reallocation.html.erb
@@ -21,6 +21,7 @@
       <%= hidden_field_tag("allocations[nomis_staff_id]", @pom.staff_id) %>
       <%= hidden_field_tag("allocations[event]", @event) %>
       <%= hidden_field_tag("allocations[event_trigger]", @event_trigger) %>
+      <%= hidden_field_tag("sort", params[:sort]) %>
       <%= hidden_field_tag("page", params[:page]) %>
       <%= submit_tag "Complete allocation", role: "button", draggable: "false", class: "govuk-button" %>
       <a class="govuk-link cancel-button" href="<%= new_prison_allocation_path(@prison, @prisoner.offender_no) %>">Cancel</a>

--- a/app/views/allocations/edit.html.erb
+++ b/app/views/allocations/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => {:page => prison_summary_unallocated_path(@prison) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Reallocate a Prison Offender Manager</h1>
 

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => prison_summary_unallocated_path(@prison) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
 

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -148,7 +148,7 @@
       <td class="govuk-table__cell govuk-!-width-one-half">POM</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
         <%= link_to @pom.full_name, prison_pom_path(@prison, @pom.staff_id), class: "govuk-link" %>
-        <%= link_to 'Reallocate', edit_prison_allocation_path(@prison, @prisoner.offender_no), class: "govuk-link pull-right" %>
+        <%= link_to 'Reallocate', edit_prison_allocation_path(@prison, @prisoner.offender_no, page: params[:page]), class: "govuk-link pull-right" %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="co-working-pom">

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -148,7 +148,7 @@
       <td class="govuk-table__cell govuk-!-width-one-half">POM</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
         <%= link_to @pom.full_name, prison_pom_path(@prison, @pom.staff_id), class: "govuk-link" %>
-        <%= link_to 'Reallocate', edit_prison_allocation_path(@prison, @prisoner.offender_no, page: params[:page]), class: "govuk-link pull-right" %>
+        <%= link_to 'Reallocate', edit_prison_allocation_path(@prison, @prisoner.offender_no, sort: params[:sort], page: params[:page]), class: "govuk-link pull-right" %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="co-working-pom">

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -1,6 +1,7 @@
 
 <%= form_tag(action, method: method, id: "case_info_form") do %>
     <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
+    <%= hidden_field_tag("sort", params[:sort])%>
     <%= hidden_field_tag("page", params[:page]) %>
 
     <div class="govuk-form-group <% if @case_info.errors[:welsh_offender].present? %>govuk-form-group--error<% end %>">

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -1,6 +1,7 @@
 
 <%= form_tag(action, method: method, id: "case_info_form") do %>
     <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
+    <%= hidden_field_tag("page", params[:page]) %>
 
     <div class="govuk-form-group <% if @case_info.errors[:welsh_offender].present? %>govuk-form-group--error<% end %>">
       <fieldset class="govuk-fieldset">

--- a/app/views/case_information/edit.html.erb
+++ b/app/views/case_information/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_prison_allocation_path(@prison, @prisoner.offender_no) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <% if @case_info.errors.count > 0 %>
   <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>

--- a/app/views/case_information/new.html.erb
+++ b/app/views/case_information/new.html.erb
@@ -1,5 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => prison_summary_pending_path(@prison) } %>
-
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <% if @case_info.errors.count > 0 %>
   <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>
@@ -10,7 +9,6 @@
 <h2 class="govuk-heading-m"><%= @prisoner.offender_no %></h2>
 
 <p class="govuk-!-margin-bottom-8">You can find this information in NDelius.</p>
-
 
 <%= render :partial => "form", :locals => {
       :action => prison_case_information_index_path(@prison),

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => new_prison_allocation_path(@prison, @prisoner.offender_no) } %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <% if @override.errors.count > 0 %>
   <%= render :partial => "/shared/validation_errors", :locals => { :errors => @override.errors } %>
@@ -20,6 +20,7 @@
             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
               <%= hidden_field_tag("override[nomis_offender_id]", @prisoner.offender_no) %>
               <%= hidden_field_tag("override[nomis_staff_id]", @pom.staff_id) %>
+              <%= hidden_field_tag("page", params[:page]) %>
               <div class="govuk-checkboxes__item">
                 <input class="govuk-checkboxes__input" id="override-conditional-1" name="override[override_reasons][]" type="checkbox" value="suitability" data-aria-controls="override-1"
                        <%= 'checked=checked' if override_reason_contains(@override, 'suitability') %> >

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -20,6 +20,7 @@
             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
               <%= hidden_field_tag("override[nomis_offender_id]", @prisoner.offender_no) %>
               <%= hidden_field_tag("override[nomis_staff_id]", @pom.staff_id) %>
+              <%= hidden_field_tag("sort", params[:sort]) %>
               <%= hidden_field_tag("page", params[:page]) %>
               <div class="govuk-checkboxes__item">
                 <input class="govuk-checkboxes__input" id="override-conditional-1" name="override[override_reasons][]" type="checkbox" value="suitability" data-aria-controls="override-1"

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -49,9 +49,9 @@
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
         <td aria-label="Action" class="govuk-table__cell ">
           <% if Flipflop.link_allocation_info? %>
-            <%= link_to "View", prison_allocation_path(@prison, nomis_offender_id: offender.offender_no, page: params[:page] || 1) %>
+            <%= link_to "View", prison_allocation_path(@prison, nomis_offender_id: offender.offender_no, sort: params[:sort], page: params[:page] || 1) %>
           <% else %>
-            <%= link_to "Reallocate", edit_prison_allocation_path(@prison, offender.offender_no, page: params[:page] || 1) %>
+            <%= link_to "Reallocate", edit_prison_allocation_path(@prison, offender.offender_no, sort: params[:sort], page: params[:page] || 1) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -49,9 +49,9 @@
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
         <td aria-label="Action" class="govuk-table__cell ">
           <% if Flipflop.link_allocation_info? %>
-            <%= link_to "View", prison_allocation_path(@prison, nomis_offender_id: offender.offender_no) %>
+            <%= link_to "View", prison_allocation_path(@prison, nomis_offender_id: offender.offender_no, page: params[:page] || 1) %>
           <% else %>
-            <%= link_to "Reallocate", edit_prison_allocation_path(@prison, offender.offender_no) %>
+            <%= link_to "Reallocate", edit_prison_allocation_path(@prison, offender.offender_no, page: params[:page] || 1) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/summary/pending.html.erb
+++ b/app/views/summary/pending.html.erb
@@ -63,7 +63,7 @@
           <% if auto_delius_import_enabled?(@prison) %>
             <%= link_to "Update", prison_case_information_path(@prison, offender.offender_no) %>
           <% else %>
-            <%= link_to "Edit", new_prison_case_information_path(@prison, offender.offender_no, page: params[:page] || 1) %></td>
+            <%= link_to "Edit", new_prison_case_information_path(@prison, offender.offender_no, sort: params[:sort], page: params[:page] || 1) %></td>
           <% end %>
         </td>
       </tr>

--- a/app/views/summary/pending.html.erb
+++ b/app/views/summary/pending.html.erb
@@ -63,7 +63,7 @@
           <% if auto_delius_import_enabled?(@prison) %>
             <%= link_to "Update", prison_case_information_path(@prison, offender.offender_no) %>
           <% else %>
-            <%= link_to "Edit", new_prison_case_information_path(@prison, offender.offender_no) %></td>
+            <%= link_to "Edit", new_prison_case_information_path(@prison, offender.offender_no, page: params[:page] || 1) %></td>
           <% end %>
         </td>
       </tr>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -70,7 +70,7 @@
           <%= offender.awaiting_allocation_for %> days
         </td>
         <td aria-label="Action" class="govuk-table__cell ">
-          <a href="<%= new_prison_allocation_path(@prison, offender.offender_no, page: params[:page] || 1) %>">Allocate</a>
+          <a href="<%= new_prison_allocation_path(@prison, offender.offender_no, sort: params[:sort], page: params[:page] || 1) %>">Allocate</a>
         </td>
       </tr>
     <% end %>

--- a/app/views/summary/unallocated.html.erb
+++ b/app/views/summary/unallocated.html.erb
@@ -70,7 +70,7 @@
           <%= offender.awaiting_allocation_for %> days
         </td>
         <td aria-label="Action" class="govuk-table__cell ">
-          <a href="<%= new_prison_allocation_path(@prison, offender.offender_no) %>">Allocate</a>
+          <a href="<%= new_prison_allocation_path(@prison, offender.offender_no, page: params[:page] || 1) %>">Allocate</a>
         </td>
       </tr>
     <% end %>

--- a/spec/controllers/overrides_controller_spec.rb
+++ b/spec/controllers/overrides_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe OverridesController, type: :controller do
+  before do
+    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(OpenStruct.new(access_token: 'token'))
+    session[:sso_data] = { 'expiry' => Time.zone.now + 1.day,
+                           'roles' => ['ROLE_ALLOC_MGR'],
+                           'caseloads' => [prison] }
+  end
+
+  let(:prison) { 'WEI' }
+
+  let(:nomis_staff_id) { 'A12345' }
+
+  let(:nomis_offender_id) { 'B44455' }
+
+  let(:params) do
+    { prison_id: 'WEI' }
+  end
+
+  let(:override_params) do
+    {
+      override: { nomis_offender_id: nomis_offender_id,
+                  nomis_staff_id: nomis_staff_id,
+                  more_detail: nil,
+                  suitability_detail: "Too high risk",
+                  override_reasons: ["continuity"]
+      }
+    }
+  end
+
+  context 'when creating an override' do
+    it 'redirects to confirm#allocation when offender has no previous allocations' do
+      post :create, params: params.merge(override_params)
+
+      expect(response).to redirect_to prison_confirm_allocation_path(prison, nomis_offender_id, nomis_staff_id)
+    end
+
+    it 'redirects to confirm#reallocation when offender has been previously allocated' do
+      allow(AllocationService).to receive(:previously_allocated_poms).and_return([nomis_offender_id])
+
+      post :create, params: params.merge(override_params)
+
+      expect(response).to redirect_to prison_confirm_reallocation_path(prison, nomis_offender_id, nomis_staff_id)
+    end
+  end
+end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -37,7 +37,7 @@ feature 'Allocation' do
 
     click_button 'Complete allocation'
 
-    expect(page).to have_current_path prison_summary_unallocated_path('LEI')
+    expect(current_url).to have_content(prison_summary_unallocated_path('LEI'))
     expect(page).to have_css('.notification', text: 'Ozullirn Abbella has been allocated to Ross Jones (Probation POM)')
   end
 
@@ -58,11 +58,10 @@ feature 'Allocation' do
 
     expect(Override.count).to eq(1)
 
-    expect(page).to have_current_path prison_confirm_allocation_path('LEI', nomis_offender_id, override_nomis_staff_id)
-
+    expect(current_url).to have_content(prison_confirm_allocation_path('LEI', nomis_offender_id, override_nomis_staff_id))
     click_button 'Complete allocation'
 
-    expect(page).to have_current_path prison_summary_unallocated_path('LEI')
+    expect(current_url).to have_content(prison_summary_unallocated_path('LEI'))
 
     # Note: after removing an old team member as a POM the MOIC integration test user is now top of the list of POMS.
     # This user is both a probation and prison POM in the system and therefore whilst it says 'Probation POM' in this
@@ -145,14 +144,14 @@ feature 'Allocation' do
       click_link 'View'
     end
 
-    expect(page).to have_current_path prison_allocation_path('LEI', nomis_offender_id)
-    expect(page).to have_link(nil, href: '/prisons/LEI/poms/485637')
+    expect(current_url).to have_content(prison_allocation_path('LEI', nomis_offender_id))
+    expect(page).to have_link(nil, href: "/prisons/LEI/poms/485637")
     expect(page).to have_css('.table_cell__left_align', text: 'Pobee-Norris, Kath')
     expect(page).to have_css('.table_cell__left_align', text: 'Supporting')
 
     click_link 'Reallocate'
 
-    expect(page).to have_current_path edit_prison_allocation_path('LEI', nomis_offender_id)
+    expect(current_url).to have_content(edit_prison_allocation_path('LEI', nomis_offender_id))
     expect(page).to have_css('.current_pom_full_name', text: 'Pobee-Norris, Kath')
     expect(page).to have_css('.current_pom_grade', text: 'Probation POM')
 
@@ -160,7 +159,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(page).to have_current_path prison_confirm_reallocation_path('LEI', nomis_offender_id, prison_officer_nomis_staff_id)
+    expect(current_url).to have_content(prison_confirm_reallocation_path('LEI', nomis_offender_id, prison_officer_nomis_staff_id))
 
     click_button 'Complete allocation'
 
@@ -178,7 +177,8 @@ feature 'Allocation' do
 
     click_button 'Complete allocation'
 
-    expect(page).to have_current_path prison_summary_unallocated_path('LEI')
+    expect(current_url).to have_content(prison_summary_unallocated_path('LEI'))
+
     expect(page).to have_css(
       '.alert',
       text: 'Ozullirn Abbella has not been allocated - please try again'

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -23,7 +23,7 @@ feature 'case information feature' do
     expect(CaseInformation.first.nomis_offender_id).to eq(nomis_offender_id)
     expect(CaseInformation.first.tier).to eq('A')
     expect(CaseInformation.first.case_allocation).to eq('NPS')
-    expect(page).to have_current_path prison_summary_pending_path('LEI')
+    expect(current_url).to have_content "/prisons/LEI/summary/pending"
 
     expect(page).to have_css('.offender_row_0', count: 1)
   end
@@ -36,10 +36,10 @@ feature 'case information feature' do
     within ".govuk-table tr:first-child td:nth-child(6)" do
       click_link 'Edit'
     end
-    expect(page).to have_selector('h1', text:'Case information')
+    expect(page).to have_selector('h1', text: 'Case information')
 
     click_link 'Back'
-    expect(page).to have_selector('h1', text:'Allocations')
+    expect(page).to have_selector('h1', text: 'Allocations')
   end
 
   it 'complains if allocation data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_case_feature } do
@@ -111,5 +111,23 @@ feature 'case information feature' do
 
     expect(page).to have_current_path new_prison_allocation_path('LEI', nomis_offender_id)
     expect(page).to have_content('CRC')
+  end
+
+  it 'returns to previously paginated page after saving',
+     vcr: { cassette_name: :case_information_return_to_previously_paginated_page } do
+    signin_user
+    visit prison_summary_pending_path('LEI', page: 3)
+
+    within ".govuk-table tr:first-child td:nth-child(6)" do
+      click_link 'Edit'
+    end
+    expect(page).to have_selector('h1', text: 'Case information')
+
+    choose('case_information_welsh_offender_No')
+    choose('case_information_case_allocation_NPS')
+    choose('case_information_tier_A')
+    click_button 'Save'
+
+    expect(current_url).to have_content("/prisons/LEI/summary/pending?page=3")
   end
 end

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -28,6 +28,20 @@ feature 'case information feature' do
     expect(page).to have_css('.offender_row_0', count: 1)
   end
 
+  it "clicking back link after viewing prisoner's case information, returns back the same paginated page",
+     vcr: { cassette_name: :case_information_back_link }, js: true do
+    signin_user
+    visit prison_summary_pending_path('LEI', page: 3)
+
+    within ".govuk-table tr:first-child td:nth-child(6)" do
+      click_link 'Edit'
+    end
+    expect(page).to have_selector('h1', text:'Case information')
+
+    click_link 'Back'
+    expect(page).to have_selector('h1', text:'Allocations')
+  end
+
   it 'complains if allocation data is missing', :raven_intercept_exception, vcr: { cassette_name: :case_information_missing_case_feature } do
     nomis_offender_id = 'G1821VA'
 

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -116,7 +116,7 @@ feature 'case information feature' do
   it 'returns to previously paginated page after saving',
      vcr: { cassette_name: :case_information_return_to_previously_paginated_page } do
     signin_user
-    visit prison_summary_pending_path('LEI', page: 3)
+    visit prison_summary_pending_path('LEI', sort: "last_name desc", page: 3)
 
     within ".govuk-table tr:first-child td:nth-child(6)" do
       click_link 'Edit'
@@ -128,6 +128,6 @@ feature 'case information feature' do
     choose('case_information_tier_A')
     click_button 'Save'
 
-    expect(current_url).to have_content("/prisons/LEI/summary/pending?page=3")
+    expect(current_url).to have_content("/prisons/LEI/summary/pending?page=3&sort=last_name+desc")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,6 @@ require 'capybara/rspec'
 require 'webmock/rspec'
 require 'paper_trail/frameworks/rspec'
 
-Capybara.javascript_driver = :selenium
 Capybara.default_max_wait_time = 4
 Capybara.asset_host = 'http://localhost:3000'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,10 @@ require 'capybara/rspec'
 require 'webmock/rspec'
 require 'paper_trail/frameworks/rspec'
 
+Capybara.javascript_driver = :selenium
+Capybara.default_max_wait_time = 4
+Capybara.asset_host = 'http://localhost:3000'
+
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e


### PR DESCRIPTION
Currently when an user is on a paginated list and they click to view or edit an allocation, they always return to page 1 of the paginated list regardless of the page they were on originally.

This PR attempts to fix that issue by using the javascript.history.back method and by storing the page no of the paginated list in the params when redirecting back to the paginated list.

I also had to make changes to the overrides_controller to correctly identifying whether the event is an allocation or reallocation. Previously all overrides were being flagged as `allocate_primary_pom` events and would return the user to `Make allocations` tab even if the event was actually `reallocate_primary_pom` and should have been returned to `See allocations` tab.

Added the 'geckodriver-helper' gem to test the javascript in the tests.