### PR TITLE
Make handover date the responsibility of the sentence_detail

### DIFF
--- a/app/models/nomis/offender.rb
+++ b/app/models/nomis/offender.rb
@@ -25,18 +25,6 @@ module Nomis
       fields.each { |k, v| instance_variable_set("@#{k}", v) } if fields.present?
     end
 
-    def early_allocation?
-      false
-    end
-
-    def nps_case?
-      case_allocation == 'NPS'
-    end
-
-    def pom_responsibility
-      ResponsibilityService.calculate_pom_responsibility(self).to_s
-    end
-
     def self.from_json(payload)
       Offender.new.tap { |obj|
         obj.load_from_json(payload)

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -60,6 +60,28 @@ module Nomis
       age >= 18
     end
 
+    def early_allocation?
+      false
+    end
+
+    def nps_case?
+      case_allocation == 'NPS'
+    end
+
+    def handover_start_date
+      @sentence.handover_start_date
+      HandoverData.from_offender(self)
+    end
+
+    def responsibility_handover_date
+      @sentence.responsibility_handover_date
+      HandoverData.from_offender(self)
+    end
+
+    def pom_responsibility
+      ResponsibilityService.calculate_pom_responsibility(self).to_s
+    end
+
     def awaiting_allocation_for
       omic_start_date = Date.new(2019, 2, 4)
 
@@ -100,14 +122,6 @@ module Nomis
       @sentence_type = SentenceType.new(payload['imprisonmentStatus'])
       @category_code = payload['categoryCode']
       @date_of_birth = deserialise_date(payload, 'dateOfBirth')
-    end
-
-    def handover_start_date
-      HandoverDateService.handover_start_date(self)
-    end
-
-    def responsibility_handover_date
-      HandoverDateService.responsibility_handover_date(self)
     end
 
     def load_case_information(record)

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -79,7 +79,7 @@ module Nomis
     end
 
     def pom_responsibility
-      ResponsibilityService.calculate_pom_responsibility(self).to_s
+      ResponsibilityService.calculate_pom_responsibility(self)
     end
 
     def awaiting_allocation_for
@@ -99,10 +99,6 @@ module Nomis
 
     def sentence_start_date
       sentence.sentence_start_date
-    end
-
-    def pom_responsibility
-      ResponsibilityService.calculate_pom_responsibility(self)
     end
 
     def full_name

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -69,13 +69,11 @@ module Nomis
     end
 
     def handover_start_date
-      @sentence.handover_start_date
-      HandoverData.from_offender(self)
+      @sentence.handover_start_date(HandoverData.from_offender(self))
     end
 
     def responsibility_handover_date
-      @sentence.responsibility_handover_date
-      HandoverData.from_offender(self)
+      @sentence.responsibility_handover_date(HandoverData.from_offender(self))
     end
 
     def pom_responsibility

--- a/app/models/nomis/sentence_detail.rb
+++ b/app/models/nomis/sentence_detail.rb
@@ -34,6 +34,14 @@ module Nomis
       dates.min.to_date
     end
 
+    def handover_start_date(offender_details)
+      HandoverDateService.handover_start_date(offender_details, self)
+    end
+
+    def responsibility_handover_date(offender_details)
+      HandoverDateService.responsibility_handover_date(offender_details, self)
+    end
+
     def full_name
       "#{last_name}, #{first_name}".titleize
     end

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -1,85 +1,97 @@
 # frozen_string_literal: true
 
+HandoverData = Struct.new(:nps_case?,
+                          :early_allocation?,
+                          :mappa_level,
+                          :indeterminate_sentence?) do
+  def self.from_offender(offender)
+    new(offender.nps_case?,
+        offender.early_allocation?,
+        offender.mappa_level,
+        offender.indeterminate_sentence?)
+  end
+end
+
 class HandoverDateService
   # rubocop:disable Metrics/LineLength
-  def self.handover_start_date(offender)
-    if offender.nps_case? && !offender.early_allocation?
-      return [offender.earliest_release_date - 8.months, 'NPS Indeterminate'] if offender.indeterminate_sentence?
+  def self.handover_start_date(subject, dates)
+    if subject.nps_case? && !subject.early_allocation?
+      return [dates.earliest_release_date - 8.months, 'NPS Indeterminate'] if subject.indeterminate_sentence?
 
-      [offender.earliest_release_date - (7.months + 15.days), 'NPS Determinate']
+      [dates.earliest_release_date - (7.months + 15.days), 'NPS Determinate']
     else
       [nil, 'CRC or Early Allocation']
     end
   end
   # rubocop:enable Metrics/LineLength
 
-  def self.responsibility_handover_date(offender)
-    if offender.nps_case?
-      nps_handover_date(offender)
+  def self.responsibility_handover_date(subject, dates)
+    if subject.nps_case?
+      nps_handover_date(subject, dates)
     else
-      [crc_handover_date(offender), 'CRC']
+      [crc_handover_date(dates), 'CRC']
     end
   end
 
 private
 
-  def self.crc_handover_date(offender)
+  def self.crc_handover_date(dates)
     [
-        offender.home_detention_curfew_eligibility_date,
-        offender.conditional_release_date
+      dates.home_detention_curfew_eligibility_date,
+      dates.conditional_release_date
     ].compact.map { |date| date - 12.weeks }.min
   end
 
-  def self.nps_handover_date(offender)
-    if offender.early_allocation?
-      return [early_allocation_handover_date(offender), 'NPS Early']
+  def self.nps_handover_date(subject, dates)
+    if subject.early_allocation?
+      return [early_allocation_handover_date(dates), 'NPS Early']
     end
 
-    if offender.indeterminate_sentence?
-      [indeterminate_responsibility_date(offender), 'NPS Inderminate']
-    elsif offender.parole_eligibility_date.present?
-      [offender.parole_eligibility_date - 8.months, 'NPS Determinate Parole Case']
-    elsif offender.mappa_level.blank?
+    if subject.indeterminate_sentence?
+      [indeterminate_responsibility_date(dates), 'NPS Inderminate']
+    elsif dates.parole_eligibility_date.present?
+      [dates.parole_eligibility_date - 8.months, 'NPS Determinate Parole Case']
+    elsif subject.mappa_level.blank?
       [nil, 'NPS - MAPPA missing from nDelius']
-    elsif offender.mappa_level.in? [1, 0]
-      [mappa1_responsibility_date(offender), 'NPS Determinate Mappa 1/N']
+    elsif subject.mappa_level.in? [1, 0]
+      [mappa1_responsibility_date(dates), 'NPS Determinate Mappa 1/N']
     else
-      [mappa_23_responsibility_date(offender), 'NPS Determinate Mappa 2/3']
+      [mappa_23_responsibility_date(dates), 'NPS Determinate Mappa 2/3']
     end
   end
 
-  def self.indeterminate_responsibility_date(offender)
+  def self.indeterminate_responsibility_date(dates)
     [
-        offender.parole_eligibility_date,
-        offender.tariff_date
+      dates.parole_eligibility_date,
+      dates.tariff_date
     ].compact.map { |date| date - 8.months }.min
   end
 
   # There are a couple of places where we need .5 of a month - which
   # we have assumed 15.days is a reasonable compromise implementation
-  def self.mappa_23_responsibility_date(offender)
+  def self.mappa_23_responsibility_date(dates)
     [
-        offender.conditional_release_date,
-        offender.automatic_release_date
+      dates.conditional_release_date,
+      dates.automatic_release_date
     ].compact.map { |date| date - (7.months + 15.days) }.min
   end
 
-  def self.mappa1_responsibility_date(offender)
+  def self.mappa1_responsibility_date(dates)
     crd_ard = [
-        offender.conditional_release_date,
-        offender.automatic_release_date
+      dates.conditional_release_date,
+      dates.automatic_release_date
     ].compact.map { |date| date - (4.months + 15.days) }.min
 
     [
-        crd_ard,
-        offender.home_detention_curfew_eligibility_date
+      crd_ard,
+      dates.home_detention_curfew_eligibility_date
     ].compact.min
   end
 
-  def self.early_allocation_handover_date(offender)
+  def self.early_allocation_handover_date(dates)
     [
-        offender.conditional_release_date,
-        offender.automatic_release_date
+      dates.conditional_release_date,
+      dates.automatic_release_date
     ].compact.map { |date| date - 15.months }.min
   end
 end

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -15,6 +15,8 @@ end
 class HandoverDateService
   # rubocop:disable Metrics/LineLength
   def self.handover_start_date(subject, dates)
+    return [nil, 'No earliest release date'] if dates.try(:earliest_release_date).nil?
+
     if subject.nps_case? && !subject.early_allocation?
       return [dates.earliest_release_date - 8.months, 'NPS Indeterminate'] if subject.indeterminate_sentence?
 
@@ -26,6 +28,8 @@ class HandoverDateService
   # rubocop:enable Metrics/LineLength
 
   def self.responsibility_handover_date(subject, dates)
+    return [nil, 'No earliest release date'] if dates.try(:earliest_release_date).nil?
+
     if subject.nps_case?
       nps_handover_date(subject, dates)
     else

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -5,13 +5,13 @@ class OffenderService
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
       next false if o.nil?
 
-      record = CaseInformation.find_by(nomis_offender_id: offender_no)
-      o.load_case_information(record)
-
       sentence_detail = get_sentence_details([o.latest_booking_id])
       if sentence_detail.present? && sentence_detail.key?(o.latest_booking_id)
         o.sentence = sentence_detail[o.latest_booking_id]
       end
+
+      record = CaseInformation.find_by(nomis_offender_id: offender_no)
+      o.load_case_information(record)
 
       o.category_code = Nomis::Elite2::OffenderApi.get_category_code(o.offender_no)
       o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -49,25 +49,25 @@ describe HandoverDateService do
   describe '#responsibility_handover_date' do
     context 'when CRC' do
       before do
-        stub_const("CRCHandoverDates", Struct.new(:home_detention_curfew_eligibility_date, :conditional_release_date))
+        stub_const("CRCHandoverDates", Struct.new(:home_detention_curfew_eligibility_date, :conditional_release_date, :earliest_release_date))
         stub_const("CRCHandoverData", Struct.new(:nps_case?, :dates, :result))
 
         stub_const("CRC_CASES", [
             CRCHandoverData.new(
               false,
-              CRCHandoverDates.new(Date.new(2019, 9, 30), Date.new(2019, 8, 1)),
+              CRCHandoverDates.new(Date.new(2019, 9, 30), Date.new(2019, 8, 1), Date.new(2019, 8, 1)),
               Date.new(2019, 5, 9)), # 12 weeks before CRD
             CRCHandoverData.new(false,
-                                CRCHandoverDates.new(Date.new(2019, 8, 1), Date.new(2019, 8, 12)),
+                                CRCHandoverDates.new(Date.new(2019, 8, 1), Date.new(2019, 8, 12), Date.new(2019, 8, 1)),
                                 Date.new(2019, 5, 9)), # 12 weeks before HDC date
             CRCHandoverData.new(false,
-                                CRCHandoverDates.new(nil, Date.new(2019, 8, 1)),
+                                CRCHandoverDates.new(nil, Date.new(2019, 8, 1), Date.new(2019, 8, 1)),
                                 Date.new(2019, 5, 9)), # 12 weeks before CRD date
             CRCHandoverData.new(false,
-                                CRCHandoverDates.new(Date.new(2019, 8, 1), nil),
+                                CRCHandoverDates.new(Date.new(2019, 8, 1), nil, Date.new(2019, 8, 1)),
                                 Date.new(2019, 5, 9)), # 12 weeks before HDC date
             CRCHandoverData.new(false,
-                                CRCHandoverDates.new(nil, nil),
+                                CRCHandoverDates.new(nil, nil, nil),
                                 nil) # no handover date
         ])
       end
@@ -89,12 +89,15 @@ describe HandoverDateService do
         let(:sentence_dates) {
           OpenStruct.new(
             conditional_release_date: crd,
-            automatic_release_date: ard)
+            automatic_release_date: ard,
+            earliest_release_date: erd
+          )
         }
 
         context 'when CRD earliest' do
           let(:ard) { Date.new(2019, 8, 1) }
           let(:crd) { Date.new(2019, 7, 1) }
+          let(:erd) { Date.new(2019, 7, 1) }
 
           it 'is 15 months before CRD' do
             expect(described_class.responsibility_handover_date(HandoverData.from_offender(offender), sentence_dates)[0]).to eq(Date.new(2018, 4, 1))
@@ -104,6 +107,7 @@ describe HandoverDateService do
         context 'when ARD earliest' do
           let(:ard) { Date.new(2019, 8, 1) }
           let(:crd) { Date.new(2019, 9, 30) }
+          let(:erd) { Date.new(2019, 8, 1) }
 
           it 'is 15 months before ARD' do
             expect(described_class.responsibility_handover_date(HandoverData.from_offender(offender), sentence_dates)[0]).to eq(Date.new(2018, 5, 1))
@@ -113,6 +117,7 @@ describe HandoverDateService do
         context 'with neither date' do
           let(:crd) { nil }
           let(:ard) { nil }
+          let(:erd) { nil }
 
           it 'cannot be calculated' do
             expect(described_class.responsibility_handover_date(HandoverData.from_offender(offender), sentence_dates)[0]).to be_nil
@@ -124,6 +129,7 @@ describe HandoverDateService do
         let(:parole_date) { nil }
         let(:crd) { Date.new(2020, 7, 16) }
         let(:hdc_date) { Date.new(2020, 6, 16) }
+        let(:erd) { Date.new(2020, 6, 16) }
 
         context 'with determinate sentence' do
           let(:mappa_level) { nil }
@@ -138,11 +144,13 @@ describe HandoverDateService do
                            conditional_release_date: crd,
                            automatic_release_date: Date.new(2020, 8, 16),
                            parole_eligibility_date: parole_date,
-                           tariff_date: Date.new(2020, 11, 1))
+                           tariff_date: Date.new(2020, 11, 1),
+                           earliest_release_date: erd)
           }
 
           context 'with parole date' do
             let(:parole_date) { Date.new(2019, 9, 30) }
+            let(:erd) { Date.new(2019, 9, 30) }
 
             it 'is 8 months before parole date' do
               expect(described_class.responsibility_handover_date(HandoverData.from_offender(offender), sentence_dates)[0]).to eq(Date.new(2019, 1, 30))
@@ -162,6 +170,7 @@ describe HandoverDateService do
 
               context 'when crd after ard' do
                 let(:crd) { Date.new(2020, 8, 17) }
+                let(:erd) { Date.new(2020, 8, 17) }
 
                 it 'is 4.5 months before ARD' do
                   expect(described_class.responsibility_handover_date(HandoverData.from_offender(offender), sentence_dates)[0]).to eq(Date.new(2020, 4, 1))
@@ -170,6 +179,7 @@ describe HandoverDateService do
 
               context 'when HDC date earlier than date indicated by CRD/ARD' do
                 let(:hdc_date) { Date.new(2020, 2, 28) }
+                let(:erd) { Date.new(2020, 2, 28) }
 
                 it 'is on HDC date' do
                   expect(described_class.responsibility_handover_date(HandoverData.from_offender(offender), sentence_dates)[0]).to eq(Date.new(2020, 2, 28))
@@ -210,7 +220,8 @@ describe HandoverDateService do
           let(:sentence_dates) {
             OpenStruct.new(
               parole_eligibility_date: parole_date,
-              tariff_date: tariff_date
+              tariff_date: tariff_date,
+              earliest_release_date: erd
             )
           }
 


### PR DESCRIPTION
Currently the offender model is responsible for calculating the handover
date using local methods and the contents of the SentenceDetail object
stored in `@sentence`.

In cases where we don't have a whole offender (but do have the case
information for that offender) such as the caseload_controller it would
be better if the handover calculation could be done with just the case
information and sentence details.

This PR moves the responsibility for asking for handover dates to
SentenceDetail where it should be provided an instance of something that
responds to `nps_case?, early_allocation? mappa_level, and
indeterminate_sentence?).  The newly moved methods will use this object
along with the local dates to request the handover dates.

## Problem

To use this in the caseload it would be necessary to replace the indeterminate_sentence? requirement with earliest_release_date.nil? because we can only determine the imprisonment type by fetching the offender.