### PR TITLE
POM-363 Fix 'prison can't be blank' issue

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -139,7 +139,7 @@ class AllocationVersion < ApplicationRecord
     if movement_type == AllocationVersion::OFFENDER_RELEASED
       movements = Nomis::Elite2::MovementApi.movements_for(allocation.nomis_offender_id)
       if movements.present?
-        movement = movements.first
+        movement = movements.last
         return movement.from_agency if movement.from_prison?
       end
     elsif movement_type == AllocationVersion::OFFENDER_TRANSFERRED


### PR DESCRIPTION
We have seen a couple of new instances of the 'prison can't be blank'
error, which happens during the MovementService run.  Following an
investigation into this we realised that we had updated the MovementApi
method 'movements_for' to sort on the createDateTime field and therefore
need to check the last movement returned, not the first.  This PR
implements this fix and should resolve the issue.