### PR TITLE
Changes how caseload/pom_details gets allocated offenders

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -62,12 +62,6 @@ class AllocationVersion < ApplicationRecord
     end
   end
 
-  # Note - this only works for active allocations, not ones that have been de-allocated
-  # If this returns false it means that we are a secondary/co-working allocation
-  def for_primary_only?
-    secondary_pom_nomis_id.blank?
-  end
-
   validate do |av|
     if av.primary_pom_nomis_id.present? &&
       av.primary_pom_nomis_id == av.secondary_pom_nomis_id

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -65,7 +65,7 @@ class PrisonOffenderManagerService
 
     # Get all of the offenders at this prison and select only those that
     # appear in an allocation.  Then for each one apply a map to determine
-    # the responsibility and pair it with the allocation and sentece.
+    # the responsibility and pair it with the allocation and sentence.
     OffenderService.get_offenders_for_prison(prison).select{ |offender|
       offender_ids.include?(offender.offender_no)
     }.map { |offender|

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -55,45 +55,40 @@ class PrisonOffenderManagerService
 
   # rubocop:disable Metrics/MethodLength
   def self.get_allocated_offenders(nomis_staff_id, prison)
+    # Get all the allocations for the POM at this prison
     allocation_list = AllocationVersion.active_pom_allocations(
       nomis_staff_id,
       prison
     )
 
     offender_ids = allocation_list.map(&:nomis_offender_id)
-    booking_ids = allocation_list.map(&:nomis_booking_id)
 
-    # Get an offender map of offender_id to sentence details and a hash of
-    # offender_no to case_info_details so we can fill in a fake offender
-    # object for each allocation. This will allow us to calculate the
-    # pom responsibility without having to make an API request per-offender.
-    offender_map = OffenderService.get_sentence_details(booking_ids)
-    case_info = CaseInformationService.get_case_info_for_offenders(offender_ids)
+    # Get all of the offenders at this prison and select only those that
+    # appear in an allocation.  Then for each one apply a map to determine
+    # the responsibility and pair it with the allocation and sentece.
+    OffenderService.get_offenders_for_prison(prison).select{ |offender|
+      offender_ids.include?(offender.offender_no)
+    }.map { |offender|
+      # This is potentially slow, possibly of the order O(NM)
+      allocation = allocation_list.detect { |alloc|
+        alloc.nomis_offender_id == offender.offender_no
+      }
 
-    allocation_list.map do |alloc|
-      offender_stub = Nomis::Offender.new
-      offender_stub.sentence = offender_map[alloc.nomis_booking_id]
-
-      record = case_info[alloc.nomis_offender_id]
-      if record.present?
-        offender_stub.tier = record.tier
-        offender_stub.case_allocation = record.case_allocation
-        offender_stub.welsh_offender = record.welsh_offender
-      end
-
-      if alloc.for_primary_only?
+      # If this is the primary POM, work out responsibility
+      if allocation.primary_pom_nomis_id == nomis_staff_id
         responsibility =
-          ResponsibilityService.calculate_pom_responsibility(offender_stub).to_s
+          ResponsibilityService.calculate_pom_responsibility(offender).to_s
       else
         responsibility = ResponsibilityService::COWORKING
       end
+
       AllocationWithSentence.new(
         nomis_staff_id,
-        alloc,
-        offender_map[alloc.nomis_booking_id],
+        allocation,
+        offender.sentence,
         responsibility
       )
-    end
+    }
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -182,10 +182,16 @@ feature "view POM's caseload" do
       end
     end
 
-    it 'can be searched by role' do
+    it 'can be searched by supporting role' do
       select 'Supporting', from: 'role'
       click_on 'Search'
-      expect(page).to have_content('Showing 1 - 16 of 16 results')
+      expect(page).to have_content('Showing 1 - 14 of 14 results')
+    end
+
+    it 'can be searched by responsible role' do
+      select 'Responsible', from: 'role'
+      click_on 'Search'
+      expect(page).to have_content('Showing 1 - 7 of 7 results')
     end
   end
 

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "get poms list" do
-  let!(:offender_missing_sentence_case_info) { create(:case_information, nomis_offender_id: 'G7949GQ') }
+  let!(:offender_missing_sentence_case_info) { create(:case_information, nomis_offender_id: 'G1247VX') }
 
   it "shows the page", vcr: { cassette_name: :show_poms_feature_list } do
     signin_user
@@ -25,7 +25,8 @@ feature "get poms list" do
 
     visit prison_pom_path('LEI', 485_637)
 
-    expect(page).to have_css(".govuk-table__row", count: 2)
+    expect(page).to have_css(".pom_cases_row_0", count: 1)
+    expect(page).not_to have_css(".pom_cases_row_1")
     expect(page).to have_content(offender_missing_sentence_case_info.nomis_offender_id)
   end
 


### PR DESCRIPTION
Because the way we were previously working out the responsibilities for
allocated offenders was incorrect (we were using fake offender
instances) this PR changes to filter the offenders in a prison to only
show those that are allocated to a POM.