### PR TITLE
Show tier on caseload screens (list and new).

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -21,7 +21,7 @@ class CaseloadController < PrisonsApplicationController
   end
 
   def new
-    @new_cases = all_allocations.select(&:new_case?)
+    @new_cases = sort_allocations(all_allocations.select(&:new_case?))
   end
 
   def handover_start

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -56,7 +56,12 @@
         </a>
         <%= sort_arrow('last_name') %>
       </th>
-      <th class="govuk-table__header" scope="col">Prisoner number</th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('allocated_at_tier') %>">
+        Tier
+        </a>
+        <%= sort_arrow('allocated_at_tier') %>
+      </th>
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('earliest_release_date') %>">
           Earliest release<br/> date
@@ -83,8 +88,16 @@
     <tbody class="govuk-table__body">
     <% @allocations.each_with_index do |offender, i| %>
       <tr class="govuk-table__row offender_row_<%= i %>">
-        <td aria-label="Prisoner name" class="govuk-table__cell "><%= highlight(offender.full_name, @q) %></td>
-        <td aria-label="Prisoner number" class="govuk-table__cell "><%= highlight(offender.nomis_offender_id, @q) %></td>
+        <td aria-label="Prisoner name" class="govuk-table__cell ">
+          <%= highlight(offender.full_name, @q) %>
+          <br/>
+          <span class='govuk-hint govuk-!-margin-bottom-0'>
+            <%= highlight(offender.nomis_offender_id, @q) %>
+          </span>
+        </td>
+        <td aria-label="Tier" class="govuk-table__cell tier">
+          <%= offender.allocated_at_tier %>
+        </td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(offender.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(offender.primary_pom_allocated_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= offender.responsibility %></td>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -10,12 +10,42 @@
   <table class="govuk-table responsive tablesorter">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Prisoner name</th>
-      <th class="govuk-table__header" scope="col">Prisoner number</th>
-      <th class="govuk-table__header" scope="col">Arrival date</th>
-      <th class="govuk-table__header" scope="col">Earliest release date</th>
-      <th class="govuk-table__header" scope="col">Allocation<br/>date</th>
-      <th class="govuk-table__header" scope="col">Role</th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('last_name') %>">
+          Prisoner name
+        </a>
+        <%= sort_arrow('last_name') %>
+      </th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('allocated_at_tier') %>">
+        Tier
+        </a>
+        <%= sort_arrow('allocated_at_tier') %>
+      </th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('sentence_start_date') %>">
+          Arrival date
+        </a>
+        <%= sort_arrow('sentence_start_date') %>
+      </th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('earliest_release_date') %>">
+          Earliest release<br/> date
+        </a>
+        <%= sort_arrow('earliest_release_date') %>
+      </th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('primary_pom_allocated_at') %>">
+          Allocation<br/>date
+        </a>
+        <%= sort_arrow('primary_pom_allocated_at') %>
+      </th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('responsibility') %>">
+          Role
+        </a>
+        <%= sort_arrow('responsibility') %>
+      </th>
       <% if Flipflop.prisoner_profile? %>
         <th class="govuk-table__header" scope="col">Action</th>
       <% end %>
@@ -24,10 +54,19 @@
     <tbody class="govuk-table__body">
     <% @new_cases.each_with_index do |allocation, i| %>
       <tr class="govuk-table__row offender_row_<%= i %>">
-        <td aria-label="Prisoner name" class="govuk-table__cell "><%= allocation.full_name %></td>
-        <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
-        <td aria-label="Arrival date" class="govuk-table__cell "><%= format_date(allocation.sentence_start_date) %></td>
-        <td aria-label="Release date" class="govuk-table__cell "><%= format_date(allocation.earliest_release_date) %></td>
+        <td aria-label="Prisoner name" class="govuk-table__cell">
+          <span class='prisoner-name'>
+            <%= allocation.full_name %>
+          </span> <br/>
+          <span class='govuk-hint govuk-!-margin-bottom-0'>
+            <%= allocation.nomis_offender_id %>
+          </span>
+        </td>
+        <td aria-label="Tier" class="govuk-table__cell ">
+          <%= allocation.allocated_at_tier %>
+        </td>
+        <td aria-label="Arrival date" class="govuk-table__cell"><%= format_date(allocation.sentence_start_date) %></td>
+        <td aria-label="Release date" class="govuk-table__cell"><%= format_date(allocation.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
         <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
         <% if Flipflop.prisoner_profile? %>

--- a/spec/features/pom_caseload_spec.rb
+++ b/spec/features/pom_caseload_spec.rb
@@ -188,6 +188,12 @@ feature "view POM's caseload" do
       expect(page).to have_content('Showing 1 - 14 of 14 results')
     end
 
+    it 'shows the tier' do
+      within('.offender_row_20 .tier') do
+        expect(page).to have_content('A')
+      end
+    end
+
     it 'can be searched by responsible role' do
       select 'Responsible', from: 'role'
       click_on 'Search'
@@ -248,6 +254,35 @@ feature "view POM's caseload" do
 
     expect(page).to have_content("New cases")
     expect(page).to have_content("Abbella, Ozullirn")
+  end
+
+  it 'can sort all cases that have been allocated to a specific POM in the last week', :versioning, vcr: { cassette_name: :show_and_sort_new_cases } do
+    signin_user('PK000223')
+
+    visit prison_confirm_allocation_path('LEI', nomis_offender_id, nomis_staff_id)
+    click_button 'Complete allocation'
+
+    visit prison_caseload_index_path('LEI')
+    within('.new-cases-count') do
+      click_link('1')
+    end
+
+    expect(page).to have_content("New cases")
+
+    expected_name = 'Abbella, Ozullirn'
+
+    # The first name...
+    within('.offender_row_0') do
+      expect(find('.prisoner-name').text).to eq(expected_name)
+    end
+
+    # After sorting ...
+    click_link('Prisoner name')
+
+    # Should be the last name
+    within('.offender_row_20') do
+      expect(find('.prisoner-name').text).to eq(expected_name)
+    end
   end
 
   it 'stops staff without the POM role from viewing the my caseload page', vcr: { cassette_name: :non_pom_caseload }  do


### PR DESCRIPTION
On the caseload screens we have now moved the prisoner number underneath
the name and added a new tier column.