### PR TITLE
Fix duplicate function name in rake tasks

### DIFF
--- a/lib/tasks/delius_import.rake
+++ b/lib/tasks/delius_import.rake
@@ -20,7 +20,7 @@ namespace :delius_etl do
       record = {}
 
       row.each_with_index do |val, idx|
-        key = fields[idx]
+        key = key_fields[idx]
         record[key] = val
       end
 
@@ -36,8 +36,8 @@ namespace :delius_etl do
     Rails.logger.info("#{row_count} Records processed #{total} changed records")
   end
 
-  def fields
-    @fields ||= [
+  def key_fields
+    @key_fields ||= [
       :crn, :pnc_no, :noms_no, :fullname, :tier, :roh_cds,
       :offender_manager, :org_private_ind, :org,
       :provider, :provider_code,

--- a/lib/tasks/delius_info.rake
+++ b/lib/tasks/delius_info.rake
@@ -60,7 +60,7 @@ namespace :delius_etl do
       :provider, :provider_code,
       :ldu, :ldu_code,
       :team, :team_code,
-      :mappa, :mappa_levels
+      :mappa, :mappa_levels, :date_of_birth
     ]
   end
 end


### PR DESCRIPTION
Duplicate function name (with different return values) cause the manual
import of the delius data file to fail because of mis-matched lists (and
only one being globally available).