### PR TITLE
Add LDU information to seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,6 +45,12 @@ LocalDivisionalUnit.create!(
     email_address: "EnglishNPS@example.com"
 )
 
+LocalDivisionalUnit.create!(
+    code: "OTHERLDU",
+    name: "English LDU 2",
+    email_address: nil
+)
+
 # The offenders below are those with release dates a few years in the future and can therefore use the
 # responsibility override workflow
 
@@ -84,6 +90,6 @@ CaseInformation.find_or_create_by!(
     case_allocation: 'NPS',
     welsh_offender: 'No',
     manual_entry: true,
-    local_divisional_unit_id: 2,
+    local_divisional_unit_id: 3,
     team_id: 34
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,3 +32,58 @@ PomDetail.find_or_create_by!(
   status: 'active',
   working_pattern: 1
 )
+
+LocalDivisionalUnit.create!(
+    code: "WELDU",
+    name: "Welsh LDU",
+    email_address: "WalesNPS@example.com"
+)
+
+LocalDivisionalUnit.create!(
+    code: "ENLDU",
+    name: "English LDU",
+    email_address: "EnglishNPS@example.com"
+)
+
+# The offenders below are those with release dates a few years in the future and can therefore use the
+# responsibility override workflow
+
+CaseInformation.find_or_create_by!(
+    nomis_offender_id: 'G7658UL',
+    tier: 'A',
+    case_allocation: 'NPS',
+    welsh_offender: 'Yes',
+    manual_entry: true,
+    local_divisional_unit_id: 1,
+    team_id: 4
+)
+
+CaseInformation.find_or_create_by!(
+    nomis_offender_id: 'G7517GF',
+    tier: 'B',
+    case_allocation: 'NPS',
+    welsh_offender: 'Yes',
+    manual_entry: true,
+    local_divisional_unit_id: 1,
+    team_id: 51
+)
+
+CaseInformation.find_or_create_by!(
+    nomis_offender_id: 'G3536UF',
+    tier: 'A',
+    case_allocation: 'NPS',
+    welsh_offender: 'No',
+    manual_entry: true,
+    local_divisional_unit_id: 2,
+    team_id: 6
+)
+
+CaseInformation.find_or_create_by!(
+    nomis_offender_id: 'G2260UO',
+    tier: 'B',
+    case_allocation: 'NPS',
+    welsh_offender: 'No',
+    manual_entry: true,
+    local_divisional_unit_id: 2,
+    team_id: 34
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,19 +33,19 @@ PomDetail.find_or_create_by!(
   working_pattern: 1
 )
 
-LocalDivisionalUnit.create!(
+LocalDivisionalUnit.find_or_create_by!(
     code: "WELDU",
     name: "Welsh LDU",
     email_address: "WalesNPS@example.com"
 )
 
-LocalDivisionalUnit.create!(
+LocalDivisionalUnit.find_or_create_by!(
     code: "ENLDU",
     name: "English LDU",
     email_address: "EnglishNPS@example.com"
 )
 
-LocalDivisionalUnit.create!(
+LocalDivisionalUnit.find_or_create_by!(
     code: "OTHERLDU",
     name: "English LDU 2",
     email_address: nil

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,19 +33,19 @@ PomDetail.find_or_create_by!(
   working_pattern: 1
 )
 
-LocalDivisionalUnit.find_or_create_by!(
+ldu1 = LocalDivisionalUnit.find_or_create_by!(
     code: "WELDU",
     name: "Welsh LDU",
     email_address: "WalesNPS@example.com"
 )
 
-LocalDivisionalUnit.find_or_create_by!(
+ldu2 = LocalDivisionalUnit.find_or_create_by!(
     code: "ENLDU",
     name: "English LDU",
     email_address: "EnglishNPS@example.com"
 )
 
-LocalDivisionalUnit.find_or_create_by!(
+ldu3 = LocalDivisionalUnit.find_or_create_by!(
     code: "OTHERLDU",
     name: "English LDU 2",
     email_address: nil
@@ -60,8 +60,7 @@ CaseInformation.find_or_create_by!(
     case_allocation: 'NPS',
     welsh_offender: 'Yes',
     manual_entry: true,
-    local_divisional_unit_id: 1,
-    team_id: 4
+    local_divisional_unit_id: ldu1.id
 )
 
 CaseInformation.find_or_create_by!(
@@ -70,18 +69,15 @@ CaseInformation.find_or_create_by!(
     case_allocation: 'NPS',
     welsh_offender: 'Yes',
     manual_entry: true,
-    local_divisional_unit_id: 1,
-    team_id: 51
+    local_divisional_unit_id: ldu1.id
 )
-
 CaseInformation.find_or_create_by!(
     nomis_offender_id: 'G3536UF',
     tier: 'A',
     case_allocation: 'NPS',
     welsh_offender: 'No',
     manual_entry: true,
-    local_divisional_unit_id: 2,
-    team_id: 6
+    local_divisional_unit_id: ldu2.id
 )
 
 CaseInformation.find_or_create_by!(
@@ -90,6 +86,5 @@ CaseInformation.find_or_create_by!(
     case_allocation: 'NPS',
     welsh_offender: 'No',
     manual_entry: true,
-    local_divisional_unit_id: 3,
-    team_id: 34
+    local_divisional_unit_id: ldu3.id
 )


### PR DESCRIPTION
We have implemented the responsibility override feature that allows
SPOs to change the responsibility from custody to community.  However,
so that the team can use this feature we need to add some LDU
information into the seeds file; this PR does that.