### PR TITLE
Better handle delius email attachment types

### DIFF
--- a/lib/delius/emails.rb
+++ b/lib/delius/emails.rb
@@ -58,7 +58,9 @@ module Delius
     end
 
     def zip_attachment(msg)
-      msg.attachments.detect { |a| a.content_type.start_with? 'application/zip' }
+      msg.attachments.detect { |a|
+        a.content_type.start_with?('application/zip', 'application/x-zip-compressed')
+      }
     end
 
     def close


### PR DESCRIPTION
application/zip is not the only content type for zip files, this PR
allows us to handle application/x-zip-compressed as well.