### PR TITLE
Install jemalloc so we can find out where it will install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN \
     libpq-dev \
     netcat \
     nodejs \
+    libjemalloc-dev \
   && timedatectl set-timezone Europe/London || true \
   && gem update bundler --no-document
 


### PR DESCRIPTION
We will need jemalloc to use a different allocator for rails. So that we know how to set the LD_PRELOAD we need to know where it'll be installed and the easiest way is to install it and see.