### PR TITLE
Try to introduce VCR=0 as a faster way of running tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,17 +31,18 @@ end
 
 require 'vcr'
 
-recording = ENV['VCR']
+vcr_mode = ENV['VCR']
+recording = vcr_mode.to_i > 0 unless vcr_mode.nil?
 
 vcr_record_mode = recording ? :all : :none
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
 
-  if recording
-    config.hook_into :webmock
-  else
+  if vcr_mode.nil?
     config.hook_into :faraday
+  else
+    config.hook_into :webmock
   end
   config.configure_rspec_metadata!
   # this allows HTTP connections to go through to webmock if cassette not specified


### PR DESCRIPTION
This PR tries to introduce VCR=0 rspec as a 2x faster way of running tests - using your existing VCR recordings from an earlier run. 

It seems to be slightly flawed, but possibly due to the way that we authenticate to NOMIS - the tests seem have a habit of randomly authenticating during a different exchange to that which was recorded (due to rspec randomising test execution order). 

Suggestions welcomed...