### PR TITLE
Separate the rswag gems as per docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,8 @@ gem 'rubyzip'
 gem 'turnout'
 gem 'zendesk_api'
 gem 'kaminari' # pagination
-gem 'rswag' # api-documentation
+gem 'rswag-api' # api-documentation
+gem 'rswag-ui'  # api-documentation interface
 
 group :development, :test do
   gem 'brakeman'
@@ -48,6 +49,7 @@ group :development, :test do
   gem 'rubocop-rails'
   gem 'dotenv-rails'
   gem 'rspec-rails'
+  gem 'rswag-specs'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,10 +265,6 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    rswag (2.0.6)
-      rswag-api (= 2.0.6)
-      rswag-specs (= 2.0.6)
-      rswag-ui (= 2.0.6)
     rswag-api (2.0.6)
       railties (>= 3.1, < 6.1)
     rswag-specs (2.0.6)
@@ -419,7 +415,9 @@ DEPENDENCIES
   rails-controller-testing
   redis
   rspec-rails
-  rswag
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop
   rubocop-performance
   rubocop-rails


### PR DESCRIPTION
If the single rsweag gem is included, it breaks the precompilation of
assets and so the documentation suggests loading the component gems
separately