### PR TITLE
fix DatabaseCleaner config 

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,13 @@ RSpec.configure do |config|
   config.before(:each) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
     DatabaseCleaner.start
   end
 


### PR DESCRIPTION
so that data shows up properly in JS browser-based tests

JS-flagged tests are run with an actual browser, which by definition runs in another thread. Hence DB cleaner config needs to be altered so that data is persisted by a transaction boundary so that the data actually shows up in the browser.