### PR TITLE
Change upcoming handover time to 30 days

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -48,13 +48,13 @@ private
       ids.include? offender.offender_no
     }
 
-    one_week_time = Time.zone.today + 7.days
+    one_month_time = Time.zone.today + 30.days
 
     upcoming_offenders = allocated_offenders.select { |offender|
       start_date = offender.handover_start_date.first
 
       start_date.present? &&
-      start_date.between?(Time.zone.today, one_week_time)
+      start_date.between?(Time.zone.today, one_month_time)
     }
 
     upcoming_offenders.map{ |offender|

--- a/app/views/caseload/handover_start.html.erb
+++ b/app/views/caseload/handover_start.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   <h2 class="govuk-heading-l">Cases close to handover</h2>
 
-  <p>All cases for start of handover to the community in the next 7 days</p>
+  <p>All cases for start of handover to the community in the next 30 days</p>
 
   <table class="govuk-table responsive tablesorter">
     <thead class="govuk-table__head">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -68,7 +68,7 @@
         <h1 class="govuk-heading-s">
           <%= link_to "See cases close to handover", prison_caseload_handover_start_path(@prison), class:"govuk-link" %>
         </h1>
-        <p class="govuk-body">All cases for start of handover to the community in the next seven days</p>
+        <p class="govuk-body">All cases for start of handover to the community in the next thirty days</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Based on feedback we are changing the definition of upcoming handover starts to those that occur in the next 30 days not the next 7 days.