### PR TITLE
POM-432 Multiple POM records bug

### DIFF
--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -4,7 +4,7 @@ class PomDetail < ApplicationRecord
   scope :by_nomis_staff_id, lambda { |nomis_staff_id|
     find_by(nomis_staff_id: nomis_staff_id)
   }
-  validates :nomis_staff_id, presence: true
+  validates :nomis_staff_id, presence: true, uniqueness: true
   validates :status, presence: true
   validates :working_pattern, presence: {
     message: 'Select number of days worked'

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -127,7 +127,7 @@ private
     pom_details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
         PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id) do |pom|
           pom.working_pattern = 0.0
-          pom.status =  'active'
+          pom.status = 'active'
         end
   end
 

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -125,7 +125,7 @@ private
 
   def self.get_pom_detail(pom_details, nomis_staff_id)
     pom_details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
-      PomDetail.create!(nomis_staff_id: nomis_staff_id,
+      PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id,
                         working_pattern: 0.0,
                         status: 'active')
   end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -126,8 +126,8 @@ private
   def self.get_pom_detail(pom_details, nomis_staff_id)
     pom_details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
       PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id,
-                        working_pattern: 0.0,
-                        status: 'active')
+                                   working_pattern: 0.0,
+                                   status: 'active')
   end
 
   def self.log_missing_pom(caseload, nomis_staff_id)

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -125,9 +125,10 @@ private
 
   def self.get_pom_detail(pom_details, nomis_staff_id)
     pom_details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
-      PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id,
-                                   working_pattern: 0.0,
-                                   status: 'active')
+        PomDetail.find_or_create_by!(nomis_staff_id: nomis_staff_id) do |pom|
+          pom.working_pattern = 0.0
+          pom.status =  'active'
+        end
   end
 
   def self.log_missing_pom(caseload, nomis_staff_id)

--- a/db/migrate/20191022074139_add_uniq_to_pom_detail_index.rb
+++ b/db/migrate/20191022074139_add_uniq_to_pom_detail_index.rb
@@ -1,0 +1,11 @@
+class AddUniqToPomDetailIndex < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :pom_details, :nomis_staff_id
+    add_index :pom_details, :nomis_staff_id, unique: true
+  end
+
+  def down
+    remove_index :pom_details, :nomis_staff_id, unique: true
+    add_index :case_information, :nomis_offender_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_090002) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["nomis_staff_id"], name: "index_pom_details_on_nomis_staff_id"
+    t.index ["nomis_staff_id"], name: "index_pom_details_on_nomis_staff_id", unique: true
   end
 
   create_table "responsibilities", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_090002) do
+ActiveRecord::Schema.define(version: 2019_10_22_074139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PomDetail, type: :model do
   it { is_expected.to validate_presence_of(:nomis_staff_id) }
+  it { is_expected.to validate_uniqueness_of(:nomis_staff_id) }
   it { is_expected.to validate_presence_of(:working_pattern).with_message('Select number of days worked') }
   it { is_expected.to validate_presence_of(:status) }
 end


### PR DESCRIPTION
We had been contacted by a number of SPOs advising that they were unable
to update their POM working patterns.  An investigation led to finding
17 POMs who have two PomDetail records, which meant that one record was
being updated, but the other being displayed with the incorrect data.
We are adding a uniqueness constraint to the nomis staff ID field in
both the db and model to prevent this happening again.