### PR TITLE
Unify the booking ids

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -112,7 +112,7 @@ private
       event: allocation_params[:event],
       event_trigger: allocation_params[:event_trigger],
       created_by_username: current_user,
-      nomis_booking_id: offender.latest_booking_id,
+      nomis_booking_id: offender.booking_id,
       allocated_at_tier: offender.tier,
       recommended_pom_type: recommended_pom_type(offender),
       prison: active_prison,

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -25,7 +25,7 @@ class PrisonersController < PrisonsApplicationController
 
   def image
     @prisoner = OffenderService.get_offender(params[:prisoner_id])
-    image_data = Nomis::Elite2::OffenderApi.get_image(@prisoner.latest_booking_id)
+    image_data = Nomis::Elite2::OffenderApi.get_image(@prisoner.booking_id)
 
     response.headers['Expires'] = 6.months.from_now.httpdate
     send_data image_data, type: 'image/jpg', disposition: 'inline'

--- a/app/models/nomis/offender.rb
+++ b/app/models/nomis/offender.rb
@@ -5,7 +5,6 @@ module Nomis
     include Deserialisable
 
     attr_accessor :gender,
-                  :latest_booking_id,
                   :main_offence,
                   :nationalities,
                   :noms_id,
@@ -28,7 +27,7 @@ module Nomis
 
     def load_from_json(payload)
       @gender = payload['gender']
-      @latest_booking_id = payload['latestBookingId']&.to_i
+      @booking_id = payload['latestBookingId']&.to_i
       @main_offence = payload['mainOffence']
       @nationalities = payload['nationalities']
       @noms_id = payload['nomsId']

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -6,7 +6,7 @@ module Nomis
              :automatic_release_date,
              to: :sentence
 
-    attr_accessor :convicted_status,
+    attr_accessor :convicted_status, :booking_id,
                   :category_code, :offender_no, :date_of_birth,
                   :first_name, :last_name
 

--- a/app/models/nomis/offender_summary.rb
+++ b/app/models/nomis/offender_summary.rb
@@ -4,7 +4,7 @@ module Nomis
   class OffenderSummary < OffenderBase
     include Deserialisable
 
-    attr_accessor :aliases, :booking_id
+    attr_accessor :aliases
 
     # custom attributes
     attr_accessor :allocation_date, :prison_arrival_date

--- a/app/models/offender_presenter.rb
+++ b/app/models/offender_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OffenderPresenter
-  delegate :offender_no, :first_name, :last_name, :latest_booking_id,
+  delegate :offender_no, :first_name, :last_name, :booking_id,
            :indeterminate_sentence?, :sentence_type_code, :describe_sentence,
            :full_name_ordered, :full_name, :main_offence,
            :sentence_start_date, :team, :prison_id,

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -8,13 +8,13 @@ class OffenderService
       record = CaseInformation.find_by(nomis_offender_id: offender_no)
       o.load_case_information(record)
 
-      sentence_detail = get_sentence_details([o.latest_booking_id])
-      if sentence_detail.present? && sentence_detail.key?(o.latest_booking_id)
-        o.sentence = sentence_detail[o.latest_booking_id]
+      sentence_detail = get_sentence_details([o.booking_id])
+      if sentence_detail.present? && sentence_detail.key?(o.booking_id)
+        o.sentence = sentence_detail[o.booking_id]
       end
 
       o.category_code = Nomis::Elite2::OffenderApi.get_category_code(o.offender_no)
-      o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.latest_booking_id)
+      o.main_offence = Nomis::Elite2::OffenderApi.get_offence(o.booking_id)
     }
   end
 
@@ -78,14 +78,14 @@ class OffenderService
   def self.get_multiple_offenders(offender_ids)
     offenders = Nomis::Elite2::OffenderApi.get_multiple_offenders(offender_ids)
 
-    booking_ids = offenders.map(&:latest_booking_id)
+    booking_ids = offenders.map(&:booking_id)
     sentence_details = Nomis::Elite2::OffenderApi.get_bulk_sentence_details(booking_ids)
 
     nomis_ids = offenders.map(&:offender_no)
     mapped_tiers = CaseInformationService.get_case_information(nomis_ids)
 
     offenders.each { |offender|
-      sentencing = sentence_details[offender.latest_booking_id]
+      sentencing = sentence_details[offender.booking_id]
       offender.sentence = sentencing if sentencing.present?
 
       case_info_record = mapped_tiers[offender.offender_no]


### PR DESCRIPTION
Currently offender_summary and offender both have a booking id, one
called booking_id and another called latest_booking_id.

This PR moves the booking_id to offender_base and removes all use of
latest_booking_id.