### PR TITLE
Ensure we close the IMAP connection before processing data

### DIFF
--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -19,10 +19,6 @@ class DeliusImportJob < ApplicationJob
   def perform
     ActiveRecord::Base.connection.disable_query_cache!
 
-    unless Rails.env.test?
-      Rails.logger = Logger.new(STDOUT)
-    end
-
     username = ENV['DELIUS_EMAIL_USERNAME']
     password = ENV['DELIUS_EMAIL_PASSWORD']
     folder = ENV['DELIUS_EMAIL_FOLDER']

--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -15,7 +15,6 @@ class DeliusImportJob < ApplicationJob
       :mappa, :mappa_levels, :date_of_birth
     ].freeze
 
-  # rubocop:disable Metrics/MethodLength
   def perform
     ActiveRecord::Base.connection.disable_query_cache!
 
@@ -49,7 +48,6 @@ class DeliusImportJob < ApplicationJob
 
     process_attachment(decoded_attachment_content) if decoded_attachment_content.present?
   end
-# rubocop:enable Metrics/MethodLength
 
 private
 

--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -15,9 +15,13 @@ class DeliusImportJob < ApplicationJob
       :mappa, :mappa_levels, :date_of_birth
     ].freeze
 
+  # rubocop:disable Metrics/MethodLength
   def perform
     ActiveRecord::Base.connection.disable_query_cache!
-    Rails.logger = Logger.new(STDOUT)
+
+    unless Rails.env.test?
+      Rails.logger = Logger.new(STDOUT)
+    end
 
     username = ENV['DELIUS_EMAIL_USERNAME']
     password = ENV['DELIUS_EMAIL_PASSWORD']
@@ -25,35 +29,52 @@ class DeliusImportJob < ApplicationJob
 
     Rails.logger.info('[DELIUS] Retrieving most recent email')
 
-    Delius::Emails.connect(username, password) { |emails|
+    decoded_attachment_content = nil
+
+    Delius::Emails.connect(username, password) do |emails|
       Rails.logger.info("[DELIUS] Set IMAP folder to #{folder}")
       emails.folder = folder
 
       Rails.logger.info('[DELIUS] Fetching latest email attachment')
       attachment = emails.latest_attachment
-      Rails.logger.info('[DELIUS] Attachment retrieved')
 
       if attachment.present?
-        process_attachment(attachment.body.decoded)
+        # At this point attachment.body is the base64 encoded attachment
+        # and so we want to store the un-encoded version ready for
+        # processing. We want to store the bytes rather than attempt
+        # to either convert to string or allow ruby to convert to
+        # string in case there are invalid UTF-8 markers in the bytearray
+        decoded_attachment_content = attachment.body.decoded.bytes
+        Rails.logger.info('[DELIUS] Attachment retrieved')
       else
         Rails.logger.error('[DELIUS] Unable to find an attachment')
       end
-    }
+    end
+
+    process_attachment(decoded_attachment_content) if decoded_attachment_content.present?
   end
+# rubocop:enable Metrics/MethodLength
 
 private
 
   # rubocop:disable Metrics/MethodLength
-  def process_attachment(contents)
+  def process_attachment(attachment_bytes)
+    # This method is passed the contents of the attachment as a bytearray
+    # once it has been base64 decoded which it will then write to a file (in
+    # binary format) before processing further.
+
     Rails.logger.info('[DELIUS] Processing attachment')
 
     Dir.mktmpdir do |directory|
-      # Unzip the provided file so that we can process the contents. This
-      # should contain a single encrypted XLSX file.
+      # Given the attachment as a bytearray, write it to a local file for
+      # processing.
       zipfile = File.join(directory, 'encrypted.zip')
       File.open(zipfile, 'wb') do |file|
-        file.write(contents)
+        file.write(attachment_bytes.pack('C*'))
       end
+
+      # Unzip the provided file so that we can process the contents. This
+      # should contain a single encrypted XLSX file.
       zipcontents = Zip::File.open(zipfile).entries.first.get_input_stream
       encrypted_xlsx = File.join(directory, 'decrypted_attachment')
       File.open(encrypted_xlsx, 'wb') do |file|

--- a/spec/jobs/delius_import_job_spec.rb
+++ b/spec/jobs/delius_import_job_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe DeliusImportJob, type: :job do
   before do
     stub_const("Net::IMAP", MockIMAP)
     stub_const("Mail", MockMailMessage)
+
+    # If you modify the fixture for this test, you will need to modify this list
+    offenders = %w[G5823GP G3902GW G3757UN G3892UH G0135GA G8152UC G2541VV G3933UL
+                   G1318GN G6877GE G5054VN G7975UA G3610VX G4739UP G0633UV G3140VC
+                   G3873VI G6041UD G0126UD G1627GD G2316UN G6709GF G1237UD G2613GF
+                   G9577VI G6217GE G4023GG G7350VX G4110UT G4971UN G9468UN G1970VH
+                   G0723UO G4704UN G1531GV G9348UN G4664UV G5676GJ G1237GV G8156GT
+                   G2214UP G5687GJ G1895GH G3086UD G3365UI G7984UU G1852UW G6168UN
+                   G7913UN G3874UT G3122UF G8322UO G3321VF G2899VU G7747UD G6473UO
+                   G6500UO G8242GE G8130VE G8918VU G1493UN G7166UG G2341UP G7633UV
+                   G7218GI G5060GO G7704GG G3868UN G0661GP G0806UN G6754VV G7331GT
+                   G4923UI G9577GE G2350UP G0686GT G5235GT G1955VA G7967UD G7142UL
+                   G5497GU G3356GT]
+    offenders.each { |offender|
+      stub_offender(offender)
+    }
   end
 
   it 'doesnt crash' do


### PR DESCRIPTION
We're seeing the IMAP connection fail in production, but this was
because we were running the data processing steps inside the closure
(that handles fetching the attachment).

This PR now only processes the attachment _after_ the IMAP connection is
closed.

Also reduces logging during tests.