### PR TITLE
Fix single offender caching

### DIFF
--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -38,14 +38,15 @@ module Nomis
       def self.get_offender(offender_no)
         # Bad NOMIS numbers mustn't produce invalid URLs
         route = "/elite2api/api/prisoners/#{URI.encode_www_form_component(offender_no)}"
-        Rails.cache.fetch(route,
-                          expires_in: Rails.configuration.cache_expiry) do
-          response = e2_client.get(route)
-          if response.empty?
-            nil
-          else
-            api_deserialiser.deserialise(Nomis::Offender, response.first)
-          end
+        response = Rails.cache.fetch("offender-#{route}",
+                                     expires_in: Rails.configuration.cache_expiry) {
+          e2_client.get(route)
+        }
+
+        if response.empty?
+          nil
+        else
+          api_deserialiser.deserialise(Nomis::Offender, response.first)
         end
       end
 


### PR DESCRIPTION
Currently the code caches the Offender object, but this means if the
code underneath that changes when it is unpickled from the cache then
data may be missing, e.g. if a field name in the model code changes.

This PR flips to storing the JSON for the offender and de-serialising
after fetching it which means that it should pick up any model changes
if the deserialisation is sound.

The key is changed so that we don't have to manually clear the cache.