### PR TITLE
Stop typhoeus logging useless info

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,3 +2,6 @@ Rails.application.configure do
   stdout_logger = ActiveSupport::Logger.new(STDOUT)
   config.lograge.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
 end
+
+# Disable logging from typhoeus (ETHON) because it's too noisy.
+Ethon.logger = Logger.new(nil)


### PR DESCRIPTION
Currently we get a log line from typhoeus in addition to a line logging
the http(s) calls to Elite2.

This PR removes the lines starting ETHON but leaves us with lines that
look like...

```
[gateway.t3.nomis-api.hmpps.dsd.io] GET
/elite2api/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true
(0.554 s)
```

Which is all we really need.  We can fix this up if we ever get around
to structured logging.