### PR TITLE
POM: 439 - OpenPrisonTransferJob fails with undefined method `nps_case?` for nil:NilClass

### DIFF
--- a/app/jobs/open_prison_transfer_job.rb
+++ b/app/jobs/open_prison_transfer_job.rb
@@ -8,9 +8,12 @@ class OpenPrisonTransferJob < ApplicationJob
   queue_as :default
 
   def perform(movement_json)
-    movement = Nomis::Movement.from_json(JSON.parse(movement_json))
+    # movement_json is already in snake case format so we just need to call Movement.new
+    movement = Nomis::Movement.new(JSON.parse(movement_json))
 
     offender = OffenderService.get_offender(movement.offender_no)
+    return if offender.nil?
+
     return unless offender.nps_case?
 
     # Re-check that they're in an open prison

--- a/app/jobs/open_prison_transfer_job.rb
+++ b/app/jobs/open_prison_transfer_job.rb
@@ -12,9 +12,7 @@ class OpenPrisonTransferJob < ApplicationJob
     movement = Nomis::Movement.new(JSON.parse(movement_json))
 
     offender = OffenderService.get_offender(movement.offender_no)
-    return if offender.nil?
-
-    return unless offender.nps_case?
+    return if offender.nil? || !offender.nps_case?
 
     # Re-check that they're in an open prison
     return unless PrisonService.open_prison?(offender.prison_id)

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
     expect(email_job).to be_nil
   end
 
+  it 'does not send an email if the offender case_information is not NPS' do
+    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap{ |o|
+      o.prison_id = open_prison_code
+      o.offender_no =  nomis_offender_id
+      o.case_allocation = 'CRC'
+    })
+    described_class.perform_now(movement_json)
+
+    email_job = enqueued_jobs.first
+    expect(email_job).to be_nil
+  end
+
   it 'does not send an email when no LDU email address' do
     allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap{ |o|
       o.prison_id = open_prison_code

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -18,17 +18,25 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
   }
   let(:movement_json) {
     {
-      offenderNo: nomis_offender_id,
-      fromAgency: closed_prison_code,
-      toAgency: open_prison_code,
-      movementType: "TRN",
-      directionCode: "IN"
+      offender_no: nomis_offender_id,
+      from_agency: closed_prison_code,
+      to_agency: open_prison_code,
+      movement_type: "TRN",
+      direction_code: "IN"
     }.to_json
   }
 
   before do
     stub_auth_token
     stub_poms(closed_prison_code, poms)
+  end
+
+  it 'does not send an email if offender_no not found on Nomis' do
+    allow(OffenderService).to receive(:get_offender).and_return(nil)
+
+    described_class.perform_now(movement_json)
+    email_job = enqueued_jobs.first
+    expect(email_job).to be_nil
   end
 
   it 'does not send an email when no LDU email address' do


### PR DESCRIPTION
The error occurs within the following code
	

**offender = OffenderService.get_offender(movement.offender_no)**
**return unless offender.nps_case?`**

We assumed that the parameter `movement_json` in `OpenPrisonTransferJob.perform` method
was in camel case format. So we call `Nomis::Movement.from_json` to convert it to snake case format. But `movement_json` was already in snake case format so calling `Nomis::Movement.from_json`, results in nil values for all of the keys _(because the`from_json` method is extracting values from camel case format hash keys. These keys do not exist in `movement_json` as the keys are in snake case format)_

So currently in the code above we were actually calling
	**offender = OffenderService.get_offender(nil)**

Anything after this point will end up resulting in the _**NilClass error**_


This commit fixes the error by calling `Nomis::Movement.new`. Because `movement_json`
is already in the right format we can just use `Nomis::Movement.new` to convert the json into Movement instance variables, which means we can call `movement.offender_no` and it will return an actual value instead of nil.

In this commit we are also handling the situation where calling `OffenderService.get_offender` returns nil.