### PR TITLE
Change how we handle image 404s

### DIFF
--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -117,6 +117,11 @@ module Nomis
         image = e2_client.raw_get(image_route)
 
         image.presence || default_image
+      rescue Faraday::ResourceNotFound
+        # It's possible that the offender does not yet have an image of their
+        # face, and so when an image can't be found, we will return the default
+        # image instead.
+        default_image
       end
 
     private

--- a/spec/services/nomis/elite2/offender_api_spec.rb
+++ b/spec/services/nomis/elite2/offender_api_spec.rb
@@ -109,17 +109,19 @@ describe Nomis::Elite2::OffenderApi do
       expect(bytes[-2, 2]).to eq(jpeg_end_sentinel)
     end
 
-    it "raises an error if there is no image available",
+    it "shows default image if there is no image available",
        vcr: { cassette_name: :offender_api_image_not_found } do
       booking_id = 1_153_753
       image_id = 1_340_556
       uri = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/images/#{image_id}/data"
 
-      WebMock.stub_request(:get, uri).to_raise(
-        Faraday::ResourceNotFound.new('error', status: 404)
-      )
+      stub_request(:get, uri).to_return(status: 404)
 
-      expect{ described_class.get_image(booking_id) }.to raise_error(Faraday::ResourceNotFound)
+      response = described_class.get_image(booking_id)
+      default_image_file = Rails.root.join('app/assets/images/default_profile_image.jpg')
+
+      image_bytes = File.read(default_image_file)
+      expect(image_bytes).to eq(response)
     end
 
     it "uses a default image if there is no available image",


### PR DESCRIPTION
Move where we handle the image 404 so that the caller does not have to
handle it.

Currently it is the responsibility of the caller to handle the 404, which increases the possibility that the caller won't and the result will be a failed request for the surrounding page.  This PR changes where the 404 is handled (in the image_api) so that the function now can only (500 errors aside) return the image from the API or the default image.  500s will still cause an error to be propagated, but the common case of a 404 will now always just return the default_image.