### PR TITLE
POM-462 - display tier from case information rather than allocation on caseload page

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -6,9 +6,9 @@
 #
 class AllocatedOffender
   delegate :last_name, :full_name, :earliest_release_date,
-           :sentence_start_date, to: :@offender
+           :sentence_start_date, :tier, to: :@offender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at,
-           :allocated_at_tier, to: :@allocation
+           to: :@allocation
 
   attr_reader :responsibility, :offender
 

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -63,10 +63,10 @@
         <%= sort_arrow('last_name') %>
       </th>
       <th class="govuk-table__header" scope="col">
-        <a href="<%= sort_link('allocated_at_tier') %>">
+        <a href="<%= sort_link('tier') %>">
         Tier
         </a>
-        <%= sort_arrow('allocated_at_tier') %>
+        <%= sort_arrow('tier') %>
       </th>
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('earliest_release_date') %>">
@@ -100,7 +100,7 @@
           </span>
         </td>
         <td aria-label="Tier" class="govuk-table__cell tier">
-          <%= offender.allocated_at_tier %>
+          <%= offender.tier %>
         </td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(offender.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(offender.primary_pom_allocated_at) %></td>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -17,10 +17,10 @@
         <%= sort_arrow('last_name') %>
       </th>
       <th class="govuk-table__header" scope="col">
-        <a href="<%= sort_link('allocated_at_tier') %>">
+        <a href="<%= sort_link('tier') %>">
         Tier
         </a>
-        <%= sort_arrow('allocated_at_tier') %>
+        <%= sort_arrow('tier') %>
       </th>
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('sentence_start_date') %>">
@@ -61,7 +61,7 @@
           </span>
         </td>
         <td aria-label="Tier" class="govuk-table__cell ">
-          <%= allocation.allocated_at_tier %>
+          <%= allocation.tier %>
         </td>
         <td aria-label="Arrival date" class="govuk-table__cell"><%= format_date(allocation.sentence_start_date) %></td>
         <td aria-label="Release date" class="govuk-table__cell"><%= format_date(allocation.earliest_release_date) %></td>

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -21,10 +21,10 @@
         <%= sort_arrow('earliest_release_date') %>
       </th>
       <th class="govuk-table__header" scope="col">
-        <a href="<%= sort_link('allocated_at_tier') %>">
+        <a href="<%= sort_link('tier') %>">
           Tier
         </a>
-        <%= sort_arrow('allocated_at_tier') %>
+        <%= sort_arrow('tier') %>
       </th>
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('primary_pom_allocated_at') %>">
@@ -46,7 +46,7 @@
       <td aria-label="Prisoner name" class="govuk-table__cell "><%= allocation.full_name %></td>
       <td aria-label="Prisoner number" class="govuk-table__cell "><%= allocation.nomis_offender_id %></td>
       <td aria-label="Earliest release date" class="govuk-table__cell "><%= format_date(allocation.earliest_release_date) %></td>
-      <td aria-label="Tier" class="govuk-table__cell "><%= allocation.allocated_at_tier %></td>
+      <td aria-label="Tier" class="govuk-table__cell "><%= allocation.tier %></td>
       <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
       <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
     </tr>


### PR DESCRIPTION
display tier from caseload rather than allocated_at_tier on allocation