### PR TITLE
[SPIKE + WIP] Provide faceting and filtering of a POM's caseload

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CaseloadController < PrisonsApplicationController
+  include CaseloadHelper
+
   before_action :ensure_pom
 
   breadcrumb -> { 'Your caseload' },
@@ -18,6 +20,7 @@ class CaseloadController < PrisonsApplicationController
     sorted_allocations = sort_allocations(filter_allocations(@caseload.allocations))
 
     @allocations = Kaminari.paginate_array(sorted_allocations).page(page)
+    @facets = filter_facets(sorted_allocations)
 
     @total_allocation_count = sorted_allocations.count
     @pending_handover_count = pending_handover_count

--- a/app/helpers/caseload_helper.rb
+++ b/app/helpers/caseload_helper.rb
@@ -1,24 +1,24 @@
 module CaseloadHelper
-
-  def filtered_allocations(allocations, filter_types)
+  def filtered_allocations(allocations, _filter_types)
     # Filters the allocations, returning only those that
     # match the named filters.
     allocations
   end
 
+  # rubocop:disable Metrics/MethodLength
   def filter_facets(allocations)
     # Provided a list of allocations, returns a hash of the
     # number of allocations matching a specific filter.  It is
     # intended that this will show facets for the currently filtered
     # allocations, so the numbers will be different based on which
     # filters were used to generate the allocations list
-    facets = CaseloadFilters.constants.map {|c|
+    facets = CaseloadFilters.constants.map { |c|
       [CaseloadFilters.const_get(c), 0]
     }.to_h
 
     one_month_time = Time.zone.today + 30.days
 
-    allocations.each { |allocation|
+    allocations.each do |allocation|
       if allocation.new_case?
         facets[CaseloadFilters::NEW_ALLOCATION] += 1
       else
@@ -40,8 +40,9 @@ module CaseloadHelper
       else
         facets[CaseloadFilters::ROLE_COWORKING] += 1
       end
-    }
+    end
 
     facets
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/caseload_helper.rb
+++ b/app/helpers/caseload_helper.rb
@@ -1,0 +1,47 @@
+module CaseloadHelper
+
+  def filtered_allocations(allocations, filter_types)
+    # Filters the allocations, returning only those that
+    # match the named filters.
+    allocations
+  end
+
+  def filter_facets(allocations)
+    # Provided a list of allocations, returns a hash of the
+    # number of allocations matching a specific filter.  It is
+    # intended that this will show facets for the currently filtered
+    # allocations, so the numbers will be different based on which
+    # filters were used to generate the allocations list
+    facets = CaseloadFilters.constants.map {|c|
+      [CaseloadFilters.const_get(c), 0]
+    }.to_h
+
+    one_month_time = Time.zone.today + 30.days
+
+    allocations.each { |allocation|
+      if allocation.new_case?
+        facets[CaseloadFilters::NEW_ALLOCATION] += 1
+      else
+        facets[CaseloadFilters::OLD_ALLOCATION] += 1
+      end
+
+      if allocation.offender.handover_start_date[0].nil?
+        facets[CaseloadFilters::HANDOVER_UNKNOWN] += 1
+      elsif allocation.offender.handover_start_date[0].between?(Time.zone.today, one_month_time)
+        facets[CaseloadFilters::HANDOVER_STARTS_SOON] += 1
+      elsif allocation.offender.handover_start_date[0] < Time.zone.today
+        facets[CaseloadFilters::HANDOVER_IN_PROGRESS] += 1
+      end
+
+      if allocation.responsibility == 'Responsible'
+        facets[CaseloadFilters::ROLE_RESPONSIBLE] += 1
+      elsif allocation.responsibility == 'Supporting'
+        facets[CaseloadFilters::ROLE_SUPPORTING] += 1
+      else
+        facets[CaseloadFilters::ROLE_COWORKING] += 1
+      end
+    }
+
+    facets
+  end
+end

--- a/app/models/caseload_filters.rb
+++ b/app/models/caseload_filters.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#:nocov:
+module CaseloadFilters
+  NEW_ALLOCATION = :new_allocation
+  OLD_ALLOCATION = :old_allocation
+
+  HANDOVER_STARTS_SOON = :handover_starts_soon
+  HANDOVER_IN_PROGRESS = :handover_in_progress
+  HANDOVER_UNKNOWN = :handover_unknown
+
+  ROLE_RESPONSIBLE = :role_responsible
+  ROLE_SUPPORTING = :role_supporting
+  ROLE_COWORKING = :role_coworking
+end
+#:nocov:

--- a/app/models/caseload_filters.rb
+++ b/app/models/caseload_filters.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #:nocov:
 module CaseloadFilters
   NEW_ALLOCATION = :new_allocation

--- a/app/models/pom_caseload.rb
+++ b/app/models/pom_caseload.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PomCaseload
-  include Rails.application.routes.url_helpers
 
   def initialize(pom_staff_id, prison_id)
     @staff_id = pom_staff_id

--- a/app/models/pom_caseload.rb
+++ b/app/models/pom_caseload.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PomCaseload
-
   def initialize(pom_staff_id, prison_id)
     @staff_id = pom_staff_id
     @prison_id = prison_id

--- a/spec/helpers/caseload_helper_spec.rb
+++ b/spec/helpers/caseload_helper_spec.rb
@@ -4,18 +4,21 @@ RSpec.describe CaseloadHelper do
   describe 'when getting facet counts' do
     let(:prison) { 'LEI' }
     let(:staff_id) { 1 }
-    let(:poms) { [ { firstName: 'Alice', position: 'PRO', staffId: staff_id } ] }
-    let(:offenders) {[
-      { "latestBookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Alice", "lastName": "Aliceson",
-        "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" },
-      { "latestBookingId": 754_206, "offenderNo": "G1234VV", "firstName": "Bob", "lastName": "Bibby",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
-      { "latestBookingId": 754_205, "offenderNo": "G1234AB", "firstName": "Carole", "lastName": "Caroleson",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
-      { "latestBookingId": 754_204, "offenderNo": "G1234GG", "firstName": "David", "lastName": "Davidson",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" }
-    ]}
-    let(:bookings) { [
+    let(:poms) { [{ firstName: 'Alice', position: 'PRO', staffId: staff_id }] }
+    let(:offenders) {
+      [
+     { "latestBookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Alice", "lastName": "Aliceson",
+       "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" },
+     { "latestBookingId": 754_206, "offenderNo": "G1234VV", "firstName": "Bob", "lastName": "Bibby",
+       "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
+     { "latestBookingId": 754_205, "offenderNo": "G1234AB", "firstName": "Carole", "lastName": "Caroleson",
+       "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
+     { "latestBookingId": 754_204, "offenderNo": "G1234GG", "firstName": "David", "lastName": "Davidson",
+       "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" }
+        ]
+    }
+    let(:bookings) {
+      [
       { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
         "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
                             "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
@@ -44,7 +47,8 @@ RSpec.describe CaseloadHelper do
                             "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
                             "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
         "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-    ] }
+    ]
+    }
 
     before do
       stub_poms(prison, poms)
@@ -55,15 +59,15 @@ RSpec.describe CaseloadHelper do
     it 'handles zero allocations' do
       facets = filter_facets([])
 
-      CaseloadFilters.constants.map {|c| CaseloadFilters.const_get(c) }.each {|f|
+      CaseloadFilters.constants.map { |c| CaseloadFilters.const_get(c) }.each { |f|
         expect(facets[f]).to eq(0)
       }
     end
 
     it 'handles new allocations', versioning: true do
-      offenders.each{ |offender|
+      offenders.each do |offender|
         create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison, primary_pom_allocated_at: DateTime.now.utc)
-      }
+      end
 
       caseload = PomCaseload.new(staff_id, prison)
       expect(caseload.allocations.count).to eq(4)
@@ -89,9 +93,9 @@ RSpec.describe CaseloadHelper do
     end
 
     it 'new and old allocations cannot > total', versioning: true do
-      offenders[0..1].each{ |offender|
+      offenders[0..1].each do |offender|
         create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
-      }
+      end
 
       Timecop.travel(10.days.ago) do
         offenders[2..3].each{ |offender|
@@ -108,9 +112,9 @@ RSpec.describe CaseloadHelper do
     end
 
     it 'handover facets can be faceted' do
-      offenders.each{ |offender|
+      offenders.each do |offender|
         create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
-      }
+      end
 
       caseload = PomCaseload.new(staff_id, prison)
       expect(caseload.allocations.count).to eq(4)
@@ -119,11 +123,11 @@ RSpec.describe CaseloadHelper do
       facets = filter_facets(caseload.allocations)
       expect(facets[CaseloadFilters::HANDOVER_UNKNOWN]).to eq(4)
 
-      allow(HandoverDateService).to receive(:handover_start_date).and_return([Date.today + 7.days, ''])
+      allow(HandoverDateService).to receive(:handover_start_date).and_return([Time.zone.today + 7.days, ''])
       facets = filter_facets(caseload.allocations)
       expect(facets[CaseloadFilters::HANDOVER_STARTS_SOON]).to eq(4)
 
-      allow(HandoverDateService).to receive(:handover_start_date).and_return([Date.today - 2.days, ''])
+      allow(HandoverDateService).to receive(:handover_start_date).and_return([Time.zone.today - 2.days, ''])
       facets = filter_facets(caseload.allocations)
       expect(facets[CaseloadFilters::HANDOVER_IN_PROGRESS]).to eq(4)
     end
@@ -145,6 +149,5 @@ RSpec.describe CaseloadHelper do
       expect(facets[CaseloadFilters::ROLE_SUPPORTING]).to eq(2)
       expect(facets[CaseloadFilters::ROLE_COWORKING]).to eq(1)
     end
-
   end
 end

--- a/spec/helpers/caseload_helper_spec.rb
+++ b/spec/helpers/caseload_helper_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe CaseloadHelper do
+  describe 'when getting facet counts' do
+    let(:prison) { 'LEI' }
+    let(:staff_id) { 1 }
+    let(:poms) { [ { firstName: 'Alice', position: 'PRO', staffId: staff_id } ] }
+    let(:offenders) {[
+      { "latestBookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Alice", "lastName": "Aliceson",
+        "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" },
+      { "latestBookingId": 754_206, "offenderNo": "G1234VV", "firstName": "Bob", "lastName": "Bibby",
+        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
+      { "latestBookingId": 754_205, "offenderNo": "G1234AB", "firstName": "Carole", "lastName": "Caroleson",
+        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
+      { "latestBookingId": 754_204, "offenderNo": "G1234GG", "firstName": "David", "lastName": "Davidson",
+        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" }
+    ]}
+    let(:bookings) { [
+      { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
+        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
+      { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
+        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
+      { "bookingId": 754_205, "offenderNo": "G1234AB", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
+        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
+      { "bookingId": 754_204, "offenderNo": "G1234GG", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
+        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
+    ] }
+
+    before do
+      stub_poms(prison, poms)
+      stub_signed_in_pom(staff_id, 'alice')
+      stub_multiple_offenders(offenders, bookings)
+    end
+
+    it 'handles zero allocations' do
+      facets = filter_facets([])
+
+      CaseloadFilters.constants.map {|c| CaseloadFilters.const_get(c) }.each {|f|
+        expect(facets[f]).to eq(0)
+      }
+    end
+
+    it 'handles new allocations', versioning: true do
+      offenders.each{ |offender|
+        create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison, primary_pom_allocated_at: DateTime.now.utc)
+      }
+
+      caseload = PomCaseload.new(staff_id, prison)
+      expect(caseload.allocations.count).to eq(4)
+
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::NEW_ALLOCATION]).to eq(4)
+      expect(facets[CaseloadFilters::OLD_ALLOCATION]).to eq(0)
+    end
+
+    it 'handles all old allocations', versioning: true do
+      Timecop.travel(10.days.ago) do
+        offenders.each{ |offender|
+          create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+        }
+      end
+
+      caseload = PomCaseload.new(staff_id, prison)
+      expect(caseload.allocations.count).to eq(4)
+
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::OLD_ALLOCATION]).to eq(4)
+      expect(facets[CaseloadFilters::NEW_ALLOCATION]).to eq(0)
+    end
+
+    it 'new and old allocations cannot > total', versioning: true do
+      offenders[0..1].each{ |offender|
+        create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+      }
+
+      Timecop.travel(10.days.ago) do
+        offenders[2..3].each{ |offender|
+          create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+        }
+      end
+
+      caseload = PomCaseload.new(staff_id, prison)
+      expect(caseload.allocations.count).to eq(4)
+
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::OLD_ALLOCATION]).to eq(2)
+      expect(facets[CaseloadFilters::NEW_ALLOCATION]).to eq(2)
+    end
+
+    it 'handover facets can be faceted' do
+      offenders.each{ |offender|
+        create(:allocation_version, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+      }
+
+      caseload = PomCaseload.new(staff_id, prison)
+      expect(caseload.allocations.count).to eq(4)
+
+      allow(HandoverDateService).to receive(:handover_start_date).and_return([nil, ''])
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::HANDOVER_UNKNOWN]).to eq(4)
+
+      allow(HandoverDateService).to receive(:handover_start_date).and_return([Date.today + 7.days, ''])
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::HANDOVER_STARTS_SOON]).to eq(4)
+
+      allow(HandoverDateService).to receive(:handover_start_date).and_return([Date.today - 2.days, ''])
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::HANDOVER_IN_PROGRESS]).to eq(4)
+    end
+
+    it 'responsibility facets can be faceted' do
+      # 1 x Responsible
+      create(:allocation_version, nomis_offender_id: offenders[0][:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+      # 2 x Supporting
+      create(:allocation_version, nomis_offender_id: offenders[1][:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+      create(:allocation_version, nomis_offender_id: offenders[2][:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
+      # 1 x Coworking
+      create(:allocation_version, nomis_offender_id: offenders[3][:offenderNo], secondary_pom_nomis_id: staff_id, prison: prison)
+
+      caseload = PomCaseload.new(staff_id, prison)
+      expect(caseload.allocations.count).to eq(4)
+
+      facets = filter_facets(caseload.allocations)
+      expect(facets[CaseloadFilters::ROLE_RESPONSIBLE]).to eq(1)
+      expect(facets[CaseloadFilters::ROLE_SUPPORTING]).to eq(2)
+      expect(facets[CaseloadFilters::ROLE_COWORKING]).to eq(1)
+    end
+
+  end
+end

--- a/spec/helpers/caseload_helper_spec.rb
+++ b/spec/helpers/caseload_helper_spec.rb
@@ -149,5 +149,11 @@ RSpec.describe CaseloadHelper do
       expect(facets[CaseloadFilters::ROLE_SUPPORTING]).to eq(2)
       expect(facets[CaseloadFilters::ROLE_COWORKING]).to eq(1)
     end
+
+    context 'when filtering allocations' do
+      it 'returns what it is given if there are no filters' do
+        expect(filtered_allocations([], [])).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
An upcoming ticket focused on redesign of various screens has a
component that describes filters for a POM's caseload.  As part of that
component it shows a facet of the total number of allocations (post
application of filters if any).

This PR implements (currently) just the calculation of the facet counts
for each PomCaseload.