### PR TITLE
Show correct responsibility when it has been overridden

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -85,7 +85,7 @@ private
     end
     if params['role'].present?
       allocations = allocations.select { |a|
-        a.responsibility == params['role']
+        a.pom_responsibility == params['role']
       }
     end
     allocations

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -10,13 +10,16 @@ class AllocatedOffender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at,
            to: :@allocation
 
-  attr_reader :responsibility, :offender
+  attr_reader :offender
 
-  def initialize(staff_id, allocation, offender, responsibility)
+  def initialize(staff_id, allocation, offender)
     @staff_id = staff_id
     @allocation = allocation
     @offender = offender
-    @responsibility = responsibility
+  end
+
+  def pom_responsibility
+    @pom_responsibility ||= overridden_responsibility || calculated_responsibility
   end
 
   # check for changes in the last week where the target value
@@ -28,5 +31,26 @@ class AllocatedOffender
       c.key?('primary_pom_nomis_id') && c['primary_pom_nomis_id'][1] == @staff_id ||
       c.key?('secondary_pom_nomis_id') && c['secondary_pom_nomis_id'][1] == @staff_id
     }.any?
+  end
+
+private
+
+  def overridden_responsibility
+    override = Responsibility.find_by(nomis_offender_id: @offender.offender_no)
+    return nil if override.nil?
+
+    if override.value == Responsibility::PRISON
+      ResponsibilityService::RESPONSIBLE.to_s
+    else
+      ResponsibilityService::SUPPORTING.to_s
+    end
+  end
+
+  def calculated_responsibility
+    if @allocation.primary_pom_nomis_id == @staff_id
+      ResponsibilityService.calculate_pom_responsibility(offender).to_s
+    else
+      ResponsibilityService::COWORKING
+    end
   end
 end

--- a/app/models/offender_presenter.rb
+++ b/app/models/offender_presenter.rb
@@ -20,6 +20,9 @@ class OffenderPresenter
   end
 
   def pom_responsibility
+    # If this presenter was provided with a responsibility object from
+    # a responsibility override, we will return that, falling back on
+    # asking the offender class to calculate it.
     if @responsibility
       if @responsibility.value == Responsibility::PRISON
         ResponsibilityService::RESPONSIBLE

--- a/app/models/pom_caseload.rb
+++ b/app/models/pom_caseload.rb
@@ -23,7 +23,6 @@ class PomCaseload
 
 private
 
-  # rubocop:disable Metrics/MethodLength
   def load_allocations
     allocation_list = AllocationVersion.active_pom_allocations(
       @staff_id, @prison_id
@@ -32,42 +31,17 @@ private
     offender_ids = allocation_list.map(&:nomis_offender_id)
     offenders = OffenderService.get_multiple_offenders(offender_ids)
 
-    # Lookup responsibility overrides and store them in a hash for this
-    # caseload
-    responsibilities = Responsibility.where(nomis_offender_id: offender_ids)
-    responsibility_overrides = responsibilities.map { |r|
-      [r.nomis_offender_id, r]
-    }.to_h
-
     offenders.map { |offender|
       # This is potentially slow, possibly of the order O(NM)
       allocation = allocation_list.detect { |alloc|
         alloc.nomis_offender_id == offender.offender_no
       }
 
-      # Do a lookup to find out if this offender has had
-      # their responsibility manually overridden. If so then
-      # use that, otherwise we need to calculate it.
-      overridden_responsibility = responsibility_overrides.fetch(offender.offender_no, nil)
-      responsibility_string = if overridden_responsibility.present?
-                                if overridden_responsibility.value == Responsibility::PRISON
-                                  ResponsibilityService::RESPONSIBLE
-                                else
-                                  ResponsibilityService::SUPPORTING
-                                end
-                              elsif allocation.primary_pom_nomis_id == @staff_id
-                                ResponsibilityService.calculate_pom_responsibility(offender)
-                              else
-                                ResponsibilityService::COWORKING
-                              end
-
       AllocatedOffender.new(
         @staff_id,
         allocation,
-        offender,
-        responsibility_string.to_s
+        offender
       )
     }
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/models/pom_caseload.rb
+++ b/app/models/pom_caseload.rb
@@ -32,25 +32,40 @@ private
     offender_ids = allocation_list.map(&:nomis_offender_id)
     offenders = OffenderService.get_multiple_offenders(offender_ids)
 
+    # Lookup responsibility overrides and store them in a hash for this
+    # caseload
+    responsibilities = Responsibility.where(nomis_offender_id: offender_ids)
+    responsibility_overrides = responsibilities.map { |r|
+      [r.nomis_offender_id, r]
+    }.to_h
+
     offenders.map { |offender|
       # This is potentially slow, possibly of the order O(NM)
       allocation = allocation_list.detect { |alloc|
         alloc.nomis_offender_id == offender.offender_no
       }
 
-      # If this is the primary POM, work out responsibility
-      if allocation.primary_pom_nomis_id == @staff_id
-        responsibility =
-          ResponsibilityService.calculate_pom_responsibility(offender).to_s
-      else
-        responsibility = ResponsibilityService::COWORKING
-      end
+      # Do a lookup to find out if this offender has had
+      # their responsibility manually overridden. If so then
+      # use that, otherwise we need to calculate it.
+      overridden_responsibility = responsibility_overrides.fetch(offender.offender_no, nil)
+      responsibility_string = if overridden_responsibility.present?
+                                if overridden_responsibility.value == Responsibility::PRISON
+                                  ResponsibilityService::RESPONSIBLE
+                                else
+                                  ResponsibilityService::SUPPORTING
+                                end
+                              elsif allocation.primary_pom_nomis_id == @staff_id
+                                ResponsibilityService.calculate_pom_responsibility(offender)
+                              else
+                                ResponsibilityService::COWORKING
+                              end
 
       AllocatedOffender.new(
         @staff_id,
         allocation,
         offender,
-        responsibility
+        responsibility_string.to_s
       )
     }
   end

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -81,10 +81,10 @@
         <%= sort_arrow('primary_pom_allocated_at') %>
       </th>
       <th class="govuk-table__header" scope="col">
-        <a href="<%= sort_link('responsibility') %>">
+        <a href="<%= sort_link('pom_responsibility') %>">
           Role
         </a>
-        <%= sort_arrow('responsibility') %>
+        <%= sort_arrow('pom_responsibility') %>
       </th>
       <th class="govuk-table__header" scope="col">Action</th>
     </tr>
@@ -104,7 +104,7 @@
         </td>
         <td aria-label="Release date" class="govuk-table__cell "><%= format_date(offender.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(offender.primary_pom_allocated_at) %></td>
-        <td aria-label="Role" class="govuk-table__cell "><%= offender.responsibility %></td>
+        <td aria-label="Role" class="govuk-table__cell "><%= offender.pom_responsibility %></td>
         <td aria-label="Action" class="govuk-table__cell ">
           <%= link_to('View', prison_prisoner_path(@prison.code, offender.nomis_offender_id), class: "govuk-link" ) %>
         </td>

--- a/app/views/caseload/new.html.erb
+++ b/app/views/caseload/new.html.erb
@@ -41,10 +41,10 @@
         <%= sort_arrow('primary_pom_allocated_at') %>
       </th>
       <th class="govuk-table__header" scope="col">
-        <a href="<%= sort_link('responsibility') %>">
+        <a href="<%= sort_link('pom_responsibility') %>">
           Role
         </a>
-        <%= sort_arrow('responsibility') %>
+        <%= sort_arrow('pom_responsibility') %>
       </th>
       <th class="govuk-table__header" scope="col">Action</th>
     </tr>
@@ -66,7 +66,7 @@
         <td aria-label="Arrival date" class="govuk-table__cell"><%= format_date(allocation.sentence_start_date) %></td>
         <td aria-label="Release date" class="govuk-table__cell"><%= format_date(allocation.earliest_release_date) %></td>
         <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
-        <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
+        <td aria-label="Role" class="govuk-table__cell "><%= allocation.pom_responsibility %></td>
         <td aria-label="Action" class="govuk-table__cell ">
           <%= link_to('View', prison_prisoner_path(@prison.code, allocation.nomis_offender_id), class: "govuk-link" ) %>
         </td>

--- a/app/views/poms/_caseload.html.erb
+++ b/app/views/poms/_caseload.html.erb
@@ -33,10 +33,10 @@
         <%= sort_arrow('primary_pom_allocated_at') %>
       </th>
       <th class="govuk-table__header" scope="col">
-        <a href="<%= sort_link('responsibility') %>">
+        <a href="<%= sort_link('pom_responsibility') %>">
           Role
         </a>
-        <%= sort_arrow('responsibility') %>
+        <%= sort_arrow('pom_responsibility') %>
       </th>
     </tr>
   </thead>
@@ -48,7 +48,7 @@
       <td aria-label="Earliest release date" class="govuk-table__cell "><%= format_date(allocation.earliest_release_date) %></td>
       <td aria-label="Tier" class="govuk-table__cell "><%= allocation.tier %></td>
       <td aria-label="Allocation date" class="govuk-table__cell "><%= format_date(allocation.primary_pom_allocated_at) %></td>
-      <td aria-label="Role" class="govuk-table__cell "><%= allocation.responsibility %></td>
+      <td aria-label="Role" class="govuk-table__cell "><%= allocation.pom_responsibility %></td>
     </tr>
     <% end %>
   </tbody>

--- a/spec/models/pom_caseload_spec.rb
+++ b/spec/models/pom_caseload_spec.rb
@@ -161,5 +161,19 @@ RSpec.describe PomCaseload, type: :model do
       responsible_pom = allocated_offenders.detect { |a| a.offender.offender_no == responsible_pom.offender_no }
       expect(responsible_pom.responsibility).to eq('Supporting')
     end
+
+    it "will get show the correct responsibility if one is overridden to prison", :versioning, vcr: { cassette_name: :get_overridden_responsibilities_prison } do
+      # Find a responsible offender
+      allocated_offenders = described_class.new(staff_id, prison).allocations
+      responsible_pom = allocated_offenders.detect { |offender| offender.responsibility == 'Supporting' }.offender
+
+      # Override their responsibility
+      create(:responsibility, nomis_offender_id: responsible_pom.offender_no, value: 'Prison')
+
+      # Confirm that the responsible offender is now supporting
+      allocated_offenders = described_class.new(staff_id, prison).allocations
+      responsible_pom = allocated_offenders.detect { |a| a.offender.offender_no == responsible_pom.offender_no }
+      expect(responsible_pom.responsibility).to eq('Responsible')
+    end
   end
 end

--- a/spec/models/pom_caseload_spec.rb
+++ b/spec/models/pom_caseload_spec.rb
@@ -147,5 +147,19 @@ RSpec.describe PomCaseload, type: :model do
       expect(allocated_offenders.count).to eq 2
       expect(allocated_offenders.map(&:responsibility)).to match_array %w[Supporting Co-Working]
     end
+
+    it "will get show the correct responsibility if one is overridden", :versioning, vcr: { cassette_name: :get_overridden_responsibilities } do
+      # Find a responsible offender
+      allocated_offenders = described_class.new(staff_id, prison).allocations
+      responsible_pom = allocated_offenders.detect { |offender| offender.responsibility == 'Responsible' }.offender
+
+      # Override their responsibility
+      create(:responsibility, nomis_offender_id: responsible_pom.offender_no)
+
+      # Confirm that the responsible offender is now supporting
+      allocated_offenders = described_class.new(staff_id, prison).allocations
+      responsible_pom = allocated_offenders.detect { |a| a.offender.offender_no == responsible_pom.offender_no }
+      expect(responsible_pom.responsibility).to eq('Supporting')
+    end
   end
 end

--- a/spec/models/pom_caseload_spec.rb
+++ b/spec/models/pom_caseload_spec.rb
@@ -145,13 +145,13 @@ RSpec.describe PomCaseload, type: :model do
     it "will get allocations for a POM made within the last 7 days", :versioning, vcr: { cassette_name: :get_new_cases } do
       allocated_offenders = described_class.new(staff_id, prison).allocations.select(&:new_case?)
       expect(allocated_offenders.count).to eq 2
-      expect(allocated_offenders.map(&:responsibility)).to match_array %w[Supporting Co-Working]
+      expect(allocated_offenders.map(&:pom_responsibility)).to match_array %w[Supporting Co-Working]
     end
 
     it "will get show the correct responsibility if one is overridden", :versioning, vcr: { cassette_name: :get_overridden_responsibilities } do
       # Find a responsible offender
       allocated_offenders = described_class.new(staff_id, prison).allocations
-      responsible_pom = allocated_offenders.detect { |offender| offender.responsibility == 'Responsible' }.offender
+      responsible_pom = allocated_offenders.detect { |offender| offender.pom_responsibility == 'Responsible' }.offender
 
       # Override their responsibility
       create(:responsibility, nomis_offender_id: responsible_pom.offender_no)
@@ -159,13 +159,13 @@ RSpec.describe PomCaseload, type: :model do
       # Confirm that the responsible offender is now supporting
       allocated_offenders = described_class.new(staff_id, prison).allocations
       responsible_pom = allocated_offenders.detect { |a| a.offender.offender_no == responsible_pom.offender_no }
-      expect(responsible_pom.responsibility).to eq('Supporting')
+      expect(responsible_pom.pom_responsibility).to eq('Supporting')
     end
 
     it "will get show the correct responsibility if one is overridden to prison", :versioning, vcr: { cassette_name: :get_overridden_responsibilities_prison } do
       # Find a responsible offender
       allocated_offenders = described_class.new(staff_id, prison).allocations
-      responsible_pom = allocated_offenders.detect { |offender| offender.responsibility == 'Supporting' }.offender
+      responsible_pom = allocated_offenders.detect { |offender| offender.pom_responsibility == 'Supporting' }.offender
 
       # Override their responsibility
       create(:responsibility, nomis_offender_id: responsible_pom.offender_no, value: 'Prison')
@@ -173,7 +173,7 @@ RSpec.describe PomCaseload, type: :model do
       # Confirm that the responsible offender is now supporting
       allocated_offenders = described_class.new(staff_id, prison).allocations
       responsible_pom = allocated_offenders.detect { |a| a.offender.offender_no == responsible_pom.offender_no }
-      expect(responsible_pom.responsibility).to eq('Responsible')
+      expect(responsible_pom.pom_responsibility).to eq('Responsible')
     end
   end
 end


### PR DESCRIPTION
When an offender has their responsibility overridden to be PROBATION,
the currently allocated POM should show as SUPPORTING, and not
RESPONSIBLE.  Allocated secondary POM will become CO-WORKING.

Currently this was not handled by the POMCaseload or the previous
PrisonOffenderManagerService function.

This PR now checks for an overriddent responsibility when determining a
POMs caseload.