### PR TITLE
Pom 456 profile tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,18 +54,21 @@ group :development, :test do
 end
 
 group :test do
-  gem 'timecop'
   gem 'capybara'
   gem 'database_cleaner'
   gem 'faker'
   gem 'geckodriver-helper'
   gem 'launchy'
+  gem 'rails-controller-testing'
+  gem 'ruby-prof', '>= 0.16.0', require: false
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'simplecov'
+  # https://evilmartians.com/chronicles/testprof-a-good-doctor-for-slow-ruby-tests
+  gem 'test-prof'
+  gem 'timecop'
   gem 'vcr'
   gem 'webmock'
-  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,7 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
+    ruby-prof (1.0.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
@@ -350,6 +351,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stackprof (0.2.12)
+    test-prof (0.10.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -444,6 +446,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-prof (>= 0.16.0)
   rubyzip
   sass-rails (~> 5.0)
   selenium-webdriver
@@ -454,6 +457,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   stackprof
+  test-prof
   timecop
   turbolinks (~> 5)
   turnout

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -14,69 +14,149 @@ RSpec.describe SummaryController, type: :controller do
 
   before do
     stub_sso_data(prison)
-
-    offenders = [
-      { "bookingId": 754_208, "offenderNo": "G1234GY", "firstName": "BOB", "lastName": "SMITH",
-        "dateOfBirth": "1995-02-02", "age": 34, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "LR" },
-      { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender",
-        "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" },
-      { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" }
-    ]
-
-    bookings = [
-      { "bookingId": 754_208, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-      { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-      { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2019-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-    ]
-
-    stub_offenders_for_prison(prison, offenders, bookings)
-
-    stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
-      with(body: %w[G1234GY G7514GW G1234VV].to_json).
-      to_return(status: 200, body: [{ offenderNo: 'G7514GW', toAgency: prison, createDateTime: Date.new(2018, 10, 1) },
-                                    { offenderNo: 'G1234VV', toAgency: prison, createDateTime: Date.new(2018, 9, 1) }].to_json)
   end
 
-  context 'when user is a POM' do
+  context 'with 2 offenders' do
     before do
-      stub_poms(prison, poms)
-      stub_sso_pom_data(prison)
-      stub_signed_in_pom(1, 'Alice')
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
-        with(headers: { 'Authorization' => 'Bearer token' }).
-        to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
+      sleep 1 # bust the 1 second cache as we're changing returned data
+
+      offenders = [
+        { "bookingId": 754_208, "offenderNo": "G1234GY", "firstName": "BOB", "lastName": "SMITH",
+          "dateOfBirth": "1995-02-02", "age": 34, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "LR" },
+        { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender",
+          "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" },
+        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES",
+          "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" }
+      ]
+
+      bookings = [
+        { "bookingId": 754_208, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
+          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
+        { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
+          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
+        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
+          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                              "bookingId": 754_207, "sentenceStartDate": "2019-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
+      ]
+
+      stub_offenders_for_prison(prison, offenders, bookings)
+
+      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
+        with(body: %w[G1234GY G7514GW G1234VV].to_json).
+        to_return(status: 200, body: [{ offenderNo: 'G7514GW', toAgency: prison, createDateTime: Date.new(2018, 10, 1) },
+                                      { offenderNo: 'G1234VV', toAgency: prison, createDateTime: Date.new(2018, 9, 1) }].to_json)
     end
 
-    it 'is not visible' do
+    context 'when user is a POM' do
+      before do
+        stub_poms(prison, poms)
+        stub_sso_pom_data(prison)
+        stub_signed_in_pom(1, 'Alice')
+        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
+          with(headers: { 'Authorization' => 'Bearer token' }).
+          to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
+      end
+
+      it 'is not visible' do
+        get :pending, params: { prison_id: prison }
+        expect(response).to redirect_to('/')
+      end
+    end
+
+    it 'gets pending records' do
       get :pending, params: { prison_id: prison }
-      expect(response).to redirect_to('/')
+      # Expecting offender (2) to use sentenceStartDate as it is newer than last arrival date in prison
+      expect(assigns(:summary).offenders.map(&:awaiting_allocation_for).map { |x| Time.zone.today - x }).
+        to match_array [Date.new(2009, 2, 8), Date.new(2018, 10, 1), Date.new(2019, 2, 8)]
+    end
+
+    it 'sorts ascending by default' do
+      get :pending, params: { prison_id: prison, sort: 'last_name' } # Default direction is asc.
+      expect(assigns(:summary).offenders.map(&:last_name)).to eq(%w[JONES Minate-Offender SMITH])
+    end
+
+    it 'sorts descending' do
+      get :pending, params: { prison_id: prison, sort: 'last_name desc' }
+
+      expect(assigns(:summary).offenders.map(&:last_name)).to eq(%w[SMITH Minate-Offender JONES])
     end
   end
 
-  it 'gets pending records' do
-    get :pending, params: { prison_id: prison }
-    # Expecting offender (2) to use sentenceStartDate as it is newer than last arrival date in prison
-    expect(assigns(:summary).offenders.map(&:awaiting_allocation_for).map { |x| Time.zone.today - x }).
-      to match_array [Date.new(2009, 2, 8), Date.new(2018, 10, 1), Date.new(2019, 2, 8)]
+  context 'with enough offenders to page' do
+    let(:range) { 0.upto(119) }
+    let(:offenders) {
+      range.map { |i|
+        { "bookingId": i, "offenderNo": "G#{10_000 - i}GW", "firstName": "Offen", "lastName": "DerNum#{i}",
+          "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" }
+      }
+    }
+    let(:bookings) {
+      range.map do |i|
+        { "bookingId": i, "offenderNo": "G#{10_000 - i}GW", "firstName": "Offen", "lastName": "DerNum#{i}", "agencyLocationId": prison,
+          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                              "bookingId": 754_207, "sentenceStartDate": "2019-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
+      end
+    }
+    let(:moves) {
+      range.map { |i| "G#{10_000 - i}GW" }
+    }
+    let(:summary) { assigns(:summary) }
+
+    render_views
+
+    # need to bust the 1 seconds cache timeout from previous page
+    # rubocop:disable RSpec/BeforeAfterAll
+    before(:all) do
+      sleep 1
+    end
+    # rubocop:enable RSpec/BeforeAfterAll
+
+    before do
+      stub_offenders_for_prison(prison, offenders, bookings)
+      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
+        with(body: moves.to_json).
+        to_return(status: 200,
+                  body: moves.map { |offender_no| { offenderNo: offender_no, toAgency: prison, createDateTime: Date.new(2018, 10, 1) } }.to_json)
+    end
+
+    it 'gets page 1 by default' do
+      get :pending, params: { prison_id: 'LEI' }
+
+      expect(summary.offenders.size).to eq(50)
+      expect(summary.offenders.current_page).to eq(1)
+    end
+
+    it 'gets page 2' do
+      get :pending, params: { prison_id: 'LEI', page: 2 }
+
+      expect(summary.offenders.size).to eq(50)
+      expect(summary.offenders.current_page).to eq(2)
+    end
+
+    it 'gets page 3' do
+      get :pending, params: { prison_id: 'LEI', page: 3 }
+
+      expect(summary.offenders.size).to eq(20)
+      expect(summary.offenders.current_page).to eq(3)
+    end
   end
 
   it 'handles trying to sort by missing field for allocated offenders' do

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 feature 'summary summary feature' do
-  describe 'awaiting summary table' do
-    before do
-      signin_user
-    end
+  before do
+    signin_user
+  end
 
+  describe 'awaiting summary table' do
     it 'redirects correctly', vcr: { cassette_name: :redirect_summary_index_feature } do
       visit prison_summary_path('LEI')
       expect(page).to have_current_path prison_summary_allocated_path('LEI')
@@ -17,22 +17,6 @@ feature 'summary summary feature' do
       expect(page).to have_css('.govuk-tabs__tab')
       expect(page).to have_content('Update information')
       expect(page).to have_css('.pagination ul.links li', count: 16)
-    end
-
-    it 'handles sorting params', vcr: { cassette_name: :summary_sorting_feature } do
-      get_ids = lambda {
-        all('tbody tr td').map(&:text).select { |c|
-          /[A-Z][0-9.][0-9.][0-9.][0-9.][A-Z][A-Z]/.match(c)
-        }
-      }
-
-      visit prison_summary_pending_path('LEI', sort: 'last_name')  # Default direction is asc.
-      asc_cells = get_ids.call
-
-      visit prison_summary_pending_path('LEI', sort: 'last_name desc')
-      desc_cells = get_ids.call
-
-      expect(asc_cells).not_to match_array(desc_cells)
     end
 
     it 'displays offenders pending allocation', vcr: { cassette_name: :awaiting_allocation_feature } do
@@ -47,28 +31,6 @@ feature 'summary summary feature' do
 
       expect(page).to have_css('.govuk-tabs__tab')
       expect(page).to have_content('See allocations')
-    end
-  end
-
-  describe 'paging' do
-    it 'shows pages for allocation', vcr: { cassette_name: :allocated_offenders_paged_feature } do
-      signin_user
-
-      visit prison_summary_pending_path('LEI')
-      expect(page).to have_link('Next')
-      expect(page).not_to have_link('Previous')
-      expect(page).not_to have_link('1', exact: true)
-
-      visit prison_summary_pending_path('LEI', page: 2)
-      expect(page).to have_link('Next')
-      expect(page).to have_link('Previous')
-      expect(page).not_to have_link('2', exact: true)
-
-      visit prison_summary_pending_path('LEI', page: 117)
-      expect(page).not_to have_link('Next')
-      expect(page).to have_link('Previous')
-      expect(page).not_to have_link('117', exact: true)
-      expect(page).not_to have_link('118', exact: true)
     end
   end
 end

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -6,12 +6,12 @@ feature 'summary summary feature' do
       signin_user
     end
 
-    it 'redirects correctly', :raven_intercept_exception, vcr: { cassette_name: :redirect_summary_index_feature } do
+    it 'redirects correctly', vcr: { cassette_name: :redirect_summary_index_feature } do
       visit prison_summary_path('LEI')
       expect(page).to have_current_path prison_summary_allocated_path('LEI')
     end
 
-    it 'displays offenders awaiting information', :raven_intercept_exception, vcr: { cassette_name: :awaiting_information_feature } do
+    it 'displays offenders awaiting information', vcr: { cassette_name: :awaiting_information_feature } do
       visit prison_summary_pending_path('LEI')
 
       expect(page).to have_css('.govuk-tabs__tab')
@@ -19,7 +19,7 @@ feature 'summary summary feature' do
       expect(page).to have_css('.pagination ul.links li', count: 16)
     end
 
-    it 'handles sorting params', :raven_intercept_exception, vcr: { cassette_name: :summary_sorting_feature } do
+    it 'handles sorting params', vcr: { cassette_name: :summary_sorting_feature } do
       get_ids = lambda {
         all('tbody tr td').map(&:text).select { |c|
           /[A-Z][0-9.][0-9.][0-9.][0-9.][A-Z][A-Z]/.match(c)
@@ -35,25 +35,23 @@ feature 'summary summary feature' do
       expect(asc_cells).not_to match_array(desc_cells)
     end
 
-    it 'displays offenders pending allocation', :raven_intercept_exception, vcr: { cassette_name: :awaiting_allocation_feature } do
+    it 'displays offenders pending allocation', vcr: { cassette_name: :awaiting_allocation_feature } do
       visit prison_summary_unallocated_path('LEI')
 
       expect(page).to have_css('.govuk-tabs__tab')
       expect(page).to have_content('Update information')
-      # expect(page).to have_css('.pagination ul.links li', count: 2)
     end
 
-    it 'displays offenders already allocated', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_feature } do
+    it 'displays offenders already allocated', vcr: { cassette_name: :allocated_offenders_feature } do
       visit prison_summary_allocated_path('LEI')
 
       expect(page).to have_css('.govuk-tabs__tab')
       expect(page).to have_content('See allocations')
-      # expect(page).to have_css('.pagination ul.links li', count: 2)
     end
   end
 
   describe 'paging' do
-    it 'shows pages for allocation', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_paged_feature } do
+    it 'shows pages for allocation', vcr: { cassette_name: :allocated_offenders_paged_feature } do
       signin_user
 
       visit prison_summary_pending_path('LEI')

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -2,16 +2,16 @@ require 'rails_helper'
 
 feature 'summary summary feature' do
   describe 'awaiting summary table' do
-    it 'redirects correctly', :raven_intercept_exception, vcr: { cassette_name: :redirect_summary_index_feature } do
+    before do
       signin_user
+    end
 
+    it 'redirects correctly', :raven_intercept_exception, vcr: { cassette_name: :redirect_summary_index_feature } do
       visit prison_summary_path('LEI')
       expect(page).to have_current_path prison_summary_allocated_path('LEI')
     end
 
     it 'displays offenders awaiting information', :raven_intercept_exception, vcr: { cassette_name: :awaiting_information_feature } do
-      signin_user
-
       visit prison_summary_pending_path('LEI')
 
       expect(page).to have_css('.govuk-tabs__tab')
@@ -20,8 +20,6 @@ feature 'summary summary feature' do
     end
 
     it 'handles sorting params', :raven_intercept_exception, vcr: { cassette_name: :summary_sorting_feature } do
-      signin_user
-
       get_ids = lambda {
         all('tbody tr td').map(&:text).select { |c|
           /[A-Z][0-9.][0-9.][0-9.][0-9.][A-Z][A-Z]/.match(c)
@@ -38,8 +36,6 @@ feature 'summary summary feature' do
     end
 
     it 'displays offenders pending allocation', :raven_intercept_exception, vcr: { cassette_name: :awaiting_allocation_feature } do
-      signin_user
-
       visit prison_summary_unallocated_path('LEI')
 
       expect(page).to have_css('.govuk-tabs__tab')
@@ -48,8 +44,6 @@ feature 'summary summary feature' do
     end
 
     it 'displays offenders already allocated', :raven_intercept_exception, vcr: { cassette_name: :allocated_offenders_feature } do
-      signin_user
-
       visit prison_summary_allocated_path('LEI')
 
       expect(page).to have_css('.govuk-tabs__tab')

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StaffMember, type: :model, vcr: :staff_member_things do
+RSpec.describe StaffMember, type: :model, vcr: { cassette_name: :staff_member_things } do
   describe '#full_name' do
     let(:pom) { described_class.new(485_846) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,11 @@ vcr_record_mode = recording ? :all : :none
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
 
-  config.hook_into :webmock
+  if recording
+    config.hook_into :webmock
+  else
+    config.hook_into :faraday
+  end
   config.configure_rspec_metadata!
   # this allows HTTP connections to go through to webmock if cassette not specified
   config.allow_http_connections_when_no_cassette = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ if ENV['CIRCLE_ARTIFACTS']
   SimpleCov.coverage_dir(dir)
 end
 
+# patch to support SAMPLE=nn to only run nn tests
+require "test_prof/recipes/rspec/sample"
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,11 +39,7 @@ vcr_record_mode = recording ? :all : :none
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
 
-  if recording
-    config.hook_into :webmock
-  else
-    config.hook_into :faraday
-  end
+  config.hook_into :webmock
   config.configure_rspec_metadata!
   # this allows HTTP connections to go through to webmock if cassette not specified
   config.allow_http_connections_when_no_cassette = true
@@ -70,5 +66,10 @@ VCR.configure do |config|
 
   config.filter_sensitive_data('authorisation_header') do |interaction|
     interaction.request.headers['Authorization']&.first
+  end
+
+  config.ignore_request do |request|
+    # don't record auth requests as they clutter the recordings
+    request.uri =~ /__identify__|session|auth/
   end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -60,8 +60,7 @@ module ApiHelper
         'Page-Offset' => '0'
       }).to_return(status: 200, body: offenders.to_json)
 
-    # Get the booking ids provided and add a non-existent booking in
-    # case none were provided
+    # Get the booking ids provided
     booking_ids = bookings.map{ |h| h[:bookingId] }.compact
     stub_request(:post, elite2bookingsapi).with(body: booking_ids.to_json).
       to_return(status: 200, body: bookings.to_json, headers: {})


### PR DESCRIPTION
Added profiling to test suite - shows (as in previous projects) that test timings are dominated by HTML parsing. Suggest pushing towards writing more controller tests (which give us more control anyway given that T3 data is old and almost unchangeable)