### PR TITLE
POM-496 - emailing the wrong POM when offender re-allocated

### DIFF
--- a/app/models/allocation_version.rb
+++ b/app/models/allocation_version.rb
@@ -73,27 +73,21 @@ class AllocationVersion < ApplicationRecord
     JSON.parse(self[:override_reasons]) if self[:override_reasons].present?
   end
 
-  def self.deallocate_offender(nomis_offender_id, movement_type)
-    alloc = AllocationVersion.find_by(
-      nomis_offender_id: nomis_offender_id
-    )
+  def deallocate_offender(movement_type)
+    self.prison = prison_fix(movement_type) if prison.blank?
 
-    return if alloc.nil?
-
-    alloc.prison = prison_fix(alloc, movement_type) if alloc.prison.blank?
-
-    alloc.primary_pom_nomis_id = nil
-    alloc.primary_pom_name = nil
-    alloc.primary_pom_allocated_at = nil
-    alloc.secondary_pom_nomis_id = nil
-    alloc.secondary_pom_name = nil
-    alloc.recommended_pom_type = nil
+    self.primary_pom_nomis_id = nil
+    self.primary_pom_name = nil
+    self.primary_pom_allocated_at = nil
+    self.secondary_pom_nomis_id = nil
+    self.secondary_pom_name = nil
+    self.recommended_pom_type = nil
     if movement_type == AllocationVersion::OFFENDER_RELEASED
-      alloc.event = DEALLOCATE_RELEASED_OFFENDER
+      self.event = DEALLOCATE_RELEASED_OFFENDER
     else
-      alloc.event = DEALLOCATE_PRIMARY_POM
+      self.event = DEALLOCATE_PRIMARY_POM
     end
-    alloc.event_trigger = movement_type
+    self.event_trigger = movement_type
 
     # This is triggered when an offender is released, and previously we
     # were setting their prison to nil to show that the current allocation
@@ -104,7 +98,7 @@ class AllocationVersion < ApplicationRecord
     #
     # Perhaps a better event name is `OFFENDER_RELEASED`.
 
-    alloc.save!
+    save!
   end
 
   def self.deallocate_primary_pom(nomis_staff_id, prison)
@@ -120,19 +114,19 @@ class AllocationVersion < ApplicationRecord
     end
   end
 
-  def self.prison_fix(allocation, movement_type)
+  def prison_fix(movement_type)
     # In some cases we have old historical data which has no prison set
     # and this causes an issue should those offenders move or be released.
     # To handle this we will attempt to set the prison to a valid code
     # based on the event that has happened.
     if movement_type == AllocationVersion::OFFENDER_RELEASED
-      movements = Nomis::Elite2::MovementApi.movements_for(allocation.nomis_offender_id)
+      movements = Nomis::Elite2::MovementApi.movements_for(nomis_offender_id)
       if movements.present?
         movement = movements.last
         return movement.from_agency if movement.from_prison?
       end
     elsif movement_type == AllocationVersion::OFFENDER_TRANSFERRED
-      offender = OffenderService.get_offender(allocation.nomis_offender_id)
+      offender = OffenderService.get_offender(nomis_offender_id)
       offender.prison_id
     end
   end

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -80,19 +80,21 @@ private
 
   def previous_pom
     # Check the versions (there MUST be previous records if this is a reallocation)
-    # and find the first version with a primary_pom id that is not the same as the
+    # and find the last version with a primary_pom id that is not the same as the
     # allocation. That will be the POM that is notified of a reallocation.
-    versions = AllocationService.get_versions_for(@allocation)
+    @previous_pom ||= begin
+      versions = AllocationService.get_versions_for(@allocation)
 
-    previous = versions.first { |version|
-      version.primary_pom_nomis_id != @allocation.primary_pom_nomis_id
-    }
-    return nil if previous.blank?
+      previous = versions.reverse.detect { |version|
+        version.primary_pom_nomis_id.present? && version.primary_pom_nomis_id != @allocation.primary_pom_nomis_id
+      }
+      return nil if previous.blank?
 
-    @previous_pom ||= PrisonOffenderManagerService.get_pom_at(
-      previous.prison,
-      previous.primary_pom_nomis_id
-    )
+      PrisonOffenderManagerService.get_pom_at(
+        previous.prison,
+        previous.primary_pom_nomis_id
+      )
+    end
   end
 
   def send_deallocation_email

--- a/lib/allocation_validation.rb
+++ b/lib/allocation_validation.rb
@@ -26,7 +26,7 @@ class AllocationValidation
       offender = OffenderService.get_offender(allocation.nomis_offender_id)
       if offender.nil?
         puts "Can't find offender #{allocation.nomis_offender_id} - probably merged, deallocating"
-        AllocationVersion.deallocate_offender(allocation.nomis_offender_id, 'offender_released')
+        allocation.deallocate_offender('offender_released')
         next
       end
 
@@ -35,7 +35,7 @@ class AllocationValidation
         # be allocated to anybody We will de-allocate the offender so they can
         # be re-allocated against a new offense.
         puts "#{offender.offender_no} is not sentenced - deallocating"
-        AllocationVersion.deallocate_offender(offender.offender_no, 'offender_released')
+        allocation.deallocate_offender('offender_released')
         next
       end
 
@@ -45,13 +45,13 @@ class AllocationValidation
       # If the offender is out, deallocate as a release
       if offender.prison_id == 'OUT'
         puts "#{offender.offender_no} appears to have been released - deallocating"
-        AllocationVersion.deallocate_offender(offender.offender_no, 'offender_released')
+        allocation.deallocate_offender('offender_released')
         next
       end
 
       # The offender is at a different prison so deallocate as a transfer
       puts "#{offender.offender_no} (allocated) appears to have been transferred to #{offender.prison_id} - deallocating"
-      AllocationVersion.deallocate_offender(offender.offender_no, 'offender_transferred')
+      allocation.deallocate_offender('offender_transferred')
     }
   end
   # rubocop:enable Metrics/LineLength

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
 
     # Create an allocation where the offender is allocated, and then deallocate so we can
     # test finding the last pom that was allocated to this offender ....
-    create(:allocation_version, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, prison: 'LEI', primary_pom_name: 'Primary POMName')
-    AllocationVersion.deallocate_offender(nomis_offender_id, AllocationVersion::OFFENDER_TRANSFERRED)
+    alloc = create(:allocation_version, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, prison: 'LEI', primary_pom_name: 'Primary POMName')
+    alloc.deallocate_offender(AllocationVersion::OFFENDER_TRANSFERRED)
 
     fakejob = double
     allow(fakejob).to receive(:deliver_later)

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -96,12 +96,12 @@ RSpec.describe EmailService, :queueing do
       x = create(:allocation_version,
                  nomis_offender_id: original_allocation.nomis_offender_id,
                  primary_pom_nomis_id: original_allocation.primary_pom_nomis_id)
-      AllocationVersion.deallocate_offender(x.nomis_offender_id, AllocationVersion::OFFENDER_RELEASED)
+      x.deallocate_offender(AllocationVersion::OFFENDER_RELEASED)
       x.reload
       x.update!(primary_pom_nomis_id: reallocation.primary_pom_nomis_id,
                 event: AllocationVersion::REALLOCATE_PRIMARY_POM,
                 event_trigger: AllocationVersion::USER)
-      AllocationVersion.deallocate_offender(x.nomis_offender_id, AllocationVersion::OFFENDER_RELEASED)
+      x.deallocate_offender(AllocationVersion::OFFENDER_RELEASED)
       x.reload
       x.update!(primary_pom_nomis_id: original_allocation.primary_pom_nomis_id,
                 event: AllocationVersion::REALLOCATE_PRIMARY_POM,


### PR DESCRIPTION
Fixed 3 bugs:

a) use detect rather than first (which doesn't take a block)
b) scan backwards rather than forwards through the versions list
c) ignore nil primary_pom_nomis_ids as this can be cleared on a release