### PR TITLE
Show overridden responsibility in prisoner profile

### DIFF
--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -12,16 +12,14 @@ class PrisonersController < PrisonsApplicationController
   def show
     @prisoner = OffenderPresenter.new(@offender,
                                       Responsibility.find_by(nomis_offender_id: id_for_show_action))
-
     @tasks = PomTasks.new.for_offender(@prisoner)
-
     @allocation = AllocationVersion.find_by(nomis_offender_id: @prisoner.offender_no)
-    @pom_responsibility = ResponsibilityService.calculate_pom_responsibility(
-      @offender
-    )
+
+    @pom_responsibility = pom_responsibility
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(
       active_prison_id, @prisoner.offender_no
     )
+
     case_information = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: id_for_show_action)
     # Only show an early allocation if it was completed after sentence start
     if case_information.present? && case_information.latest_early_allocation.present? &&
@@ -39,6 +37,27 @@ class PrisonersController < PrisonsApplicationController
   end
 
 private
+
+  def pom_responsibility
+    @pom_responsibility ||= overridden_responsibility || calculated_responsibility
+  end
+
+  def overridden_responsibility
+    override = Responsibility.find_by(nomis_offender_id: @offender.offender_no)
+    return nil if override.nil?
+
+    if override.value == Responsibility::PRISON
+      ResponsibilityService::RESPONSIBLE.to_s
+    else
+      ResponsibilityService::SUPPORTING.to_s
+    end
+  end
+
+  def calculated_responsibility
+    ResponsibilityService.calculate_pom_responsibility(
+      @offender
+    )
+  end
 
   def id_for_show_action
     params[:id]

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -30,6 +30,13 @@ feature 'View a prisoner profile page' do
       expect(cat_code).to eq('C')
     end
 
+    it 'shows an overridden responsibility', :raven_intercept_exception, vcr: { cassette_name: :show_offender_with_override_spec } do
+      create(:responsibility, nomis_offender_id: 'G7998GJ')
+      visit prison_prisoner_path('LEI', 'G7998GJ')
+
+      expect(page).to have_content('Supporting')
+    end
+
     it 'shows the prisoner image', :raven_intercept_exception, vcr: { cassette_name: :show_offender_spec_image } do
       visit prison_prisoner_image_path('LEI', 'G7998GJ', format: :jpg)
       expect(page.response_headers['Content-Type']).to eq('image/jpg')


### PR DESCRIPTION
If the prisoner has an overridden responsibility, it was not being shown
in the prisoner profile page.  Now it is.

We should probably refactor where/how we do this as we now have similar
code in two different places.

Fixes POM-502

Also created POM-504 to refactor the determination of responsibility