### PR TITLE
OffenderPresenter has a missing function that should be delegated

### DIFF
--- a/app/models/offender_presenter.rb
+++ b/app/models/offender_presenter.rb
@@ -11,7 +11,7 @@ class OffenderPresenter
            :category_code, :conditional_release_date, :automatic_release_date,
            :awaiting_allocation_for, :allocated_pom_name, :allocation_date,
            :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
-           :handover_start_date, :responsibility_handover_date,
+           :handover_start_date, :responsibility_handover_date, :nps_case?,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level,  to: :@offender
 
   def initialize(offender, responsibility)


### PR DESCRIPTION
The OffenderPresenter needs to delegate nps_case? for situations where
it is used for determining the POM recommendation.

This was not caught because the tests used a struct where this was
defined.  Adding this function should make the test reflect the object
and should enable open prisons to allocate offenders.