### PR TITLE
Fix AllocationVersion migration issue

### DIFF
--- a/db/migrate/20190503130410_create_allocation_versions_table.rb
+++ b/db/migrate/20190503130410_create_allocation_versions_table.rb
@@ -18,8 +18,6 @@ class CreateAllocationVersionsTable < ActiveRecord::Migration[5.2]
       t.integer :nomis_booking_id
       t.integer :event
       t.integer :event_trigger
-      t.datetime :created_at, null: false
-      t.datetime :updated_at, null: false
       t.timestamps
       t.index [:nomis_offender_id], name: :index_allocation_versions_on_nomis_offender_id
       t.index [:primary_pom_nomis_id], name: :index_allocation_versions_on_primary_pom_nomis_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -39,7 +39,7 @@ describe PrisonOffenderManagerService do
         expect(subject).to be_kind_of(Enumerable)
         expect(subject.count).to eq(13)
         # 1 POM in T3 (Toby Retallick) is marked inactive, so expect one less active one
-        expect(subject.select { |pom| pom.status == 'active' }.count).to eq(12)
+        expect(subject.count { |pom| pom.status == 'active' }).to eq(12)
         # would like these to both be true as integratopn test user has both positions
         # expect(moic_integration_tests.prison_officer?).to eq(true)
         expect(moic_integration_tests.probation_officer?).to eq(true)


### PR DESCRIPTION
Whilst working on setting up Heroku we discovered that the migration
which creates the AllocationVersion table contains both 't.timestamps'
and 't.datetime: created_at/updated_at'.  When trying to run db:migrate
it would throw this error: "ArgumentError: you can't define an already
defined column 'created_at'", cancelling this and all later migrations.
This PR removes the 'datetime' fields and solely relies on Rails'
timestamps, which should fix this migration.