### PR TITLE
[POM-518] Heroku - get Notify working

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma_prod.rb
-worker: bundle exec sidekiq -C config/sidekiq.yml -c 2
+worker: bundle exec sidekiq -C config/sidekiq.yml
 release: bundle exec rails db:migrate

--- a/app.json
+++ b/app.json
@@ -2,6 +2,14 @@
   "scripts": {
     "postdeploy": "bundle exec rails db:seed"
   },
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "worker": {
+      "quantity": 1
+    }
+  },
   "addons": [
     {
       "plan": "heroku-postgresql",

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,14 +26,21 @@ module OffenderManagementAllocationClient
     config.exceptions_app = routes
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
-    config.allocation_manager_host = ENV.fetch(
-      'ALLOCATION_MANAGER_HOST',
-      'http://localhost:3000'
-    )
-    Rails.application.routes.default_url_options[:host] = ENV.fetch(
-      'ALLOCATION_MANAGER_HOST',
-      'http://localhost:3000'
-    )
+    config.allocation_manager_host =
+      ENV.fetch(
+        'ALLOCATION_MANAGER_HOST',
+        'http://localhost:3000'
+  )
+    Rails.application.routes.default_url_options[:host] =
+      if ENV['HEROKU_APP_NAME'].present?
+        ENV.fetch('HEROKU_APP_NAME') + ".herokuapp.com"
+      else
+        ENV.fetch(
+          'ALLOCATION_MANAGER_HOST',
+          'http://localhost:3000'
+        )
+      end
+
     config.sentry_dsn = ENV['SENTRY_DSN']&.strip
     config.keyworker_api_host = ENV['KEYWORKER_API_HOST']&.strip
     config.digital_prison_service_host = ENV['DIGITAL_PRISON_SERVICE_HOST']&.strip

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module OffenderManagementAllocationClient
   )
     Rails.application.routes.default_url_options[:host] =
       if ENV['HEROKU_APP_NAME'].present?
-        ENV.fetch('HEROKU_APP_NAME') + ".herokuapp.com"
+        ENV.fetch('HEROKU_APP_NAME') + '.herokuapp.com'
       else
         ENV.fetch(
           'ALLOCATION_MANAGER_HOST',


### PR DESCRIPTION
At present the sidekiq worker doesn't start once a branch/PR is deployed
and this means that email jobs get sent to the Sidekiq queue, but aren't
processed.

This commit tries another configuration which specifies the number of
workers we want in the app.json file.  It also removes the default
setting of workers from the Procfile, to try and avoid
conflict/confusion.