### PR TITLE
POM-530 - Remove Ross as a POM on T3

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_095310) do
+ActiveRecord::Schema.define(version: 2019_11_26_081703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,9 @@ PomDetail.find_or_create_by!(
   working_pattern: 1
 )
 
-# Ross Jones
+# Moic POM
 PomDetail.find_or_create_by!(
-  nomis_staff_id: 485_752,
+  nomis_staff_id: 485_926,
   status: 'active',
   working_pattern: 0.2
 )

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -59,7 +59,7 @@ describe 'Allocation API' do
           primary_pom = JSON.parse(response.body)['primary_pom']
           secondary_pom = JSON.parse(response.body)['secondary_pom']
 
-          expect(primary_pom['staff_id']).to eq(485_752)
+          expect(primary_pom['staff_id']).to eq(485_926)
           expect(primary_pom['name']).to eq('Hyon Zboncak')
 
           expect(secondary_pom).to eq({})

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     end
 
     primary_pom_nomis_id do
-      485_752
+      485_926
       # using fake POM numbers tends to cause crashes
       # Faker::Number.number(digits: 7)
     end

--- a/spec/factories/movement.rb
+++ b/spec/factories/movement.rb
@@ -1,7 +1,7 @@
 require 'faker'
 
 FactoryBot.define do
-  factory :movement, class: Nomis::Movement do
+  factory :movement, class: 'Nomis::Movement' do
     skip_create
     from_agency do
       'LEI'

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Allocation' do
   let!(:probation_officer_nomis_staff_id) { 485_636 }
-  let!(:prison_officer_nomis_staff_id) { 485_752 }
+  let!(:prison_officer_nomis_staff_id) { 485_926 }
   let!(:nomis_offender_id) { 'G7266VD' }
   let(:offender_name) { 'Omistius Annole' }
   let!(:never_allocated_offender) { 'G1670VU' }
@@ -30,17 +30,17 @@ feature 'Allocation' do
     expect(page).to have_content('There is 1 POM unavailable for new allocations.')
 
     within('.recommended_pom_row_0') do
-      expect(page).to have_content 'Jones, Ross'
+      expect(page).to have_content 'Integration-Tests, Moic'
       click_link 'Allocate'
     end
 
     expect(page).to have_css('h1', text: 'Confirm allocation')
-    expect(page).to have_css('p', text: "You are allocating #{offender_name} to Ross Jones")
+    expect(page).to have_css('p', text: "You are allocating #{offender_name} to Moic Integration-Tests")
 
     click_button 'Complete allocation'
 
     expect(current_url).to have_content(prison_summary_unallocated_path('LEI'))
-    expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Ross Jones (Probation POM)")
+    expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Moic Integration-Tests (Probation POM)")
   end
 
   scenario 'overriding an allocation', vcr: { cassette_name: :override_allocation_feature_ok } do
@@ -143,6 +143,7 @@ feature 'Allocation' do
       click_link 'View'
     end
 
+
     expect(current_url).to have_content(prison_allocation_path('LEI', nomis_offender_id))
     expect(page).to have_link(nil, href: "/prisons/LEI/poms/485637")
     expect(page).to have_css('.table_cell__left_align', text: 'Pobee-Norris, Kath')
@@ -158,7 +159,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(current_url).to have_content(prison_confirm_reallocation_path('LEI', nomis_offender_id, prison_officer_nomis_staff_id))
+    expect(current_url).to have_content(prison_confirm_reallocation_path('LEI', nomis_offender_id, 485758))
 
     click_button 'Complete allocation'
 

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -143,7 +143,6 @@ feature 'Allocation' do
       click_link 'View'
     end
 
-
     expect(current_url).to have_content(prison_allocation_path('LEI', nomis_offender_id))
     expect(page).to have_link(nil, href: "/prisons/LEI/poms/485637")
     expect(page).to have_css('.table_cell__left_align', text: 'Pobee-Norris, Kath')
@@ -159,7 +158,7 @@ feature 'Allocation' do
       click_link 'Allocate'
     end
 
-    expect(current_url).to have_content(prison_confirm_reallocation_path('LEI', nomis_offender_id, 485758))
+    expect(current_url).to have_content(prison_confirm_reallocation_path('LEI', nomis_offender_id, 485_758))
 
     click_button 'Complete allocation'
 

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 feature 'Allocation History' do
   let!(:probation_pom) do
     {
-      primary_pom_nomis_id: 485_752,
-      primary_pom_name: 'Jones, Ross',
-      email: 'Ross.jonessss@digital.justice.gov.uk'
+      primary_pom_nomis_id: 485_926,
+      primary_pom_name: 'Pom, Moic',
+      email: 'pom@digital.justice.gov.uk'
     }
   end
 

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -80,8 +80,8 @@ feature "view an offender's allocation information" do
       allocation = Allocation.find_by(nomis_offender_id: nomis_offender_id_with_keyworker)
 
       allocation.update!(event: Allocation::ALLOCATE_SECONDARY_POM,
-                         secondary_pom_nomis_id: 485_752,
-                         secondary_pom_name: "Jones, Ross")
+                         secondary_pom_nomis_id: 485_926,
+                         secondary_pom_name: "Pom, Moic")
 
       visit prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id_with_keyworker)
 
@@ -89,7 +89,7 @@ feature "view an offender's allocation information" do
 
       within table_row do
         expect(page).to have_link('Remove')
-        expect(page).to have_content('Co-working POM Jones, Ross')
+        expect(page).to have_content('Co-working POM Pom, Moic')
       end
     end
 

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "ChangeParoleReviewDates", type: :feature do
   # This ID has an indeterminate sentence
   let(:nomis_offender_id) { 'G0549UO' }
   let!(:case_info) { create(:case_information, nomis_offender_id: nomis_offender_id) }
-  let!(:alloc) { create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: 485_752) }
+  let!(:alloc) { create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: 485_926) }
   let(:year) { Time.zone.today.year + 1 }
   let(:yesterday) { Time.zone.yesterday }
 

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 feature 'Co-working' do
   let!(:nomis_offender_id) { 'G4273GI' }
-  let!(:probation_pom) do
+  let!(:prison_pom) do
     {
-      staff_id: 485_752,
-      pom_name: 'Ross Jones',
-      email: 'Ross.jonessss@digital.justice.gov.uk'
+      staff_id: 485_926,
+      pom_name: 'Moic Pom',
+      email: 'pom@digital.justice.gov.uk'
     }
   end
 
@@ -29,8 +29,8 @@ feature 'Co-working' do
       create(
         :allocation,
         nomis_offender_id: nomis_offender_id,
-        primary_pom_nomis_id: probation_pom[:staff_id],
-        primary_pom_name: probation_pom[:pom_name],
+        primary_pom_nomis_id: prison_pom[:staff_id],
+        primary_pom_name: prison_pom[:pom_name],
         recommended_pom_type: 'probation'
       )
     }
@@ -80,11 +80,11 @@ feature 'Co-working' do
     scenario 'show confirm co-working POM allocation page', vcr: { cassette_name: :show_confirm_coworking_page } do
       visit prison_confirm_coworking_allocation_path(
         'LEI',
-        nomis_offender_id, probation_pom[:staff_id], secondary_pom[:staff_id]
+        nomis_offender_id, prison_pom[:staff_id], secondary_pom[:staff_id]
             )
 
       expect(page).to have_content("Confirm co-working allocation")
-      expect(page).to have_content("You are allocating co-working POM #{secondary_pom[:pom_name]} to Ozullirn Abbella. The responsible POM is #{probation_pom[:pom_name]}.")
+      expect(page).to have_content("You are allocating co-working POM #{secondary_pom[:pom_name]} to Ozullirn Abbella. The responsible POM is #{prison_pom[:pom_name]}.")
       expect(page).to have_content("We will send a confirmation email to #{secondary_pom[:email]}")
       expect(page).to have_button('Complete allocation')
       expect(page).to have_link('Cancel')
@@ -112,8 +112,8 @@ feature 'Co-working' do
       create(
         :allocation,
         nomis_offender_id: nomis_offender_id,
-        primary_pom_nomis_id: probation_pom[:staff_id],
-        primary_pom_name: probation_pom[:pom_name],
+        primary_pom_nomis_id: prison_pom[:staff_id],
+        primary_pom_name: prison_pom[:pom_name],
         secondary_pom_nomis_id: secondary_pom[:staff_id],
         secondary_pom_name: secondary_pom[:pom_name],
         recommended_pom_type: 'probation'
@@ -128,8 +128,8 @@ feature 'Co-working' do
       end
 
       expect(page).to have_current_path('/prisons/LEI/coworking/G4273GI/confirm_coworking_removal')
-      expect(page).to have_content "You are removing co-working POM #{secondary_pom[:pom_name]} who was working with Abbella, Ozullirn. The Supporting POM is #{probation_pom[:pom_name]}."
-      expect(page).to have_content "We will send a confirmation email to #{probation_pom[:email]}"
+      expect(page).to have_content "You are removing co-working POM #{secondary_pom[:pom_name]} who was working with Abbella, Ozullirn. The Supporting POM is #{prison_pom[:pom_name]}."
+      expect(page).to have_content "We will send a confirmation email to #{prison_pom[:email]}"
     end
 
     scenario 'cancel removal of a co-working POM', vcr: { cassette_name: :coworking_pom_cancel } do

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -8,7 +8,7 @@ feature 'Responsibility override' do
   end
 
   let(:offender_id) { 'G8060UF' }
-  let(:pom_id) { 485_752 }
+  let(:pom_id) { 485_926 }
 
   context 'when overriding responsibility', :queueing, vcr: { cassette_name: :override_responsibility } do
     before do

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -33,10 +33,10 @@ feature "get poms list" do
   it "allows viewing a POM", vcr: { cassette_name: :show_poms_feature_view } do
     signin_user
 
-    visit "/prisons/LEI/poms/485752"
+    visit "/prisons/LEI/poms/485926"
 
     expect(page).to have_css(".govuk-button", count: 1)
-    expect(page).to have_content("Jones, Ross")
+    expect(page).to have_content("Pom, Moic")
     expect(page).to have_content("Caseload")
     expect(page).to have_css('.govuk-breadcrumbs')
     expect(page).to have_css('.govuk-breadcrumbs__link', count: 3)
@@ -52,18 +52,18 @@ feature "get poms list" do
         prison: 'LEI',
         allocated_at_tier: 'A',
         created_by_username: 'PK000223',
-        primary_pom_nomis_id: 485_752,
+        primary_pom_nomis_id: 485_926,
         primary_pom_allocated_at: DateTime.now.utc,
-        recommended_pom_type: 'probation',
+        recommended_pom_type: 'prison',
         event: Allocation::ALLOCATE_PRIMARY_POM,
         event_trigger: Allocation::USER
       )
     end
 
-    visit "/prisons/LEI/poms/485752"
+    visit "/prisons/LEI/poms/485926"
 
     expect(page).to have_css(".govuk-button", count: 1)
-    expect(page).to have_content("Jones, Ross")
+    expect(page).to have_content("Pom, Moic")
     expect(page).to have_content("Caseload")
     expect(page).to have_css('.govuk-breadcrumbs')
     expect(page).to have_css('.govuk-breadcrumbs__link', count: 3)
@@ -90,7 +90,7 @@ feature "get poms list" do
   it "allows editing a POM", vcr: { cassette_name: :show_poms_feature_edit } do
     signin_user
 
-    visit "/prisons/LEI/poms/485752/edit"
+    visit "/prisons/LEI/poms/485926/edit"
 
     expect(page).to have_css(".govuk-button", count: 1)
     expect(page).to have_css(".govuk-radios__item", count: 14)

--- a/spec/mailers/pom_mailer_spec.rb
+++ b/spec/mailers/pom_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PomMailer, type: :mailer do
   describe 'new_allocation_email' do
     let(:params) do
       {
-        pom_name: "Jones, Ross",
+        pom_name: "Pom, Moic",
         pom_email: "something@example.com",
         responsibility: "supporting",
         offender_name: "Franks, Jason",
@@ -61,7 +61,7 @@ RSpec.describe PomMailer, type: :mailer do
         previous_pom_name: "Pobee-Norris, Kath",
         responsibility: "Supporting",
         previous_pom_email: "another@example.com",
-        new_pom_name: "Jones, Ross",
+        new_pom_name: "Pom, Moic",
         offender_name: "Marks, Simon",
         offender_no: "GE4595D",
         url: "http:://example.com",
@@ -100,7 +100,7 @@ RSpec.describe PomMailer, type: :mailer do
       {
         email_address: "something@example.com",
         pom_name: "Pobee-Norris, Kath",
-        secondary_pom_name: "Jones, Ross",
+        secondary_pom_name: "Pom, Moic",
         nomis_offender_id: "GE4595D",
         offender_name: "Marks, Simon",
         url: "http:://example.com"

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -43,7 +43,6 @@ describe AllocationService do
         to match(
           hash_including(
             "message" => message,
-            "pom_name" => "Ross",
             "offender_name" => "Abdoria, Ongmetain",
             "nomis_offender_id" => "G7806VO",
             "pom_email" => "pom@digital.justice.gov.uk",

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -10,7 +10,7 @@ describe AllocationService do
 
   describe '#allocate_secondary', :queueing do
     let(:kath_id) { 485_637 }
-    let(:ross_id) { 485_752 }
+    let(:ross_id) { 485_926 }
     let(:nomis_offender_id) { 'G7806VO' }
     let(:primary_pom_id) { ross_id }
     let(:secondary_pom_id) { kath_id }
@@ -20,7 +20,7 @@ describe AllocationService do
       create(:allocation,
              nomis_offender_id: nomis_offender_id,
              primary_pom_nomis_id: primary_pom_id,
-             primary_pom_name: 'JONES, ROSS')
+             primary_pom_name: 'Pom, Moic')
     }
 
     it 'sends an email to both primary and secondary POMS', vcr: { cassette_name: :allocation_service_allocate_secondary } do
@@ -46,8 +46,8 @@ describe AllocationService do
             "pom_name" => "Ross",
             "offender_name" => "Abdoria, Ongmetain",
             "nomis_offender_id" => "G7806VO",
-            "coworking_pom_name" => "POBEE-NORRIS, KATH",
-            "pom_email" => "Ross.jonessss@digital.justice.gov.uk",
+            "pom_email" => "pom@digital.justice.gov.uk",
+            "pom_name" => "Moic",
             "url" => "http://localhost:3000/prisons/LEI/caseload"
           ))
 
@@ -60,7 +60,7 @@ describe AllocationService do
             "offender_name" => "Abdoria, Ongmetain",
             "nomis_offender_id" => "G7806VO",
             "responsibility" => "supporting",
-            "responsible_pom_name" => 'JONES, ROSS',
+            "responsible_pom_name" => 'Pom, Moic',
             "pom_email" => "kath.pobee-norris@digital.justice.gov.uk",
             "url" => "http://localhost:3000/prisons/LEI/caseload"
           ))
@@ -94,7 +94,7 @@ describe AllocationService do
       update_params = {
         nomis_offender_id: nomis_offender_id,
         allocated_at_tier: 'B',
-        primary_pom_nomis_id: 485_752,
+        primary_pom_nomis_id: 485_926,
         event: Allocation::REALLOCATE_PRIMARY_POM,
         created_by_username: 'PK000223'
       }
@@ -151,7 +151,7 @@ describe AllocationService do
     it "Can get previous poms for an offender where there are some", versioning: true, vcr: { cassette_name: :allocation_service_previous_allocations } do
       nomis_offender_id = 'GHF1234'
       previous_primary_pom_nomis_id = 345_567
-      updated_primary_pom_nomis_id = 485_752
+      updated_primary_pom_nomis_id = 485_926
 
       allocation = create(
         :allocation,
@@ -173,7 +173,7 @@ describe AllocationService do
   it 'can get the current allocated primary POM', versioning: true, vcr: { cassette_name: 'current_allocated_primary_pom' }  do
     nomis_offender_id = 'G2911GD'
     previous_primary_pom_nomis_id = 485_637
-    updated_primary_pom_nomis_id = 485_752
+    updated_primary_pom_nomis_id = 485_926
 
     allocation = create(
       :allocation,
@@ -187,8 +187,8 @@ describe AllocationService do
 
     current_pom = described_class.current_pom_for(nomis_offender_id, 'LEI')
 
-    expect(current_pom.full_name).to eq("Jones, Ross")
-    expect(current_pom.grade).to eq("Probation POM")
+    expect(current_pom.full_name).to eq("Pom, Moic")
+    expect(current_pom.grade).to eq("Prison POM")
   end
 
   it 'can set the correct com_name', versioning: true, vcr: { cassette_name: 'allocation_service_com_name' }  do

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe EmailService do
       a.nomis_offender_id = 'G2911GD'
       a.created_by_username = 'PK000223'
       a.nomis_booking_id = 0
-      a.secondary_pom_nomis_id = 485_752
-      a.secondary_pom_name = "Jones, Ross"
+      a.secondary_pom_nomis_id = 485_926
+      a.secondary_pom_name = "Pom, Moic"
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
       a.event = Allocation::ALLOCATE_SECONDARY_POM

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -35,7 +35,7 @@ describe OffenderService do
 
   describe "#set_allocated_pom_name" do
     let(:offenders) { Prison.new('LEI').offenders.first(3) }
-    let(:nomis_staff_id) { 485_752 }
+    let(:nomis_staff_id) { 485_926 }
 
     before do
       PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
@@ -49,7 +49,7 @@ describe OffenderService do
       expect(updated_offenders).to be_kind_of(Array)
       expect(updated_offenders.first).to be_kind_of(Nomis::OffenderSummary)
       expect(updated_offenders.count).to eq(offenders.count)
-      expect(updated_offenders.first.allocated_pom_name).to eq('Jones, Ross')
+      expect(updated_offenders.first.allocated_pom_name).to eq('Pom, Moic')
       expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
     end
 
@@ -58,7 +58,7 @@ describe OffenderService do
       allocate_offender(nil)
 
       updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
-      expect(updated_offenders.first.allocated_pom_name).to eq('Jones, Ross')
+      expect(updated_offenders.first.allocated_pom_name).to eq('Pom, Moic')
       expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
     end
   end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -37,9 +37,9 @@ describe PrisonOffenderManagerService do
       it "can get a list of POMs",
          vcr: { cassette_name: :pom_service_get_poms_list } do
         expect(subject).to be_kind_of(Enumerable)
-        expect(subject.count).to eq(13)
+        expect(subject.count).to eq(12)
         # 1 POM in T3 (Toby Retallick) is marked inactive, so expect one less active one
-        expect(subject.count { |pom| pom.status == 'active' }).to eq(12)
+        expect(subject.count { |pom| pom.status == 'active' }).to eq(11)
         # would like these to both be true as integratopn test user has both positions
         # expect(moic_integration_tests.prison_officer?).to eq(true)
         expect(moic_integration_tests.probation_officer?).to eq(true)
@@ -51,7 +51,7 @@ describe PrisonOffenderManagerService do
          vcr: { cassette_name: :pom_service_get_poms_by_ids } do
         names = described_class.get_pom_names('LEI')
         expect(names).to be_kind_of(Hash)
-        expect(names.count).to eq(13)
+        expect(names.count).to eq(12)
       end
     end
 


### PR DESCRIPTION
Ross has left the team and as such we need to remove him as a POM on T3.
This PR replaces Ross with a generic POM that has been created to avoid
the issue of having to re-write tests each time a team member leaves.