### PR TITLE
Add Peterborough Female prison code

### DIFF
--- a/app/services/prison_service.rb
+++ b/app/services/prison_service.rb
@@ -92,6 +92,7 @@ class PrisonService
     PrisonInfo.new('ONI', 'HMP Onley', :england),
     PrisonInfo.new('OWI', 'HMP Oakwood', :england),
     PrisonInfo.new('PBI', 'HMP Peterborough', :england),
+    PrisonInfo.new('PFI', 'HMP Peterborough (Female)', :england),
     PrisonInfo.new('PDI', 'HMP/YOI Portland', :england),
     PrisonInfo.new('PNI', 'HMP Preston', :england),
     PrisonInfo.new('PRI', 'HMP Parc', :wales),

--- a/spec/services/prison_service_spec.rb
+++ b/spec/services/prison_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PrisonService do
 
   it "can return all the prison codes" do
     codes = described_class.prison_codes
-    expect(codes.count).to eq(124)
+    expect(codes.count).to eq(125)
   end
 
   it "will return nil for an unknown code" do


### PR DESCRIPTION
We do not currently have this prison code in our codebase, but have staff that work across both the male and female.  We have an ongoing issue with staff at Peterborough not being able to access the service and it is thought that this is down to the missing prison code