### PR TITLE
Revert "Bump listen from 3.1.5 to 3.2.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :test do
 end
 
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.3'
+  gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     fast_underscore (0.3.1)
-    ffi (1.11.3)
+    ffi (1.11.1)
     flamegraph (0.9.5)
     flipflop (2.6.0)
       activesupport (>= 4.0)
@@ -160,9 +160,10 @@ GEM
     kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    listen (3.2.1)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loaf (0.8.1)
       rails (>= 3.2)
     lograge (0.11.2)
@@ -321,6 +322,7 @@ GEM
       rubocop (>= 0.60.0)
     ruby-prof (1.0.0)
     ruby-progressbar (1.10.1)
+    ruby_dep (1.5.0)
     rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sassc (2.2.1)
@@ -432,7 +434,7 @@ DEPENDENCIES
   jwt
   kaminari
   launchy
-  listen (>= 3.0.5, < 3.3)
+  listen (>= 3.0.5, < 3.2)
   loaf
   lograge
   logstash-event


### PR DESCRIPTION
This reverts commit 5ceef92ef8a2633c6261017a81e7c64e0d123825.

It seems that it is responsible for the recent instability in our tests