### PR TITLE
Refactor 2 phase construction

### DIFF
--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -23,6 +23,8 @@ module HmppsApi
       }
     end
 
+    # This must only reference fields that are present in
+    # https://https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//prisoners/getPrisonersOffenderNo
     def load_from_json(payload)
       @booking_id = payload['latestBookingId']&.to_i
       @prison_id = payload['latestLocationId']

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -139,6 +139,10 @@ module HmppsApi
       @responsibility_override.present?
     end
 
+    # This list must only contain fields that are both supplied by
+    # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//prisoners/getPrisonersOffenderNo
+    # and also by
+    # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//locations/getOffendersAtLocationDescription
     def load_from_json(payload)
       # It is expected that this method will be called by the subclass which
       # will have been given a payload at the class level, and will call this

--- a/app/models/hmpps_api/offender_summary.rb
+++ b/app/models/hmpps_api/offender_summary.rb
@@ -24,6 +24,8 @@ module HmppsApi
       }
     end
 
+    # This list must only contain values that are returned by
+    # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//locations/getOffendersAtLocationDescription
     def load_from_json(payload)
       @booking_id = payload.fetch('bookingId').to_i
       @prison_id = payload.fetch('agencyId')

--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -11,14 +11,10 @@ module HmppsApi
                 :licence_expiry_date,
                 :sentence_start_date,
                 :tariff_date,
-                :sentence_expiry_date,
                 :actual_parole_date
 
-    def initialize(fields = {})
-      fields.each do |k, v|
-        instance_variable_set("@#{k}", v)
-      end
-    end
+    # Note - this is hiding a defect - we never get sentence_expiry_date from NOMIS (but maybe we should?)
+    attr_accessor :sentence_expiry_date
 
     def automatic_release_date
       @automatic_release_override_date.presence || @automatic_release_date

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe OffenderHelper do
     it 'can show Custody for Prison' do
       off = build(:offender).tap { |o|
         o.load_case_information(build(:case_information))
-        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                               automatic_release_date: Time.zone.today + 20.months
+        o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                         'automaticReleaseDate' => (Time.zone.today + 20.months).to_s)
       }
       offp = OffenderPresenter.new(off)
 
@@ -39,7 +39,7 @@ RSpec.describe OffenderHelper do
 
     it 'can show Community for Probation' do
       off = build(:offender).tap { |o|
-        o.sentence = HmppsApi::SentenceDetail.new automatic_release_date: Time.zone.today
+        o.sentence = HmppsApi::SentenceDetail.from_json("automaticReleaseDate" => Time.zone.today.to_s)
       }
       offp = OffenderPresenter.new(off)
 
@@ -51,8 +51,8 @@ RSpec.describe OffenderHelper do
     it 'returns false if offender is not sentenced' do
       offender = build(:offender).tap { |o|
         o.load_case_information(build(:case_information))
-        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                                  automatic_release_date: Time.zone.today + 20.months
+        o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                         'automaticReleaseDate' => (Time.zone.today + 20.months).to_s)
       }
 
       expect(offender.sentenced?).to eq(false)
@@ -62,8 +62,8 @@ RSpec.describe OffenderHelper do
     it 'returns false if offender does not have a handover start date' do
       offender = build(:offender, :indeterminate).tap { |o|
         o.load_case_information(build(:case_information))
-        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today + 20.months,
-                                                  automatic_release_date: nil
+        o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today + 20.months).to_s,
+            )
       }
 
       expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
@@ -72,9 +72,9 @@ RSpec.describe OffenderHelper do
     it 'returns false if offender has more than 45 days until start of handover' do
       offender = build(:offender).tap { |o|
         o.load_case_information(build(:case_information))
-        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                                  automatic_release_date: Time.zone.today + 20.months,
-                                                  release_date: Time.zone.today + 20.months
+        o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                         'automaticReleaseDate' => (Time.zone.today + 20.months).to_s,
+                                                         'releaseDate' => (Time.zone.today + 20.months).to_s)
       }
 
       expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
@@ -84,9 +84,9 @@ RSpec.describe OffenderHelper do
       it "returns false if offender has a 'COM'" do
         offender = build(:offender).tap { |o|
           o.load_case_information(build(:case_information, com_name: "Betty White"))
-          o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                                    automatic_release_date: Time.zone.today + 8.months,
-                                                    release_date: Time.zone.today + 20.months
+          o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                           'automaticReleaseDate' => (Time.zone.today + 8.months).to_s,
+                                                           'releaseDate' => (Time.zone.today + 20.months).to_s)
         }
 
         expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
@@ -96,9 +96,9 @@ RSpec.describe OffenderHelper do
         it "returns false if offender has an LDU email address" do
           offender = build(:offender).tap { |o|
             o.load_case_information(build(:case_information))
-            o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                                      automatic_release_date: Time.zone.today + 8.months,
-                                                      release_date: Time.zone.today + 20.months
+            o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                             'automaticReleaseDate' => (Time.zone.today + 8.months).to_s,
+                                                             'releaseDate' => (Time.zone.today + 20.months).to_s)
           }
 
           expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
@@ -107,9 +107,9 @@ RSpec.describe OffenderHelper do
         it "returns true if offender has no LDU" do
           offender = build(:offender).tap { |o|
             o.load_case_information(build(:case_information, team: nil))
-            o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                                      automatic_release_date: Time.zone.today + 8.months,
-                                                      release_date: Time.zone.today + 20.months
+            o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                              'automaticReleaseDate' => (Time.zone.today + 8.months).to_s,
+                                                              'releaseDate' => (Time.zone.today + 20.months).to_s)
           }
 
           expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(true)
@@ -119,9 +119,9 @@ RSpec.describe OffenderHelper do
           offender = build(:offender).tap { |o|
             o.load_case_information(build(:case_information,
                                           team: build(:team, local_divisional_unit: build(:local_divisional_unit, email_address: nil))))
-            o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
-                                                      automatic_release_date: Time.zone.today + 8.months,
-                                                      release_date: Time.zone.today + 20.months
+            o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
+                                                              'automaticReleaseDate' => (Time.zone.today + 8.months).to_s,
+                                                              'releaseDate' => (Time.zone.today + 20.months).to_s)
           }
 
           expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(true)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -19,14 +19,20 @@ RSpec.describe SearchHelper do
       expect(text).to eq('<a href="/prisons/LEI/allocations/A/new">Allocate</a>')
     end
 
-    it "will change to view if there is an allocation" do
-      offender = HmppsApi::Offender.new(
-        offender_no: 'A',
-        allocated_pom_name: 'Bob'
-      ).tap { |o| o.load_case_information(build(:case_information, tier: 'A')) }
+    context 'with an allocation' do
+      let(:case_info) { build(:case_information, tier: 'A') }
 
-      text, _link = cta_for_offender('LEI', offender)
-      expect(text).to eq('<a href="/prisons/LEI/allocations/A">View</a>')
+      it "will change to view" do
+        offender = HmppsApi::Offender.new(
+          offender_no: 'G1234FX'
+        ).tap { |o|
+          o.allocated_pom_name = 'Bob'
+          o.load_case_information(case_info)
+        }
+
+        text, _link = cta_for_offender('LEI', offender)
+        expect(text).to eq('<a href="/prisons/LEI/allocations/G1234FX">View</a>')
+      end
     end
   end
 end

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -80,8 +80,8 @@ describe HmppsApi::Offender do
     context 'when in custody' do
       let(:offender) {
         build(:offender).tap { |o|
-          o.sentence = HmppsApi::SentenceDetail.new(automatic_release_date: Time.zone.today + 1.year,
-                                                 sentence_start_date: Time.zone.today)
+          o.sentence = HmppsApi::SentenceDetail.from_json('automaticReleaseDate' => (Time.zone.today + 1.year).to_s,
+                                                           'sentenceStartDate' => Time.zone.today.to_s)
           o.load_case_information(build(:case_information, case_allocation: 'NPS', mappa_level: 0))
         }
       }

--- a/spec/models/hmpps_api/offender_summary_spec.rb
+++ b/spec/models/hmpps_api/offender_summary_spec.rb
@@ -15,7 +15,7 @@ describe HmppsApi::OffenderSummary do
 
       context 'with just the sentence expiry date' do
         before do
-          subject.sentence = HmppsApi::SentenceDetail.new(sentence_expiry_date: today_plus1)
+          subject.sentence = HmppsApi::SentenceDetail.new.tap { |s| s.sentence_expiry_date = today_plus1 }
         end
 
         it 'uses the SED' do
@@ -25,10 +25,12 @@ describe HmppsApi::OffenderSummary do
 
       context 'with many dates' do
         before do
-          subject.sentence = HmppsApi::SentenceDetail.new(sentence_expiry_date: sentence_expiry_date,
-                                                       licence_expiry_date: licence_expiry_date,
-                                                       nomis_post_recall_release_date: post_recall_release_date,
-                                                       actual_parole_date: actual_parole_date)
+          subject.sentence = HmppsApi::SentenceDetail.from_json(
+            'licenceExpiryDate' => licence_expiry_date.to_s,
+            'postRecallReleaseDate' => post_recall_release_date.to_s,
+            'actualParoleDate' => actual_parole_date.to_s).tap { |detail|
+            detail.sentence_expiry_date = sentence_expiry_date
+          }
         end
 
         context 'with future dates' do
@@ -77,10 +79,10 @@ describe HmppsApi::OffenderSummary do
 
     context 'with sentence detail with dates' do
       before do
-        subject.sentence = HmppsApi::SentenceDetail.new(
-          sentence_start_date: Date.new(2005, 2, 3),
-          parole_eligibility_date: parole_eligibility_date,
-          conditional_release_date: conditional_release_date)
+        subject.sentence = HmppsApi::SentenceDetail.from_json(
+          'sentenceStartDate' => Date.new(2005, 2, 3).to_s,
+          'paroleEligibilityDate' => parole_eligibility_date.to_s,
+          'conditionalReleaseDate' => conditional_release_date.to_s)
       end
 
       context 'when comprised of dates in the past and the future' do
@@ -110,9 +112,9 @@ describe HmppsApi::OffenderSummary do
   describe '#sentenced?' do
     context 'with sentence detail with a release date' do
       before do
-        subject.sentence = HmppsApi::SentenceDetail.new(
-          sentence_start_date: Date.new(2005, 2, 3),
-          release_date: Time.zone.today)
+        subject.sentence = HmppsApi::SentenceDetail.from_json(
+          'sentenceStartDate' => Date.new(2005, 2, 3).to_s,
+          'releaseDate' => Time.zone.today.to_s)
       end
 
       it 'marks the offender as sentenced' do

--- a/spec/models/hmpps_api/sentence_detail_spec.rb
+++ b/spec/models/hmpps_api/sentence_detail_spec.rb
@@ -7,7 +7,7 @@ describe HmppsApi::SentenceDetail, model: true do
   describe "#automatic_release_date" do
     context "when override present" do
       subject {
-        described_class.new automatic_release_date: date, automatic_release_override_date: override
+        described_class.from_json 'automaticRelease_date' => date.to_s, 'automaticReleaseOverrideDate' => override.to_s
       }
 
       it "overrides" do
@@ -17,7 +17,7 @@ describe HmppsApi::SentenceDetail, model: true do
 
     context "without override" do
       subject {
-        described_class.new automatic_release_date: date, automatic_release_override_date: nil
+        described_class.from_json('automaticReleaseDate' => date.to_s)
       }
 
       it "uses original" do
@@ -29,7 +29,7 @@ describe HmppsApi::SentenceDetail, model: true do
   describe "#conditional_release_date" do
     context "when override present" do
       subject {
-        described_class.new conditional_release_date: date, conditional_release_override_date: override
+        described_class.from_json 'conditionalReleaseDate' => date.to_s, 'conditionalReleaseOverrideDate' => override.to_s
       }
 
       it "overrides" do
@@ -39,7 +39,7 @@ describe HmppsApi::SentenceDetail, model: true do
 
     context "without override" do
       subject {
-        described_class.new conditional_release_date: date
+        described_class.from_json('conditionalReleaseDate' => date.to_s)
       }
 
       it "uses original" do
@@ -49,18 +49,20 @@ describe HmppsApi::SentenceDetail, model: true do
   end
 
   describe "#nomis_post_recall_release_date" do
-    subject do
-      described_class.new nomis_post_recall_release_date: date, nomis_post_recall_release_override_date: override
-    end
-
     context "when override present" do
+      subject do
+        described_class.from_json('postRecallReleaseDate' => date.to_s, 'postRecallReleaseOverrideDate' => override.to_s)
+      end
+
       it "overrides" do
         expect(subject.nomis_post_recall_release_date).to eq(override)
       end
     end
 
     context "without override" do
-      let(:override) { nil }
+      subject do
+        described_class.from_json('postRecallReleaseDate' => date.to_s)
+      end
 
       it "uses original" do
         expect(subject.nomis_post_recall_release_date).to eq(date)
@@ -70,9 +72,14 @@ describe HmppsApi::SentenceDetail, model: true do
 
   describe "#post_recall_release_date" do
     subject {
-      described_class.new automatic_release_date: date,
-                          automatic_release_override_date: override,
-                          actual_parole_date: actual_parole_date
+      if actual_parole_date.nil?
+        described_class.from_json 'automaticReleaseDate' => date.to_s,
+                                  'automaticReleaseOverrideDate' => override.to_s
+      else
+        described_class.from_json 'automaticReleaseDate' => date.to_s,
+                                  'automaticReleaseOverrideDate' => override.to_s,
+                                  'actualParoleDate' => actual_parole_date.to_s
+      end
     }
 
     let(:earliest_date) { Date.new(2019, 1, 2) }

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 describe RecommendationService do
   let(:tier_a) {
     build(:offender,
-          sentence: HmppsApi::SentenceDetail.new(
-            sentence_start_date: Time.zone.today,
-            automatic_release_date: Time.zone.today + 15.months)).tap { |o|
+          sentence: HmppsApi::SentenceDetail.from_json(
+            'sentenceStartDate' => Time.zone.today.to_s,
+            'automaticReleaseRate' => (Time.zone.today + 15.months).to_s)).tap { |o|
       o.load_case_information(build(:case_information, tier: 'A'))
     }
   }
   let(:tier_d) {
     build(:offender,
-          sentence: HmppsApi::SentenceDetail.new(
-            sentence_start_date: Time.zone.today,
-            automatic_release_date: Time.zone.today + 10.months)).tap { |o|
+          sentence: HmppsApi::SentenceDetail.from_json(
+            'sentenceStartDate' => Time.zone.today.to_s,
+            'automaticReleaseDate' => (Time.zone.today + 10.months).to_s)).tap { |o|
       o.load_case_information(build(:case_information, tier: 'D'))
     }
   }

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe "debugging/debugging", type: :view do
   let(:offender) do
-    offender = build(:offender, firstName: 'John', lastName: 'Dory')
-    offender.sentence = HmppsApi::SentenceDetail.new(
-      sentence_start_date: Time.zone.today,
-      automatic_release_date: Time.zone.today + 10.months,
-      tariff_date: Date.new(2033, 8, 1),
-      nomis_post_recall_release_date: Date.new(2028, 11, 8),
-      licence_expiry_date: Date.new(2025, 10, 7))
-    return offender
+    build(:offender, firstName: 'John', lastName: 'Dory').tap { |offender|
+      offender.sentence = HmppsApi::SentenceDetail.from_json(
+        'sentenceStartDate' => Time.zone.today.to_s,
+        'automaticReleaseDate' => (Time.zone.today + 10.months).to_s,
+        'tariffDate' => Date.new(2033, 8, 1).to_s,
+        'postRecallReleaseDate' => Date.new(2028, 11, 8).to_s,
+        'licenceExpiryDate' => Date.new(2025, 10, 7).to_s)
+    }
   end
 
   let(:prison) { build(:prison) }


### PR DESCRIPTION
Getting rid of 2-phase construction (new followed by attribute assignment) should allow us to convert a lot of attr_accessors into attr_readers and thus make our Offender models have greater encapsulation.

It also removes the SentenceDetail constructor used by tests, which hid a subtle bug around sentenceExpiryDate where we never read that field from NOMIS 