### PR TITLE
remove earliest_release_date from sentence details

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -2,10 +2,9 @@
 
 # This class is a 'presenter' designed to prevent clients having to know whether
 # a field lives in the allocation or sentence details when both are returned
-# e.g. PomCaseload.new().allocations
 #
 class AllocatedOffender
-  delegate :last_name, :full_name, :earliest_release_date,
+  delegate :last_name, :full_name,
            :sentence_start_date, :tier, to: :@offender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at,
            to: :@allocation
@@ -16,6 +15,10 @@ class AllocatedOffender
     @staff_id = staff_id
     @allocation = allocation
     @offender = offender
+  end
+
+  def earliest_release_date
+    HandoverDateService.earliest_release_date(@offender)
   end
 
   def pom_responsibility

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -80,10 +80,6 @@ module Nomis
       sentence_type_code == 'DET'
     end
 
-    def earliest_release_date
-      sentence.earliest_release_date
-    end
-
     def pom_responsibility
       ResponsibilityService.calculate_pom_responsibility(self)
     end

--- a/app/models/nomis/sentence_detail.rb
+++ b/app/models/nomis/sentence_detail.rb
@@ -24,17 +24,6 @@ module Nomis
       @conditional_release_override_date.presence || @conditional_release_date
     end
 
-    def earliest_release_date
-      dates = [
-          release_date,
-          parole_eligibility_date,
-          tariff_date
-      ].compact
-      return nil if dates.empty?
-
-      dates.min.to_date
-    end
-
     def full_name
       "#{last_name}, #{first_name}".titleize
     end

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -7,7 +7,7 @@ class OffenderPresenter
            :sentence_start_date, :team, :prison_id,
            :home_detention_curfew_eligibility_date, :tariff_date,
            :date_of_birth, :release_date, :parole_eligibility_date,
-           :welsh_offender, :case_allocation, :earliest_release_date,
+           :welsh_offender, :case_allocation,
            :category_code, :conditional_release_date, :automatic_release_date,
            :awaiting_allocation_for, :allocated_pom_name, :allocation_date,
            :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
@@ -17,6 +17,10 @@ class OffenderPresenter
   def initialize(offender, responsibility)
     @offender = offender
     @responsibility = responsibility
+  end
+
+  def earliest_release_date
+    HandoverDateService.earliest_release_date(@offender.sentence)
   end
 
   def pom_responsibility

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -4,7 +4,7 @@ class HandoverDateService
   HandoverData = Struct.new :start_date, :handover_date, :reason
 
   def self.handover(offender)
-    if offender.earliest_release_date.nil?
+    if earliest_release_date(offender).nil?
       HandoverData.new nil, nil, 'No earliest release date'
     elsif offender.nps_case?
       date, reason = nps_handover_date(offender)
@@ -14,15 +14,23 @@ class HandoverDateService
     end
   end
 
+  def self.earliest_release_date(offender)
+    [
+      offender.release_date,
+      offender.parole_eligibility_date,
+      offender.tariff_date
+    ].compact.min
+  end
+
 private
 
   def self.nps_start_date(offender)
     if offender.early_allocation?
       early_allocation_handover_date(offender)
     elsif offender.indeterminate_sentence?
-      offender.earliest_release_date - 8.months
+      earliest_release_date(offender) - 8.months
     else
-      offender.earliest_release_date - (7.months + 15.days)
+      earliest_release_date(offender) - (7.months + 15.days)
     end
   end
 

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -15,9 +15,9 @@ class ResponsibilityService
   def self.calculate_pom_responsibility(offender)
     if offender.immigration_case? || open_prison_nps_offender?(offender)
       SUPPORTING
-    elsif offender.earliest_release_date.nil?
+    elsif HandoverDateService.earliest_release_date(offender).nil?
       RESPONSIBLE
-    elsif offender.indeterminate_sentence? && offender.earliest_release_date < Time.zone.today
+    elsif offender.indeterminate_sentence? && HandoverDateService.earliest_release_date(offender) < Time.zone.today
       RESPONSIBLE
     else
       standard_rules(offender)
@@ -60,7 +60,7 @@ private
   private
 
     def release_date_gt_10_mths?(offender)
-      offender.earliest_release_date >
+      HandoverDateService.earliest_release_date(offender) >
         DateTime.now.utc.to_date + 10.months
     end
   end
@@ -91,7 +91,7 @@ private
     end
 
     def release_date_gt_15_mths_at_policy_date?(offender)
-      offender.earliest_release_date >
+      HandoverDateService.earliest_release_date(offender) >
         WELSH_POLICY_START_DATE + 15.months
     end
   end
@@ -133,7 +133,7 @@ private
     end
 
     def release_date_gt_mths_at_policy_date?(offender, threshold)
-      offender.earliest_release_date >
+      HandoverDateService.earliest_release_date(offender) >
         ORIGINAL_ENGLISH_POLICY_START_DATE + threshold
     end
   end
@@ -167,7 +167,7 @@ private
   end
 
   def self.release_date_gt_12_weeks?(offender)
-    offender.earliest_release_date >
+    HandoverDateService.earliest_release_date(offender) >
       DateTime.now.utc.to_date + 12.weeks
   end
 end

--- a/spec/models/nomis/offender_summary_spec.rb
+++ b/spec/models/nomis/offender_summary_spec.rb
@@ -4,7 +4,6 @@ describe Nomis::OffenderSummary, model: true do
   it "handles no earliest date" do
     o = described_class.new
     o.sentence = Nomis::SentenceDetail.new
-    expect(o.sentence.earliest_release_date).to be_nil
     expect(o.sentenced?).to be false
   end
 
@@ -15,7 +14,7 @@ describe Nomis::OffenderSummary, model: true do
       off.sentence.release_date = Date.new(2010, 1, 1)
       off.sentence.parole_eligibility_date = Date.new(2009, 1, 1)
     }
-    expect(o.sentence.earliest_release_date).to eq(Date.new(2009, 1, 1))
+    expect(HandoverDateService.earliest_release_date(o.sentence)).to eq(Date.new(2009, 1, 1))
     expect(o.sentenced?).to be true
   end
 end

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -14,7 +14,7 @@ describe HandoverDateService do
       context 'with normal allocation' do
         let(:release_date) { Date.new(2020, 8, 30) }
 
-        let(:offender) { OpenStruct.new(indeterminate_sentence?: indeterminate, nps_case?: true, earliest_release_date: release_date) }
+        let(:offender) { OpenStruct.new(indeterminate_sentence?: indeterminate, nps_case?: true, release_date: release_date) }
 
         context 'with determinate sentence' do
           let(:indeterminate) { false }
@@ -45,15 +45,24 @@ describe HandoverDateService do
 
   describe '#responsibility_handover_date' do
     context 'when CRC' do
-      before do
-        stub_const("CRCHandoverData", Struct.new(:nps_case?, :home_detention_curfew_eligibility_date, :conditional_release_date, :earliest_release_date, :result))
+      # rubocop:disable RSpec/LeakyConstantDeclaration
+      CrcHandoverData = Struct.new(:nps_case?, :home_detention_curfew_eligibility_date, :conditional_release_date, :release_date, :result) do
+        def tariff_date
+          nil
+        end
 
+        def parole_eligibility_date
+          nil
+        end
+      end
+      # rubocop:enable RSpec/LeakyConstantDeclaration
+      before do
         stub_const("CRC_CASES", [
-            CRCHandoverData.new(false, Date.new(2019, 9, 30), Date.new(2019, 8, 1), Date.new(2019, 8, 1), Date.new(2019, 5, 9)), # 12 weeks before CRD
-            CRCHandoverData.new(false, Date.new(2019, 8, 1), Date.new(2019, 8, 12), Date.new(2019, 8, 1), Date.new(2019, 5, 9)), # 12 weeks before HDC date
-            CRCHandoverData.new(false, nil, Date.new(2019, 8, 1), Date.new(2019, 5, 9), Date.new(2019, 5, 9)), # 12 weeks before CRD date
-            CRCHandoverData.new(false, Date.new(2019, 8, 1), nil, Date.new(2019, 8, 1), Date.new(2019, 5, 9)), # 12 weeks before HDC date
-            CRCHandoverData.new(false, nil, nil, nil, nil) # no handover date
+          CrcHandoverData.new(false, Date.new(2019, 9, 30), Date.new(2019, 8, 1), Date.new(2019, 8, 1), Date.new(2019, 5, 9)), # 12 weeks before CRD
+          CrcHandoverData.new(false, Date.new(2019, 8, 1), Date.new(2019, 8, 12), Date.new(2019, 8, 1), Date.new(2019, 5, 9)), # 12 weeks before HDC date
+          CrcHandoverData.new(false, nil, Date.new(2019, 8, 1), Date.new(2019, 5, 9), Date.new(2019, 5, 9)), # 12 weeks before CRD date
+          CrcHandoverData.new(false, Date.new(2019, 8, 1), nil, Date.new(2019, 8, 1), Date.new(2019, 5, 9)), # 12 weeks before HDC date
+          CrcHandoverData.new(false, nil, nil, nil, nil) # no handover date
         ])
       end
 
@@ -73,7 +82,7 @@ describe HandoverDateService do
                          early_allocation?: true,
                          conditional_release_date: crd,
                          automatic_release_date: ard,
-                         earliest_release_date: erd)
+                         release_date: erd)
         }
 
         context 'when CRD earliest' do
@@ -125,7 +134,7 @@ describe HandoverDateService do
                            automatic_release_date: Date.new(2020, 8, 16),
                            parole_eligibility_date: parole_date,
                            tariff_date: Date.new(2020, 11, 1),
-                           earliest_release_date: Date.new(2020, 8, 16))
+                           release_date: Date.new(2020, 8, 16))
           }
 
           context 'with parole date' do
@@ -207,7 +216,7 @@ describe HandoverDateService do
                            nps_case?: true,
                            parole_eligibility_date: parole_date,
                            tariff_date: tariff_date,
-                           earliest_release_date: erd)
+                           release_date: erd)
           }
 
           context 'with tariff date earliest' do

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -20,7 +20,7 @@ describe ResponsibilityService do
       let(:offender) {
         OpenStruct.new indeterminate_sentence?: true,
                        recalled?: false,
-                       earliest_release_date: Time.zone.today - 1.year,
+                       release_date: Time.zone.today - 1.year,
                        sentenced?: true
       }
 
@@ -37,7 +37,7 @@ describe ResponsibilityService do
                        nps_case?: true,
                        indeterminate_sentence?: true,
                        recalled?: false,
-                       earliest_release_date: Time.zone.today - 1.year,
+                       release_date: Time.zone.today - 1.year,
                        sentenced?: true
       }
 
@@ -55,7 +55,7 @@ describe ResponsibilityService do
                        indeterminate_sentence?: false,
                        recalled?: recalled,
                        sentence_start_date: start_date,
-                       earliest_release_date: release_date,
+                       release_date: release_date,
                        parole_eligibility_date: parole_date,
                        sentenced?: true,
                        prison_id: prison
@@ -317,7 +317,7 @@ describe ResponsibilityService do
         let(:offender) {
           OpenStruct.new welsh_offender: true,
                          recalled?: true,
-                         earliest_release_date: Date.new(2021, 1, 2),
+                         release_date: Date.new(2021, 1, 2),
                          sentenced?: true
         }
 


### PR DESCRIPTION
Comments welcomed - not convinced that this necessarily helps. The issue seems more around release_date - although recent comments from Louise Ball do seem to back up the use of the PED/TED/release_date field so maybe this isn't necessary?