### PR TITLE
POM-605 - Fix responsibility calc on debugging page

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -4,11 +4,13 @@ class DebuggingController < PrisonsApplicationController
   def debugging
     nomis_offender_id = id
 
-    @offender = offender(nomis_offender_id)
-    if @offender.present?
-      @offender = OffenderPresenter.new(@offender, nil)
+    prisoner = OffenderService.get_offender(nomis_offender_id)
+
+    if prisoner.present?
+      @offender = OffenderPresenter.new((prisoner),
+                            Responsibility.find_by(nomis_offender_id: nomis_offender_id))
+
       @allocation = Allocation.find_by(nomis_offender_id: @offender.offender_no)
-      @override = Responsibility.find_by(nomis_offender_id: @offender.offender_no)
       @movements =
         Nomis::Elite2::MovementApi.movements_for(@offender.offender_no).last
     end
@@ -56,9 +58,9 @@ private
     params[:offender_no]
   end
 
-  def offender(offender_no)
-    return nil if offender_no.blank?
-
-    OffenderService.get_offender(offender_no)
-  end
+  # def offender(offender_no)
+  #   return nil if offender_no.blank?
+  #
+  #   OffenderService.get_offender(offender_no)
+  # end
 end

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -7,8 +7,8 @@ class DebuggingController < PrisonsApplicationController
     prisoner = OffenderService.get_offender(nomis_offender_id)
 
     if prisoner.present?
-      @offender = OffenderPresenter.new((prisoner),
-                            Responsibility.find_by(nomis_offender_id: nomis_offender_id))
+      @offender = OffenderPresenter.new(prisoner,
+                                        Responsibility.find_by(nomis_offender_id: nomis_offender_id))
 
       @allocation = Allocation.find_by(nomis_offender_id: @offender.offender_no)
       @movements =

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class OffenderPresenter
-
   attr_reader :offender
 
   delegate :offender_no, :first_name, :last_name, :booking_id,

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class OffenderPresenter
+
+  attr_reader :offender
+
   delegate :offender_no, :first_name, :last_name, :booking_id,
            :indeterminate_sentence?, :sentence_type_code, :describe_sentence,
            :full_name_ordered, :full_name, :main_offence,

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -241,6 +241,43 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 <% end %>
 
+  <table class="govuk-table" id="community_information">
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Community information</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Local divisional unit (LDU)</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= @offender.ldu.try(:name) || "Unknown"%>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Local divisional unit (LDU) email address</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <% if @offender.ldu.try(:email_address) %>
+          <%= mail_to(@offender.ldu.email_address, @offender.ldu.email_address) %>
+        <% else %>
+          Unknown
+        <% end %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Team</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= @offender.team.presence || "Unknown"%>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+        <%= @allocation&.com_name.presence || "Unknown" %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+
 <% unless @movements.blank? %>
   <table class="govuk-table">
     <tbody class="govuk-table__body">

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -12,7 +12,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 34)
+      expect(page).to have_css('tbody tr', count: 39)
       expect(page).to have_content("Not currently allocated")
 
       table_row = page.find(:css, 'tr.govuk-table__row#convicted', text: 'Convicted?')
@@ -34,7 +34,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 39)
+      expect(page).to have_css('tbody tr', count: 44)
 
       pom_table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
 


### PR DESCRIPTION
The responsibility and POM role haven't been displaying the correct data
IF a case responsibility has been overridden.  The controller has been
updated to ensure this is now correct by making use of the Offender
Presenter.

Also, I've added COM/LDU (community info) to the debugging page as Laura
requested this