### PR TITLE
Remove any whitespace surrounding offender ids when searching

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -2,7 +2,6 @@
 
 class DebuggingController < PrisonsApplicationController
   def debugging
-
     nomis_offender_id = id.present? ? id.strip! : id
 
     @offender = offender(nomis_offender_id)

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -2,7 +2,8 @@
 
 class DebuggingController < PrisonsApplicationController
   def debugging
-    nomis_offender_id = id
+
+    nomis_offender_id = id.present? ? id.strip! : id
 
     @offender = offender(nomis_offender_id)
     if @offender.present?

--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -2,7 +2,7 @@
 
 class DebuggingController < PrisonsApplicationController
   def debugging
-    nomis_offender_id = id.present? ? id.strip! : id
+    nomis_offender_id = id
 
     @offender = offender(nomis_offender_id)
     if @offender.present?
@@ -53,7 +53,7 @@ private
   end
 
   def id
-    params[:offender_no]
+    params[:offender_no].present? ? params[:offender_no].strip : params[:offender_no]
   end
 
   def offender(offender_no)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,7 +11,7 @@ class SearchController < PrisonsApplicationController
       redirect_to(prison_caseload_index_path(q: search_term)) && return
     end
 
-    @q = search_term
+    @q = search_term.strip!
     offenders = SearchService.search_for_offenders(@q, @prison)
     @offenders = get_slice_for_page(offenders)
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,7 +11,7 @@ class SearchController < PrisonsApplicationController
       redirect_to(prison_caseload_index_path(q: search_term)) && return
     end
 
-    @q = search_term.strip!
+    @q = search_term
     offenders = SearchService.search_for_offenders(@q, @prison)
     @offenders = get_slice_for_page(offenders)
 
@@ -36,6 +36,6 @@ private
   end
 
   def search_term
-    params['q']
+    params['q'].strip
   end
 end


### PR DESCRIPTION
The search and debugging pages return no offender(s) if whitespace exists, so we're going to strip the string of these to avoid this scenario