### PR TITLE
Update prison offender manager service spec tests

### DIFF
--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -37,9 +37,9 @@ describe PrisonOffenderManagerService do
       it "can get a list of POMs",
          vcr: { cassette_name: :pom_service_get_poms_list } do
         expect(subject).to be_kind_of(Enumerable)
-        expect(subject.count).to eq(12)
+        expect(subject.count).to eq(14)
         # 1 POM in T3 (Toby Retallick) is marked inactive, so expect one less active one
-        expect(subject.count { |pom| pom.status == 'active' }).to eq(11)
+        expect(subject.count { |pom| pom.status == 'active' }).to eq(13)
         # would like these to both be true as integratopn test user has both positions
         # expect(moic_integration_tests.prison_officer?).to eq(true)
         expect(moic_integration_tests.probation_officer?).to eq(true)
@@ -51,7 +51,7 @@ describe PrisonOffenderManagerService do
          vcr: { cassette_name: :pom_service_get_poms_by_ids } do
         names = described_class.get_pom_names('LEI')
         expect(names).to be_kind_of(Hash)
-        expect(names.count).to eq(12)
+        expect(names.count).to eq(14)
       end
     end
 


### PR DESCRIPTION
We have added two additional prison POMs so we have updated the
tests to reflect this change.