### PR TITLE
Fix responsibility override on debugging page

### DIFF
--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OffenderPresenter
-  attr_reader :offender
+  attr_reader :offender, :responsibility
 
   delegate :offender_no, :first_name, :last_name, :booking_id,
            :indeterminate_sentence?, :sentence_type_code, :describe_sentence,

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -100,7 +100,7 @@
     <tr class="govuk-table__row" id="responsibility-override">
       <td class="govuk-table__cell govuk-!-width-one-half">Responsibility overridden?</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-        <%= @override.nil? ? 'No' : 'Yes' %>
+        <%= @offender.responsibility.present? ? 'Yes' : 'No' %>
       </td>
     </tr>
     <tr class="govuk-table__row">


### PR DESCRIPTION
The 'responsibility overridden?' section of the debugging page hadn't
been updated to reflect the changes we've been making, and has been
displaying the answer to whether the recommended POM type was overridden
at allocation.  Therefore this PR updates the page to display whether
the case responsibility has been overridden to the community or not.