### PR TITLE
Return 'unknown', not error, if dates are missing

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -19,7 +19,10 @@ class HandoverDateService
 private
 
   def self.nps_start_date(offender)
-    if offender.early_allocation?
+    if offender.conditional_release_date.blank? &&
+      offender.automatic_release_date.blank?
+     'Unknown'
+    elsif offender.early_allocation?
       offender.conditional_release_date - 18.months
     elsif offender.indeterminate_sentence?
       offender.tariff_date - 8.months # earliest_release_date

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -53,6 +53,20 @@ describe HandoverDateService do
         expect(described_class.handover(offender).start_date).to eq(Date.new(2019, 12, 2))
       end
     end
+
+    context 'when data is missing' do
+      let(:offender) {
+        OpenStruct.new indeterminate_sentence?: false,
+                       nps_case?: true,
+                       automatic_release_date: nil,
+                       tariff_date: nil
+      }
+
+      it 'is unknown' do
+        result = described_class.handover(offender)
+        expect(result.start_date).to eq("Unknown")
+      end
+    end
   end
 
   describe '#responsibility_handover_date' do


### PR DESCRIPTION
Notably, this is a change in what this method returns, so if a component higher up the stack is expecting a Date (and this isn't covered by acceptance specs), this may not fix the issue.