### PR TITLE
Update Handover calculation to catch more cases

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -8,6 +8,12 @@ class HandoverDateService
       HandoverData.new nil, nil, 'Recall case - no handover date calculation'
     elsif offender.nps_case? && offender.indeterminate_sentence? && offender.tariff_date.nil?
       HandoverData.new nil, nil, 'No earliest release date'
+    elsif offender.nps_case? &&
+        !offender.indeterminate_sentence? &&
+        offender.automatic_release_date.nil? &&
+        offender.conditional_release_date.nil? &&
+        offender.parole_eligibility_date.nil?
+      HandoverData.new nil, nil, 'No earliest release date'
     elsif offender.nps_case?
       date, reason = nps_handover_date(offender)
       HandoverData.new nps_start_date(offender), date, reason

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -3,6 +3,8 @@
 class HandoverDateService
   HandoverData = Struct.new :start_date, :handover_date, :reason
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def self.handover(offender)
     if offender.recalled?
       HandoverData.new nil, nil, 'Recall case - no handover date calculation'
@@ -21,6 +23,8 @@ class HandoverDateService
       HandoverData.new nil, crc_handover_date(offender), 'CRC Case'
     end
   end
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/PerceivedComplexity
 
 private
 


### PR DESCRIPTION
Following the deployment of the responsibility and handover calculations
we started getting errors in regards to handover dates failing due to
determinate offenders not having conditional release dates, automatic
release dates or parole eligibilty dates.  This is a temporary fix to
catch these cases, and display no handover date due to not having
'earliest release date'. We will then need to decide how to proceed with
these cases moving forwards.