### PR TITLE
Revert "Update Handover calculation to catch more cases"

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -3,18 +3,10 @@
 class HandoverDateService
   HandoverData = Struct.new :start_date, :handover_date, :reason
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def self.handover(offender)
     if offender.recalled?
       HandoverData.new nil, nil, 'Recall case - no handover date calculation'
     elsif offender.nps_case? && offender.indeterminate_sentence? && offender.tariff_date.nil?
-      HandoverData.new nil, nil, 'No earliest release date'
-    elsif offender.nps_case? &&
-        !offender.indeterminate_sentence? &&
-        offender.automatic_release_date.nil? &&
-        offender.conditional_release_date.nil? &&
-        offender.parole_eligibility_date.nil?
       HandoverData.new nil, nil, 'No earliest release date'
     elsif offender.nps_case?
       date, reason = nps_handover_date(offender)
@@ -23,8 +15,6 @@ class HandoverDateService
       HandoverData.new nil, crc_handover_date(offender), 'CRC Case'
     end
   end
-# rubocop:enable Metrics/CyclomaticComplexity
-# rubocop:enable Metrics/PerceivedComplexity
 
 private
 


### PR DESCRIPTION
Reverts ministryofjustice/offender-management-allocation-manager#1070

This needs to be reverted as a fix to the handover dates, which is part of a larger piece of work that we're now reverting