### PR TITLE
Expose post recall release dates

### DIFF
--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -1,6 +1,7 @@
 module Nomis
   class OffenderBase
     delegate :home_detention_curfew_eligibility_date,
+             :post_recall_release_date, :post_recall_release_override_date,
              :conditional_release_date, :release_date,
              :parole_eligibility_date, :tariff_date,
              :automatic_release_date,

--- a/app/models/nomis/sentence_detail.rb
+++ b/app/models/nomis/sentence_detail.rb
@@ -7,6 +7,8 @@ module Nomis
     attr_accessor :first_name, :last_name,
                   :home_detention_curfew_eligibility_date,
                   :parole_eligibility_date,
+                  :post_recall_release_date,
+                  :post_recall_release_override_date,
                   :release_date,
                   :sentence_start_date,
                   :tariff_date
@@ -50,6 +52,8 @@ module Nomis
         obj.sentence_start_date = deserialise_date(payload, 'sentenceStartDate')
         obj.tariff_date = deserialise_date(payload, 'tariffDate')
         obj.automatic_release_date = deserialise_date(payload, 'automaticReleaseDate')
+        obj.post_recall_release_date = deserialise_date(payload, 'postRecallReleaseDate')
+        obj.post_recall_release_override_date = deserialise_date(payload, 'postRecallReleaseOverrideDate')
         obj.conditional_release_date = deserialise_date(
           payload, 'conditionalReleaseDate'
         )

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -14,6 +14,7 @@ class OffenderPresenter
            :awaiting_allocation_for, :allocated_pom_name, :allocation_date,
            :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
+           :post_recall_release_date, :post_recall_release_override_date,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level,  to: :@offender
 
   def initialize(offender, responsibility)


### PR DESCRIPTION
Whilst investigating issues with POM-574 where we stopped using
Elite2's 'release_date' field in favour of the underlying dates, we
found that cases with post recall dates are not showing properly.
This exposes these dates within the app so we can investigate further