### PR TITLE
Fix summary helper spec

### DIFF
--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -2,13 +2,21 @@ require 'rails_helper'
 
 RSpec.describe SummaryHelper do
   it "says schedule is tomorrow if arrival date is today" do
-    sched = delius_schedule_for(Time.zone.today)
-    expect(sched).to eq('Tomorrow')
+    # '18/11/2019' was a Monday. We need to travel to a weekday
+    # as otherwise this will fail if run over the weekend
+    Timecop.travel(Date.parse('18/11/2019')) do
+      sched = delius_schedule_for(Time.zone.today)
+      expect(sched).to eq('Tomorrow')
+    end
   end
 
   it "says schedule is today if arrival date is yesterday" do
-    sched = delius_schedule_for(Time.zone.today - 1.day)
-    expect(sched).to eq('Today')
+    # '19/11/2019' was a Tuesday. We need to travel to a weekday
+    # as otherwise this will fail if run over the weekend
+    Timecop.travel(Date.parse('19/11/2019')) do
+      sched = delius_schedule_for(Time.zone.today - 1.day)
+      expect(sched).to eq('Today')
+    end
   end
 
   it "says monday if today is not mon-fri" do


### PR DESCRIPTION
The summary helper specs need to be updated to use Timecop to travel on
the first two specs to ensure they run on a week day, as otherwise if
the specs are run over the weekend they'll fail