### PR TITLE
Add tests around the minimum data needed from NOMIS

### DIFF
--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -9,7 +9,20 @@ context 'when NOMIS is missing information' do
     stub_user_name = 'example_user'
     stub_staff_id = 1
     stub_poms = [{ staffId: 1, position: RecommendationService::PRISON_POM }]
-    stub_offenders = [{ offenderNo: 1 }]
+    stub_offenders = [{
+      offenderNo: "A1",
+      bookingId: 1,
+      dateOfBirth: '1990-01-01',
+      imprisonmentStatus: 'LIFE'
+    }]
+
+    stub_bookings = [{
+      bookingId: 1,
+      sentenceDetail: {
+        releaseDate: 30.years.from_now.iso8601,
+        sentenceStartDate: Time.zone.now.iso8601
+      }
+    }]
 
     Rails.configuration.nomis_oauth_host = stub_auth_host
 
@@ -31,13 +44,15 @@ context 'when NOMIS is missing information' do
       to_return(status: 200, body: stub_offenders.to_json)
 
     stub_request(:post, "#{stub_api_host}/offender-sentences/bookings").
-      to_return(status: 200, body: [].to_json)
+      to_return(status: 200, body: stub_bookings.to_json)
 
     signin_pom_user(stub_user_name)
   end
 
   describe 'the caseload page' do
     it 'does not error' do
+      create(:allocation, nomis_offender_id: "A1", primary_pom_nomis_id: 1)
+
       visit prison_caseload_index_path(stub_prison_code)
 
       expect(page).to have_content('Showing 1 - 1 of 1 results')

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -1,61 +1,112 @@
 require 'rails_helper'
 
 context 'when NOMIS is missing information' do
-  let(:stub_prison_code) { 'LEI' }
+  let(:prison_code) { 'LEI' }
+  let(:offender_no) { 'A1' }
+  let(:stub_api_host) { 'http://nomis.mock/elite2api/api' }
 
-  before do
-    stub_auth_host = 'http://nomis.mock'
-    stub_api_host = 'http://nomis.mock/elite2api/api'
-    stub_user_name = 'example_user'
-    stub_staff_id = 1
-    stub_poms = [{ staffId: 1, position: RecommendationService::PRISON_POM }]
-    stub_offenders = [{
-      offenderNo: "A1",
-      bookingId: 1,
-      dateOfBirth: '1990-01-01',
-      imprisonmentStatus: 'LIFE'
-    }]
+  describe 'when logged in' do
+    before do
+      user_name = 'example_user'
+      staff_id = 1
 
-    stub_bookings = [{
-      bookingId: 1,
-      sentenceDetail: {
-        releaseDate: 30.years.from_now.iso8601,
-        sentenceStartDate: Time.zone.now.iso8601
-      }
-    }]
+      stub_auth_host = 'http://nomis.mock'
+      stub_poms = [{ staffId: 1, position: RecommendationService::PRISON_POM }]
 
-    Rails.configuration.nomis_oauth_host = stub_auth_host
+      Rails.configuration.nomis_oauth_host = stub_auth_host
 
-    stub_request(:post, "#{stub_auth_host}/auth/oauth/token").
-      with(query: { grant_type: 'client_credentials' }).
-      to_return(status: 200, body: {}.to_json)
+      stub_request(:post, "#{stub_auth_host}/auth/oauth/token").
+        with(query: { grant_type: 'client_credentials' }).
+        to_return(status: 200, body: {}.to_json)
 
-    stub_request(:get, "#{stub_api_host}/users/example_user").
-      to_return(status: 200, body: { staffId: stub_staff_id }.to_json)
+      stub_request(:get, "#{stub_api_host}/users/example_user").
+        to_return(status: 200, body: { staffId: staff_id }.to_json)
 
-    stub_request(:get, "#{stub_api_host}/staff/#{stub_staff_id}/emails").
-      to_return(status: 200, body: [].to_json)
+      stub_request(:get, "#{stub_api_host}/staff/#{staff_id}/emails").
+        to_return(status: 200, body: [].to_json)
 
-    stub_request(:get, "#{stub_api_host}/staff/roles/#{stub_prison_code}/role/POM").
-      to_return(status: 200, body: stub_poms.to_json)
+      stub_request(:get, "#{stub_api_host}/staff/roles/#{prison_code}/role/POM").
+        to_return(status: 200, body: stub_poms.to_json)
 
-    stub_request(:get, "#{stub_api_host}/locations/description/#{stub_prison_code}/inmates").
-      with(query: { convictedStatus: 'Convicted', returnCategory: true }).
-      to_return(status: 200, body: stub_offenders.to_json)
+      signin_pom_user(user_name)
+    end
 
-    stub_request(:post, "#{stub_api_host}/offender-sentences/bookings").
-      to_return(status: 200, body: stub_bookings.to_json)
+    describe 'the caseload page' do
+      before do
+        stub_offenders = [{
+          offenderNo: offender_no,
+          bookingId: 1,
+          dateOfBirth: '1990-01-01',
+          imprisonmentStatus: 'LIFE'
+        }]
 
-    signin_pom_user(stub_user_name)
-  end
+        stub_bookings = [{
+          bookingId: 1,
+          sentenceDetail: {
+            releaseDate: 30.years.from_now.iso8601,
+            sentenceStartDate: Time.zone.now.iso8601
+          }
+        }]
 
-  describe 'the caseload page' do
-    it 'does not error' do
-      create(:allocation, nomis_offender_id: "A1", primary_pom_nomis_id: 1)
+        stub_request(:get, "#{stub_api_host}/locations/description/#{prison_code}/inmates").
+          with(query: { convictedStatus: 'Convicted', returnCategory: true }).
+          to_return(status: 200, body: stub_offenders.to_json)
 
-      visit prison_caseload_index_path(stub_prison_code)
+        stub_request(:post, "#{stub_api_host}/offender-sentences/bookings").
+          to_return(status: 200, body: stub_bookings.to_json)
+      end
 
-      expect(page).to have_content('Showing 1 - 1 of 1 results')
+      it 'does not error' do
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: 1)
+
+        visit prison_caseload_index_path(prison_code)
+
+        expect(page).to have_content('Showing 1 - 1 of 1 results')
+      end
+    end
+
+    describe 'the prisoner page' do
+      let(:booking_id) { 1 }
+
+      before do
+        stub_bookings = [{
+          bookingId: booking_id,
+          sentenceDetail: {
+            releaseDate: 30.years.from_now.iso8601,
+            sentenceStartDate: Time.zone.now.iso8601
+          }
+        }]
+
+        stub_offender = [{
+          offenderNo: offender_no,
+          latestBookingId: booking_id
+        }]
+
+        stub_request(:get, "#{stub_api_host}/prisoners/#{offender_no}").
+          to_return(status: 200, body: stub_offender.to_json)
+
+        stub_request(:post, "#{stub_api_host}/offender-assessments/CATEGORY").
+          to_return(status: 200, body: {}.to_json)
+
+        stub_request(:get, "#{stub_api_host}/bookings/#{booking_id}/mainOffence").
+          to_return(status: 200, body: {}.to_json)
+
+        stub_request(:post, "#{stub_api_host}/offender-sentences/bookings").
+          to_return(status: 200, body: stub_bookings.to_json)
+
+        stub_keyworker_host = 'http://keyworker.mock'
+
+        Rails.configuration.keyworker_api_host = stub_keyworker_host
+
+        stub_request(:get, "#{stub_keyworker_host}/key-worker/#{prison_code}/offender/#{offender_no}").
+          to_return(status: 200, body: {}.to_json)
+      end
+
+      it 'does not error' do
+        visit prison_prisoner_path(prison_code, offender_no)
+
+        expect(page).to have_content('Prisoner information')
+      end
     end
   end
 end

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+context 'when NOMIS is missing information' do
+  let(:stub_prison_code) { 'LEI' }
+
+  before do
+    stub_auth_host = 'http://nomis.mock'
+    stub_api_host = 'http://nomis.mock/elite2api/api'
+    stub_user_name = 'example_user'
+    stub_staff_id = 1
+    stub_poms = [{ staffId: 1, position: RecommendationService::PRISON_POM }]
+    stub_offenders = [{ offenderNo: 1 }]
+
+    Rails.configuration.nomis_oauth_host = stub_auth_host
+
+    stub_request(:post, "#{stub_auth_host}/auth/oauth/token").
+      with(query: { grant_type: 'client_credentials' }).
+      to_return(status: 200, body: {}.to_json)
+
+    stub_request(:get, "#{stub_api_host}/users/example_user").
+      to_return(status: 200, body: { staffId: stub_staff_id }.to_json)
+
+    stub_request(:get, "#{stub_api_host}/staff/#{stub_staff_id}/emails").
+      to_return(status: 200, body: [].to_json)
+
+    stub_request(:get, "#{stub_api_host}/staff/roles/#{stub_prison_code}/role/POM").
+      to_return(status: 200, body: stub_poms.to_json)
+
+    stub_request(:get, "#{stub_api_host}/locations/description/#{stub_prison_code}/inmates").
+      with(query: { convictedStatus: 'Convicted', returnCategory: true }).
+      to_return(status: 200, body: stub_offenders.to_json)
+
+    stub_request(:post, "#{stub_api_host}/offender-sentences/bookings").
+      to_return(status: 200, body: [].to_json)
+
+    signin_pom_user(stub_user_name)
+  end
+
+  describe 'the caseload page' do
+    it 'does not error' do
+      visit prison_caseload_index_path(stub_prison_code)
+
+      expect(page).to have_content('Showing 1 - 1 of 1 results')
+    end
+  end
+end

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -3,17 +3,15 @@ require 'rails_helper'
 context 'when NOMIS is missing information' do
   let(:prison_code) { 'LEI' }
   let(:offender_no) { 'A1' }
-  let(:stub_api_host) { 'http://nomis.mock/elite2api/api' }
+  let(:stub_auth_host) { Rails.configuration.nomis_oauth_host }
+  let(:stub_api_host) { "#{stub_auth_host}/elite2api/api" }
+  let(:stub_keyworker_host) { Rails.configuration.keyworker_api_host }
 
   describe 'when logged in' do
     before do
       user_name = 'example_user'
       staff_id = 1
-
-      stub_auth_host = 'http://nomis.mock'
       stub_poms = [{ staffId: 1, position: RecommendationService::PRISON_POM }]
-
-      Rails.configuration.nomis_oauth_host = stub_auth_host
 
       stub_request(:post, "#{stub_auth_host}/auth/oauth/token").
         with(query: { grant_type: 'client_credentials' }).
@@ -93,10 +91,6 @@ context 'when NOMIS is missing information' do
 
         stub_request(:post, "#{stub_api_host}/offender-sentences/bookings").
           to_return(status: 200, body: stub_bookings.to_json)
-
-        stub_keyworker_host = 'http://keyworker.mock'
-
-        Rails.configuration.keyworker_api_host = stub_keyworker_host
 
         stub_request(:get, "#{stub_keyworker_host}/key-worker/#{prison_code}/offender/#{offender_no}").
           to_return(status: 200, body: {}.to_json)

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -108,5 +108,20 @@ context 'when NOMIS is missing information' do
         expect(page).to have_content('Prisoner information')
       end
     end
+
+    describe 'the handover start page' do
+      before do
+        stub_request(:get, "#{stub_api_host}/locations/description/#{prison_code}/inmates?convictedStatus=Convicted&returnCategory=true").
+          to_return(status: 200, body: [].to_json, headers: {})
+      end
+
+      it 'does not error' do
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: 1)
+
+        visit prison_caseload_handover_start_path(prison_code)
+
+        expect(page).to have_content('All cases for start of handover to the community in the next 30 days')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Background

When we released https://github.com/ministryofjustice/offender-management-allocation-manager/commit/3a3ec5af141639e17ed5621873110f67bcb2b638 (which updates how the recommended responsibility is calculated), we discovered issues in production with certain offenders. These offenders, when looked up in the NOMIS API, were missing certain dates the app always expects to be present.

When this data isn't present, the app 'crashes' (returning a 500 for the request, but continuing to serve other requests). This is the case for pages with multiple offenders if only a single one is missing data.

### This PR

Adds a spec to illustrate the minimum information needed from NOMIS to load three pages 
- show my caseload
- show a prisoner
- show my handover cases

We picked these three pages because those are the ones we have Sentry errors about from the launch of https://github.com/ministryofjustice/offender-management-allocation-manager/commit/3a3ec5af141639e17ed5621873110f67bcb2b638.

Notably, it does not stop the app crashing when https://github.com/ministryofjustice/offender-management-allocation-manager/commit/3a3ec5af141639e17ed5621873110f67bcb2b638 is re-introduced. 

The plan is to get this onto master, then we can run these tests with changed calculations and see what fails.