### PR TITLE
Initialize Sidekiq logger and set log level

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -22,6 +22,8 @@ if Rails.env.production?
       read_timeout: 1.0,
       write_timeout: 1.0
     }
+
+    config.logger.level = Logger::FATAL
   end
 
   Sidekiq.configure_client do |config|


### PR DESCRIPTION
When an ActiveJob job fails it continues to log all the arguments.  This
PR initializes a Sidekiq logger and sets the log level to FATAL to
validate if this stops the information from being logged.