### PR TITLE
Update logging level to INFO

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,8 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -52,6 +53,9 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "offender_management_allocation_client_production"
+
+  # ActionMailer logger initialised and the level is set to FATAL to ensure that sensitive data isn't logged e.g. when
+  # sending emails via Notify it displays the contents of the email in the logs.
   config.action_mailer.logger = ActiveSupport::Logger.new(STDOUT)
   config.action_mailer.logger.level = ActiveSupport::Logger::Severity::FATAL
   config.action_mailer.perform_caching = false

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,6 +23,7 @@ if Rails.env.production?
       write_timeout: 1.0
     }
 
+    # Sidekiq logger initialised and the level is set to FATAL to ensure that sensitive data isn't logged.
     config.logger.level = Logger::FATAL
   end
 


### PR DESCRIPTION
At present the logging level within the app is set to DEBUG, which is
not good practice in terms of production, and therefore it is being set
to INFO.

In addition to this comments have been added around the Sidekiq and
ActionMailer loggers to explain that these have been added to ensure
that email contents, and arguments in error states, are not being
logged.