### PR TITLE
Fix leap year age bug

### DIFF
--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -101,11 +101,17 @@ module Nomis
       "#{first_name} #{last_name}".titleize
     end
 
-    # rubocop:disable Rails/Date
     def age
-      @age ||= ((Time.zone.now - date_of_birth.to_time) / 1.year.seconds).floor
+      now = Time.zone.now
+
+      birth_years_ago = now.year - date_of_birth.year
+
+      month_passed = date_of_birth.month >= now.month
+      day_passed = date_of_birth.day >= now.day
+      birthday_passed_this_year = month_passed & day_passed
+
+      @age ||= birthday_passed_this_year ? birth_years_ago : birth_years_ago - 1
     end
-    # rubocop:enable Rails/Date
 
     def load_from_json(payload)
       # It is expected that this method will be called by the subclass which

--- a/spec/models/nomis/offender_summary_spec.rb
+++ b/spec/models/nomis/offender_summary_spec.rb
@@ -63,4 +63,22 @@ describe Nomis::OffenderSummary do
       end
     end
   end
+
+  describe '#age' do
+    context 'with a date of birth 50 years ago' do
+      before { subject.date_of_birth = 50.years.ago }
+
+      it 'returns 50' do
+        expect(subject.age).to eq(50)
+      end
+    end
+
+    context 'with a date of birth 50 years and one day ago' do
+      before { subject.date_of_birth = 50.years.ago - 1.day }
+
+      it 'returns 49' do
+        expect(subject.age).to eq(49)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Whilst looking at how missing information impacts our service, we found a bug with how age is calculated. 

We'd taken the opportunity to refactor/add a few specs around `OffenderSummary`, which can be happily merged separately to the rest of the missing information work.