### PR TITLE
Correct "next delius import day" when there's a movement today

### DIFF
--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -3,7 +3,7 @@
 module SummaryHelper
   def delius_schedule_for(arrival_date)
     return 'Monday' if Time.zone.today.on_weekend?
-    return 'Tomorrow' if arrival_date == Time.zone.today
+    return 'Tomorrow' if arrival_date.to_date == Time.zone.today
 
     'Today'
   end

--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -1,32 +1,63 @@
 require 'rails_helper'
 
-RSpec.describe SummaryHelper do
-  it "says schedule is tomorrow if arrival date is today" do
-    # '18/11/2019' was a Monday. We need to travel to a weekday
-    # as otherwise this will fail if run over the weekend
-    Timecop.travel(Date.parse('18/11/2019')) do
-      sched = delius_schedule_for(Time.zone.today)
-      expect(sched).to eq('Tomorrow')
+describe SummaryHelper do
+  describe 'the next delius import' do
+    let(:result) { Timecop.travel(today) { delius_schedule_for(arrival) } }
+
+    context 'when today is Monday' do
+      let(:today) { Date.parse('Monday 18 Nov 2019') }
+
+      context 'when the prisoner arrived today' do
+        let(:arrival) { today }
+
+        it 'is tomorrow' do
+          expect(result).to eq('Tomorrow')
+        end
+      end
+
+      context 'when the prisoner arrived yesterday' do
+        let(:arrival) { today - 1 }
+
+        it 'is tomorrow' do
+          expect(result).to eq('Today')
+        end
+      end
+
+      context 'when the prisoner arrived today at 4pm' do
+        let(:arrival) { today + 16.hours }
+
+        it 'is tomorrow' do
+          expect(result).to eq('Tomorrow')
+        end
+      end
+
+      context 'when the prisoner arrived yesterday at 4pm' do
+        let(:arrival) { today - 8.hours }
+
+        it 'is tomorrow' do
+          expect(result).to eq('Today')
+        end
+      end
     end
-  end
 
-  it "says schedule is today if arrival date is yesterday" do
-    # '19/11/2019' was a Tuesday. We need to travel to a weekday
-    # as otherwise this will fail if run over the weekend
-    Timecop.travel(Date.parse('19/11/2019')) do
-      sched = delius_schedule_for(Time.zone.today - 1.day)
-      expect(sched).to eq('Today')
-    end
-  end
+    context 'when today is Saturday' do
+      let(:today) { Date.parse('Saturday 16 Nov 2019') }
 
-  it "says monday if today is not mon-fri" do
-    # '16/11/2019' was a saturday
-    Timecop.travel(Date.parse('16/11/2019')) do
-      sched = delius_schedule_for(Time.zone.today)
-      expect(sched).to eq('Monday')
+      context 'when the prisoner arrived today' do
+        let(:arrival) { today }
 
-      sched = delius_schedule_for(Time.zone.today - 1.day)
-      expect(sched).to eq('Monday')
+        it 'is Monday' do
+          expect(result).to eq('Monday')
+        end
+      end
+
+      context 'when the prisoner arrived yesterday' do
+        let(:arrival) { today - 1 }
+
+        it 'is Monday' do
+          expect(result).to eq('Monday')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Similarly to https://github.com/ministryofjustice/offender-management-allocation-manager/commit/9deba6f41495bc5b5a86aeef64a96a026d2ea39d, this commit changes a summary helper (responsible for displaying information about new arrivals) to test equality on the base of calendar days, not exact time-stamp.

This commit also refactors the related tests, and adds new ones to cover the case of more specific timestamps being in `arrival_date`.