### PR TITLE
Process movements for offenders moving to immigration centres

### DIFF
--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -40,6 +40,7 @@ class MovementService
 
 private
 
+  # rubocop:disable Metrics/MethodLength
   def self.process_transfer(transfer)
     return false unless transfer.direction_code == 'IN'
 
@@ -50,6 +51,14 @@ private
       # move to open prisons so we will trigger this job to send
       # an email to the LDU
       OpenPrisonTransferJob.perform_later(transfer.to_json)
+    end
+
+    # When the movement is from immigration or a detention centre and is not going back to a prison,
+    # remove the case information and deallocate offender
+    if (transfer.from_agency == 'IMM' || transfer.from_agency == 'MHI') && !transfer.to_prison?
+      release_offender(transfer.offender_no)
+
+      return true
     end
 
     # Bail if this is a new admission to prison
@@ -88,17 +97,31 @@ private
     alloc&.deallocate_offender(Allocation::OFFENDER_TRANSFERRED)
     true
   end
+  # rubocop:enable Metrics/MethodLength
 
   # When an offender is released, we can no longer rely on their
   # case information (in case they come back one day), and we
   # should de-activate any current allocations.
   def self.process_release(release)
-    return false unless release.to_agency == 'OUT' && release.from_prison?
+    return false unless release.to_agency == 'OUT'
 
-    Rails.logger.info("[MOVEMENT] Processing release for #{release.offender_no}")
+    if release.from_agency == 'MHI' || release.from_agency == 'IMM'
+      release_offender(release.offender_no)
 
-    CaseInformation.where(nomis_offender_id: release.offender_no).destroy_all
-    alloc = Allocation.find_by(nomis_offender_id: release.offender_no)
+      return true
+    end
+
+    return false unless release.from_prison?
+
+    release_offender(release.offender_no)
+    true
+  end
+
+  def self.release_offender(offender_no)
+    Rails.logger.info("[MOVEMENT] Processing release for #{offender_no}")
+
+    CaseInformation.where(nomis_offender_id: offender_no).destroy_all
+    alloc = Allocation.find_by(nomis_offender_id: offender_no)
     # frozen_string_literal: true
     # We need to check whether the from_agency is from within the prison estate
     # to know whether it is a transfer.  If it isn't then we want to bail and
@@ -113,7 +136,5 @@ private
     # case information (in case they come back one day), and we
     # should de-activate any current allocations.
     alloc&.deallocate_offender(Allocation::OFFENDER_RELEASED)
-
-    true
   end
 end

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -53,9 +53,12 @@ private
       OpenPrisonTransferJob.perform_later(transfer.to_json)
     end
 
-    # When the movement is from immigration or a detention centre and is not going back to a prison,
-    # remove the case information and deallocate offender
-    if (transfer.from_agency == 'IMM' || transfer.from_agency == 'MHI') && !transfer.to_prison?
+    # Remove the case information and deallocate offender
+    # when the movement is from immigration or a detention centre
+    # and is not going back to a prison OR
+    # when the movement is from a prison to an immigration or detention centre
+    if ((%w[IMM MHI].include? transfer.from_agency) && !transfer.to_prison?) ||
+    ((%w[IMM MHI].include? transfer.to_agency) && transfer.from_prison?)
       release_offender(transfer.offender_no)
 
       return true

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -212,7 +212,8 @@ describe MovementService do
           let(:movement_type) { 'ADM' }
           let(:direction_code) { 'IN' }
 
-          it 'does not process movement' do
+          it 'does not process movement',
+             vcr: { cassette_name: :immigration_transfer_from_MHI_to_prison_not_successful } do
             processed = described_class.process_movement(immigration_movement)
             expect(processed).to be false
           end
@@ -224,7 +225,24 @@ describe MovementService do
           let(:movement_type) { 'TRN' }
           let(:direction_code) { 'IN' }
 
-          it 'can process release movement for offender', vcr: { cassette_name: :immigration_movement_service_successful } do
+          it 'can process release movement for offender',
+             vcr: { cassette_name: :immigration_transfer_from_MHI_to_IMM_successful } do
+            processed = described_class.process_movement(immigration_movement)
+
+            expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
+            expect(allocation.event_trigger).to eq 'offender_released'
+            expect(processed).to be true
+          end
+        end
+
+        context 'with the offender moving from a prison to MHI or IMM' do
+          let(:from_agency) { 'LEI' }
+          let(:to_agency) { 'MHI' }
+          let(:movement_type) { 'ADM' }
+          let(:direction_code) { 'IN' }
+
+          it 'can process release movement for offender',
+             vcr: { cassette_name: :immigration_transfer_from_prison_to_IMM_successful } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -241,7 +259,8 @@ describe MovementService do
           let(:movement_type) { 'TRN' }
           let(:direction_code) { 'IN' }
 
-          it 'does not process movement' do
+          it 'does not process movement',
+             vcr: { cassette_name: :immigration_transfer_from_IMM_to_prison_not_successful } do
             processed = described_class.process_movement(immigration_movement)
             expect(processed).to be false
           end
@@ -253,7 +272,8 @@ describe MovementService do
           let(:movement_type) { 'ADM' }
           let(:direction_code) { 'IN' }
 
-          it 'can process release movement for offender', vcr: { cassette_name: :immigration_movement_service_successful } do
+          it 'can process release movement for offender',
+             vcr: { cassette_name: :immigration_transfer_from_IMM_to_MHI_successful } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -272,7 +292,8 @@ describe MovementService do
           let(:movement_type) { 'REL' }
           let(:direction_code) { 'OUT' }
 
-          it 'can release movement' do
+          it 'can release movement',
+             vcr: { cassette_name: :immigration_release_from_MHI_to_OUT_successful } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -287,7 +308,8 @@ describe MovementService do
           let(:movement_type) { 'REL' }
           let(:direction_code) { 'OUT' }
 
-          it 'can release movement' do
+          it 'can release movement',
+             vcr: { cassette_name: :immigration_release_from_IMM_to_OUT_successful } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -189,4 +189,113 @@ describe MovementService do
       expect(processed).to be false
     end
   end
+
+  describe "processing offenders moved to/from immigration estates" do
+    before do
+      create(:allocation, nomis_offender_id: 'G4273GI')
+    end
+
+    let(:allocation) { Allocation.find_by(nomis_offender_id: 'G4273GI') }
+
+    let(:immigration_movement) do
+      create(:movement, offender_no: 'G4273GI', direction_code: direction_code, create_date_time: Date.new(2020, 1, 6),
+                        movement_type: movement_type, from_agency: from_agency, to_agency: to_agency)
+    end
+
+    context 'when movement is a transfer' do
+      let(:case_info) { create(:case_information, nomis_offender_id: 'G4273GI') }
+
+      context 'when the from_agency is MHI' do
+        context 'with the offender going into a prison estate' do
+          let(:from_agency) { 'MHI' }
+          let(:to_agency){ 'PVI' }
+          let(:movement_type) { 'ADM' }
+          let(:direction_code) { 'IN' }
+
+          it 'does not process movement' do
+            processed = described_class.process_movement(immigration_movement)
+            expect(processed).to be false
+          end
+        end
+
+        context 'with the offender moving OUT of the prison estate' do
+          let(:from_agency) { 'MHI' }
+          let(:to_agency) { 'IMM' }
+          let(:movement_type) { 'TRN' }
+          let(:direction_code) { 'IN' }
+
+          it 'can process release movement for offender', vcr: { cassette_name: :immigration_movement_service_successful } do
+            processed = described_class.process_movement(immigration_movement)
+
+            expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
+            expect(allocation.event_trigger).to eq 'offender_released'
+            expect(processed).to be true
+          end
+        end
+      end
+
+      context 'when the from_agency is IMM' do
+        context 'with the offender going into a prison estate' do
+          let(:from_agency) { 'IMM' }
+          let(:to_agency) { 'PVI' }
+          let(:movement_type) { 'TRN' }
+          let(:direction_code) { 'IN' }
+
+          it 'does not process movement' do
+            processed = described_class.process_movement(immigration_movement)
+            expect(processed).to be false
+          end
+        end
+
+        context 'when the offender is moving OUT of the prison estate' do
+          let(:from_agency) { 'IMM' }
+          let(:to_agency) { 'MHI' }
+          let(:movement_type) { 'ADM' }
+          let(:direction_code) { 'IN' }
+
+          it 'can process release movement for offender', vcr: { cassette_name: :immigration_movement_service_successful } do
+            processed = described_class.process_movement(immigration_movement)
+
+            expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
+            expect(allocation.event_trigger).to eq 'offender_released'
+            expect(processed).to be true
+          end
+        end
+      end
+    end
+
+    context 'when movement is a release' do
+      context 'when offender moving to an immigration centre' do
+        context 'when the from_agency is MHI' do
+          let(:from_agency) { 'MHI' }
+          let(:to_agency) { 'OUT' }
+          let(:movement_type) { 'REL' }
+          let(:direction_code) { 'OUT' }
+
+          it 'can release movement' do
+            processed = described_class.process_movement(immigration_movement)
+
+            expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
+            expect(allocation.event_trigger).to eq 'offender_released'
+            expect(processed).to be true
+          end
+        end
+
+        context 'when the from_agency is IMM' do
+          let(:from_agency) { 'IMM' }
+          let(:to_agency) { 'OUT' }
+          let(:movement_type) { 'REL' }
+          let(:direction_code) { 'OUT' }
+
+          it 'can release movement' do
+            processed = described_class.process_movement(immigration_movement)
+
+            expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
+            expect(allocation.event_trigger).to eq 'offender_released'
+            expect(processed).to be true
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is the result of a bug that was showing incorrect numbers of Prison Offender Manager (POM) allocations in a particular prison. Looking into this issue we were able to identify that a couple of POM's had not been de-allocated when an offender had been released or transferred,
and this was resulting in the incorrect POM allocation counts.

The MovementService handles de-allocating POMs when an offender moves prison, so we ran a check across all prisons to find out if there were more situations where POM's were showing up as allocated to an offender that was no longer at the POM's prison.

We found approximately 140 other cases and the vast majority were due to offenders moving from prison to an immigration centre, awaiting deportation. The MovementService did not process these movements as immigration centres are not part of the prison estate and as a result these offenders were not being de-allocated from their POM when they moved.

This commit intends to fix this issue with the MovementService by de-allocating the POM and deleting the CaseInformation when the offender is being transferred or released to an immigration centre - signified by the agency code "IMM" (Immigration) or "MHI" (Morton Hall Immigration Removal Centre).