### PR TITLE
Fix age calculation bugs

### DIFF
--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -104,13 +104,15 @@ module Nomis
     def age
       now = Time.zone.now
 
+      if now.month == date_of_birth.month
+        birthday_passed = now.day >= date_of_birth.day
+      elsif now.month > date_of_birth.month
+        birthday_passed = true
+      end
+
       birth_years_ago = now.year - date_of_birth.year
 
-      month_passed = date_of_birth.month >= now.month
-      day_passed = date_of_birth.day >= now.day
-      birthday_passed_this_year = month_passed & day_passed
-
-      @age ||= birthday_passed_this_year ? birth_years_ago : birth_years_ago - 1
+      @age ||= birthday_passed ? birth_years_ago : birth_years_ago - 1
     end
 
     def load_from_json(payload)

--- a/spec/models/nomis/offender_summary_spec.rb
+++ b/spec/models/nomis/offender_summary_spec.rb
@@ -73,11 +73,21 @@ describe Nomis::OffenderSummary do
       end
     end
 
-    context 'with a date of birth 50 years and one day ago' do
-      before { subject.date_of_birth = 50.years.ago - 1.day }
+    context 'with a date of birth just under 50 years ago' do
+      before { subject.date_of_birth = 50.years.ago + 1.day }
 
       it 'returns 49' do
         expect(subject.age).to eq(49)
+      end
+    end
+
+    context 'with an 18th birthday in a past month' do
+      Timecop.travel('19 Feb 2020') do
+        before { subject.date_of_birth = '5 Jan 2002'.to_date }
+
+        it 'returns 18' do
+          expect(subject.age).to eq(18)
+        end
       end
     end
   end


### PR DESCRIPTION
When fixing leap year bugs in 9d43da, other bugs were introduced around birthdays. Oops.

This commit introduces more testing, fixes the existing tests (turns out *adding* time makes things *closer* to the current day, who knew?), and fixes the implementation.