### PR TITLE
Fix recall calculations

### DIFF
--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -19,6 +19,8 @@ class ResponsibilityService
   def self.calculate_pom_responsibility(offender)
     if offender.immigration_case? || open_prison_nps_offender?(offender)
       SUPPORTING
+    elsif offender.recalled?
+      SUPPORTING
     elsif determinate_with_no_release_dates?(offender)
       RESPONSIBLE
     elsif offender.indeterminate_sentence? && (offender.tariff_date.nil? ||
@@ -32,9 +34,7 @@ class ResponsibilityService
 private
 
   def self.standard_rules(offender)
-    if offender.recalled?
-      SUPPORTING
-    elsif nps_case?(offender) || offender.indeterminate_sentence?
+    if nps_case?(offender) || offender.indeterminate_sentence?
       nps_rules(offender)
     else
       crc_rules(offender)

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -185,7 +185,7 @@ feature "view POM's caseload" do
     it 'can be searched by supporting role' do
       select 'Supporting', from: 'role'
       click_on 'Search'
-      expect(page).to have_content('Showing 1 - 10 of 10 results')
+      expect(page).to have_content('Showing 1 - 15 of 15 results')
     end
 
     it 'shows the tier' do
@@ -197,7 +197,7 @@ feature "view POM's caseload" do
     it 'can be searched by responsible role' do
       select 'Responsible', from: 'role'
       click_on 'Search'
-      expect(page).to have_content('Showing 1 - 11 of 11 results')
+      expect(page).to have_content('Showing 1 - 6 of 6 results')
     end
   end
 

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -27,6 +27,18 @@ describe ResponsibilityService do
       end
     end
 
+    context 'when an offender has been recalled & does not have any relevant release dates' do
+      let(:offender) {
+        OpenStruct.new recalled?: true
+      }
+
+      it 'will show the case as POM supporting' do
+        resp = described_class.calculate_pom_responsibility(offender)
+
+        expect(resp).to eq ResponsibilityService::SUPPORTING
+      end
+    end
+
     context 'when relevant release dates are missing' do
       let(:offender) {
         OpenStruct.new immigration_case?: false,


### PR DESCRIPTION
We received a Zendesk ticket from a prison alerting us to a recalled
offender that was still showing as the POM being responsible.  An
investigation led us to realise that this particular offender didn't
have the relevant release dates and therefore was defaulting to
responsible.  We have re-ordered the calculation list to ensure that
recalled offenders drop out/default to supporting before other scenarios
are taken into account.