### PR TITLE
Fix issue when co-working POM no longer a POM

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -30,7 +30,7 @@ class AllocationsController < PrisonsApplicationController
     secondary_pom_nomis_id = @allocation.secondary_pom_nomis_id
     unless secondary_pom_nomis_id.nil?
       @coworker = StaffMember.new(secondary_pom_nomis_id)
-      redirect_to prison_pom_non_pom_path(@prison, @coworker.staff_id) unless @coworker.pom_at?(@prison.code)
+      redirect_to prison_pom_non_pom_path(@prison.code, @coworker.staff_id) unless @coworker.pom_at?(@prison.code)
     end
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_prison_id, @prisoner.offender_no)
   end


### PR DESCRIPTION
We recently received a report from an SPO where when trying to view an
offender's allocation that they were being redirected to the /401 page.
Following an investigation it was discovered that the co-working POM was
no longer an active POM at the prison, and it wasn't redirecting to the
page to notify the SPO/letting them deallocate their cases.  It appears
that a small typo had caused this issue so looking to resolve it
with this PR.  Now if the co-working POM is no longer active the SPO will be redirected to the non-pom page.