### PR TITLE
Fix responsibility handover date for NPS determinate offenders

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -102,13 +102,13 @@ private
   def self.mappa1_responsibility_date(offender)
     if offender.home_detention_curfew_actual_date.present?
       offender.home_detention_curfew_actual_date
-    elsif offender.home_detention_curfew_eligibility_date.present?
-      offender.home_detention_curfew_eligibility_date
     else
-      [
+      earliest_date = [
         offender.conditional_release_date,
         offender.automatic_release_date
       ].compact.map { |date| date - (4.months + 15.days) }.min
+
+      [earliest_date, offender.home_detention_curfew_eligibility_date].compact.min
     end
   end
 

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -179,8 +179,10 @@ describe HandoverDateService do
                 end
               end
 
-              context 'when HDCED is present' do
+              context 'when HDCED is present and earlier than the ARD/CRD calculated date' do
                 let(:hdced_date) {  Date.new(2020, 6, 16) }
+                let(:ard) { Date.new(2020, 11, 10) }
+                let(:crd) { Date.new(2020, 12, 5) }
 
                 it 'is set to HDCED' do
                   expect(described_class.handover(offender).handover_date).to eq(hdced_date)
@@ -215,11 +217,19 @@ describe HandoverDateService do
                 end
               end
 
-              context 'when HDC date earlier than date indicated by CRD/ARD' do
+              context 'when HDC date earlier than the CRD/ARD calculated date' do
                 let(:hdced_date) { Date.new(2020, 2, 28) }
 
                 it 'is on HDC date' do
                   expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 2, 28))
+                end
+              end
+
+              context 'when HDCED date later than date indicated by CRD/ARD' do
+                let(:hdced_date) { Date.new(2021, 2, 14) }
+
+                it 'is 4.5 months before CRD' do
+                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
                 end
               end
 


### PR DESCRIPTION
Following a Zendesk ticket from a prison querying the responsibility
handover date for an NPS determinate offender. We were displaying the
HDCED date as the responsibility handover date, even though the CRD/ARD
calculation date was earlier.

After further consideration it has been decided that we should return
the earliest release date from the CRD/ARD calculation or the HDCED,
if there is no MAPPA or HDCAD date.

This PR provides the fix for this issue.