### PR TITLE
POM-637 Get POM name from NOMIS

### DIFF
--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -21,7 +21,7 @@ module Api
     def primary_pom_details
       {
         staff_id: @allocation.primary_pom_nomis_id,
-        name: @allocation.primary_pom_name
+        name: fetch_pom_name(@allocation.primary_pom_nomis_id)
       }
     end
 
@@ -30,7 +30,7 @@ module Api
 
       {
         staff_id: @allocation.secondary_pom_nomis_id,
-        name: @allocation.secondary_pom_name
+        name: fetch_pom_name(@allocation.primary_pom_nomis_id)
       }
     end
 
@@ -40,6 +40,12 @@ module Api
 
     def offender_number
       params[:offender_no]
+    end
+
+    def fetch_pom_name(staff_id)
+      pom_firstname, pom_secondname =
+        PrisonOffenderManagerService.get_pom_name(staff_id)
+      "#{pom_secondname}, #{pom_firstname}"
     end
   end
 end

--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -41,11 +41,5 @@ module Api
     def offender_number
       params[:offender_no]
     end
-
-    def fetch_pom_name(staff_id)
-      pom_firstname, pom_secondname =
-        PrisonOffenderManagerService.get_pom_name(staff_id)
-      "#{pom_secondname}, #{pom_firstname}"
-    end
   end
 end

--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -21,7 +21,7 @@ module Api
     def primary_pom_details
       {
         staff_id: @allocation.primary_pom_nomis_id,
-        name: fetch_pom_name(@allocation.primary_pom_nomis_id)
+        name: helpers.fetch_pom_name(@allocation.primary_pom_nomis_id)
       }
     end
 
@@ -30,7 +30,7 @@ module Api
 
       {
         staff_id: @allocation.secondary_pom_nomis_id,
-        name: fetch_pom_name(@allocation.primary_pom_nomis_id)
+        name: helpers.fetch_pom_name(@allocation.primary_pom_nomis_id)
       }
     end
 

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -15,10 +15,13 @@ class PrisonersController < PrisonsApplicationController
     @tasks = PomTasks.new.for_offender(@prisoner)
     @allocation = Allocation.find_by(nomis_offender_id: @prisoner.offender_no)
 
-    @primary_pom_name = helpers.fetch_pom_name(@allocation.primary_pom_nomis_id).titleize if @allocation.present?
+    if @allocation.present?
+      @primary_pom_name = helpers.fetch_pom_name(@allocation.primary_pom_nomis_id).
+          titleize
+    end
 
     if @allocation.present? && @allocation.secondary_pom_name.present?
-      @secondary_pom_name = fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
+      @secondary_pom_name = helpers.fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
     end
 
     @pom_responsibility = pom_responsibility

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -15,10 +15,10 @@ class PrisonersController < PrisonsApplicationController
     @tasks = PomTasks.new.for_offender(@prisoner)
     @allocation = Allocation.find_by(nomis_offender_id: @prisoner.offender_no)
 
-    @primary_pom_name = fetch_pom_name(@allocation.primary_pom_nomis_id) if @allocation.present?
+    @primary_pom_name = helpers.fetch_pom_name(@allocation.primary_pom_nomis_id).titleize if @allocation.present?
 
     if @allocation.present? && @allocation.secondary_pom_name.present?
-      @secondary_pom_name = fetch_pom_name(@allocation.secondary_pom_nomis_id)
+      @secondary_pom_name = fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
     end
 
     @pom_responsibility = pom_responsibility
@@ -43,12 +43,6 @@ class PrisonersController < PrisonsApplicationController
   end
 
 private
-
-  def fetch_pom_name(staff_id)
-    pom_firstname, pom_secondname =
-      PrisonOffenderManagerService.get_pom_name(staff_id)
-    "#{pom_secondname.titleize}, #{pom_firstname.titleize}"
-  end
 
   def pom_responsibility
     @pom_responsibility ||= overridden_responsibility || calculated_responsibility

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -15,6 +15,12 @@ class PrisonersController < PrisonsApplicationController
     @tasks = PomTasks.new.for_offender(@prisoner)
     @allocation = Allocation.find_by(nomis_offender_id: @prisoner.offender_no)
 
+    @primary_pom_name = fetch_pom_name(@allocation.primary_pom_nomis_id) if @allocation.present?
+
+    if @allocation.present? && @allocation.secondary_pom_name.present?
+      @secondary_pom_name = fetch_pom_name(@allocation.secondary_pom_nomis_id)
+    end
+
     @pom_responsibility = pom_responsibility
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(
       active_prison_id, @prisoner.offender_no
@@ -37,6 +43,12 @@ class PrisonersController < PrisonsApplicationController
   end
 
 private
+
+  def fetch_pom_name(staff_id)
+    pom_firstname, pom_secondname =
+      PrisonOffenderManagerService.get_pom_name(staff_id)
+    "#{pom_secondname.titleize}, #{pom_firstname.titleize}"
+  end
 
   def pom_responsibility
     @pom_responsibility ||= overridden_responsibility || calculated_responsibility

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,10 +65,4 @@ module ApplicationHelper
       mail_to(email)
     end
   end
-
-  def fetch_pom_name(staff_id)
-    pom_firstname, pom_secondname =
-      PrisonOffenderManagerService.get_pom_name(staff_id)
-    "#{pom_secondname}, #{pom_firstname}"
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,7 +68,7 @@ module ApplicationHelper
 
   def fetch_pom_name(staff_id)
     pom_firstname, pom_secondname =
-        PrisonOffenderManagerService.get_pom_name(staff_id)
+      PrisonOffenderManagerService.get_pom_name(staff_id)
     "#{pom_secondname}, #{pom_firstname}"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,4 +65,10 @@ module ApplicationHelper
       mail_to(email)
     end
   end
+
+  def fetch_pom_name(staff_id)
+    pom_firstname, pom_secondname =
+        PrisonOffenderManagerService.get_pom_name(staff_id)
+    "#{pom_secondname}, #{pom_firstname}"
+  end
 end

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -22,4 +22,10 @@ module PomHelper
      'four and a half days'
     ][pattern]
   end
+
+  def fetch_pom_name(staff_id)
+    pom_firstname, pom_secondname =
+      PrisonOffenderManagerService.get_pom_name(staff_id)
+    "#{pom_secondname}, #{pom_firstname}"
+  end
 end

--- a/app/views/prisoners/_allocation_info.html.erb
+++ b/app/views/prisoners/_allocation_info.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">POM</td>
-  <td class="govuk-table__cell table_cell__left_align">
+  <td class="govuk-table__cell table_cell__left_align" id="primary_pom_name">
     <%= @primary_pom_name %>
   </td>
 </tr>

--- a/app/views/prisoners/_allocation_info.html.erb
+++ b/app/views/prisoners/_allocation_info.html.erb
@@ -1,14 +1,14 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">POM</td>
   <td class="govuk-table__cell table_cell__left_align">
-    <%= allocation.primary_pom_name.titleize %>
+    <%= @primary_pom_name %>
   </td>
 </tr>
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">Co-working POM</td>
   <td class="govuk-table__cell table_cell__left_align">
     <% if allocation.secondary_pom_name.present? %>
-      <%= allocation.secondary_pom_name.titleize %>
+      <%= @secondary_pom_name %>
     <% else %>
       N/A
     <% end %>

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -51,7 +51,7 @@ describe 'Allocation API' do
 
         let(:offender_no) { 'G4273GI' }
         let!(:allocation) {
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_name: 'Hyon Zboncak')
+          create(:allocation, nomis_offender_id: offender_no, primary_pom_name: 'POM, MOIC')
         }
         let(:Authorization) { "Bearer #{token}" }
 
@@ -60,7 +60,7 @@ describe 'Allocation API' do
           secondary_pom = JSON.parse(response.body)['secondary_pom']
 
           expect(primary_pom['staff_id']).to eq(485_926)
-          expect(primary_pom['name']).to eq('Hyon Zboncak')
+          expect(primary_pom['name']).to eq('POM, MOIC')
 
           expect(secondary_pom).to eq({})
         end

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -51,15 +51,20 @@ describe 'Allocation API' do
 
         let(:offender_no) { 'G4273GI' }
         let!(:allocation) {
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_name: 'POM, MOIC')
+          create(:allocation, nomis_offender_id: offender_no, primary_pom_name: 'OLD_NAME, MOIC')
         }
         let(:Authorization) { "Bearer #{token}" }
 
         run_test! do |_|
+          # check primary POM name stored in allocation
+          allocation = Allocation.last
+          expect(allocation.primary_pom_name).to eq('OLD_NAME, MOIC')
+
           primary_pom = JSON.parse(response.body)['primary_pom']
           secondary_pom = JSON.parse(response.body)['secondary_pom']
 
           expect(primary_pom['staff_id']).to eq(485_926)
+          # ensure the API returns the POM name stored in NOMIS rather than the allocation
           expect(primary_pom['name']).to eq('POM, MOIC')
 
           expect(secondary_pom).to eq({})

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -18,7 +18,7 @@ feature 'View a prisoner profile page' do
 
   context 'with an allocation' do
     let!(:alloc) {
-      create(:allocation, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637')
+      create(:allocation, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637', primary_pom_name: 'Pobno, Kath')
     }
 
     it 'shows the prisoner information', :raven_intercept_exception, vcr: { cassette_name: :show_offender_spec } do
@@ -28,6 +28,18 @@ feature 'View a prisoner profile page' do
       expect(page).to have_content('07/07/1968')
       cat_code = find('h3#category-code').text
       expect(cat_code).to eq('C')
+    end
+
+    it 'shows the POM name (fetched from NOMIS)', :raven_intercept_exception, vcr: { cassette_name: :show_offender_pom_spec } do
+      visit prison_prisoner_path('LEI', 'G7998GJ')
+
+      # check the primary POM name stored in the allocation
+      allocation = Allocation.last
+      expect(allocation.primary_pom_name).to eq('Pobno, Kath')
+
+      # ensure that the POM name displayed is the one actually returned from NOMIS
+      pom_name = find('#primary_pom_name').text
+      expect(pom_name).to eq('Pobee-Norris, Kath')
     end
 
     it 'shows an overridden responsibility', :raven_intercept_exception, vcr: { cassette_name: :show_offender_with_override_spec } do

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -83,6 +83,9 @@ context 'when NOMIS is missing information' do
           latestBookingId: booking_id
         }]
 
+        stub_request(:get, "#{stub_api_host}/staff/#{staff_id}").
+            to_return(status: 200, body: { staffId: staff_id, firstName: "TEST", lastName: "MOIC" }.to_json)
+
         stub_request(:get, "#{stub_api_host}/prisoners/#{offender_no}").
           to_return(status: 200, body: stub_offender.to_json)
 
@@ -97,6 +100,9 @@ context 'when NOMIS is missing information' do
 
         stub_request(:get, "#{stub_keyworker_host}/key-worker/#{prison_code}/offender/#{offender_no}").
           to_return(status: 200, body: {}.to_json)
+
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
+        create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
       end
 
       it 'does not error' do

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -84,7 +84,7 @@ context 'when NOMIS is missing information' do
         }]
 
         stub_request(:get, "#{stub_api_host}/staff/#{staff_id}").
-            to_return(status: 200, body: { staffId: staff_id, firstName: "TEST", lastName: "MOIC" }.to_json)
+          to_return(status: 200, body: { staffId: staff_id, firstName: "TEST", lastName: "MOIC" }.to_json)
 
         stub_request(:get, "#{stub_api_host}/prisoners/#{offender_no}").
           to_return(status: 200, body: stub_offender.to_json)

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe PomHelper do
       expect(format_working_pattern(1.0)).to eq('Full time')
     end
   end
+
+  describe 'fetch_pom_name' do
+    it 'fetches the POM name from NOMIS' do
+      expect(fetch_pom_name(485_926)).to eq('POM, MOIC')
+    end
+  end
 end


### PR DESCRIPTION
We have received a report from a user advising that one of their POM’s
has changed their name, it’s been updated in NOMIS but it’s still
showing up as the old name on DPS.  A quick investigation unearthed that
when DPS calls the MOIC API we are sending back the POM name in the
allocation record, and not from NOMIS, so it won’t show the correct name
if the POM has changed their name.  We need to update this, and other
places where we display the POM name in MOIC to fetch the name from
NOMIS to ensure it’s accurate/up to date.

I have also updated the prisoner page to get the POM name from NOMIS too.