### PR TITLE
Fix responsibility override email bug

### DIFF
--- a/app/controllers/responsibilities_controller.rb
+++ b/app/controllers/responsibilities_controller.rb
@@ -2,7 +2,7 @@
 
 class ResponsibilitiesController < PrisonsApplicationController
   def new
-    if ldu_email_address(params[:nomis_offender_id])
+    if ldu_email_address(params[:nomis_offender_id]).present?
       @responsibility = Responsibility.new nomis_offender_id: params[:nomis_offender_id]
     else
       render 'error'

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -66,7 +66,7 @@ feature 'Responsibility override', :versioning do
     end
   end
 
-  context "when override isn't possible due to lack of LDU address", vcr: { cassette_name: :cant_override_responsibility } do
+  context "when override isn't possible due to email address is nil", vcr: { cassette_name: :cant_override_responsibility_nil_email } do
     before do
       ldu = create(:local_divisional_unit, email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
@@ -74,6 +74,24 @@ feature 'Responsibility override', :versioning do
     end
 
     it 'doesnt override' do
+      visit new_prison_allocation_path('LEI', offender_id)
+
+      within '.responsibility_change' do
+        click_link 'Change'
+      end
+
+      expect(page).to have_content "Responsibility for this case can't be changed"
+    end
+  end
+
+  context "when override isn't possible due to email address is an empty string", vcr: { cassette_name: :cant_override_responsibility_blank_email } do
+    before do
+      ldu = create(:local_divisional_unit, email_address: "")
+      team = create(:team, local_divisional_unit: ldu)
+      create(:case_information, nomis_offender_id: offender_id, team: team)
+    end
+
+    it 'doesnt allow an override to take place' do
       visit new_prison_allocation_path('LEI', offender_id)
 
       within '.responsibility_change' do


### PR DESCRIPTION
We have been seeing Sentry alerts
(https://sentry.service.dsd.io/mojds/live1-allocation-manager-produ/issues/40529/?referrer=slack)
 related to missing email addresses for the responsibility override
feature; where an SPO can override responsibility to the community.
Investigation into this bug uncovered a bug where if an offender is
linked to an LDU, but that LDU has an empty string for an email address
then it still allows the SPO to complete the override.  However, this
will clearly not result in an email being sent and so this PR adds a
specific check for the presence of an email to prevent this happening in
the future.