### PR TITLE
Don't adjust handover date for MAPPA if it's long before release dates

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -93,8 +93,13 @@ private
     ].compact.map { |date| date - 8.months }.min
   end
 
-  def self.mappa_23_responsibility_date(_offender)
-    Time.zone.today
+  def self.mappa_23_responsibility_date(offender)
+    earliest_date = [
+      offender.conditional_release_date,
+      offender.automatic_release_date
+    ].compact.map { |date| date - (4.months + 15.days) }.min
+
+    [Time.zone.today, earliest_date].max
   end
 
   # There are a couple of places where we need .5 of a month - which

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -191,8 +191,7 @@ describe HandoverDateService do
               end
             end
 
-            context 'without mappa' do
-              # mappa level 0 means MAAPA doesn't apply
+            context "with mappa level 0 (maapa doesn't apply)" do
               let(:mappa_level) { 0 }
 
               context 'when crd before ard' do

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -255,6 +255,15 @@ describe HandoverDateService do
               it 'is todays date' do
                 expect(result).to eq(Time.zone.today)
               end
+
+              context 'with release dates far in the future' do
+                let(:conditional_release_date) { '20 June 2100'.to_date }
+                let(:automatic_release_date) { '20 June 2100'.to_date }
+
+                it 'returns 4.5 months before those release dates' do
+                  expect(result).to eq('5 Feb 2100'.to_date)
+                end
+              end
             end
 
             context 'with mappa level 3' do
@@ -262,6 +271,15 @@ describe HandoverDateService do
 
               it 'is todays date' do
                 expect(result).to eq(Time.zone.today)
+              end
+
+              context 'with release dates far in the future' do
+                let(:conditional_release_date) { '20 June 2100'.to_date }
+                let(:automatic_release_date) { '20 June 2100'.to_date }
+
+                it 'returns 4.5 months before those release dates' do
+                  expect(result).to eq('5 Feb 2100'.to_date)
+                end
               end
             end
           end

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -70,94 +70,101 @@ describe HandoverDateService do
   end
 
   describe 'calculating when responsibilty switches from custody to community' do
+    let(:result) { described_class.handover(offender).handover_date }
+
+    let(:offender) do
+      double(
+        recalled?: false,
+        nps_case?: nps_case,
+        indeterminate_sentence?: indeterminate_sentence,
+        early_allocation?: early_allocation,
+        automatic_release_date: ard,
+        conditional_release_date: crd,
+        home_detention_curfew_actual_date: hdcad,
+        home_detention_curfew_eligibility_date: hdced,
+        mappa_level: mappa_level,
+        parole_eligibility_date: parole_date,
+        tariff_date: tariff_date
+      )
+    end
+
     let(:ard) { nil }
     let(:crd) { nil }
     let(:hdcad) { nil }
     let(:hdced) { nil }
+    let(:parole_date) { nil }
+    let(:mappa_level) { nil }
+    let(:tariff_date) { nil }
+    let(:indeterminate_sentence) { nil }
+    let(:early_allocation) { nil }
 
     context 'when CRC' do
-      let(:offender) {
-        OpenStruct.new  recalled?: false,
-                        nps_case?: false,
-                        automatic_release_date: ard,
-                        conditional_release_date: crd,
-                        home_detention_curfew_actual_date: hdcad,
-                        home_detention_curfew_eligibility_date: hdced
-      }
+      let(:nps_case) { false }
 
       context 'when 12 weeks before the CRD date' do
-        let(:ard)   { Date.new(2019, 8, 1) }
-        let(:crd)   { Date.new(2019, 8, 12) }
+        let(:ard) { Date.new(2019, 8, 1) }
+        let(:crd) { Date.new(2019, 8, 12) }
 
         it 'will return the handover date 12 weeks before the CRD' do
-          expect(described_class.handover(offender).handover_date).to eq Date.new(2019, 5, 9)
+          expect(result).to eq Date.new(2019, 5, 9)
         end
       end
 
       context 'when 12 weeks before the ARD date' do
-        let(:ard)   { Date.new(2019, 8, 12) }
-        let(:crd)   { Date.new(2019, 8, 1) }
+        let(:ard) { Date.new(2019, 8, 12) }
+        let(:crd) { Date.new(2019, 8, 1) }
 
         it 'will return the handover date 12 weeks before the ARD' do
-          expect(described_class.handover(offender).handover_date).to eq Date.new(2019, 5, 9)
+          expect(result).to eq Date.new(2019, 5, 9)
         end
       end
 
       context 'when HDCED date is present' do
-        let(:ard)   { Date.new(2019, 8, 1) }
-        let(:crd)   { Date.new(2019, 8, 12) }
+        let(:ard) { Date.new(2019, 8, 1) }
+        let(:crd) { Date.new(2019, 8, 12) }
         let(:hdced) { Date.new(2019, 7, 25) }
 
         it 'the handover date will be on the HDCED date' do
-          expect(described_class.handover(offender).handover_date).to eq Date.new(2019, 7, 25)
+          expect(result).to eq Date.new(2019, 7, 25)
         end
       end
 
       context 'when HDCAD date is present' do
-        let(:ard)   { Date.new(2019, 8, 1) }
-        let(:crd)   { Date.new(2019, 8, 12) }
+        let(:ard) { Date.new(2019, 8, 1) }
+        let(:crd) { Date.new(2019, 8, 12) }
         let(:hdcad) { Date.new(2019, 7, 26) }
         let(:hdced) { Date.new(2019, 7, 25) }
 
         it 'the handover date will be on the HDCAD date' do
-          expect(described_class.handover(offender).handover_date).to eq Date.new(2019, 7, 26)
+          expect(result).to eq Date.new(2019, 7, 26)
         end
       end
 
       context 'when there are no release related dates' do
         it 'will return no handover date' do
-          expect(described_class.handover(offender).handover_date).to eq nil
+          expect(result).to be_nil
         end
       end
     end
 
     context 'when NPS' do
+      let(:nps_case) { true }
+
       context 'with normal allocation' do
-        let(:ted)         { Date.new(2020, 11, 1) }
-        let(:crd)         { Date.new(2020, 7, 16) }
-        let(:ard)         { Date.new(2020, 8, 16) }
-        let(:parole_date) { nil }
+        let(:early_allocation) { false }
+
+        let(:tariff_date) { Date.new(2020, 11, 1) }
+        let(:crd) { Date.new(2020, 7, 16) }
+        let(:ard) { Date.new(2020, 8, 16) }
 
         context 'with determinate sentence' do
-          let(:mappa_level) { nil }
-
-          let(:offender) {
-            OpenStruct.new(inderminate_sentence?: false,
-                           nps_case?: true,
-                           mappa_level: mappa_level,
-                           home_detention_curfew_eligibility_date: hdced,
-                           conditional_release_date: crd,
-                           automatic_release_date: ard,
-                           parole_eligibility_date: parole_date,
-                           tariff_date: ted,
-                           home_detention_curfew_actual_date: hdcad)
-          }
+          let(:indeterminate_sentence) { false }
 
           context 'with parole eligibility' do
             let(:parole_date) { Date.new(2019, 9, 30) }
 
             it 'is 8 months before parole date' do
-              expect(described_class.handover(offender).handover_date).to eq(Date.new(2019, 1, 30))
+              expect(result).to eq(Date.new(2019, 1, 30))
             end
           end
 
@@ -167,7 +174,7 @@ describe HandoverDateService do
 
               context 'when crd before ard' do
                 it 'is 4.5 months before CRD' do
-                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
+                  expect(result).to eq(Date.new(2020, 3, 1))
                 end
               end
 
@@ -177,7 +184,7 @@ describe HandoverDateService do
                 let(:crd) { Date.new(2020, 12, 5) }
 
                 it 'is set to HDCED' do
-                  expect(described_class.handover(offender).handover_date).to eq(hdced)
+                  expect(result).to eq(hdced)
                 end
               end
 
@@ -186,7 +193,7 @@ describe HandoverDateService do
                 let(:hdcad) { Date.new(2020, 6, 20) }
 
                 it 'is set to HDCAD' do
-                  expect(described_class.handover(offender).handover_date).to eq(hdcad)
+                  expect(result).to eq(hdcad)
                 end
               end
             end
@@ -196,7 +203,7 @@ describe HandoverDateService do
 
               context 'when crd before ard' do
                 it 'is 4.5 months before CRD' do
-                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
+                  expect(result).to eq(Date.new(2020, 3, 1))
                 end
               end
 
@@ -204,7 +211,7 @@ describe HandoverDateService do
                 let(:crd) { Date.new(2020, 8, 17) }
 
                 it 'is 4.5 months before ARD' do
-                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 4, 1))
+                  expect(result).to eq(Date.new(2020, 4, 1))
                 end
               end
 
@@ -212,7 +219,7 @@ describe HandoverDateService do
                 let(:hdced) { Date.new(2020, 2, 28) }
 
                 it 'is on HDC date' do
-                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 2, 28))
+                  expect(result).to eq(Date.new(2020, 2, 28))
                 end
               end
 
@@ -220,7 +227,7 @@ describe HandoverDateService do
                 let(:hdced) { Date.new(2021, 2, 14) }
 
                 it 'is 4.5 months before CRD' do
-                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
+                  expect(result).to eq(Date.new(2020, 3, 1))
                 end
               end
 
@@ -229,7 +236,7 @@ describe HandoverDateService do
                 let(:hdced) { Date.new(2020, 2, 28) }
 
                 it 'is on HDCAD date' do
-                  expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 2, 15))
+                  expect(result).to eq(Date.new(2020, 2, 15))
                 end
               end
             end
@@ -238,7 +245,7 @@ describe HandoverDateService do
               let(:mappa_level) { 1 }
 
               it 'is 4.5 months before CRD/ARD date or on HDC date' do
-                expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
+                expect(result).to eq(Date.new(2020, 3, 1))
               end
             end
 
@@ -246,7 +253,7 @@ describe HandoverDateService do
               let(:mappa_level) { 2 }
 
               it 'is todays date' do
-                expect(described_class.handover(offender).handover_date).to eq(Time.zone.today)
+                expect(result).to eq(Time.zone.today)
               end
             end
 
@@ -254,49 +261,41 @@ describe HandoverDateService do
               let(:mappa_level) { 3 }
 
               it 'is todays date' do
-                expect(described_class.handover(offender).handover_date).to eq(Time.zone.today)
+                expect(result).to eq(Time.zone.today)
               end
             end
           end
         end
 
         context "with indeterminate sentence" do
-          let(:offender) {
-            OpenStruct.new(indeterminate_sentence?: true,
-                           nps_case?: true,
-                           tariff_date: tariff_date)
-          }
+          let(:indeterminate_sentence) { true }
 
           context 'with tariff date in the future' do
             let(:tariff_date) { Date.new(2020, 11, 1) }
 
             it 'is 8 months before tariff date' do
-              expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
+              expect(result).to eq(Date.new(2020, 3, 1))
             end
           end
 
-          context 'with neither date' do
+          context 'with no tariff date' do
             let(:tariff_date) { nil }
 
             it 'cannot be calculated' do
-              expect(described_class.handover(offender).handover_date).to be_nil
+              expect(result).to be_nil
             end
           end
         end
       end
 
       context 'with early_allocation' do
-        let(:offender) {
-          OpenStruct.new(nps_case?: true,
-                         early_allocation?: true,
-                         conditional_release_date: crd)
-        }
+        let(:early_allocation) { true }
 
         context 'when CRD earliest' do
           let(:crd) { Date.new(2019, 7, 1) }
 
           it 'is 15 months before CRD' do
-            expect(described_class.handover(offender).handover_date).to eq(Date.new(2018, 4, 1))
+            expect(result).to eq(Date.new(2018, 4, 1))
           end
         end
       end

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -78,20 +78,20 @@ describe HandoverDateService do
         nps_case?: nps_case,
         indeterminate_sentence?: indeterminate_sentence,
         early_allocation?: early_allocation,
-        automatic_release_date: ard,
-        conditional_release_date: crd,
-        home_detention_curfew_actual_date: hdcad,
-        home_detention_curfew_eligibility_date: hdced,
+        automatic_release_date: automatic_release_date,
+        conditional_release_date: conditional_release_date,
+        home_detention_curfew_actual_date: home_detention_curfew_actual_date,
+        home_detention_curfew_eligibility_date: home_detention_curfew_eligibility_date,
         mappa_level: mappa_level,
         parole_eligibility_date: parole_date,
         tariff_date: tariff_date
       )
     end
 
-    let(:ard) { nil }
-    let(:crd) { nil }
-    let(:hdcad) { nil }
-    let(:hdced) { nil }
+    let(:automatic_release_date) { nil }
+    let(:conditional_release_date) { nil }
+    let(:home_detention_curfew_actual_date) { nil }
+    let(:home_detention_curfew_eligibility_date) { nil }
     let(:parole_date) { nil }
     let(:mappa_level) { nil }
     let(:tariff_date) { nil }
@@ -102,8 +102,8 @@ describe HandoverDateService do
       let(:nps_case) { false }
 
       context 'when 12 weeks before the CRD date' do
-        let(:ard) { Date.new(2019, 8, 1) }
-        let(:crd) { Date.new(2019, 8, 12) }
+        let(:automatic_release_date) { Date.new(2019, 8, 1) }
+        let(:conditional_release_date) { Date.new(2019, 8, 12) }
 
         it 'will return the handover date 12 weeks before the CRD' do
           expect(result).to eq Date.new(2019, 5, 9)
@@ -111,8 +111,8 @@ describe HandoverDateService do
       end
 
       context 'when 12 weeks before the ARD date' do
-        let(:ard) { Date.new(2019, 8, 12) }
-        let(:crd) { Date.new(2019, 8, 1) }
+        let(:automatic_release_date) { Date.new(2019, 8, 12) }
+        let(:conditional_release_date) { Date.new(2019, 8, 1) }
 
         it 'will return the handover date 12 weeks before the ARD' do
           expect(result).to eq Date.new(2019, 5, 9)
@@ -120,9 +120,9 @@ describe HandoverDateService do
       end
 
       context 'when HDCED date is present' do
-        let(:ard) { Date.new(2019, 8, 1) }
-        let(:crd) { Date.new(2019, 8, 12) }
-        let(:hdced) { Date.new(2019, 7, 25) }
+        let(:automatic_release_date) { Date.new(2019, 8, 1) }
+        let(:conditional_release_date) { Date.new(2019, 8, 12) }
+        let(:home_detention_curfew_eligibility_date) { Date.new(2019, 7, 25) }
 
         it 'the handover date will be on the HDCED date' do
           expect(result).to eq Date.new(2019, 7, 25)
@@ -130,10 +130,10 @@ describe HandoverDateService do
       end
 
       context 'when HDCAD date is present' do
-        let(:ard) { Date.new(2019, 8, 1) }
-        let(:crd) { Date.new(2019, 8, 12) }
-        let(:hdcad) { Date.new(2019, 7, 26) }
-        let(:hdced) { Date.new(2019, 7, 25) }
+        let(:automatic_release_date) { Date.new(2019, 8, 1) }
+        let(:conditional_release_date) { Date.new(2019, 8, 12) }
+        let(:home_detention_curfew_actual_date) { Date.new(2019, 7, 26) }
+        let(:home_detention_curfew_eligibility_date) { Date.new(2019, 7, 25) }
 
         it 'the handover date will be on the HDCAD date' do
           expect(result).to eq Date.new(2019, 7, 26)
@@ -154,8 +154,8 @@ describe HandoverDateService do
         let(:early_allocation) { false }
 
         let(:tariff_date) { Date.new(2020, 11, 1) }
-        let(:crd) { Date.new(2020, 7, 16) }
-        let(:ard) { Date.new(2020, 8, 16) }
+        let(:conditional_release_date) { Date.new(2020, 7, 16) }
+        let(:automatic_release_date) { Date.new(2020, 8, 16) }
 
         context 'with determinate sentence' do
           let(:indeterminate_sentence) { false }
@@ -179,21 +179,21 @@ describe HandoverDateService do
               end
 
               context 'when HDCED is present and earlier than the ARD/CRD calculated date' do
-                let(:hdced) {  Date.new(2020, 6, 16) }
-                let(:ard) { Date.new(2020, 11, 10) }
-                let(:crd) { Date.new(2020, 12, 5) }
+                let(:home_detention_curfew_eligibility_date) {  Date.new(2020, 6, 16) }
+                let(:automatic_release_date) { Date.new(2020, 11, 10) }
+                let(:conditional_release_date) { Date.new(2020, 12, 5) }
 
                 it 'is set to HDCED' do
-                  expect(result).to eq(hdced)
+                  expect(result).to eq(home_detention_curfew_eligibility_date)
                 end
               end
 
               context 'when HDCAD is present' do
-                let(:hdced) { Date.new(2020, 6, 16) }
-                let(:hdcad) { Date.new(2020, 6, 20) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2020, 6, 16) }
+                let(:home_detention_curfew_actual_date) { Date.new(2020, 6, 20) }
 
                 it 'is set to HDCAD' do
-                  expect(result).to eq(hdcad)
+                  expect(result).to eq(home_detention_curfew_actual_date)
                 end
               end
             end
@@ -208,7 +208,7 @@ describe HandoverDateService do
               end
 
               context 'when crd after ard' do
-                let(:crd) { Date.new(2020, 8, 17) }
+                let(:conditional_release_date) { Date.new(2020, 8, 17) }
 
                 it 'is 4.5 months before ARD' do
                   expect(result).to eq(Date.new(2020, 4, 1))
@@ -216,7 +216,7 @@ describe HandoverDateService do
               end
 
               context 'when HDC date earlier than the CRD/ARD calculated date' do
-                let(:hdced) { Date.new(2020, 2, 28) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2020, 2, 28) }
 
                 it 'is on HDC date' do
                   expect(result).to eq(Date.new(2020, 2, 28))
@@ -224,7 +224,7 @@ describe HandoverDateService do
               end
 
               context 'when HDCED date later than date indicated by CRD/ARD' do
-                let(:hdced) { Date.new(2021, 2, 14) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2021, 2, 14) }
 
                 it 'is 4.5 months before CRD' do
                   expect(result).to eq(Date.new(2020, 3, 1))
@@ -232,8 +232,8 @@ describe HandoverDateService do
               end
 
               context 'when HDCAD is present' do
-                let(:hdcad) { Date.new(2020, 2, 15) }
-                let(:hdced) { Date.new(2020, 2, 28) }
+                let(:home_detention_curfew_actual_date) { Date.new(2020, 2, 15) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2020, 2, 28) }
 
                 it 'is on HDCAD date' do
                   expect(result).to eq(Date.new(2020, 2, 15))
@@ -292,7 +292,7 @@ describe HandoverDateService do
         let(:early_allocation) { true }
 
         context 'when CRD earliest' do
-          let(:crd) { Date.new(2019, 7, 1) }
+          let(:conditional_release_date) { Date.new(2019, 7, 1) }
 
           it 'is 15 months before CRD' do
             expect(result).to eq(Date.new(2018, 4, 1))

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe HandoverDateService do
-  describe '#handover_start_date' do
+  describe 'calculating when community start supporting custody' do
     context 'when NPS' do
       let(:offender) {
         OpenStruct.new indeterminate_sentence?: indeterminate,
@@ -69,7 +69,7 @@ describe HandoverDateService do
     end
   end
 
-  describe '#responsibility_handover_date' do
+  describe 'calculating when responsibilty switches from custody to community' do
     let(:ard) { nil }
     let(:crd) { nil }
     let(:hdcad) { nil }

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -70,6 +70,11 @@ describe HandoverDateService do
   end
 
   describe '#responsibility_handover_date' do
+    let(:ard) { nil }
+    let(:crd) { nil }
+    let(:hdcad) { nil }
+    let(:hdced) { nil }
+
     context 'when CRC' do
       let(:offender) {
         OpenStruct.new  recalled?: false,
@@ -83,8 +88,6 @@ describe HandoverDateService do
       context 'when 12 weeks before the CRD date' do
         let(:ard)   { Date.new(2019, 8, 1) }
         let(:crd)   { Date.new(2019, 8, 12) }
-        let(:hdcad) { nil }
-        let(:hdced) { nil }
 
         it 'will return the handover date 12 weeks before the CRD' do
           expect(described_class.handover(offender).handover_date).to eq Date.new(2019, 5, 9)
@@ -94,8 +97,6 @@ describe HandoverDateService do
       context 'when 12 weeks before the ARD date' do
         let(:ard)   { Date.new(2019, 8, 12) }
         let(:crd)   { Date.new(2019, 8, 1) }
-        let(:hdcad) { nil }
-        let(:hdced) { nil }
 
         it 'will return the handover date 12 weeks before the ARD' do
           expect(described_class.handover(offender).handover_date).to eq Date.new(2019, 5, 9)
@@ -105,7 +106,6 @@ describe HandoverDateService do
       context 'when HDCED date is present' do
         let(:ard)   { Date.new(2019, 8, 1) }
         let(:crd)   { Date.new(2019, 8, 12) }
-        let(:hdcad) { nil }
         let(:hdced) { Date.new(2019, 7, 25) }
 
         it 'the handover date will be on the HDCED date' do
@@ -125,11 +125,6 @@ describe HandoverDateService do
       end
 
       context 'when there are no release related dates' do
-        let(:ard)   { nil }
-        let(:crd)   { nil }
-        let(:hdcad) { nil }
-        let(:hdced) { nil }
-
         it 'will return no handover date' do
           expect(described_class.handover(offender).handover_date).to eq nil
         end
@@ -138,12 +133,10 @@ describe HandoverDateService do
 
     context 'when NPS' do
       context 'with normal allocation' do
-        let(:parole_date) { nil }
         let(:ted)         { Date.new(2020, 11, 1) }
         let(:crd)         { Date.new(2020, 7, 16) }
         let(:ard)         { Date.new(2020, 8, 16) }
-        let(:hdced_date)  { nil }
-        let(:hdcad_date)  { nil }
+        let(:parole_date) { nil }
 
         context 'with determinate sentence' do
           let(:mappa_level) { nil }
@@ -152,12 +145,12 @@ describe HandoverDateService do
             OpenStruct.new(inderminate_sentence?: false,
                            nps_case?: true,
                            mappa_level: mappa_level,
-                           home_detention_curfew_eligibility_date: hdced_date,
+                           home_detention_curfew_eligibility_date: hdced,
                            conditional_release_date: crd,
                            automatic_release_date: ard,
                            parole_eligibility_date: parole_date,
                            tariff_date: ted,
-                           home_detention_curfew_actual_date: hdcad_date)
+                           home_detention_curfew_actual_date: hdcad)
           }
 
           context 'with parole eligibility' do
@@ -179,21 +172,21 @@ describe HandoverDateService do
               end
 
               context 'when HDCED is present and earlier than the ARD/CRD calculated date' do
-                let(:hdced_date) {  Date.new(2020, 6, 16) }
+                let(:hdced) {  Date.new(2020, 6, 16) }
                 let(:ard) { Date.new(2020, 11, 10) }
                 let(:crd) { Date.new(2020, 12, 5) }
 
                 it 'is set to HDCED' do
-                  expect(described_class.handover(offender).handover_date).to eq(hdced_date)
+                  expect(described_class.handover(offender).handover_date).to eq(hdced)
                 end
               end
 
               context 'when HDCAD is present' do
-                let(:hdced_date) { Date.new(2020, 6, 16) }
-                let(:hdcad_date) { Date.new(2020, 6, 20) }
+                let(:hdced) { Date.new(2020, 6, 16) }
+                let(:hdcad) { Date.new(2020, 6, 20) }
 
                 it 'is set to HDCAD' do
-                  expect(described_class.handover(offender).handover_date).to eq(hdcad_date)
+                  expect(described_class.handover(offender).handover_date).to eq(hdcad)
                 end
               end
             end
@@ -217,7 +210,7 @@ describe HandoverDateService do
               end
 
               context 'when HDC date earlier than the CRD/ARD calculated date' do
-                let(:hdced_date) { Date.new(2020, 2, 28) }
+                let(:hdced) { Date.new(2020, 2, 28) }
 
                 it 'is on HDC date' do
                   expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 2, 28))
@@ -225,7 +218,7 @@ describe HandoverDateService do
               end
 
               context 'when HDCED date later than date indicated by CRD/ARD' do
-                let(:hdced_date) { Date.new(2021, 2, 14) }
+                let(:hdced) { Date.new(2021, 2, 14) }
 
                 it 'is 4.5 months before CRD' do
                   expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 3, 1))
@@ -233,8 +226,8 @@ describe HandoverDateService do
               end
 
               context 'when HDCAD is present' do
-                let(:hdcad_date) { Date.new(2020, 2, 15) }
-                let(:hdced_date) { Date.new(2020, 2, 28) }
+                let(:hdcad) { Date.new(2020, 2, 15) }
+                let(:hdced) { Date.new(2020, 2, 28) }
 
                 it 'is on HDCAD date' do
                   expect(described_class.handover(offender).handover_date).to eq(Date.new(2020, 2, 15))


### PR DESCRIPTION
A case was spotted where an offender is due to be released some time away (longer than 4.5 months, which is the general amount of time handover happens for), but is displaying *today* as their handover date. This also means their responsibility is showing as community rather than custody.

This was due to a 'MAPPA' flag being set in nDelius, which our service takes to mean "this person is being released imminently, so hand them over now". In actuality, this flag can be set far in advance of a handover process (even if it "shouldn't" be set), so this can lead our service to display confusing/incorrect information.

We suspect this is something that will happen a fair amount, so changing our service to respond sensibly is a good idea.

[The behaviour for home detention dates already looks like it's correct to me](https://github.com/ministryofjustice/offender-management-allocation-manager/blob/master/app/services/handover_date_service.rb#L105-L112), as it takes the release dates as well.