### PR TITLE
Handle missing dates in MAPPA handover calculation

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -99,7 +99,7 @@ private
       offender.automatic_release_date
     ].compact.map { |date| date - (4.months + 15.days) }.min
 
-    [Time.zone.today, earliest_date].max
+    [Time.zone.today, earliest_date].compact.max
   end
 
   # There are a couple of places where we need .5 of a month - which

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -264,6 +264,15 @@ describe HandoverDateService do
                   expect(result).to eq('5 Feb 2100'.to_date)
                 end
               end
+
+              context 'with missing release dates' do
+                let(:conditional_release_date) { nil }
+                let(:automatic_release_date) { nil }
+
+                it 'returns today' do
+                  expect(result).to eq(Time.zone.today)
+                end
+              end
             end
 
             context 'with mappa level 3' do
@@ -279,6 +288,15 @@ describe HandoverDateService do
 
                 it 'returns 4.5 months before those release dates' do
                   expect(result).to eq('5 Feb 2100'.to_date)
+                end
+              end
+
+              context 'with missing release dates' do
+                let(:conditional_release_date) { nil }
+                let(:automatic_release_date) { nil }
+
+                it 'returns today' do
+                  expect(result).to eq(Time.zone.today)
                 end
               end
             end


### PR DESCRIPTION
This case of missing data was missed in the changes in 39134a - if `max` is called on an array with nil and non-nil entries, it'll explode.

This commit `compacts` the array first as a quick fix - the idea of 'if there is missing data behave this way' could do with being pulled up into clearer, separate components in the future, as this keeps biting me!