### PR TITLE
Fix Allocations API

### DIFF
--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -30,7 +30,7 @@ module Api
 
       {
         staff_id: @allocation.secondary_pom_nomis_id,
-        name: helpers.fetch_pom_name(@allocation.primary_pom_nomis_id)
+        name: helpers.fetch_pom_name(@allocation.secondary_pom_nomis_id)
       }
     end
 


### PR DESCRIPTION
An issue was raised where the DPS quick look screen was showing the same
name for both the primary and secondary POM.  A look at the code
revealed an error where the primary_pom_nomis_id was being passed to
both methods where we fetch the primary and secondary POM name from NOMIS. This PR fixes this
error!