### PR TITLE
Update process of POM being made inactive

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -56,6 +56,7 @@ class PomsController < PrisonsApplicationController
     if pom_detail.save
       if pom_detail.status == 'inactive'
         Allocation.deallocate_primary_pom(nomis_staff_id, active_prison_id)
+        Allocation.deallocate_secondary_pom(nomis_staff_id, active_prison_id)
       end
       redirect_to prison_pom_path(active_prison_id, id: nomis_staff_id)
     else

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -121,6 +121,17 @@ class Allocation < ApplicationRecord
     end
   end
 
+  def self.deallocate_secondary_pom(nomis_staff_id, prison)
+    active_pom_allocations(nomis_staff_id, prison).each do |alloc|
+      alloc.secondary_pom_nomis_id = nil
+      alloc.secondary_pom_name = nil
+      alloc.event = DEALLOCATE_SECONDARY_POM
+      alloc.event_trigger = USER
+
+      alloc.save!
+    end
+  end
+
   def prison_fix(movement_type)
     # In some cases we have old historical data which has no prison set
     # and this causes an issue should those offenders move or be released.


### PR DESCRIPTION
At present an SPO is able to make a POM inactive by updating the POM's
profile, and once done this will deallocate the POM's cases.  However,
at present this is only deallocating the cases where they are the
primary POM, resulting in allocations which continue to have an inactive
POM associated to them.  Therefore this PR updates the process and
ensures that the POM is removed all allocations, both as a primary and
secondary POM.