### PR TITLE
POM-566: SPO to see cases coming up for handover at their prison

### DIFF
--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -79,15 +79,22 @@ private
   end
 
   def sort_params(summary_type)
-    if params['sort'].blank?
-      return [:sentence_start_date, :asc] unless summary_type == :allocated
-
-      return [nil, nil]
-    end
+    return default_sort_params(summary_type) if params['sort'].blank?
 
     parts = params['sort'].split.map { |s| s.downcase.to_sym }
     return [parts[0], :asc] if parts.count == 1
 
     parts
+  end
+
+  def default_sort_params(summary_type)
+    case summary_type
+    when :allocated
+      [nil, nil]
+    when :handovers
+      [:handover_start_date, :asc]
+    else
+      [:sentence_start_date, :asc]
+    end
   end
 end

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -48,6 +48,14 @@ class SummaryController < PrisonsApplicationController
     @summary = SummaryPresenter.new summary
   end
 
+  def handovers
+    summary = create_summary(:handovers)
+    items = offenders(:handovers, summary.handovers)
+
+    @offenders = Kaminari.paginate_array(items).page(page)
+    @summary = SummaryPresenter.new summary
+  end
+
 private
 
   def offenders(summary_type, offenders)

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -79,12 +79,16 @@ private
   end
 
   def sort_params(summary_type)
-    return default_sort_params(summary_type) if params['sort'].blank?
+    sort_params = params['sort'] || ''
+    parts = sort_params.split.map { |s| s.downcase.to_sym }
 
-    parts = params['sort'].split.map { |s| s.downcase.to_sym }
-    return [parts[0], :asc] if parts.count == 1
-
-    parts
+    if parts.blank?
+      default_sort_params(summary_type)
+    elsif parts.second.blank?
+      parts + [:asc]
+    else
+      parts
+    end
   end
 
   def default_sort_params(summary_type)

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -15,6 +15,7 @@ module Nomis
     # Custom attributes
     attr_accessor :crn,
                   :allocated_pom_name, :case_allocation,
+                  :allocated_com_name,
                   :welsh_offender, :tier, :parole_review_date,
                   :sentence, :mappa_level,
                   :ldu, :team

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Summary
-  attr_accessor :allocated, :unallocated, :pending, :new_arrivals
-  def initialize(summary_type, allocated:, unallocated:, pending:, new_arrivals:)
+  attr_accessor :allocated, :unallocated, :pending, :new_arrivals, :handovers
+  def initialize(summary_type, allocated:, unallocated:, pending:, new_arrivals:, handovers:)
     @summary_type = summary_type
     @allocated = allocated
     @unallocated = unallocated
     @pending = pending
     @new_arrivals = new_arrivals
+    @handovers = handovers
   end
 end

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -2,12 +2,12 @@
 
 class Summary
   attr_accessor :allocated, :unallocated, :pending, :new_arrivals, :handovers
-  def initialize(summary_type, allocated:, unallocated:, pending:, new_arrivals:, handovers:)
+  def initialize(summary_type, buckets)
     @summary_type = summary_type
-    @allocated = allocated
-    @unallocated = unallocated
-    @pending = pending
-    @new_arrivals = new_arrivals
-    @handovers = handovers
+    @allocated = buckets[:allocated]
+    @unallocated = buckets[:unallocated]
+    @pending = buckets[:pending]
+    @new_arrivals = buckets[:new_arrivals]
+    @handovers = buckets[:handovers]
   end
 end

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -12,7 +12,7 @@ class OffenderPresenter
            :date_of_birth, :release_date, :parole_eligibility_date,
            :welsh_offender, :case_allocation, :earliest_release_date,
            :category_code, :conditional_release_date, :automatic_release_date,
-           :awaiting_allocation_for, :allocated_pom_name, :allocation_date,
+           :awaiting_allocation_for, :allocated_pom_name, :allocation_date, :allocated_com_name,
            :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
            :post_recall_release_date, :post_recall_release_override_date,

--- a/app/presenters/summary_presenter.rb
+++ b/app/presenters/summary_presenter.rb
@@ -1,10 +1,11 @@
 class SummaryPresenter
-  attr_reader :unallocated_total, :allocated_total, :pending_total, :new_arrivals_total
+  attr_reader :unallocated_total, :allocated_total, :pending_total, :new_arrivals_total, :handovers_total
 
   def initialize(summary)
     @unallocated_total = summary.unallocated.count
     @allocated_total = summary.allocated.count
     @pending_total = summary.pending.count
     @new_arrivals_total = summary.new_arrivals.count
+    @handovers_total = summary.handovers.count
   end
 end

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -31,8 +31,7 @@ class SummaryService
     offenders = prison.offenders
     active_allocations_hash = AllocationService.active_allocations(offenders.map(&:offender_no), prison.code)
 
-    # Add POM allocation details to offender objects. We use this information in 'allocated' and 'handovers' views.
-    add_allocated_poms(offenders, active_allocations_hash)
+    add_allocated_poms_and_coms(offenders, active_allocations_hash)
 
     # We need arrival dates for all offenders and all summary types because it is used to
     # detect new arrivals and so we would not be able to count them without knowing their
@@ -123,12 +122,18 @@ private
     end
   end
 
-  def self.add_allocated_poms(offenders, active_allocations_hash)
+  def self.add_allocated_poms_and_coms(offenders, active_allocations_hash)
     offenders.each do |offender|
-      alloc = active_allocations_hash[offender.offender_no]
       next unless active_allocations_hash.key?(offender.offender_no)
+
+      alloc = active_allocations_hash[offender.offender_no]
+
+      # Add POM details
       offender.allocated_pom_name = restructure_pom_name(alloc.primary_pom_name)
       offender.allocation_date = (alloc.primary_pom_allocated_at || alloc.updated_at)&.to_date
+
+      # Add COM details
+      offender.allocated_com_name = alloc.com_name
     end
   end
 

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -31,6 +31,9 @@ class SummaryService
     offenders = prison.offenders
     active_allocations_hash = AllocationService.active_allocations(offenders.map(&:offender_no), prison.code)
 
+    # Add POM allocation details to offender objects. We use this information in 'allocated' and 'handovers' views.
+    add_allocated_poms(offenders, active_allocations_hash)
+
     # We need arrival dates for all offenders and all summary types because it is used to
     # detect new arrivals and so we would not be able to count them without knowing their
     # prison_arrival_date
@@ -55,12 +58,6 @@ class SummaryService
       if approaching_handover?(offender)
         buckets[:handovers].items << offender
       end
-    end
-
-    # For the allocated and handover offenders, we need to provide the allocated POM's name
-    [:allocated, :handovers].each do |bucket_name|
-      bucket_offenders = buckets[bucket_name].items
-      add_allocated_poms(bucket_offenders, active_allocations_hash)
     end
 
     Summary.new(summary_type, allocated: buckets[:allocated],

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -52,8 +52,9 @@ class SummaryService
         buckets[:pending].items << offender
       end
 
-      # TODO: Add filtering logic for upcoming handover cases. All offenders are included for now.
-      buckets[:handovers].items << offender
+      if approaching_handover?(offender)
+        buckets[:handovers].items << offender
+      end
     end
 
     # For the allocated and handover offenders, we need to provide the allocated POM's name
@@ -79,6 +80,22 @@ private
       offender.awaiting_allocation_for <= 2
     else
       offender.prison_arrival_date.to_date == Time.zone.today
+    end
+  end
+
+  def self.approaching_handover?(offender)
+    today = Time.zone.today
+    thirty_days_time = today + 30.days
+
+    start_date = offender.handover_start_date
+    handover_date = offender.responsibility_handover_date
+
+    return false if start_date.nil?
+
+    if start_date.future?
+      start_date.between?(today, thirty_days_time)
+    else
+      today.between?(start_date, handover_date)
     end
   end
 

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -22,7 +22,8 @@ class SummaryService
     buckets = { allocated: Bucket.new(sortable_fields),
                 unallocated: Bucket.new(sortable_fields),
                 pending: Bucket.new(sortable_fields),
-                new_arrivals: Bucket.new(sortable_fields)
+                new_arrivals: Bucket.new(sortable_fields),
+                handovers: Bucket.new(sortable_fields)
     }
 
     offenders = prison.offenders
@@ -48,6 +49,9 @@ class SummaryService
       else
         buckets[:pending].items << offender
       end
+
+      # TODO: Add filtering logic for upcoming handover cases. All offenders are included for now.
+      buckets[:handovers].items << offender
     end
 
     # For the allocated offenders, we need to provide the allocated POM's
@@ -61,7 +65,8 @@ class SummaryService
     Summary.new(summary_type, allocated: buckets[:allocated],
                               unallocated: buckets[:unallocated],
                               pending: buckets[:pending],
-                              new_arrivals: buckets[:new_arrivals])
+                              new_arrivals: buckets[:new_arrivals],
+                              handovers: buckets[:handovers])
   end
 
 # rubocop:enable Metrics/MethodLength

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -13,6 +13,8 @@ class SummaryService
                         sort_fields_for_allocated
                       elsif summary_type == :new_arrivals
                         sort_fields_for_new_arrivals
+                      elsif summary_type == :handovers
+                        sort_fields_for_handovers
                       else
                         default_sortable_fields
                       end
@@ -86,6 +88,10 @@ private
 
   def self.sort_fields_for_new_arrivals
     [:last_name, :prison_arrival_date, :earliest_release_date]
+  end
+
+  def self.sort_fields_for_handovers
+    [:last_name, :earliest_release_date, :handover_start_date, :responsibility_handover_date, :allocated_pom_name]
   end
 
   def self.default_sortable_fields

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -104,7 +104,7 @@ private
   end
 
   def self.sort_fields_for_handovers
-    [:last_name, :earliest_release_date, :handover_start_date, :responsibility_handover_date, :allocated_pom_name]
+    [:last_name, :handover_start_date, :responsibility_handover_date, :case_allocation]
   end
 
   def self.default_sortable_fields

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -59,11 +59,7 @@ class SummaryService
       end
     end
 
-    Summary.new(summary_type, allocated: buckets[:allocated],
-                              unallocated: buckets[:unallocated],
-                              pending: buckets[:pending],
-                              new_arrivals: buckets[:new_arrivals],
-                              handovers: buckets[:handovers])
+    Summary.new(summary_type, buckets)
   end
 
 # rubocop:enable Metrics/MethodLength

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -53,6 +53,14 @@
       <p class="govuk-body">Prisoners whose case information has not yet been matched with nDelius.</p>
     </div>
   </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="wrapper">
+      <h1 class="govuk-heading-s">
+        <%= link_to "See all handover cases", prison_summary_handovers_path(@prison.code), class:"govuk-link" %>
+      </h1>
+      <p class="govuk-body">All cases that are within the handover period or start the handover process to the community in the next 30 days.</p>
+    </div>
+  </div>
 </div>
 
 <% end  %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -56,9 +56,9 @@
   <div class="govuk-grid-column-one-third">
     <div class="wrapper">
       <h1 class="govuk-heading-s">
-        <%= link_to "See all handover cases", prison_summary_handovers_path(@prison.code), class:"govuk-link" %>
+        <%= link_to "See case handover status", prison_summary_handovers_path(@prison.code), class:"govuk-link" %>
       </h1>
-      <p class="govuk-body">All cases that are within the handover period or start the handover process to the community in the next 30 days.</p>
+      <p class="govuk-body">Cases where responsibility is being handed over (or is within 30 days of handover) to the community probation team.</p>
     </div>
   </div>
 </div>

--- a/app/views/summary/_summary_subnav.html.erb
+++ b/app/views/summary/_summary_subnav.html.erb
@@ -27,6 +27,12 @@
         Newly arrived (<%= @summary.new_arrivals_total %>)
       </a>
     </li>
+
+    <li class="moj-sub-navigation__item">
+      <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :handovers %>
+        href="<%= prison_summary_handovers_path(@prison.code) %>">
+        Handover cases (<%= @summary.handovers_total %>)
+      </a>
+    </li>
   </ul>
 </nav>
-

--- a/app/views/summary/_summary_subnav.html.erb
+++ b/app/views/summary/_summary_subnav.html.erb
@@ -31,7 +31,7 @@
     <li class="moj-sub-navigation__item">
       <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :handovers %>
         href="<%= prison_summary_handovers_path(@prison.code) %>">
-        Handover cases (<%= @summary.handovers_total %>)
+        See case handover status (<%= @summary.handovers_total %>)
       </a>
     </li>
   </ul>

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -78,7 +78,7 @@
           <%= offender.allocated_pom_name || "Not allocated" %>
         </td>
         <td aria-label="COM" class="govuk-table__cell">
-          TODO
+          <%= offender.allocated_com_name || "Not allocated" %>
         </td>
         <td aria-label="Service provider" class="govuk-table__cell">
           <%= service_provider_label(offender.case_allocation) %>

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -48,16 +48,13 @@
         <%= sort_arrow('responsibility_handover_date') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
-        <a href="<%= sort_link('responsibility_handover_date') %>">
+        <a href="<%= sort_link('allocated_pom_name') %>">
           POM
         </a>
-        <%= sort_arrow('responsibility_handover_date') %>
+        <%= sort_arrow('allocated_pom_name') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
-        <a href="<%= sort_link('responsibility_handover_date') %>">
-          Service provider
-        </a>
-        <%= sort_arrow('responsibility_handover_date') %>
+        Service provider
       </th>
     </tr>
     </thead>
@@ -71,11 +68,20 @@
             <%= offender.offender_no %>
           </span>
         </td>
-        <td aria-label="Arrival date" class="govuk-table__cell">
-          <%= format_date(offender.prison_arrival_date) %>
-        </td>
         <td aria-label="Earliest release date" class="govuk-table__cell">
           <%= format_date(offender.earliest_release_date, replacement: "Unknown") %>
+        </td>
+        <td aria-label="Handover start date" class="govuk-table__cell">
+          <%= format_date(offender.handover_start_date, replacement: "Unknown") %>
+        </td>
+        <td aria-label="Responsibility changes" class="govuk-table__cell">
+          <%= format_date(offender.responsibility_handover_date, replacement: "Unknown") %>
+        </td>
+        <td aria-label="POM" class="govuk-table__cell">
+          <%= offender.allocated_pom_name || "Not allocated" %>
+        </td>
+        <td aria-label="Service provider" class="govuk-table__cell">
+          <%= service_provider_label(offender.case_allocation) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -8,10 +8,8 @@
 
 <%= render(:partial => 'summary_subnav', :locals => {:active => :handovers}) %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Handover cases</h1>
-<p>
-  All cases that are within the handover period or start the handover process to the community in the next 30 days.
-</p>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Case handover status</h1>
+<p>Cases where responsibility is being handed over (or is within 30 days of handover) to the community probation team.</p>
 
 <section id="awaiting-allocation">
   <%= render(

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -1,0 +1,91 @@
+<% content_for :switcher do %>
+  <%= render '/layouts/prison_switcher' %>
+<% end %>
+
+<div class="govuk-!-margin-bottom-4">
+  <%= render "search/search_box" %>
+</div>
+
+<%= render(:partial => 'summary_subnav', :locals => {:active => :handovers}) %>
+
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Handover cases</h1>
+<p>
+  All cases that are within the handover period or start the handover process to the community in the next 30 days.
+</p>
+
+<section id="awaiting-allocation">
+  <%= render(
+          :partial => 'shared/pagination',
+          :locals => {
+              :data => @offenders,
+          }) %>
+
+  <table class="govuk-table responsive tablesorter">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('last_name') %>">
+          Prisoner
+        </a>
+        <%= sort_arrow('last_name') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('earliest_release_date') %>">
+          Earliest release date
+        </a>
+        <%= sort_arrow('earliest_release_date') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('handover_start_date') %>">
+          Handover start date
+        </a>
+        <%= sort_arrow('handover_start_date') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('responsibility_handover_date') %>">
+          Responsibility changes
+        </a>
+        <%= sort_arrow('responsibility_handover_date') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('responsibility_handover_date') %>">
+          POM
+        </a>
+        <%= sort_arrow('responsibility_handover_date') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('responsibility_handover_date') %>">
+          Service provider
+        </a>
+        <%= sort_arrow('responsibility_handover_date') %>
+      </th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% @offenders.each_with_index do |offender, i| %>
+      <tr class="govuk-table__row offender_row_<%= i %>">
+        <td aria-label="Prisoner name" class="govuk-table__cell ">
+          <%= offender.full_name %>
+          <br/>
+          <span class='govuk-hint govuk-!-margin-bottom-0'>
+            <%= offender.offender_no %>
+          </span>
+        </td>
+        <td aria-label="Arrival date" class="govuk-table__cell">
+          <%= format_date(offender.prison_arrival_date) %>
+        </td>
+        <td aria-label="Earliest release date" class="govuk-table__cell">
+          <%= format_date(offender.earliest_release_date, replacement: "Unknown") %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+
+  <%= render(
+          :partial => 'shared/pagination',
+          :locals => {
+              :data => @offenders,
+          }) %>
+
+</section>

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -30,12 +30,6 @@
         <%= sort_arrow('last_name') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
-        <a href="<%= sort_link('earliest_release_date') %>">
-          Earliest release date
-        </a>
-        <%= sort_arrow('earliest_release_date') %>
-      </th>
-      <th class="govuk-table__header sorter-false" xscope="col">
         <a href="<%= sort_link('handover_start_date') %>">
           Handover start date
         </a>
@@ -54,6 +48,12 @@
         <%= sort_arrow('allocated_pom_name') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('allocated_com_name') %>">
+          COM
+        </a>
+        <%= sort_arrow('allocated_com_name') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
         Service provider
       </th>
     </tr>
@@ -68,9 +68,6 @@
             <%= offender.offender_no %>
           </span>
         </td>
-        <td aria-label="Earliest release date" class="govuk-table__cell">
-          <%= format_date(offender.earliest_release_date, replacement: "Unknown") %>
-        </td>
         <td aria-label="Handover start date" class="govuk-table__cell">
           <%= format_date(offender.handover_start_date, replacement: "Unknown") %>
         </td>
@@ -79,6 +76,9 @@
         </td>
         <td aria-label="POM" class="govuk-table__cell">
           <%= offender.allocated_pom_name || "Not allocated" %>
+        </td>
+        <td aria-label="COM" class="govuk-table__cell">
+          TODO
         </td>
         <td aria-label="Service provider" class="govuk-table__cell">
           <%= service_provider_label(offender.case_allocation) %>

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -42,19 +42,16 @@
         <%= sort_arrow('responsibility_handover_date') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
-        <a href="<%= sort_link('allocated_pom_name') %>">
-          POM
-        </a>
-        <%= sort_arrow('allocated_pom_name') %>
+        POM
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
-        <a href="<%= sort_link('allocated_com_name') %>">
-          COM
-        </a>
-        <%= sort_arrow('allocated_com_name') %>
+        COM
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
-        Service provider
+        <a href="<%= sort_link('case_allocation') %>">
+          Service provider
+        </a>
+        <%= sort_arrow('case_allocation') %>
       </th>
     </tr>
     </thead>

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -53,6 +53,9 @@
         </a>
         <%= sort_arrow('case_allocation') %>
       </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        Action
+      </th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -78,7 +81,10 @@
           <%= offender.allocated_com_name || "Not allocated" %>
         </td>
         <td aria-label="Service provider" class="govuk-table__cell">
-          <%= service_provider_label(offender.case_allocation) %>
+          <%= offender.case_allocation %>
+        </td>
+        <td aria-label="Action" class="govuk-table__cell ">
+          <%= cta_for_offender(@prison.code, offender) %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
     get('/summary/unallocated' => 'summary#unallocated')
     get('/summary/pending' => 'summary#pending')
     get('/summary/new-arrivals' => 'summary#new_arrivals')
+    get('/summary/handovers' => 'summary#handovers')
   end
 
   match "/401", :to => "errors#unauthorized", :via => :all

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DashboardController, type: :controller do
         expect(response.body).not_to have_content('Update case information')
         expect(response.body).not_to have_content('Newly arrived')
         expect(response.body).not_to have_content('View all offender managers')
-        expect(response.body).not_to have_content('See all handover cases')
+        expect(response.body).not_to have_content('See case handover status')
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe DashboardController, type: :controller do
         expect(response.body).to have_content('Update case information')
         expect(response.body).to have_content('Newly arrived')
         expect(response.body).to have_content('View all offender managers')
-        expect(response.body).to have_content('See all handover cases')
+        expect(response.body).to have_content('See case handover status')
       end
     end
   end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe DashboardController, type: :controller do
         expect(response.body).not_to have_content('Update case information')
         expect(response.body).not_to have_content('Newly arrived')
         expect(response.body).not_to have_content('View all offender managers')
+        expect(response.body).not_to have_content('See all handover cases')
       end
     end
 
@@ -72,6 +73,7 @@ RSpec.describe DashboardController, type: :controller do
         expect(response.body).to have_content('Update case information')
         expect(response.body).to have_content('Newly arrived')
         expect(response.body).to have_content('View all offender managers')
+        expect(response.body).to have_content('See all handover cases')
       end
     end
   end

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -44,7 +44,7 @@ feature 'summary summary feature' do
       visit prison_summary_handovers_path('LEI')
 
       expect(page).to have_css('.moj-sub-navigation__item')
-      expect(page).to have_content('Handover cases')
+      expect(page).to have_content('Case handover status')
     end
   end
 end

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -39,5 +39,12 @@ feature 'summary summary feature' do
       expect(page).to have_css('.moj-sub-navigation__item')
       expect(page).to have_content('Newly arrived')
     end
+
+    it 'displays offenders approaching their handover date', vcr: { cassette_name: :approaching_handover_feature } do
+      visit prison_summary_handovers_path('LEI')
+
+      expect(page).to have_css('.moj-sub-navigation__item')
+      expect(page).to have_content('Handover cases')
+    end
   end
 end

--- a/spec/features/spo_handover_cases_feature_spec.rb
+++ b/spec/features/spo_handover_cases_feature_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+feature "SPO viewing upcoming handover cases" do
+  let(:prison) { 'LEI' }
+
+  context 'when signed in as an SPO', vcr: { cassette_name: :spo_handover_cases_feature } do
+    before do
+      allow_any_instance_of(Nomis::OffenderBase).to receive_messages(
+        handover_start_date: handover_start_date,
+        responsibility_handover_date: responsibility_handover_date
+      )
+      signin_spo_user
+      visit prison_summary_handovers_path(prison)
+    end
+
+    context 'with handovers that start within the next thirty days' do
+      let(:handover_start_date) { 15.days.from_now }
+      let(:responsibility_handover_date) { 4.months.from_now }
+
+      it 'displays them on the page' do
+        expect(page).to have_selector('.offender_row_0')
+      end
+    end
+
+    context "with handovers that start in more than 30 days' time" do
+      let(:handover_start_date) { 31.days.from_now }
+      let(:responsibility_handover_date) { 4.months.from_now }
+
+      it 'does not display them on the page' do
+        expect(page).not_to have_selector('.offender_row_0')
+      end
+    end
+
+    context 'with handovers that have already started, but have not yet completed' do
+      let(:handover_start_date) { 15.days.ago }
+      let(:responsibility_handover_date) { 3.months.from_now }
+
+      it 'displays them on the page' do
+        expect(page).to have_selector('.offender_row_0')
+      end
+    end
+
+    context 'with handovers that have already completed' do
+      let(:handover_start_date) { 4.months.ago }
+      let(:responsibility_handover_date) { 15.days.ago }
+
+      it 'does not display them on the page' do
+        expect(page).not_to have_selector('.offender_row_0')
+      end
+    end
+  end
+
+  it 'stops staff without the SPO role from viewing the page'  do
+    signin_pom_user
+    visit prison_summary_handovers_path(prison)
+    expect(page).to have_current_path('/401')
+  end
+end


### PR DESCRIPTION
This Pull Request adds a new 'Handover cases' summary page under the 'Allocate a prisoner to an offender manager' section. This page is accessible to SPOs, and displays all offenders in the currently selected prison who are approaching handover.

This new page will show offenders whose:
- handover start date is within 30 days, or
- handover is in progress, but has not completed – i.e. the handover start date has passed, but the responsibility hasn't yet switched to the community