### PR TITLE
Lint changed files w/GOV.UK rubocop

### DIFF
--- a/.rubocop-govuk.yml
+++ b/.rubocop-govuk.yml
@@ -1,0 +1,4 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
+  gem 'rubocop-govuk'
   gem 'dotenv-rails'
   # needed to support Rails 6.0
   gem 'rspec-rails', '~> 4.0.0.beta2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     rubocop-rails (2.4.2)
@@ -493,6 +497,7 @@ DEPENDENCIES
   rswag-specs
   rswag-ui
   rubocop
+  rubocop-govuk
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: setup
+setup:
+	find .git/hooks -type l -exec rm {} \;\
+	&& find config/git-hooks -type f -exec ln -sf ../../{} .git/hooks/ \;
+

--- a/README.md
+++ b/README.md
@@ -23,13 +23,10 @@ This application uses Ruby v2.6.2. Use [RVM](https://rvm.io/) or similar to mana
 
 ### Setup
 
-Install the git pre-commit hook before you start working on this repository so
-that we're all using some checks to help us avoid committing unencrypted
-secrets. From the root of the repo:
-
-```
-ln -s ../../config/git-hooks/pre-commit.sh .git/hooks/pre-commit
-```
+Run `make setup` to install git pre-commit hooks that:
+- check you have git-crypt installed
+- help you avoid committing unencrypted secrets
+- lint changed files using govuk rubocop
 
 To test that the pre-commit hook is set up correctly, try removing the `diff`
 attribute from a line in a `.gitattributes` file and then committing something -

--- a/config/git-hooks/pre-commit
+++ b/config/git-hooks/pre-commit
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Usage:
-#    $> cd /path/to/repository
-#    $> ln -s ../../config/git-hooks/pre-commit.sh .git/hooks/pre-commit
-#
-
 ################################################################################
 # https://github.com/AGWA/git-crypt/issues/45#issuecomment-151985431
 # Pre-commit hook to avoid accidentally adding unencrypted files which are
@@ -30,3 +25,7 @@ if [[ $? -eq 0 ]]; then
   echo "Did you mean to add this file to the git-crypt config in .gitattributes?"
   exit 1
 fi
+
+# Check only new files with govuk cops
+git diff --cached --name-only --diff-filter=ACM |
+  xargs bundle exec rubocop --config .rubocop-govuk.yml


### PR DESCRIPTION
This PR introduces a [pre-commit git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) that lints your changed files, using the [GOV.UK rubocop rules](https://github.com/alphagov/rubocop-govuk). 

The build still runs against the 'old' linting rules, so you can ignore this completely, if you like.

If you want to use this, run `make setup` in the root of the project directory. 
This will install the other existing pre-commit hooks (around `git-crypt`) as well.

(You can also install this hook, but ignore it for any given commit with [the `--no-verify` flag](https://git-scm.com/docs/git-commit)).