### PR TITLE
Show community information to SPO users

### DIFF
--- a/app/presenters/allocation_presenter.rb
+++ b/app/presenters/allocation_presenter.rb
@@ -3,7 +3,7 @@
 class AllocationPresenter
   delegate :primary_pom_nomis_id, :event, :event_trigger, :secondary_pom_nomis_id, :prison,
            :allocated_at_tier, :nomis_offender_id, :primary_pom_name, :override_reasons, :suitability_detail,
-           :override_detail,
+           :override_detail, :com_name,
            :created_by_name, :nomis_booking_id, :recommended_pom_type, :secondary_pom_name, to: :@allocation
 
   def initialize(allocation, version)

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -8,6 +8,8 @@
 
 <%= render 'allocations/case_information' %>
 
+<%= render 'prisoners/community_information' %>
+
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible" />
 
 <%= render 'allocations/pom_tables' %>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -122,4 +122,6 @@
     </tr>
     </tbody>
   </table>
+
+  <%= render 'prisoners/community_information' %>
 </div>


### PR DESCRIPTION
Community information is now visible to SPO users on the 'allocation information' and 'new allocation' pages. This closes Jira ticket POM-650.

Previously, community information was only visible to the allocated POM user. However, the decision was made for SPOs to be able to see this information to allow them to cover for POMs who are unable to work.

Since there is so much cross-over between these pages and the POM's 'view prisoner' page, I've reused the 'Community information' partial from that page (`prisoners/community_information`). Eventually, an effort should be made to reconcile all the different prisoner/allocation views, since there's currently a lot of duplication. That task is captured in Jira ticket POM-366, and is a much larger piece of work than this ticket.