### PR TITLE
Make failing tests less brittle

### DIFF
--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Prison, type: :model do
     it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
       offender_array = offenders.to_a
       expect(offender_array).to be_kind_of(Array)
-      expect(offender_array.length).to eq(831)
+      expect(offender_array.length).to be > 800
       expect(offender_array.first).to be_kind_of(Nomis::OffenderSummary)
     end
   end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe SearchService do
   it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
     offenders = described_class.search_for_offenders('', Prison.new('LEI'))
-    expect(offenders.count).to eq(831)
+    expect(offenders.count).to be > 800
   end
 
   it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do


### PR DESCRIPTION
Many of our tests have a dependency on the T3 NOMIS API. Due to recent changes in the number of prisoner records returned by the API, some of our tests have started failing. Specifically: tests which depended on there being exactly 831 prisoners in the prison HMP Leeds (LEI) were failing. This isn't the first time we've experienced this, as evidenced by commit 0dea5f3f64a13b53cdb047468f87f86100388b54.

The number of prisoners in HMP Leeds on T3 can change from time to time, although it always tends to be over 800. Therefore, I've adjusted the tests to be less fragile: rather than expect *exactly* 831 prisoners, the tests now expect *at least* 800 prisoners. This should be sufficient to prevent future test failures caused by similar changes in the dataset, but still reliable enough to highlight a significant change in the API response.

### Why not stub API calls?

Our use of the NOMIS API is quite complex – most features of our application depend on a combination of numerous API calls. Many of the existing tests don't stub out every API call used. Instead, we use VCR to cache responses from this API at runtime – speeding up our test suite, but not removing the external dependency entirely. We've been advised that the data returned by this API is based on production data – it's anonymised, but there's a possibility it could be reverse engineered to find a particular person. Therefore, we're not able to commit the cached responses ('VCR cassettes') to this git repository.