### PR TITLE
Update tests to reflect change in T3 data

### DIFF
--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -109,7 +109,6 @@ private
       return nil if release_date.blank?
 
       handover_date_in_future = HandoverDateService.handover(offender).handover_date > Time.zone.today
-
       if handover_date_in_future && release_date >= cutoff
         RESPONSIBLE
       else

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
         get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
         pom_emails = assigns(:pom_emails)
 
-        expect(pom_emails.count).to eq(3)
+        expect(pom_emails.count).to eq(2)
         expect(pom_emails[primary_pom_without_email_id]).to eq(nil)
         expect(pom_emails[updated_primary_pom_nomis_id]).to eq('pom4@prison.gov.uk')
         expect(pom_emails[previous_primary_pom_nomis_id]).to eq('pom3@prison.gov.uk')

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -37,9 +37,9 @@ describe PrisonOffenderManagerService do
       it "can get a list of POMs",
          vcr: { cassette_name: :pom_service_get_poms_list } do
         expect(subject).to be_kind_of(Enumerable)
-        expect(subject.count).to eq(14)
+        expect(subject.count).to eq(15)
         # 1 POM in T3 (Toby Retallick) is marked inactive, so expect one less active one
-        expect(subject.count { |pom| pom.status == 'active' }).to eq(13)
+        expect(subject.count { |pom| pom.status == 'active' }).to eq(14)
         # would like these to both be true as integratopn test user has both positions
         # expect(moic_integration_tests.prison_officer?).to eq(true)
         expect(moic_integration_tests.probation_officer?).to eq(true)
@@ -51,7 +51,7 @@ describe PrisonOffenderManagerService do
          vcr: { cassette_name: :pom_service_get_poms_by_ids } do
         names = described_class.get_pom_names('LEI')
         expect(names).to be_kind_of(Hash)
-        expect(names.count).to eq(14)
+        expect(names.count).to eq(15)
       end
     end
 


### PR DESCRIPTION
Currently, some test that use VCR cassettes are failing on master. This is because allot of the test rely on external data. As we knew why this data changed, it was sufficient amend the tests to reflect this change. 

More specifically, some tests relating to the number of prison offender managers (POM) were failing, this was because we had a new joiner who we added as a POM. 