### PR TITLE
This test failed due to changes in T3 data. It is known that T3

### DIFF
--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -78,7 +78,7 @@ feature 'Provide debugging information for our team to use' do
       visit prison_debugging_prison_path('LEI')
 
       expect(page).to have_text("Prison Debugging")
-      expect(page).to have_css('tbody tr', count: 228)
+      expect(page).to have_css('tbody tr', minimum: 220)
       expect(page).to have_css('.govuk-data-label', text: 'With missing information')
     end
   end


### PR DESCRIPTION
This test failed due to changes in T3 data. It is known that T3 data gets recycled occasionally so we should not be relying on exact numbers.

This commit sets the expectation that the test will pass if we have a minimum number of offenders. It is not fail-safe but a better solution than using precise numbers.