### PR TITLE
POM-685: Update ‘Active’ Team → LDU relationships in the nightly Delius import

### DIFF
--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -104,9 +104,35 @@ private
 
   def process_decrypted_file(filename)
     Rails.logger.info('[DELIUS] Processing decrypted file')
-
-    total = 0
     processor = Delius::Processor.new(filename)
+    update_team_names_and_ldus(processor)
+    upsert_delius_data_records(processor)
+  end
+
+  def update_team_names_and_ldus(processor)
+    processor.each_with_index do |row, index|
+      # skip header row in row[0]
+      next if index == 0
+
+      record = {}
+
+      # For each row, map the column to the appropriate column name
+      # as the existing column names are not very hash/symbol friendly
+      row.each_with_index do |val, idx|
+        key = FIELDS[idx]
+        record[key] = val
+      end
+
+      UpdateTeamNameAndLduService.update(
+        team_code: record[:team_code],
+        team_name: record[:team],
+        ldu_code: record[:ldu_code]
+      )
+    end
+  end
+
+  def upsert_delius_data_records(processor)
+    total = 0
     processor.each_with_index do |row, index|
       # skip header row in row[0]
       next if index == 0

--- a/app/services/update_team_name_and_ldu_service.rb
+++ b/app/services/update_team_name_and_ldu_service.rb
@@ -1,0 +1,36 @@
+class UpdateTeamNameAndLduService
+  def self.update(team_code:, team_name:, ldu_code:)
+    new(team_code: team_code, team_name: team_name, ldu_code: ldu_code).update
+  end
+
+  def initialize(team_code:, team_name:, ldu_code:)
+    @team = Team.find_by(code: team_code)
+    @team_name = team_name
+    @ldu_code = ldu_code
+  end
+
+  def update
+    return unless name_needs_updating? || ldu_needs_updating?
+
+    if name_needs_updating?
+      @team.name = @team_name
+    end
+
+    if ldu_needs_updating?
+      ldu = LocalDivisionalUnit.find_by(code: @ldu_code)
+      @team.local_divisional_unit = ldu
+    end
+
+    @team.save
+  end
+
+private
+
+  def name_needs_updating?
+    @team.name != @team_name
+  end
+
+  def ldu_needs_updating?
+    @team.local_divisional_unit&.code != @ldu_code
+  end
+end

--- a/app/services/update_team_name_and_ldu_service.rb
+++ b/app/services/update_team_name_and_ldu_service.rb
@@ -14,19 +14,9 @@ class UpdateTeamNameAndLduService
   def update
     return if @team.nil?
 
-    return unless name_needs_updating? || ldu_needs_updating?
-
-    if name_needs_updating?
-      @team.name = @team_name
-    end
-
-    if ldu_needs_updating?
-      ldu = LocalDivisionalUnit.find_by(code: @ldu_code)
-      @team.local_divisional_unit = ldu
-      return Rails.logger.error("Couldn't find LDU with code #{@ldu_code}") if ldu.nil?
-    end
-
-    @team.save
+    update_name if name_needs_updating?
+    update_ldu if ldu_needs_updating?
+    @team.save if @team.changed?
   end
 
 private
@@ -35,7 +25,18 @@ private
     @team.name != @team_name
   end
 
+  def update_name
+    @team.name = @team_name
+  end
+
   def ldu_needs_updating?
     @team.local_divisional_unit&.code != @ldu_code
+  end
+
+  def update_ldu
+    ldu = LocalDivisionalUnit.find_by(code: @ldu_code)
+    return Rails.logger.error("Couldn't find LDU with code #{@ldu_code}") if ldu.nil?
+
+    @team.local_divisional_unit = ldu
   end
 end

--- a/app/services/update_team_name_and_ldu_service.rb
+++ b/app/services/update_team_name_and_ldu_service.rb
@@ -7,9 +7,13 @@ class UpdateTeamNameAndLduService
     @team = Team.find_by(code: team_code)
     @team_name = team_name
     @ldu_code = ldu_code
+
+    Rails.logger.error("Couldn't find team with code #{team_code}") if @team.nil?
   end
 
   def update
+    return if @team.nil?
+
     return unless name_needs_updating? || ldu_needs_updating?
 
     if name_needs_updating?
@@ -19,6 +23,7 @@ class UpdateTeamNameAndLduService
     if ldu_needs_updating?
       ldu = LocalDivisionalUnit.find_by(code: @ldu_code)
       @team.local_divisional_unit = ldu
+      return Rails.logger.error("Couldn't find LDU with code #{@ldu_code}") if ldu.nil?
     end
 
     @team.save

--- a/spec/features/delius_import_job_feature_spec.rb
+++ b/spec/features/delius_import_job_feature_spec.rb
@@ -52,9 +52,7 @@ feature "Delius import feature" do
   end
 
   context "when the team is associated with an LDU" do
-    before do
-      create(:team, code: 'A')
-    end
+    before { create(:team, code: 'A') }
 
     it "imports the Delius spreadsheet and creates case information" do
       visit prison_summary_pending_path(prison)

--- a/spec/services/update_team_name_and_ldu_service_spec.rb
+++ b/spec/services/update_team_name_and_ldu_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe UpdateTeamNameAndLduService do
     end
   end
 
-  context "when the team doesn't exist" do
+  context "when a team with the specified code doesn't exist" do
     it "logs an error" do
       expect_message = "Couldn't find team with code TEAM1"
       expect(Rails.logger).to receive(:error).with(expect_message)
@@ -64,7 +64,7 @@ RSpec.describe UpdateTeamNameAndLduService do
     end
   end
 
-  context "when the team exists, but the LDU doesn't" do
+  context "when an LDU with the specified code doesn't exist" do
     before do
       create(:team, code: 'TEAM1')
     end
@@ -72,11 +72,6 @@ RSpec.describe UpdateTeamNameAndLduService do
     it "logs an error" do
       expect_message = "Couldn't find LDU with code LDU1"
       expect(Rails.logger).to receive(:error).with(expect_message)
-      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
-    end
-
-    it "doesn't update the team record" do
-      expect_any_instance_of(Team).not_to receive(:save)
       described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
     end
   end

--- a/spec/services/update_team_name_and_ldu_service_spec.rb
+++ b/spec/services/update_team_name_and_ldu_service_spec.rb
@@ -55,4 +55,29 @@ RSpec.describe UpdateTeamNameAndLduService do
       described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
     end
   end
+
+  context "when the team doesn't exist" do
+    it "logs an error" do
+      expect_message = "Couldn't find team with code TEAM1"
+      expect(Rails.logger).to receive(:error).with(expect_message)
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+    end
+  end
+
+  context "when the team exists, but the LDU doesn't" do
+    before do
+      create(:team, code: 'TEAM1')
+    end
+
+    it "logs an error" do
+      expect_message = "Couldn't find LDU with code LDU1"
+      expect(Rails.logger).to receive(:error).with(expect_message)
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+    end
+
+    it "doesn't update the team record" do
+      expect_any_instance_of(Team).not_to receive(:save)
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+    end
+  end
 end

--- a/spec/services/update_team_name_and_ldu_service_spec.rb
+++ b/spec/services/update_team_name_and_ldu_service_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe UpdateTeamNameAndLduService do
+  context "when the team has the wrong name" do
+    before do
+      team = create(:team, code: 'TEAM1', name: 'The wrong team name')
+      team.local_divisional_unit.code = 'LDU1'
+      team.local_divisional_unit.save
+    end
+
+    it "updates the team name" do
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+      team = Team.find_by(code: 'TEAM1')
+      expect(team.name).to eq('Team One')
+    end
+  end
+
+  context "when the team doesn't have an associated LDU" do
+    before do
+      team = build(:team, code: 'TEAM1', name: 'Team One')
+      team.local_divisional_unit = nil
+      team.save(validate: false)
+      create(:local_divisional_unit, code: 'LDU1')
+    end
+
+    it "associates the team with the LDU" do
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+      team = Team.find_by(code: 'TEAM1')
+      expect(team.local_divisional_unit.code).to eq('LDU1')
+    end
+  end
+
+  context "when the team is associated with the wrong LDU" do
+    before do
+      create(:team, code: 'TEAM1', name: 'Team One')
+      create(:local_divisional_unit, code: 'LDU1')
+    end
+
+    it "associates the team with the correct LDU" do
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+      team = Team.find_by(code: 'TEAM1')
+      expect(team.local_divisional_unit.code).to eq('LDU1')
+    end
+  end
+
+  context "when the team name and LDU are already correct" do
+    before do
+      team = create(:team, code: 'TEAM1', name: 'Team One')
+      team.local_divisional_unit.code = 'LDU1'
+      team.local_divisional_unit.save
+    end
+
+    it "doesn't update the team record" do
+      expect_any_instance_of(Team).not_to receive(:save)
+      described_class.update(team_code: 'TEAM1', team_name: 'Team One', ldu_code: 'LDU1')
+    end
+  end
+end


### PR DESCRIPTION
Jira ticket: [POM-685](https://dsdmoj.atlassian.net/browse/POM-685)
Co-authored-by: @maysakanoni

---

The Delius import spreadsheet is the 'source of truth' for the names of active teams and their associations to LDUs. This PR updates the Delius import job to automatically update the names and associations between Teams and LDUs in our database to reflect those received in the Delius extract.

We've created a new service object, `UpdateTeamNameAndLduService`, which updates the team names and associations to LDUs in our database. It will not create new Team or LDU records in our database.

We've also added to the `DeliusImportJob`, which is the job that runs nightly to perform the import. The change involves performing a second pass over the Delius import spreadsheet:

1. **NEW**: Update ‘Active’ Team → LDU relationships
2. Update `DeliusData` to trigger updates on `CaseInformation` records

Since we're now performing two passes over the spreadsheet, we took the opportunity to DRY-up the looping functionality so that we don't end up needing to repeat that. This looping functionality is now handled by the new `for_each_record` method in the `DeliusImportJob` class.