### PR TITLE
Change production certificate manifest

### DIFF
--- a/deploy/production/certificate.yaml
+++ b/deploy/production/certificate.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha3
 kind: Certificate
 metadata:
   name: allocation-manager-certificate
@@ -9,11 +9,5 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: moic.service.justice.gov.uk
-  acme:
-    config:
-    - domains:
-      - moic.service.justice.gov.uk
-      - allocation-manager-production.apps.live-1.cloud-platform.service.justice.gov.uk
-      dns01:
-        provider: route53-cloud-platform
+  dnsNames:
+  - moic.service.justice.gov.uk


### PR DESCRIPTION
Cert-manager was changed in live one recently, which means the api version has changed. This also requires a change to the spec stanza.