### PR TITLE
POM-670 additional fields for earliest release date

### DIFF
--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -5,7 +5,7 @@ module Nomis
              :conditional_release_date, :release_date,
              :parole_eligibility_date, :tariff_date,
              :automatic_release_date, :licence_expiry_date,
-             :post_recall_release_date,
+             :post_recall_release_date, :earliest_release_date,
              to: :sentence
 
     attr_accessor :convicted_status, :booking_id,
@@ -81,10 +81,6 @@ module Nomis
 
     def immigration_case?
       sentence_type_code == 'DET'
-    end
-
-    def earliest_release_date
-      sentence.earliest_release_date
     end
 
     def pom_responsibility

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -157,13 +157,13 @@ feature "view POM's caseload" do
       end
     end
 
-    it 'can be sorted by release date' do
+    it 'can be sorted by earliest release date' do
       page.all('th')[2].find('a').click
       within '.offender_row_6' do
-        expect(page).to have_content('Anikariah, Aeticake')
+        expect(page).to have_content('Anslana, Diydonopher')
       end
       within '.offender_row_7' do
-        expect(page).to have_content('Kaceria, Omaertain')
+        expect(page).to have_content('Felitha, Asjmonzo')
       end
     end
 


### PR DESCRIPTION
This change adds 4 new fields to the earliest_release_date calculation (if the 5 major ones are all missing). It uses the same logic as the other dates, except that this has been tweaked slightly so that if the only dates available are in the past, then the **latest** date is chosen rather than the oldest as it is more likely to be correct. 