### PR TITLE
POM-658 hide handover dates when COM responsible 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ AllCops:
     - 'lib/tasks/elasticsearch.rake'
     - 'spec/dummy/db/**/*'
     - 'config/routes.rb'
+    - 'spec/factories/*.rb'
 
 Style/MultilineBlockChain:
   Enabled: false

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -84,7 +84,7 @@ module Nomis
     end
 
     def pom_responsibility
-      ResponsibilityService.calculate_pom_responsibility(self)
+      @pom_responsibility ||= ResponsibilityService.calculate_pom_responsibility(self)
     end
 
     def sentence_start_date
@@ -163,7 +163,11 @@ module Nomis
   private
 
     def handover
-      @handover ||= HandoverDateService.handover(self)
+      @handover ||= if pom_responsibility&.custody?
+                      HandoverDateService.handover(self)
+                    else
+                      HandoverDateService::NO_HANDOVER_DATE
+                    end
     end
   end
 end

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -3,6 +3,9 @@
 class HandoverDateService
   HandoverData = Struct.new :start_date, :handover_date, :reason
 
+  # if COM responsible, then handover dates all empty
+  NO_HANDOVER_DATE = HandoverData.new nil, nil, 'COM Responsibility'
+
   def self.handover(offender)
     if offender.recalled?
       HandoverData.new nil, nil, 'Recall case - no handover date calculation'

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -182,23 +182,20 @@ private
 
   class CrcRules
     def self.responsibility(offender)
-      if release_date_gt_12_weeks?(offender)
+      # CRC can look at HDC date, NPS is not supposed to
+      earliest_release_date =
+        offender.home_detention_curfew_actual_date.presence ||
+          [offender.automatic_release_date,
+           offender.conditional_release_date,
+           offender.home_detention_curfew_eligibility_date].compact.min
+
+      return nil if earliest_release_date.nil?
+
+      if earliest_release_date > DateTime.now.utc.to_date + 12.weeks
         RESPONSIBLE
       else
         SUPPORTING
       end
-    end
-
-  private
-
-    # CRC can look at HDC date, NPS is not supposed to
-    def self.release_date_gt_12_weeks?(offender)
-      earliest_release_date =
-        offender.home_detention_curfew_actual_date.presence ||
-            [offender.automatic_release_date,
-             offender.conditional_release_date,
-             offender.home_detention_curfew_eligibility_date].compact.min
-      earliest_release_date > DateTime.now.utc.to_date + 12.weeks
     end
   end
 

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -35,7 +35,7 @@ class ResponsibilityService
 private
 
   def self.standard_rules(offender)
-    if nps_case?(offender) || offender.indeterminate_sentence?
+    if offender.nps_case? || offender.indeterminate_sentence?
       nps_rules(offender)
     else
       crc_rules(offender)
@@ -205,10 +205,6 @@ private
 
   def self.welsh_offender?(offender)
     offender.welsh_offender == true
-  end
-
-  def self.nps_case?(offender)
-    offender.nps_case?
   end
 
   def self.determinate_with_no_release_dates?(offender)

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :offender, class: 'Nomis::Offender' do
+    inprisonment_status do 'SENT03' end
+    sentence do
+      Nomis::SentenceDetail.new.tap { |s|
+        s.automatic_release_date = Time.zone.today + 1.year
+        s.sentence_start_date = Time.zone.today
+      }
+    end
+    prison_id { 'LEI' }
+    case_allocation { 'NPS' }
+    mappa_level { 0 }
+  end
+end

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -2,10 +2,8 @@ FactoryBot.define do
   factory :offender, class: 'Nomis::Offender' do
     inprisonment_status do 'SENT03' end
     sentence do
-      Nomis::SentenceDetail.new.tap { |s|
-        s.automatic_release_date = Time.zone.today + 1.year
-        s.sentence_start_date = Time.zone.today
-      }
+      Nomis::SentenceDetail.new automatic_release_date: Time.zone.today + 1.year,
+                                sentence_start_date: Time.zone.today
     end
     prison_id { 'LEI' }
     case_allocation { 'NPS' }

--- a/spec/models/nomis/offender_spec.rb
+++ b/spec/models/nomis/offender_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Nomis::Offender do
+  describe '#handover_start_date' do
+    context 'when in custody' do
+      let(:offender) { build(:offender) }
+
+      it 'has a value' do
+        expect(offender.handover_start_date).not_to eq(nil)
+      end
+    end
+
+    context 'when COM responsible already' do
+      let(:offender) { build(:offender, sentence: Nomis::SentenceDetail.new) }
+
+      it 'doesnt has a value' do
+        expect(offender.handover_start_date).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 describe HandoverDateService do
   describe 'calculating when community start supporting custody' do
+    context 'when recalled' do
+      let(:offender) { OpenStruct.new(recalled?: true) }
+
+      it 'is not calculated' do
+        expect(described_class.handover(offender).start_date).to be_nil
+      end
+    end
+
     context 'when NPS' do
       let(:offender) {
         OpenStruct.new indeterminate_sentence?: indeterminate,


### PR DESCRIPTION
all handover data is now N/A if the offender has already been handed over to the community