### PR TITLE
Add rake task for seeing missing handover emails

### DIFF
--- a/app/services/view_handover_email_addresses_summary.rb
+++ b/app/services/view_handover_email_addresses_summary.rb
@@ -10,13 +10,19 @@ class ViewHandoverEmailAddressesSummary
   def offender_category(offender)
     case_info = CaseInformation.find_by(nomis_offender_id: offender.offender_no)
 
-    return :missing_delius_record if missing_delius_record?(case_info)
-    return :missing_team_link if missing_team_link?(case_info)
-    return :missing_team_information if missing_team_information?(case_info)
-    return :missing_local_delivery_unit if missing_local_delivery_unit?(case_info)
-    return :missing_local_delivery_unit_email if missing_email?(case_info)
-
-    :has_email_address
+    if missing_delius_record?(case_info)
+      :missing_delius_record
+    elsif missing_team_link?(case_info)
+      :missing_team_link
+    elsif missing_team_information?(case_info)
+      :missing_team_information
+    elsif missing_local_delivery_unit?(case_info)
+      :missing_local_delivery_unit
+    elsif missing_email?(case_info)
+      :missing_local_delivery_unit_email
+    else
+      :has_email_address
+    end
   end
 
   def missing_delius_record?(case_info)
@@ -46,7 +52,7 @@ class ViewHandoverEmailAddressesSummary
       missing_team_link: 0,
       missing_team_information: 0,
       missing_local_delivery_unit: 0,
-      missing_local_delivery_unit_email: 0
+      missing_local_delivery_unit_email: 0,
     }
   end
 end

--- a/app/services/view_handover_email_addresses_summary.rb
+++ b/app/services/view_handover_email_addresses_summary.rb
@@ -16,10 +16,10 @@ class ViewHandoverEmailAddressesSummary
       :missing_team_link
     elsif missing_team_information?(case_info)
       :missing_team_information
-    elsif missing_local_delivery_unit?(case_info)
-      :missing_local_delivery_unit
+    elsif missing_local_divisional_unit?(case_info)
+      :missing_local_divisional_unit
     elsif missing_email?(case_info)
-      :missing_local_delivery_unit_email
+      :missing_local_divisional_unit_email
     else
       :has_email_address
     end
@@ -37,7 +37,7 @@ class ViewHandoverEmailAddressesSummary
     case_info.team.blank?
   end
 
-  def missing_local_delivery_unit?(case_info)
+  def missing_local_divisional_unit?(case_info)
     case_info.team.local_divisional_unit_id.blank?
   end
 
@@ -51,8 +51,8 @@ class ViewHandoverEmailAddressesSummary
       missing_delius_record: 0,
       missing_team_link: 0,
       missing_team_information: 0,
-      missing_local_delivery_unit: 0,
-      missing_local_delivery_unit_email: 0,
+      missing_local_divisional_unit: 0,
+      missing_local_divisional_unit_email: 0,
     }
   end
 end

--- a/app/services/view_handover_email_addresses_summary.rb
+++ b/app/services/view_handover_email_addresses_summary.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class ViewHandoverEmailAddressesSummary
+  def execute(offenders)
+    grouped_offenders = offenders.group_by { |offender| offender_category(offender) }
+
+    empty_groups.merge(grouped_offenders.transform_values(&:count))
+  end
+
+  def offender_category(offender)
+    case_info = CaseInformation.find_by(nomis_offender_id: offender.offender_no)
+
+    return :missing_delius_record if missing_delius_record?(case_info)
+    return :missing_team_link if missing_team_link?(case_info)
+    return :missing_team_information if missing_team_information?(case_info)
+    return :missing_local_delivery_unit if missing_local_delivery_unit?(case_info)
+    return :missing_local_delivery_unit_email if missing_email?(case_info)
+
+    :has_email_address
+  end
+
+  def missing_delius_record?(case_info)
+    case_info.nil?
+  end
+
+  def missing_team_link?(case_info)
+    case_info.team_id.blank?
+  end
+
+  def missing_team_information?(case_info)
+    case_info.team.blank?
+  end
+
+  def missing_local_delivery_unit?(case_info)
+    case_info.team.local_divisional_unit_id.blank?
+  end
+
+  def missing_email?(case_info)
+    case_info.team.local_divisional_unit.email_address.blank?
+  end
+
+  def empty_groups
+    {
+      has_email_address: 0,
+      missing_delius_record: 0,
+      missing_team_link: 0,
+      missing_team_information: 0,
+      missing_local_delivery_unit: 0,
+      missing_local_delivery_unit_email: 0
+    }
+  end
+end

--- a/app/services/view_handover_email_addresses_summary.rb
+++ b/app/services/view_handover_email_addresses_summary.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# See how many of the given offenders are missing an email address for handover, and why
+#
+# Use this via the rake task:
+#   rails handover_email_summary_by_prison [PRISON_CODE]
+#
+# Or in the Rails console:
+#   prison = Prison.new(PRISON_CODE)
+#   offenders = prison.offenders
+#   pp ViewHandoverEmailAddressesSummary.new.execute(offenders)
+
 class ViewHandoverEmailAddressesSummary
   def execute(offenders)
     grouped_offenders = offenders.group_by { |offender| offender_category(offender) }

--- a/lib/tasks/view_handover_email_summary_by_prison.rake
+++ b/lib/tasks/view_handover_email_summary_by_prison.rake
@@ -4,7 +4,7 @@ require 'rake'
 
 desc 'See how many prisoners in a given prison are missing email address for handover, and why'
 task handover_email_summary_by_prison: :environment do
-  ARGV.each do |a| task a.to_sym do; end end
+  ARGV.each do |a| task a.to_sym => :environment do; end end
   prison_code = ARGV[1]
 
   offenders = Prison.new(prison_code).offenders

--- a/lib/tasks/view_handover_email_summary_by_prison.rake
+++ b/lib/tasks/view_handover_email_summary_by_prison.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+desc 'See how many prisoners in a given prison are missing email address for handover, and why'
+task handover_email_summary_by_prison: :environment do
+  ARGV.each do |a| task a.to_sym do; end end
+  prison_code = ARGV[1]
+
+  offenders = Prison.new(prison_code).offenders
+
+  pp ViewHandoverEmailAddressesSummary.new.execute(offenders)
+end

--- a/spec/services/view_handover_email_addresses_summary_spec.rb
+++ b/spec/services/view_handover_email_addresses_summary_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
-describe 'view handover email addresses summary' do
-  subject { ViewHandoverEmailAddressesSummary.new }
-
+describe ViewHandoverEmailAddressesSummary do
   let(:result) { subject.execute(offenders) }
 
-  context 'given an empty list of offenders' do
+  context 'with an empty list of offenders' do
     let(:offenders) { [] }
 
     it 'returns zero for each category' do
@@ -20,7 +18,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given one offender with no associated case information' do
+  context 'with one offender and no associated case information' do
     let(:offenders) { [double(offender_no: 1)] }
 
     it 'returns the right counts' do
@@ -35,7 +33,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given two offenders with no case information' do
+  context 'with two offenders and no case information' do
     let(:offenders) { [double(offender_no: 1), double(offender_no: 2)] }
 
     it 'returns the right counts' do
@@ -50,7 +48,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given an offender with case information with no team link' do
+  context 'with an offender that has case information but no team link' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before { create(:case_information, nomis_offender_id: 1, team: nil) }
@@ -67,7 +65,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given an offender with case information with an orphaned team link' do
+  context 'with an offender that has case information with an orphaned team link' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do
@@ -87,7 +85,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given an offender that cannot be linked to a local delivery unit' do
+  context 'with an offender that cannot be linked to a local delivery unit' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do
@@ -108,7 +106,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given an offender that is linked to a local delivery unit with no email' do
+  context 'with an offender that is linked to a local delivery unit which has no email address' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do
@@ -131,7 +129,7 @@ describe 'view handover email addresses summary' do
     end
   end
 
-  context 'given an offender with a local delivery unit email' do
+  context 'with an offender that has a local delivery unit email address' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do

--- a/spec/services/view_handover_email_addresses_summary_spec.rb
+++ b/spec/services/view_handover_email_addresses_summary_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+describe 'view handover email addresses summary' do
+  subject { ViewHandoverEmailAddressesSummary.new }
+
+  let(:result) { subject.execute(offenders) }
+
+  context 'given an empty list of offenders' do
+    let(:offenders) { [] }
+
+    it 'returns zero for each category' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 0,
+        missing_team_link: 0,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+
+  context 'given one offender with no associated case information' do
+    let(:offenders) { [double(offender_no: 1)] }
+
+    it 'returns the right counts' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 1,
+        missing_team_link: 0,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+
+  context 'given two offenders with no case information' do
+    let(:offenders) { [double(offender_no: 1), double(offender_no: 2)] }
+
+    it 'returns the right counts' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 2,
+        missing_team_link: 0,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+
+  context 'given an offender with case information with no team link' do
+    let(:offenders) { [double(offender_no: 1)] }
+
+    before { create(:case_information, nomis_offender_id: 1, team: nil) }
+
+    it 'returns the right counts' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 0,
+        missing_team_link: 1,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+
+  context 'given an offender with case information with an orphaned team link' do
+    let(:offenders) { [double(offender_no: 1)] }
+
+    before do
+      create(:case_information, nomis_offender_id: 1, team_id: 1)
+      Team.destroy_all
+    end
+
+    it 'returns the right counts' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 0,
+        missing_team_link: 0,
+        missing_team_information: 1,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+
+  context 'given an offender that cannot be linked to a local delivery unit' do
+    let(:offenders) { [double(offender_no: 1)] }
+
+    before do
+      create(:case_information, nomis_offender_id: 1, team_id: 10)
+      team_without_ldu = build(:team, id: 10, local_divisional_unit: nil)
+      team_without_ldu.save(validate: false)
+    end
+
+    it 'returns the right counts' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 0,
+        missing_team_link: 0,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 1,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+
+  context 'given an offender that is linked to a local delivery unit with no email' do
+    let(:offenders) { [double(offender_no: 1)] }
+
+    before do
+      create(:case_information, nomis_offender_id: 1, team_id: 10)
+
+      ldu = create(:local_divisional_unit, email_address: nil)
+
+      create(:team, id: 10, local_divisional_unit: ldu)
+    end
+
+    it 'returns the right counts' do
+      expect(result).to eq(
+        has_email_address: 0,
+        missing_delius_record: 0,
+        missing_team_link: 0,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 1
+                           )
+    end
+  end
+
+  context 'given an offender with a local delivery unit email' do
+    let(:offenders) { [double(offender_no: 1)] }
+
+    before do
+      create(:case_information, nomis_offender_id: 1, team_id: 10)
+      create(:team, id: 10, local_divisional_unit: create(:local_divisional_unit))
+    end
+
+    it 'returns the correct counts' do
+      expect(result).to eq(
+        has_email_address: 1,
+        missing_delius_record: 0,
+        missing_team_link: 0,
+        missing_team_information: 0,
+        missing_local_delivery_unit: 0,
+        missing_local_delivery_unit_email: 0
+                           )
+    end
+  end
+end

--- a/spec/services/view_handover_email_addresses_summary_spec.rb
+++ b/spec/services/view_handover_email_addresses_summary_spec.rb
@@ -12,8 +12,8 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 0,
         missing_team_link: 0,
         missing_team_information: 0,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end
@@ -27,8 +27,8 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 1,
         missing_team_link: 0,
         missing_team_information: 0,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end
@@ -42,8 +42,8 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 2,
         missing_team_link: 0,
         missing_team_information: 0,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end
@@ -59,8 +59,8 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 0,
         missing_team_link: 1,
         missing_team_information: 0,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end
@@ -79,13 +79,13 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 0,
         missing_team_link: 0,
         missing_team_information: 1,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end
 
-  context 'with an offender that cannot be linked to a local delivery unit' do
+  context 'with an offender that cannot be linked to a local divisional unit' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do
@@ -100,13 +100,13 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 0,
         missing_team_link: 0,
         missing_team_information: 0,
-        missing_local_delivery_unit: 1,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 1,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end
 
-  context 'with an offender that is linked to a local delivery unit which has no email address' do
+  context 'with an offender that is linked to a local divisional unit which has no email address' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do
@@ -123,13 +123,13 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 0,
         missing_team_link: 0,
         missing_team_information: 0,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 1
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 1
                            )
     end
   end
 
-  context 'with an offender that has a local delivery unit email address' do
+  context 'with an offender that has a local divisional unit email address' do
     let(:offenders) { [double(offender_no: 1)] }
 
     before do
@@ -143,8 +143,8 @@ describe ViewHandoverEmailAddressesSummary do
         missing_delius_record: 0,
         missing_team_link: 0,
         missing_team_information: 0,
-        missing_local_delivery_unit: 0,
-        missing_local_delivery_unit_email: 0
+        missing_local_divisional_unit: 0,
+        missing_local_divisional_unit_email: 0
                            )
     end
   end


### PR DESCRIPTION
This PR includes a rake task, which can be run with:
`rake handover_email_summary_by_prison [prison_code]`

Notably, this rake task cannot give information across the entire estate, only for an individual prison. I expect it's possible to get a view across the state in one task with some fault-tolerance / batch-processing work.

Also, this rake task outputs the raw counts for each category, not any IDs to investigate. It should be easy to change this in the service if more detail is needed.

This PR is draft, because these counts are not battle-tested yet. I expect there is at least one problem - I haven't yet seen a way to differentiate between:
- This record is not marked as 'NPS' because it doesn't have the
relevant Delius record stored against it yet.
- This record is genuinely not marked as 'NPS'.