### PR TITLE
convert SentenceDetail#post-recall-override-date into a hidden property

### DIFF
--- a/app/models/nomis/sentence_detail.rb
+++ b/app/models/nomis/sentence_detail.rb
@@ -8,8 +8,6 @@ module Nomis
                   :home_detention_curfew_eligibility_date,
                   :home_detention_curfew_actual_date,
                   :parole_eligibility_date,
-                  :post_recall_release_date,
-                  :post_recall_release_override_date,
                   :release_date,
                   :sentence_start_date,
                   :tariff_date
@@ -17,7 +15,9 @@ module Nomis
     attr_writer :automatic_release_date,
                 :automatic_release_override_date,
                 :conditional_release_date,
-                :conditional_release_override_date
+                :conditional_release_override_date,
+                :post_recall_release_date,
+                :post_recall_release_override_date
 
     def automatic_release_date
       @automatic_release_override_date.presence || @automatic_release_date
@@ -25,6 +25,10 @@ module Nomis
 
     def conditional_release_date
       @conditional_release_override_date.presence || @conditional_release_date
+    end
+
+    def post_recall_release_date
+      @post_recall_release_override_date.presence || @post_recall_release_date
     end
 
     def earliest_release_date

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -15,7 +15,7 @@ class OffenderPresenter
            :awaiting_allocation_for, :allocated_pom_name, :allocation_date, :allocated_com_name,
            :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
-           :post_recall_release_date, :post_recall_release_override_date,
+           :post_recall_release_date,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level,  to: :@offender
 
   def initialize(offender, responsibility)


### PR DESCRIPTION
This change matches the others in SentenceDetail. The presence of an 'OverrideDate' in some API fields should be encapsulated within the API-focussed SentenceDetail class, and should not leak into the application. This has already been done for automatic_release and conditional_release dates.