### PR TITLE
Fix vcr flakiness

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,7 +424,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.1)
-    vcr (5.0.0)
+    vcr (5.1.0)
     web-console (4.0.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,8 +44,11 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
+  # weirdly this assignment is implemented as a merge in VCR, so it only
+  # overwrites the specified configuration options
   config.default_cassette_options = {
-    record: :all,
+    # the default in :once, which seems to mess-up our cassette re-use
+    record: :new_episodes,
     match_requests_on: [
       :method,
       :uri,


### PR DESCRIPTION
I think this might fix the VCR flakiness we have been seeing in circle:ci and locally. We were setting record :all explcitly (which is not the default - record unless present is) and re-using cassettes, which might have resulted in some weird race conditions with cassettes being overwritten (badly) while they were still in use in other places (e.g. OS level flushes etc).

This does seem to be more stable 