### PR TITLE
Add offender counts to teams page in Active Admin

### DIFF
--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -13,6 +13,8 @@ ActiveAdmin.register Team do
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end
+
+  # Columns for index page
   index do
     selectable_column
     id_column
@@ -27,4 +29,11 @@ ActiveAdmin.register Team do
     column 'Updated at', :updated_at
     actions
   end
+
+  # Filter fields
+  filter :name
+  filter :code
+  filter :shadow_code
+  filter :local_divisional_unit, collection: proc { LocalDivisionalUnit.order(:name) }
+  filter :case_information_count, label: 'Offender count'
 end

--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -13,4 +13,18 @@ ActiveAdmin.register Team do
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :code
+    column 'Shadow code', :shadow_code
+    column 'LDU', :local_divisional_unit
+    column 'Offenders' do |team|
+      team.case_information.count
+    end
+    column 'Created at', :created_at
+    column 'Updated at', :updated_at
+    actions
+  end
 end

--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -20,8 +20,8 @@ ActiveAdmin.register Team do
     column :code
     column 'Shadow code', :shadow_code
     column 'LDU', :local_divisional_unit
-    column 'Offenders' do |team|
-      team.case_information.count
+    column 'Offenders', sortable: :case_information_count do |team|
+      team.case_information.size
     end
     column 'Created at', :created_at
     column 'Updated at', :updated_at

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -3,7 +3,7 @@
 class CaseInformation < ApplicationRecord
   self.table_name = 'case_information'
 
-  belongs_to :team, optional: true
+  belongs_to :team, optional: true, counter_cache: :case_information_count
 
   has_many :early_allocations,
            foreign_key: :nomis_offender_id,

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,5 +7,5 @@ class Team < ApplicationRecord
 
   belongs_to :local_divisional_unit
 
-  has_many :case_information, dependent: :restrict_with_error
+  has_many :case_information, dependent: :restrict_with_error, counter_cache: :case_information_count
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -6,4 +6,6 @@ class Team < ApplicationRecord
   scope :nps, -> { where('teams.code like ?', 'N%') }
 
   belongs_to :local_divisional_unit
+
+  has_many :case_information, dependent: :restrict_with_error
 end

--- a/db/migrate/20200528112343_add_case_information_count_to_teams.rb
+++ b/db/migrate/20200528112343_add_case_information_count_to_teams.rb
@@ -1,0 +1,19 @@
+class AddCaseInformationCountToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :teams, :case_information_count, :integer, null: false, default: 0
+
+    reversible do |dir|
+      dir.up { seed_counts }
+    end
+  end
+
+  # Populate case_information_count for all teams
+  def seed_counts
+    execute <<-SQL.squish
+        UPDATE teams
+           SET case_information_count = (SELECT count(*)
+                                           FROM case_information
+                                          WHERE case_information.team_id = teams.id)
+    SQL
+  end
+end

--- a/db/migrate/20200528165050_add_shadow_code_index_to_teams.rb
+++ b/db/migrate/20200528165050_add_shadow_code_index_to_teams.rb
@@ -1,0 +1,5 @@
+class AddShadowCodeIndexToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_index :teams, :shadow_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_112343) do
+ActiveRecord::Schema.define(version: 2020_05_28_165050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_112343) do
     t.integer "case_information_count", default: 0, null: false
     t.index ["code"], name: "index_teams_on_code"
     t.index ["local_divisional_unit_id"], name: "index_teams_on_local_divisional_unit_id"
+    t.index ["shadow_code"], name: "index_teams_on_shadow_code"
   end
 
   create_table "tier_changes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_12_110913) do
+ActiveRecord::Schema.define(version: 2020_05_28_112343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2019_12_12_110913) do
     t.datetime "updated_at", null: false
     t.string "shadow_code"
     t.bigint "local_divisional_unit_id"
+    t.integer "case_information_count", default: 0, null: false
     t.index ["code"], name: "index_teams_on_code"
     t.index ["local_divisional_unit_id"], name: "index_teams_on_local_divisional_unit_id"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,15 +4,12 @@ SimpleCov.start 'rails' do
   add_filter 'app/services/nomis/error/'
   add_filter 'lib/allocation_validation.rb'
   add_filter 'app/jobs/custom_stats_logging_job.rb'
+  add_filter 'app/admin/'
   add_group "Services", "app/services"
 
   # Try to set this to current coverage levels so that it never goes down after a PR
-  # 23 lines uncovered at 99.22% coverage
-  # had to drop this by .01 as a result of re-structuring code and exposing a path that
-  # we were not testing anyway.
-  minimum_coverage 99.22
-  # 22 lines uncovered at 99.25% coverage
-  minimum_coverage 99.25
+  # 22 lines uncovered at 99.3% coverage
+  minimum_coverage 99.3
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.1
 end


### PR DESCRIPTION
Jira ticket: [POM-717](https://dsdmoj.atlassian.net/browse/POM-717)

---

This pull request adds an 'offenders' column to the 'Teams' page in Active Admin:

![localhost_3000_admin_teams_order=id_desc(iPad)](https://user-images.githubusercontent.com/7735945/83168395-54573380-a109-11ea-9a20-0b4841017b6f.png)

This column shows the number of offenders ('case information' records) assigned to each team.

This is an enabler for us cleaning up our team data, as it'll allow us to see which teams are in use, and which ones are redundant.

### Database changes

I've used a [counter cache](https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-counter-cache) to maintain a count of the number of offenders in each team. This adds a new `case_information_count` field to the `teams` database.

A database migration will create this new column and seed it for existing team records.

### Other changes

I've also fixed a couple of small but related things:

- **Active Admin:** The "Local Divisional Units" dropdown/select list in the "Filter" sidebar panel on the Teams page is now sorted alphabetically. Previously this was unsorted, so was very difficult to find the desired LDU if using this filter.
- **Database index:** I've added a database index on the `teams.shadow_code` column. We frequently find teams by their shadow code in our application, so we should really have an index for that read pattern.
- **Code coverage:** I've configured Simplecov to ignore files in the `app/admin/` directory, as testing the functionality of our Active Admin is not a priority. We do, however, still have a feature test to cover user access permissions in [`spec/features/active_admin_feature_spec.rb`](https://github.com/ministryofjustice/offender-management-allocation-manager/blob/master/spec/features/active_admin_feature_spec.rb)