### PR TITLE
Bind prometheus exporter to all network interfaces

### DIFF
--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -104,7 +104,7 @@ spec:
         - name: allocation-manager-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
-          command: ['sh', '-c', "bundle exec prometheus_exporter"]
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           ports:
             - containerPort: 9394
           livenessProbe:

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -118,7 +118,7 @@ spec:
         - name: allocation-manager-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
-          command: ['sh', '-c', "bundle exec prometheus_exporter"]
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           ports:
             - containerPort: 9394
           resources:

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -110,7 +110,7 @@ spec:
         - name: allocation-manager-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
-          command: ['sh', '-c', "bundle exec prometheus_exporter"]
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           ports:
             - containerPort: 9394
           livenessProbe:


### PR DESCRIPTION
There was a breaking change introduced in version 0.5.0 of the `prometheus_exporter` gem. By default, prometheus exporter now only binds to the `localhost` interface to avoid insecure configurations. These changes happened in commit: discourse/prometheus_exporter@f83b4f4

In our setup (running as docker containers inside a kubernetes pod) we need prometheus exporter to bind to ALL interfaces (as it previously did) rather than only to `localhost`. Without this, our rails application is unable to communicate with prometheus exporter, outputting messages like this in the log:

```
Prometheus Exporter, failed to send message Cannot assign requested address - connect(2) for "localhost" port 9394
```

This commit uses the new runtime option `-b (--bind)` to tell prometheus exporter to bind to all interfaces. This re-implements the old behaviour, making it once again available within the kube pod for our rails app to communicate with.