### PR TITLE
rollback listen to try and remove test flakiness (part deux)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,9 @@ group :test do
 end
 
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.3'
+  # for some reason listen 3.2.x interferes with VCR 5.x so that we end up with flakey specs
+  # which seem to fail around 50% of the time. So peg it back to 3.1 for now.
+  gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,9 +188,10 @@ GEM
     kaminari-core (1.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
-    listen (3.2.1)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loaf (0.8.1)
       rails (>= 3.2)
     lograge (0.11.2)
@@ -308,7 +309,7 @@ GEM
       activesupport (>= 5.0)
       i18n
       polyamorous (= 2.3.0)
-    rb-fsevent (0.10.3)
+    rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.3)
@@ -364,6 +365,7 @@ GEM
       rubocop (>= 0.68.1)
     ruby-prof (1.4.1)
     ruby-progressbar (1.10.1)
+    ruby_dep (1.5.0)
     rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sassc (2.2.1)
@@ -476,7 +478,7 @@ DEPENDENCIES
   jwt
   kaminari
   launchy
-  listen (>= 3.0.5, < 3.3)
+  listen (>= 3.0.5, < 3.2)
   loaf
   lograge
   logstash-event


### PR DESCRIPTION
We still have a number of flaky tests with VCR cassettes on circle:ci - almost to the point of not being able to push through some changesets. This change was identified as the 'cause' last time, so possibly pegging this back will have some effect on future tests.