### PR TITLE
Fix invalid YAML in `deployment.yaml` files

### DIFF
--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -69,10 +69,10 @@ spec:
                   name: allocation-rds-instance-output
                   key: postgres_user
             - name: REDIS_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: elasticache-offender-management-allocation-manager-token-cache-preprod
-                    key: url
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-offender-management-allocation-manager-token-cache-preprod
+                  key: url
         - name: allocation-manager-sidekiq
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
@@ -107,10 +107,10 @@ spec:
                   name: allocation-rds-instance-output
                   key: postgres_user
             - name: REDIS_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: elasticache-offender-management-allocation-manager-token-cache-preprod
-                    key: url
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-offender-management-allocation-manager-token-cache-preprod
+                  key: url
         - name: allocation-manager-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -76,10 +76,10 @@ spec:
                   name: allocation-rds-instance-output
                   key: postgres_user
             - name: REDIS_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: elasticache-offender-management-allocation-manager-token-cache-production
-                    key: url
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-offender-management-allocation-manager-token-cache-production
+                  key: url
         - name: allocation-manager-sidekiq
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
@@ -121,10 +121,10 @@ spec:
                   name: allocation-rds-instance-output
                   key: postgres_user
             - name: REDIS_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: elasticache-offender-management-allocation-manager-token-cache-production
-                    key: url
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-offender-management-allocation-manager-token-cache-production
+                  key: url
         - name: allocation-manager-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -113,10 +113,10 @@ spec:
                   name: allocation-rds-instance-output
                   key: postgres_user
             - name: REDIS_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: elasticache-offender-management-allocation-manager-token-cache-staging
-                    key: url
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-offender-management-allocation-manager-token-cache-staging
+                  key: url
         - name: allocation-manager-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always


### PR DESCRIPTION
Invalid YAML was introduced in 886f14e where I added configuration to dynamically pull Redis credentials from the Cloud Platform environment.

This commit fixes the bad formatting which was invalidating the YAML and causing Kubernetes deployments to fail.