### PR TITLE
fixed test that only passed by accident on circle

### DIFF
--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -167,50 +167,54 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
     end
 
     context 'without DeliusDataJob' do
-      before do
-        allocation = create(:allocation,
-                            nomis_offender_id: offender_no,
-                            nomis_booking_id: 1,
-                            primary_pom_nomis_id: 4,
-                            allocated_at_tier: 'A',
-                            prison: 'PVI',
-                            recommended_pom_type: 'probation',
-                            event: Allocation::ALLOCATE_PRIMARY_POM,
-                            event_trigger: Allocation::USER,
-                            created_by_username: 'PK000223'
-        )
-        allocation.update!(
-          primary_pom_nomis_id: 5,
-          prison: 'LEI',
-          event: Allocation::REALLOCATE_PRIMARY_POM,
-          event_trigger: Allocation::USER,
-          created_by_username: 'PK000223'
-        )
-      end
-
       render_views
 
-      it "Can get the allocation history for an offender", versioning: true do
-        get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
-        allocation_list = assigns(:history).to_a
+      context 'with an allocation' do
+        before do
+          allocation = create(:allocation,
+                              nomis_offender_id: offender_no,
+                              nomis_booking_id: 1,
+                              primary_pom_nomis_id: 4,
+                              allocated_at_tier: 'A',
+                              prison: 'PVI',
+                              recommended_pom_type: 'probation',
+                              event: Allocation::ALLOCATE_PRIMARY_POM,
+                              event_trigger: Allocation::USER,
+                              created_by_username: 'PK000223'
+          )
+          allocation.update!(
+            primary_pom_nomis_id: 5,
+            prison: 'LEI',
+            event: Allocation::REALLOCATE_PRIMARY_POM,
+            event_trigger: Allocation::USER,
+            created_by_username: 'PK000223'
+          )
+        end
 
-        expect(allocation_list.count).to eq(2)
-        # We get back a list of prison, allocation_array pairs
-        expect(allocation_list.map(&:size)).to eq([2, 2])
-        # Prisons are 1 each - LEI then PVI
-        expect(allocation_list.first.first).to eq('LEI')
-        expect(allocation_list.last.first).to eq('PVI')
+        it "Can get the allocation history for an offender", versioning: true do
+          get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
+          allocation_list = assigns(:history).to_a
 
-        # we have 2 1-element arrays
-        arrays = allocation_list.map { |al| al.second.first }
-        expect(arrays.size).to eq(2)
+          expect(allocation_list.count).to eq(2)
+          # We get back a list of prison, allocation_array pairs
+          expect(allocation_list.map(&:size)).to eq([2, 2])
+          # Prisons are 1 each - LEI then PVI
+          expect(allocation_list.first.first).to eq('LEI')
+          expect(allocation_list.last.first).to eq('PVI')
 
-        expect(arrays.first.nomis_offender_id).to eq(offender_no)
-        # expect to see reallocate event before allocate as the history is reversed
-        expect(arrays.first.event).to eq('reallocate_primary_pom')
-        expect(arrays.last.nomis_booking_id).to eq(1)
+          # we have 2 1-element arrays
+          arrays = allocation_list.map { |al| al.second.first }
+          expect(arrays.size).to eq(2)
+
+          expect(arrays.first.nomis_offender_id).to eq(offender_no)
+          # expect to see reallocate event before allocate as the history is reversed
+          expect(arrays.first.event).to eq('reallocate_primary_pom')
+          expect(arrays.last.nomis_booking_id).to eq(1)
+        end
       end
+    end
 
+    context 'with a different allocation' do
       it "can get email addresses of POM's who have been allocated to an offender given the allocation history", versioning: true do
         previous_primary_pom_nomis_id = 3
         updated_primary_pom_nomis_id = 4


### PR DESCRIPTION
We have one test which creates an invalid scenario with mutiple allocation records for the same offender but different prisons (shame the code allows such a thing). 
As a result there was one test that failed in specific environments, as Allocation.find_by(nomis_offender_id: <x>) sometimes picked up a different allocation (one bleeding through from an earlier test) resulting in weird test failures. 
This PR fixes up this test by seperating the 2 tests so the bleed-through no longer happens.