### PR TITLE
Fix off-by-1 error in fetching offenders (pom-682 precursor)

### DIFF
--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -47,7 +47,7 @@ private
     def each
       number_of_requests = max_requests_count
 
-      (0..number_of_requests).each do |request_no|
+      (0..number_of_requests - 1).each do |request_no|
         offenders = fetch_page_of_offenders(
           page_number: request_no,
           page_size: FETCH_SIZE
@@ -84,7 +84,6 @@ private
 
       offenders.each { |offender|
         sentencing = sentence_details[offender.booking_id]
-        # TODO: - if sentencing.present? is false, then we crash in offender#sentenced?
         offender.sentence = sentencing if sentencing.present?
 
         case_info_record = mapped_tiers[offender.offender_no]

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -37,14 +37,6 @@ RSpec.describe DebuggingController, type: :controller do
           with(
             headers: {
               'Page-Limit' => '200',
-              'Page-Offset' => '200'
-            }).
-          to_return(status: 200, body: {}.to_json, headers: { 'Total-Records' => '3' })
-
-      stub_request(:get, elite2listapi).
-          with(
-            headers: {
-              'Page-Limit' => '200',
               'Page-Offset' => '0'
             }).
           to_return(status: 200,

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -72,13 +72,6 @@ RSpec.describe SearchController, type: :controller do
                                 "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
             "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }].to_json, headers: {})
 
-      stub_request(:get, elite2listapi).
-        with(
-          headers: {
-            'Page-Limit' => '200',
-            'Page-Offset' => '200'
-          }).
-        to_return(status: 200, body: {}.to_json, headers: {})
       stub_request(:get, "#{elite2api}/staff/roles/#{prison}/role/POM").
         with(
           headers: {

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -67,16 +67,6 @@ feature "view POM's caseload" do
       to_return(status: 200, body: {}.to_json, headers: { 'Total-Records' => '3' })
 
     stub_request(:get, elite2listapi).
-    with(
-      headers: {
-        'Authorization' => 'Bearer token',
-        'Expect' => '',
-        'Page-Limit' => '200',
-        'Page-Offset' => '200'
-      }).
-    to_return(status: 200, body: {}.to_json, headers: { 'Total-Records' => '3' })
-
-    stub_request(:get, elite2listapi).
       with(
         headers: {
           'Authorization' => 'Bearer token',


### PR DESCRIPTION
There has been an off-by-1 error in fetching offenders for a long time, with appropriate stubs to support its existence :-) 
During the development of POM-682, this surfaced as we had to either fix the bug or add to the noise with stubs that shouldn't be needed. 
So this is the bug fix, with the test noise removed.