### PR TITLE
Add factories for offenders and bookings

### DIFF
--- a/app/models/nomis/movement.rb
+++ b/app/models/nomis/movement.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module Nomis
-  class MovementType
-    RELEASE = 'REL'
-    TRANSFER = 'TRN'
-    ADMISSION = 'ADM'
-  end
-
   class MovementDirection
     IN = 'IN'
     OUT = 'OUT'

--- a/app/models/nomis/movement_type.rb
+++ b/app/models/nomis/movement_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Nomis
+  module MovementType
+    RELEASE = 'REL'
+    TRANSFER = 'TRN'
+    ADMISSION = 'ADM'
+    TEMPORARY = 'TAP'
+  end
+end

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -11,69 +11,50 @@ RSpec.describe DebuggingController, type: :controller do
     stub_sso_data(prison, 'user')
     stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
       with(
-        body: "[\"G7806VO\"]",
-        headers: {
-          'Authorization' => 'Bearer token',
-          'Content-Type' => 'application/json',
-          'Expect' => '',
-          'User-Agent' => 'Faraday v0.15.4'
-        }).
-      to_return(status: 200, body: [].to_json, headers: {})
+        body: "[\"G7806VO\"]").
+      to_return(body: [].to_json)
   end
 
   context 'when debugging at a prison level' do
     it 'can show debugging information for an entire prison' do
       stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
-      to_return(status: 200, body: [].to_json)
-      stub_request(:get, elite2listapi).
-          with(
-            headers: {
-              'Page-Limit' => '1',
-              'Page-Offset' => '1'
-            }).
-          to_return(status: 200, body: {}.to_json, headers: { 'Total-Records' => '3' })
+        to_return(status: 200, body: [].to_json)
 
-      stub_request(:get, elite2listapi).
-          with(
-            headers: {
-              'Page-Limit' => '200',
-              'Page-Offset' => '0'
-            }).
-          to_return(status: 200,
-                    body: [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
-                             "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
-                             "age": 28, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                             "facialImageId": 1_392_829,
-                             "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
-                           { "bookingId": 754_206, "bookingNo": "K09212", "offenderNo": "G1234VV", "firstName": "ROSS",
-                             "lastName": "JONES", "dateOfBirth": "2004-02-02",
-                             "age": 15, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                             "facialImageId": 1_392_900,
-                             "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
-                           { "bookingId": 1, "bookingNo": "K09213", "offenderNo": "G1234XX", "firstName": "BOB",
-                             "lastName": "SMITH", "dateOfBirth": "1995-02-02",
-                             "age": 34, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                             "facialImageId": 1_392_900,
-                             "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }
-                    ].to_json)
-      stub_request(:post, elite2bookingsapi).
-          with(body: "[754207,754206,1]").
-          to_return(status: 200, body: [
-              { "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "WEI",
-                "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                                    "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                                    "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                                    "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                                    "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-                "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-              { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": "WEI",
-                "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                                    "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                                    "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                                    "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                                    "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-                "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-          ].to_json, headers: {})
+      offenders = [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
+                     "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
+                     "age": 28, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
+                     "facialImageId": 1_392_829,
+                     "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
+                   { "bookingId": 754_206, "bookingNo": "K09212", "offenderNo": "G1234VV", "firstName": "ROSS",
+                     "lastName": "JONES", "dateOfBirth": "2004-02-02",
+                     "age": 15, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
+                     "facialImageId": 1_392_900,
+                     "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
+                   { "bookingId": 1, "bookingNo": "K09213", "offenderNo": "G1234XX", "firstName": "BOB",
+                     "lastName": "SMITH", "dateOfBirth": "1995-02-02",
+                     "age": 34, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
+                     "facialImageId": 1_392_900,
+                     "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }
+      ]
+
+      bookings = [
+        { "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "WEI",
+          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
+        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": "WEI",
+          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
+      ]
+
+      stub_offenders_for_prison(prison, offenders, bookings)
 
       get :prison_info, params: { prison_id: prison }
       expect(response.status).to eq(200)
@@ -106,11 +87,11 @@ RSpec.describe DebuggingController, type: :controller do
       stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false").
         with(
           body: "[\"G7806VO\"]").
-          to_return(status: 200, body: [{ offenderNo: offender_no,
-                                          fromAgency: "LEI",
-                                          toAgency: "WEI",
-                                          movementType: "TRN",
-                                          directionCode: "IN" }].to_json, headers: {})
+        to_return(status: 200, body: [{ offenderNo: offender_no,
+                                        fromAgency: "LEI",
+                                        toAgency: "WEI",
+                                        movementType: "TRN",
+                                        directionCode: "IN" }].to_json, headers: {})
 
       create(:case_information, nomis_offender_id: offender_no)
       create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: pom_staff_id, primary_pom_name: primary_pom_name)

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -40,37 +40,20 @@ RSpec.describe SearchController, type: :controller do
     end
 
     it 'can search' do
-      stub_request(:get, elite2listapi).
-        with(
-          headers: {
-            'Page-Limit' => '1',
-            'Page-Offset' => '1'
-          }).
-        to_return(status: 200, body: {}.to_json, headers: { 'Total-Records' => '31' })
+      offenders = [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
+                     "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
+                     "age": 28, "agencyId": "LEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
+                     "facialImageId": 1_392_829,
+                     "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }]
+      bookings =  [{ "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "LEI",
+                     "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                                         "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                                         "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
+                                         "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                                         "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
+                     "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }]
 
-      stub_request(:get, elite2listapi).
-        with(
-          headers: {
-            'Page-Limit' => '200',
-            'Page-Offset' => '0'
-          }).
-        to_return(status: 200,
-                  body: [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
-                           "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
-                           "age": 28, "agencyId": "LEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                           "facialImageId": 1_392_829,
-                           "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }
-                  ].to_json)
-      stub_request(:post, elite2bookingsapi).
-        with(body: "[754207]").
-        to_return(status: 200, body: [
-          { "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "LEI",
-            "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                                "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                                "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                                "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                                "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-            "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }].to_json, headers: {})
+      stub_offenders_for_prison(prison, offenders, bookings)
 
       stub_request(:get, "#{elite2api}/staff/roles/#{prison}/role/POM").
         with(

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -220,20 +220,7 @@ RSpec.describe SummaryController, type: :controller do
         }
       }
 
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/locations/description/BRI/inmates?convictedStatus=Convicted&returnCategory=true").
-        with(headers: { "Page-Limit": '1' }).
-        to_return(body: [].to_json, headers: { "Total Records": "6" })
-
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/locations/description/BRI/inmates?convictedStatus=Convicted&returnCategory=true").
-        with(headers: { 'Page-Offset' => '0' }).
-        to_return(body: inmates.to_json)
-
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/locations/description/BRI/inmates?convictedStatus=Convicted&returnCategory=true").
-        with(headers: { 'Page-Offset' => '200' }).
-        to_return(body: [].to_json)
-
-      stub_request(:post, 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/offender-sentences/bookings').
-        to_return(body: bookings.to_json)
+      stub_offenders_for_prison(prison, inmates, bookings)
 
       stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
         to_return(status: 200, body: movements.to_json)

--- a/spec/factories/movement.rb
+++ b/spec/factories/movement.rb
@@ -1,21 +1,33 @@
-require 'faker'
-
 FactoryBot.define do
   factory :movement, class: 'Nomis::Movement' do
     skip_create
-    from_agency do
+
+    initialize_with do
+      Nomis::Movement.from_json(attributes.stringify_keys)
+    end
+
+    trait :tap do
+      movementType do 'TAP' end
+      directionCode  { 'OUT' }
+    end
+
+    fromAgency do
       'LEI'
     end
 
-    to_agency do
+    sequence(:createDateTime) do |seq|
+      (Time.zone.today - seq.days).to_s
+    end
+
+    toAgency do
       'SWI'
     end
 
-    direction_code do
+    directionCode do
       'IN'
     end
 
-    movement_type do
+    movementType do
       'ADM'
     end
   end

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -1,12 +1,46 @@
 FactoryBot.define do
-  factory :offender, class: 'Nomis::Offender' do
-    inprisonment_status do 'SENT03' end
-    sentence do
-      Nomis::SentenceDetail.new automatic_release_date: Time.zone.today + 1.year,
-                                sentence_start_date: Time.zone.today
+  class Elite2Booking
+    attr_reader :sentenceDetail
+
+    # rubocop:disable Naming/VariableName
+    def initialize(data)
+      @sentenceDetail = data[:sentenceDetail]
     end
-    prison_id { 'LEI' }
-    case_allocation { 'NPS' }
-    mappa_level { 0 }
+    # rubocop:enable Naming/VariableName
+  end
+
+  factory :offender, class: 'Nomis::OffenderSummary' do
+    initialize_with { Nomis::OffenderSummary.from_json(attributes) }
+
+    imprisonmentStatus { 'SENT03' }
+    prisonId { 'LEI' }
+
+    # offender numbers are of the form <letter><4 numbers><2 letters>
+    sequence(:offenderNo) do |seq|
+      number = seq / 26 + 1000
+      letter = ('A'..'Z').to_a[seq % 26]
+      "T#{number}T#{letter}"
+    end
+    sequence(:bookingId) { |x| x + 700_000 }
+    convictedStatus { 'Convicted' }
+    dateOfBirth { Date.new(1990, 12, 6).to_s }
+    firstName { Faker::Name.first_name }
+    # We have some issues with corrupting the display
+    # of names containing Mc or Du :-(
+    lastName do
+      Faker::Name.last_name.titleize
+    end
+    categoryCode { 'C' }
+  end
+
+  factory :booking, class: 'Elite2Booking' do
+    initialize_with do new(attributes) end
+
+    sequence(:sentenceDetail) { |seq|
+      {
+        'tariffDate' => Date.new(2032 + seq % 5, 3, 17) - (seq * 2).days,
+        'sentenceStartDate' => Date.new(2009, 2, 8)
+      }
+    }
   end
 end

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -10,119 +10,71 @@ feature "view POM's caseload" do
   let(:elite2listapi) { "#{elite2api}/locations/description/#{prison}/inmates?convictedStatus=Convicted&returnCategory=true" }
   let(:elite2bookingsapi) { "#{elite2api}/offender-sentences/bookings" }
 
+  let(:offender_map) {
+    {
+      'G7266VD' => 1_073_602,
+      'G8563UA' => 1_020_605,
+      'G6068GV' => 1_030_841,
+      'G0572VU' => 861_029,
+      'G8668GF' => 1_106_348,
+      'G9465UP' => 1_186_259,
+      'G9372GQ' => 752_833,
+      'G1618UI' => 1_161_236,
+      'G4328GK' => 1_055_341,
+      'G4143VX' => 1_083_858,
+      'G8180UO' => 1_172_076,
+      'G8909GV' => 877_782,
+      'G8339GD' => 260_708,
+      'G1992GH' => 1_179_167,
+      'G1986GG' => 1_165_890,
+      'G6262GI' => 961_997,
+      'G6653UC' => 1_009_990,
+      'G5992GA' => 928_042,
+      'G4706UP' => 1_180_800,
+      'G9344UG' => 841_994
+    }
+  }
+  let(:offenders) {
+    offender_map.merge(nomis_offender_id => 1_153_753).
+      map { |nomis_id, booking_id| attributes_for(:offender).merge(offenderNo: nomis_id, bookingId: booking_id) }
+  }
+  let(:sorted_offenders) {
+    offenders.sort_by { |o| "#{o.fetch(:lastName)}, #{o.fetch(:firstName)}" }
+  }
+  let(:first_offender) { sorted_offenders.first }
+  let(:moved_offender) { sorted_offenders.fourth }
+  let(:bookings) { offenders.map { |o| attributes_for(:booking).merge(offenderNo: o.fetch(:offenderNo), bookingId: o.fetch(:bookingId)) } }
+
   # create 21 allocations for prisoners named A-K so that we can verify that default sorted paging works
   before do
-    create(:case_information, nomis_offender_id: 'G7266VD')
-    create(:case_information, nomis_offender_id: 'G8563UA')
-    create(:case_information, nomis_offender_id: 'G6068GV')
-    create(:case_information, nomis_offender_id: 'G0572VU')
-    create(:case_information, nomis_offender_id: 'G8668GF')
-    create(:case_information, nomis_offender_id: 'G9465UP')
-    create(:case_information, nomis_offender_id: 'G9372GQ')
-    create(:case_information, nomis_offender_id: 'G1618UI')
-    create(:case_information, nomis_offender_id: 'G4328GK')
-    create(:case_information, nomis_offender_id: 'G4143VX')
-    create(:case_information, nomis_offender_id: 'G8180UO')
-    create(:case_information, nomis_offender_id: 'G8909GV')
-    create(:case_information, nomis_offender_id: 'G8339GD')
-    create(:case_information, nomis_offender_id: 'G1992GH')
-    create(:case_information, nomis_offender_id: 'G1986GG')
-    create(:case_information, nomis_offender_id: 'G6262GI')
-    create(:case_information, nomis_offender_id: 'G6653UC')
-    create(:case_information, nomis_offender_id: 'G1718GG')
-    create(:case_information, nomis_offender_id: 'G4706UP')
-    create(:case_information, nomis_offender_id: 'G9344UG')
+    poms =
+      [
+        build(:pom,
+              firstName: 'Alice',
+              position: RecommendationService::PRISON_POM,
+              staffId: nomis_staff_id
+        )
+      ]
+
+    stub_poms(prison, poms)
+    stub_offenders_for_prison(prison, offenders, bookings)
+
+    offender_map.each do |nomis_offender_id, nomis_booking_id|
+      create(:case_information, nomis_offender_id: nomis_offender_id)
+      create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, nomis_booking_id: nomis_booking_id)
+    end
     create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'Yes')
+    create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, nomis_booking_id: 1_153_753)
 
-    create(:allocation, nomis_offender_id: 'G7266VD', primary_pom_nomis_id: '485926', nomis_booking_id: '1073602')
-    create(:allocation, nomis_offender_id: 'G8563UA', primary_pom_nomis_id: '485926', nomis_booking_id: '1020605')
-    create(:allocation, nomis_offender_id: 'G6068GV', primary_pom_nomis_id: '485926', nomis_booking_id: '1030841')
-    create(:allocation, nomis_offender_id: 'G0572VU', primary_pom_nomis_id: '485926', nomis_booking_id: '861029')
-    create(:allocation, nomis_offender_id: 'G8668GF', primary_pom_nomis_id: '485926', nomis_booking_id: '1106348')
-    create(:allocation, nomis_offender_id: 'G9465UP', primary_pom_nomis_id: '485926', nomis_booking_id: '1186259')
-    create(:allocation, nomis_offender_id: 'G9372GQ', primary_pom_nomis_id: '485926', nomis_booking_id: '752833')
-    create(:allocation, nomis_offender_id: 'G1618UI', primary_pom_nomis_id: '485926', nomis_booking_id: '1161236')
-    create(:allocation, nomis_offender_id: 'G4328GK', primary_pom_nomis_id: '485926', nomis_booking_id: '1055341')
-    create(:allocation, nomis_offender_id: 'G4143VX', primary_pom_nomis_id: '485926', nomis_booking_id: '1083858')
-    create(:allocation, nomis_offender_id: 'G8180UO', primary_pom_nomis_id: '485926', nomis_booking_id: '1172076')
-    create(:allocation, nomis_offender_id: 'G8909GV', primary_pom_nomis_id: '485926', nomis_booking_id: '877782')
-    create(:allocation, nomis_offender_id: 'G8339GD', primary_pom_nomis_id: '485926', nomis_booking_id: '260708')
-    create(:allocation, nomis_offender_id: 'G1992GH', primary_pom_nomis_id: '485926', nomis_booking_id: '1179167')
-    create(:allocation, nomis_offender_id: 'G1986GG', primary_pom_nomis_id: '485926', nomis_booking_id: '1165890')
-    create(:allocation, nomis_offender_id: 'G6262GI', primary_pom_nomis_id: '485926', nomis_booking_id: '961997')
-    create(:allocation, nomis_offender_id: 'G6653UC', primary_pom_nomis_id: '485926', nomis_booking_id: '1009990')
-    create(:allocation, nomis_offender_id: 'G1718GG', primary_pom_nomis_id: '485926', nomis_booking_id: '928042')
-    create(:allocation, nomis_offender_id: 'G4706UP', primary_pom_nomis_id: '485926', nomis_booking_id: '1180800')
-    create(:allocation, nomis_offender_id: 'G9344UG', primary_pom_nomis_id: '485926', nomis_booking_id: '841994')
-    create(:allocation, nomis_offender_id: 'G4273GI', primary_pom_nomis_id: '485926', nomis_booking_id: '1153753')
-
-    stub_request(:get, elite2listapi).
-      with(
-        headers: {
-          'Authorization' => 'Bearer token',
-          'Expect' => '',
-          'Page-Limit' => '1',
-          'Page-Offset' => '1'
-        }).
-      to_return(status: 200, body: {}.to_json, headers: { 'Total-Records' => '3' })
-
-    stub_request(:get, elite2listapi).
-      with(
-        headers: {
-          'Authorization' => 'Bearer token',
-          'Expect' => '',
-          'Page-Limit' => '200',
-          'Page-Offset' => '0'
-        }).
-      to_return(status: 200,
-                body: [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
-                         "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
-                         "age": 28, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                         "facialImageId": 1_392_829,
-                         "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
-                       { "bookingId": 754_206, "bookingNo": "K09212", "offenderNo": "G1234VV", "firstName": "ROSS",
-                         "lastName": "JONES", "dateOfBirth": "2004-02-02",
-                         "age": 15, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                         "facialImageId": 1_392_900,
-                         "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
-                       { "bookingId": 1, "bookingNo": "K09213", "offenderNo": "G1234XX", "firstName": "BOB",
-                         "lastName": "SMITH", "dateOfBirth": "1995-02-02",
-                         "age": 34, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                         "facialImageId": 1_392_900,
-                         "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }
-                ].to_json)
-    stub_request(:post, elite2bookingsapi).
-      with(body: "[754207,754206,1]").
-      to_return(status: 200, body: [
-        { "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "WEI",
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": "WEI",
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-        ].to_json, headers: {})
+    offenders.last(15).each do |o|
+      create(:responsibility, nomis_offender_id: o.fetch(:offenderNo), value: Responsibility::PROBATION)
+    end
 
     allow_any_instance_of(Nomis::OffenderBase).to receive(:handover_start_date).and_return(tomorrow)
   end
 
-  context 'when paginating', vcr: { cassette_name: :show_poms_caseload } do
+  context 'when paginating' do
     before do
-      stub_const("NAMES", ["Abbella, Ozullirn", 'Allix, Aobmethani',
-                           'Almesa, Akoresjan', 'Amabeth, Eeonyan', 'Anasterie, Aobmethani', 'Andexia, Obinins',
-                           'Andoy, Demolarichard', 'Androne, Alblisdavid', 'Anikariah, Aeticake',
-                           'Annole, Omistius', 'Anslana, Diydonopher',
-                           "Bennany, Yruicafar", "Cadary, Avncent", "Daijedo, Egvaning",
-                           'Ebonuardo, Omimchi', 'Felitha, Asjmonzo', 'Gabrijah, Eastzo', 'Hah, Dyfastoaul',
-                           'Ibriyah, Aiamce', 'Jabexia, Elnuunbo', 'Kaceria, Omaertain'
-      ])
       signin_pom_user
 
       visit prison_caseload_index_path('LEI')
@@ -131,7 +83,9 @@ feature "view POM's caseload" do
     it 'displays paginated cases for a specific POM' do
       expect(page).to have_content("Showing 1 - 21 of 21 results")
       expect(page).to have_content("Your caseload (21)")
-      NAMES.first(20).each_with_index do |name, index|
+      sorted_offenders.first(20).each_with_index do |offender, index|
+        name = "#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}"
+
         within ".offender_row_#{index}" do
           expect(page).to have_content(name)
         end
@@ -140,7 +94,8 @@ feature "view POM's caseload" do
 
     it 'can be reverse sorted by name' do
       click_link 'Prisoner name'
-      NAMES.last(20).reverse.each_with_index do |name, index|
+      sorted_offenders.last(20).reverse.each_with_index do |offender, index|
+        name = "#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}"
         within ".offender_row_#{index}" do
           expect(page).to have_content(name)
         end
@@ -149,26 +104,34 @@ feature "view POM's caseload" do
 
     it 'can be sorted by earliest release date' do
       page.all('th')[2].find('a').click
-      within '.offender_row_6' do
-        expect(page).to have_content('Anslana, Diydonopher')
-      end
-      within '.offender_row_7' do
-        expect(page).to have_content('Felitha, Asjmonzo')
+
+      bookings_by_release_date = bookings.sort_by { |o| o.fetch(:sentenceDetail).fetch('tariffDate') }
+      [6, 7].each do |row_index|
+        within ".offender_row_#{row_index}" do
+          offender = offenders.detect { |o| o.fetch(:offenderNo) == bookings_by_release_date[row_index].fetch(:offenderNo) }
+          name = "#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}"
+          expect(page).to have_content(name)
+        end
       end
     end
 
     it 'can be searched by string' do
-      fill_in 'q', with: 'oz'
+      # make sure of at least one search hit.
+      search = first_offender.fetch(:lastName)[1..4]
+      expected_count = offenders.count { |o| o.fetch(:lastName).include?(search) || o.fetch(:firstName).include?(search) }
+      fill_in 'q', with: search
       click_on 'Search'
-      expect(page).to have_content('Showing 1 - 1 of 1 results')
+      expect(page).to have_content("Showing 1 - #{expected_count} of #{expected_count} results")
     end
 
     it 'can be searched by number' do
       fill_in 'q', with: '8180U'
       click_on 'Search'
       expect(page).to have_content('Showing 1 - 1 of 1 results')
+      offender = offenders.detect { |o| o.fetch(:offenderNo) == 'G8180UO' }
+      name = "#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}"
       within '.offender_row_0' do
-        expect(page).to have_content('Kaceria, Omaertain')
+        expect(page).to have_content(name)
       end
     end
 
@@ -191,7 +154,7 @@ feature "view POM's caseload" do
     end
   end
 
-  context 'when looking at handover start', vcr: { cassette_name: :show_poms_caseload_handover_start } do
+  context 'when looking at handover start' do
     before {
       signin_pom_user
       visit prison_caseload_index_path('LEI')
@@ -212,32 +175,21 @@ feature "view POM's caseload" do
     end
   end
 
-  it 'allows a POM to view the prisoner profile page for a specific offender',  vcr: { cassette_name: :show_poms_caseload_prisoner_profile } do
+  it 'allows a POM to view the prisoner profile page for a specific offender' do
     signin_pom_user
-    visit prison_caseload_index_path('LEI')
+    visit prison_caseload_index_path(prison)
+
+    expected_name = "#{first_offender.fetch(:lastName)}, #{first_offender.fetch(:firstName)}"
 
     within('.offender_row_0') do
+      expect(page).to have_content(expected_name)
       click_link 'View'
     end
 
-    expect(page).to have_css('h2', text: 'Abbella, Ozullirn')
-    expect(page).to have_content('15/08/1980')
-    cat_code = find('h3#category-code').text
-    expect(cat_code).to eq('C')
+    expect(page).to have_current_path(prison_prisoner_path(prison, first_offender.fetch(:offenderNo)), ignore_query: true)
   end
 
-  it 'displays all cases that have been allocated to a specific POM in the last week', :versioning, vcr: { cassette_name: :show_new_cases } do
-    signin_pom_user
-    visit prison_caseload_index_path('LEI')
-    within('.new-cases-count') do
-      click_link('1')
-    end
-
-    expect(page).to have_content("New cases")
-    expect(page).to have_content("Abbella, Ozullirn")
-  end
-
-  it 'can sort all cases that have been allocated to a specific POM in the last week', :versioning, vcr: { cassette_name: :show_and_sort_new_cases } do
+  it 'can sort all cases that have been allocated to a specific POM in the last week', :versioning do
     # Sign in as a POM
     signin_pom_user
     visit prison_caseload_index_path('LEI')
@@ -247,7 +199,7 @@ feature "view POM's caseload" do
 
     expect(page).to have_content("New cases")
 
-    expected_name = 'Abbella, Ozullirn'
+    expected_name = "#{first_offender.fetch(:lastName)}, #{first_offender.fetch(:firstName)}"
 
     # The first name...
     within('.offender_row_0') do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -155,14 +155,14 @@ RSpec.describe Allocation, type: :model do
     end
 
     describe 'cleaning up old broken data' do
-      let!(:offender_no) { 'G2911GD' }
-      let!(:movement) {
-        create(:movement,
-               offender_no: offender_no,
-               direction_code: 'OUT',
-               movement_type: 'REL',
-               to_agency: 'OUT',
-               from_agency: 'BAI')
+      let(:offender_no) { 'G2911GD' }
+      let(:movement) {
+        build(:movement,
+              offenderNo: offender_no,
+              directionCode: 'OUT',
+              movementType: 'REL',
+              toAgency: 'OUT',
+              fromAgency: 'BAI')
       }
       let!(:alloc) {
         a = build(

--- a/spec/models/nomis/offender_spec.rb
+++ b/spec/models/nomis/offender_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 describe Nomis::Offender do
   describe '#handover_start_date' do
     context 'when in custody' do
-      let(:offender) { build(:offender) }
+      let(:offender) {
+        build(:offender).tap { |o|
+          o.sentence = Nomis::SentenceDetail.new(automatic_release_date: Time.zone.today + 1.year,
+                                                 sentence_start_date: Time.zone.today)
+          o.case_allocation = 'NPS'
+          o.mappa_level = 0
+        }
+      }
 
       it 'has a value' do
         expect(offender.handover_start_date).not_to eq(nil)
@@ -11,7 +18,7 @@ describe Nomis::Offender do
     end
 
     context 'when COM responsible already' do
-      let(:offender) { build(:offender, sentence: Nomis::SentenceDetail.new) }
+      let(:offender) { build(:offender).tap { |o| o.sentence = Nomis::SentenceDetail.new } }
 
       it 'doesnt has a value' do
         expect(offender.handover_start_date).to eq(nil)

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 describe MovementService do
   include ActiveJob::TestHelper
 
-  let!(:new_offender_court) { create(:movement, offender_no: 'G4273GI', from_agency: 'COURT')   }
-  let!(:new_offender_nil) { create(:movement, offender_no: 'G4273GI', from_agency: nil)   }
-  let!(:transfer_out) { create(:movement, offender_no: 'G4273GI', direction_code: 'OUT', movement_type: 'TRN')   }
+  let(:new_offender_court) { build(:movement, offenderNo: 'G4273GI', fromAgency: 'COURT')   }
+  let(:new_offender_nil) { build(:movement, offenderNo: 'G4273GI', fromAgency: nil)   }
+  let(:transfer_out) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'TRN')   }
 
   it "can get recent movements",
      vcr: { cassette_name: :movement_service_recent_spec }  do
@@ -92,12 +92,12 @@ describe MovementService do
   end
 
   describe "processing an offender transfer" do
-    let!(:transfer_adm_no_to_agency) { create(:movement, offender_no: 'G4273GI', to_agency: 'COURT')   }
-    let!(:transfer_in) { create(:movement, offender_no: 'G4273GI', direction_code: 'IN', movement_type: 'ADM', from_agency: 'VEI', to_agency: 'CFI')   }
-    let!(:admission) { create(:movement, offender_no: 'G4273GI', to_agency: 'LEI', from_agency: 'COURT')   }
+    let(:transfer_adm_no_to_agency) { build(:movement, offenderNo: 'G4273GI', toAgency: 'COURT')   }
+    let(:transfer_in) { build(:movement, offenderNo: 'G4273GI', directionCode: 'IN', movementType: 'ADM', fromAgency: 'VEI', toAgency: 'CFI')   }
+    let(:admission) { create(:movement, offenderNo: 'G4273GI', toAgency: 'LEI', fromAgency: 'COURT')   }
 
     let!(:existing_allocation) { create(:allocation, nomis_offender_id: 'G4273GI', prison: 'LEI')   }
-    let!(:existing_alloc_transfer) { create(:movement, offender_no: 'G4273GI', from_agency: 'PRI', to_agency: 'LEI')   }
+    let(:existing_alloc_transfer) { build(:movement, offenderNo: 'G4273GI', fromAgency: 'PRI', toAgency: 'LEI')   }
 
     it "can process transfers were offender already allocated at new prison",
        vcr: { cassette_name: :movement_service_transfer_in_existing_spec }  do
@@ -107,7 +107,7 @@ describe MovementService do
     end
 
     context 'when processing an admission' do
-      let(:transfer_adm) { create(:movement, offender_no: 'G4273GI', from_agency: 'PRI', to_agency: 'PVI')   }
+      let(:transfer_adm) { build(:movement, offenderNo: 'G4273GI', fromAgency: 'PRI', toAgency: 'PVI')   }
       let(:updated_allocation) { existing_allocation.reload }
 
       it "can process transfer movements IN",
@@ -128,7 +128,7 @@ describe MovementService do
 
     it "can starts an open prison transfer",
        vcr: { cassette_name: :movement_service_transfer_to_open_spec }  do
-      open_prison_transfer = create(:movement, offender_no: 'G4273GI', to_agency: 'HDI')
+      open_prison_transfer = build(:movement, offenderNo: 'G4273GI', toAgency: 'HDI')
 
       expect {
         processed = described_class.process_movement(open_prison_transfer)
@@ -157,16 +157,16 @@ describe MovementService do
 
     it "will ignore an unknown movement type",
        vcr: { cassette_name: :movement_service_unknown_spec }  do
-      unknown_movement_type = create(:movement, offender_no: 'G4273GI', movement_type: 'TMP')
+      unknown_movement_type = build(:movement, offenderNo: 'G4273GI', movementType: 'TMP')
       processed = described_class.process_movement(unknown_movement_type)
       expect(processed).to be false
     end
   end
 
   describe "processing an offender release" do
-    let!(:valid_release) { create(:movement, offender_no: 'G4273GI', direction_code: 'OUT', movement_type: 'REL', to_agency: 'OUT', from_agency: 'BAI')   }
-    let!(:invalid_release1) { create(:movement, offender_no: 'G4273GI', direction_code: 'OUT', movement_type: 'REL', to_agency: 'LEI')   }
-    let!(:invalid_release2) { create(:movement, offender_no: 'G4273GI', direction_code: 'OUT', movement_type: 'REL', from_agency: 'COURT')   }
+    let(:valid_release) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'REL', toAgency: 'OUT', fromAgency: 'BAI')   }
+    let(:invalid_release1) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'REL', toAgency: 'LEI')   }
+    let(:invalid_release2) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'REL', fromAgency: 'COURT')   }
 
     let!(:case_info) { create(:case_information, nomis_offender_id: 'G4273GI') }
     let!(:allocation) { create(:allocation, nomis_offender_id: 'G4273GI') }
@@ -198,8 +198,8 @@ describe MovementService do
     let(:allocation) { Allocation.find_by(nomis_offender_id: 'G4273GI') }
 
     let(:immigration_movement) do
-      create(:movement, offender_no: 'G4273GI', direction_code: direction_code, create_date_time: Date.new(2020, 1, 6),
-                        movement_type: movement_type, from_agency: from_agency, to_agency: to_agency)
+      build(:movement, offenderNo: 'G4273GI', directionCode: direction_code, createDateTime: Date.new(2020, 1, 6).to_s,
+                       movementType: movement_type, fromAgency: from_agency, toAgency: to_agency)
     end
 
     context 'when movement is a transfer' do

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -1,66 +1,73 @@
+# frozen_string_literal: true
+
 module ApiHelper
+  T3 = 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api'
+
   def stub_offender(nomis_id, booking_number: 754_165, imprisonment_status: 'SENT03', dob: "1985-03-19")
-    stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/prisoners/#{nomis_id}").
-      to_return(status: 200, body: [{ offenderNo: nomis_id,
+    stub_request(:get, "#{T3}/prisoners/#{nomis_id}").
+      to_return(body: [{ offenderNo: nomis_id,
                                       gender: 'Male',
                                       convictedStatus: 'Convicted',
                                       latestBookingId: booking_number,
                                       imprisonmentStatus: imprisonment_status,
                                       dateOfBirth: dob }].to_json)
 
-    stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/offender-sentences/bookings").
+    stub_request(:post, "#{T3}/offender-sentences/bookings").
       with(
         body: [booking_number].to_json
       ).
-      to_return(status: 200, body: [{ offenderNo: nomis_id, bookingId: booking_number,
+      to_return(body: [{ offenderNo: nomis_id, bookingId: booking_number,
                                       sentenceDetail: { sentenceStartDate: Time.zone.today - 2.months,
                                                         conditionalReleaseDate: Time.zone.today + 22.months } }].to_json)
 
-    stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/offender-assessments/CATEGORY").
+    stub_request(:post, "#{T3}/offender-assessments/CATEGORY").
       with(
         body: [nomis_id].to_json
       ).
-      to_return(status: 200, body: {}.to_json)
+      to_return(body: {}.to_json)
 
-    stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/bookings/#{booking_number}/mainOffence").
-      to_return(status: 200, body: {}.to_json)
+    stub_request(:get, "#{T3}/bookings/#{booking_number}/mainOffence").
+      to_return(body: {}.to_json)
+  end
+
+  def stub_movements(movements = [])
+    stub_request(:post, "#{T3}/movements/offenders?movementTypes=ADM&movementTypes=TRN&latestOnly=false").
+      to_return(body: movements.to_json)
   end
 
   def stub_poms(prison, poms)
-    stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/roles/#{prison}/role/POM").
+    stub_request(:get, "#{T3}/staff/roles/#{prison}/role/POM").
       with(
         headers: {
           'Page-Limit' => '100',
           'Page-Offset' => '0'
         }).
-      to_return(status: 200, body: poms.to_json)
+      to_return(body: poms.to_json)
     poms.each do |pom|
       stub_pom_emails(pom.staffId, pom.emails)
     end
   end
 
   def stub_pom_emails(staff_id, emails)
-    stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/#{staff_id}/emails").
-      to_return(status: 200, body: emails.to_json)
+    stub_request(:get, "#{T3}/staff/#{staff_id}/emails").
+      to_return(body: emails.to_json)
   end
 
   def stub_signed_in_pom(staff_id, username)
     stub_auth_token
-    stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/#{username}").
-      to_return(status: 200, body: { 'staffId': staff_id }.to_json)
+    stub_request(:get, "#{T3}/users/#{username}").
+      to_return(body: { 'staffId': staff_id }.to_json)
   end
 
   def stub_offenders_for_prison(prison, offenders, bookings)
     # Stub the call to get_offenders_for_prison. Takes a list of offender hashes (in nomis camelCase format) and
     # a list of bookings (same key format). It it your responsibility to make sure they contain the data you want
     # and if you provide a booking, that the id matches between the offender and booking hashes.
-    elite2api = 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api'
-    elite2listapi = "#{elite2api}/locations/description/#{prison}/inmates?convictedStatus=Convicted&returnCategory=true"
-    elite2bookingsapi = "#{elite2api}/offender-sentences/bookings"
+    elite2listapi = "#{T3}/locations/description/#{prison}/inmates?convictedStatus=Convicted&returnCategory=true"
+    elite2bookingsapi = "#{T3}/offender-sentences/bookings"
 
     # Stub the call that will get the total number of records
     stub_request(:get, elite2listapi).to_return(
-      status: 200,
       body: {}.to_json,
       headers: { 'Total-Records' => offenders.count.to_s }
     )
@@ -70,28 +77,24 @@ module ApiHelper
       headers: {
         'Page-Limit' => '200',
         'Page-Offset' => '0'
-      }).to_return(status: 200, body: offenders.to_json)
+      }).to_return(body: offenders.to_json)
 
     # Get the booking ids provided
-    booking_ids = bookings.map { |h| h[:bookingId] }.compact
+    booking_ids = offenders.map { |h| h.fetch(:bookingId) }
     stub_request(:post, elite2bookingsapi).with(body: booking_ids.to_json).
-      to_return(status: 200, body: bookings.to_json, headers: {})
+      to_return(body: bookings.to_json, headers: {})
   end
 
   def stub_multiple_offenders(offenders, bookings)
-    elite2api = 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api'
-    elite2listapi = "#{elite2api}/prisoners"
-    elite2bookingsapi = "#{elite2api}/offender-sentences/bookings"
+    elite2listapi = "#{T3}/prisoners"
+    elite2bookingsapi = "#{T3}/offender-sentences/bookings"
 
     stub_request(:post, elite2listapi).to_return(
-      status: 200,
       body: offenders.to_json
     )
 
-    # Get the booking ids provided and add a non-existent booking in
-    # case none were provided
     stub_request(:post, elite2bookingsapi).
-      to_return(status: 200, body: bookings.to_json, headers: {})
+      to_return(body: bookings.to_json, headers: {})
   end
 
   def reload_page


### PR DESCRIPTION
POM-682 generated a lot of noise in terms of re-factoring of tests and adding new factories to help with writing tests. This PR breaks out those changes so that they can be re-used and so it doesn't clutter the actual story implementation