### PR TITLE
Fix broken tests which relied on ex-team member

### DIFF
--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/1").
         to_return(status: 200, body: {}.to_json, headers: {})
 
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/PK000223").
+      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/MOIC_POM").
         to_return(status: 200, body: { staffId: 3 }.to_json, headers: {})
 
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/4").
@@ -180,14 +180,14 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
                               recommended_pom_type: 'probation',
                               event: Allocation::ALLOCATE_PRIMARY_POM,
                               event_trigger: Allocation::USER,
-                              created_by_username: 'PK000223'
+                              created_by_username: 'MOIC_POM'
           )
           allocation.update!(
             primary_pom_nomis_id: 5,
             prison: 'LEI',
             event: Allocation::REALLOCATE_PRIMARY_POM,
             event_trigger: Allocation::USER,
-            created_by_username: 'PK000223'
+            created_by_username: 'MOIC_POM'
           )
         end
 

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     created_by_username do
-      'PK000223'
+      'MOIC_POM'
     end
 
     created_by_name do

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -133,7 +133,7 @@ feature 'Allocation' do
     create(
       :allocation,
       nomis_offender_id: nomis_offender_id,
-      primary_pom_nomis_id: 485_637,
+      primary_pom_nomis_id: 485_735,
       recommended_pom_type: 'probation'
     )
 
@@ -144,14 +144,14 @@ feature 'Allocation' do
     end
 
     expect(current_url).to have_content(prison_allocation_path('LEI', nomis_offender_id))
-    expect(page).to have_link(nil, href: "/prisons/LEI/poms/485637")
-    expect(page).to have_css('.table_cell__left_align', text: 'Pobee-Norris, Kath')
+    expect(page).to have_link(nil, href: "/prisons/LEI/poms/485735")
+    expect(page).to have_css('.table_cell__left_align', text: 'Jara Duncan, Laura')
     expect(page).to have_css('.table_cell__left_align', text: 'Responsible')
 
     click_link 'Reallocate'
 
     expect(current_url).to have_content(edit_prison_allocation_path('LEI', nomis_offender_id))
-    expect(page).to have_css('.current_pom_full_name', text: 'Pobee-Norris, Kath')
+    expect(page).to have_css('.current_pom_full_name', text: 'Jara Duncan, Laura')
     expect(page).to have_css('.current_pom_grade', text: 'Probation POM')
 
     within('.recommended_pom_row_0') do

--- a/spec/features/contact_us_feature_spec.rb
+++ b/spec/features/contact_us_feature_spec.rb
@@ -11,12 +11,12 @@ feature 'Getting help' do
   end
 
   it 'shows a pre-filled contact form when a user is signed in', :raven_intercept_exception, vcr: { cassette_name: :help_logged_in } do
-    signin_user('PK000223')
+    signin_user('MOIC_POM')
     visit '/'
     click_link 'Contact us'
 
     expect(page.find("#prison").value).to eq('HMP Leeds')
-    expect(page.find("#name").value).to eq('Kath Pobee-Norris')
+    expect(page.find("#name").value).to eq('Moic Pom')
 
     expect(page).to have_button('Submit')
   end

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -12,9 +12,9 @@ feature 'Co-working', :versioning do
 
   let!(:secondary_pom) do
     {
-      staff_id: 485_637,
-      pom_name: 'Kath Pobee-Norris',
-      email: 'kath.pobee-norris@digital.justice.gov.uk'
+      staff_id: 485_758,
+      pom_name: 'Moic Integration-Tests',
+      email: 'ommiicc@digital.justice.gov.uk'
     }
   end
 
@@ -62,7 +62,7 @@ feature 'Co-working', :versioning do
     end
 
     scenario 'show correct unavailable message', vcr: { cassette_name: :show_coworking_unavailable } do
-      inactive_poms = [485_637, 485_833]
+      inactive_poms = [485_758, 485_833]
       inactive_texts = ['There is 1 unavailable POM for new allocation',
                         'There are 2 unavailable POMs for new allocation']
 
@@ -97,12 +97,12 @@ feature 'Co-working', :versioning do
 
       allocation.reload
       expect(allocation.secondary_pom_nomis_id).to eq(secondary_pom[:staff_id])
-      expect(allocation.secondary_pom_name).to eq("POBEE-NORRIS, KATH")
+      expect(allocation.secondary_pom_name).to eq("INTEGRATION-TESTS, MOIC")
 
       visit prison_allocation_path('LEI', nomis_offender_id)
       within '#co-working-pom' do
         expect(page).to have_content 'Remove'
-        expect(page).to have_content 'Pobee-Norris, Kath'
+        expect(page).to have_content 'Integration-Tests, Moic'
       end
     end
   end

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocations } do
-  let(:nomis_staff_id) { 485_637 }
+  let(:nomis_staff_id) { 485_926 }
 
   # This booking id is the latest one for the offender in T3
   let(:nomis_offender_id) { 'G4273GI' }

--- a/spec/features/feedback_feature_spec.rb
+++ b/spec/features/feedback_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'feedback' do
   it 'provides a link to the feedback form', vcr: { cassette_name: :feedback_link } do
-    signin_user('PK000223')
+    signin_user('MOIC_POM')
 
     visit '/'
 

--- a/spec/features/help_feature_spec.rb
+++ b/spec/features/help_feature_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Help' do
   context 'when accessing help page' do
     it 'provides a link to the help pages', vcr: { cassette_name: :help_link } do
-      signin_user('PK000223')
+      signin_user('MOIC_POM')
 
       visit '/'
       expect(page).to have_link('Help', href: '/help')

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -6,7 +6,7 @@ feature 'Inactive POM' do
     let(:inactive_pom)      { 485_595 }
     let(:nomis_offender_id) { "G4273GI" }
     let(:prison)            { "LEI" }
-    let(:active_pom) { 485_637 }
+    let(:active_pom) { 485_926 }
 
     before do
       signin_user

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "view POM's caseload" do
-  let(:nomis_staff_id) { 485_637 }
+  let(:nomis_staff_id) { 485_926 }
   let(:nomis_offender_id) { 'G4273GI' }
   let(:tomorrow) { Date.tomorrow }
 
@@ -34,27 +34,27 @@ feature "view POM's caseload" do
     create(:case_information, nomis_offender_id: 'G9344UG')
     create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'Yes')
 
-    create(:allocation, nomis_offender_id: 'G7266VD', primary_pom_nomis_id: '485637', nomis_booking_id: '1073602')
-    create(:allocation, nomis_offender_id: 'G8563UA', primary_pom_nomis_id: '485637', nomis_booking_id: '1020605')
-    create(:allocation, nomis_offender_id: 'G6068GV', primary_pom_nomis_id: '485637', nomis_booking_id: '1030841')
-    create(:allocation, nomis_offender_id: 'G0572VU', primary_pom_nomis_id: '485637', nomis_booking_id: '861029')
-    create(:allocation, nomis_offender_id: 'G8668GF', primary_pom_nomis_id: '485637', nomis_booking_id: '1106348')
-    create(:allocation, nomis_offender_id: 'G9465UP', primary_pom_nomis_id: '485637', nomis_booking_id: '1186259')
-    create(:allocation, nomis_offender_id: 'G9372GQ', primary_pom_nomis_id: '485637', nomis_booking_id: '752833')
-    create(:allocation, nomis_offender_id: 'G1618UI', primary_pom_nomis_id: '485637', nomis_booking_id: '1161236')
-    create(:allocation, nomis_offender_id: 'G4328GK', primary_pom_nomis_id: '485637', nomis_booking_id: '1055341')
-    create(:allocation, nomis_offender_id: 'G4143VX', primary_pom_nomis_id: '485637', nomis_booking_id: '1083858')
-    create(:allocation, nomis_offender_id: 'G8180UO', primary_pom_nomis_id: '485637', nomis_booking_id: '1172076')
-    create(:allocation, nomis_offender_id: 'G8909GV', primary_pom_nomis_id: '485637', nomis_booking_id: '877782')
-    create(:allocation, nomis_offender_id: 'G8339GD', primary_pom_nomis_id: '485637', nomis_booking_id: '260708')
-    create(:allocation, nomis_offender_id: 'G1992GH', primary_pom_nomis_id: '485637', nomis_booking_id: '1179167')
-    create(:allocation, nomis_offender_id: 'G1986GG', primary_pom_nomis_id: '485637', nomis_booking_id: '1165890')
-    create(:allocation, nomis_offender_id: 'G6262GI', primary_pom_nomis_id: '485637', nomis_booking_id: '961997')
-    create(:allocation, nomis_offender_id: 'G6653UC', primary_pom_nomis_id: '485637', nomis_booking_id: '1009990')
-    create(:allocation, nomis_offender_id: 'G1718GG', primary_pom_nomis_id: '485637', nomis_booking_id: '928042')
-    create(:allocation, nomis_offender_id: 'G4706UP', primary_pom_nomis_id: '485637', nomis_booking_id: '1180800')
-    create(:allocation, nomis_offender_id: 'G9344UG', primary_pom_nomis_id: '485637', nomis_booking_id: '841994')
-    create(:allocation, nomis_offender_id: 'G4273GI', primary_pom_nomis_id: '485637', nomis_booking_id: '1153753')
+    create(:allocation, nomis_offender_id: 'G7266VD', primary_pom_nomis_id: '485926', nomis_booking_id: '1073602')
+    create(:allocation, nomis_offender_id: 'G8563UA', primary_pom_nomis_id: '485926', nomis_booking_id: '1020605')
+    create(:allocation, nomis_offender_id: 'G6068GV', primary_pom_nomis_id: '485926', nomis_booking_id: '1030841')
+    create(:allocation, nomis_offender_id: 'G0572VU', primary_pom_nomis_id: '485926', nomis_booking_id: '861029')
+    create(:allocation, nomis_offender_id: 'G8668GF', primary_pom_nomis_id: '485926', nomis_booking_id: '1106348')
+    create(:allocation, nomis_offender_id: 'G9465UP', primary_pom_nomis_id: '485926', nomis_booking_id: '1186259')
+    create(:allocation, nomis_offender_id: 'G9372GQ', primary_pom_nomis_id: '485926', nomis_booking_id: '752833')
+    create(:allocation, nomis_offender_id: 'G1618UI', primary_pom_nomis_id: '485926', nomis_booking_id: '1161236')
+    create(:allocation, nomis_offender_id: 'G4328GK', primary_pom_nomis_id: '485926', nomis_booking_id: '1055341')
+    create(:allocation, nomis_offender_id: 'G4143VX', primary_pom_nomis_id: '485926', nomis_booking_id: '1083858')
+    create(:allocation, nomis_offender_id: 'G8180UO', primary_pom_nomis_id: '485926', nomis_booking_id: '1172076')
+    create(:allocation, nomis_offender_id: 'G8909GV', primary_pom_nomis_id: '485926', nomis_booking_id: '877782')
+    create(:allocation, nomis_offender_id: 'G8339GD', primary_pom_nomis_id: '485926', nomis_booking_id: '260708')
+    create(:allocation, nomis_offender_id: 'G1992GH', primary_pom_nomis_id: '485926', nomis_booking_id: '1179167')
+    create(:allocation, nomis_offender_id: 'G1986GG', primary_pom_nomis_id: '485926', nomis_booking_id: '1165890')
+    create(:allocation, nomis_offender_id: 'G6262GI', primary_pom_nomis_id: '485926', nomis_booking_id: '961997')
+    create(:allocation, nomis_offender_id: 'G6653UC', primary_pom_nomis_id: '485926', nomis_booking_id: '1009990')
+    create(:allocation, nomis_offender_id: 'G1718GG', primary_pom_nomis_id: '485926', nomis_booking_id: '928042')
+    create(:allocation, nomis_offender_id: 'G4706UP', primary_pom_nomis_id: '485926', nomis_booking_id: '1180800')
+    create(:allocation, nomis_offender_id: 'G9344UG', primary_pom_nomis_id: '485926', nomis_booking_id: '841994')
+    create(:allocation, nomis_offender_id: 'G4273GI', primary_pom_nomis_id: '485926', nomis_booking_id: '1153753')
 
     stub_request(:get, elite2listapi).
       with(

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -18,12 +18,12 @@ feature "get poms list" do
   end
 
   it "handles missing sentence data", vcr: { cassette_name: :show_poms_feature_missing_sentence } do
-    signin_user('PK000223')
+    signin_user('MOIC_POM')
 
-    visit prison_confirm_allocation_path('LEI', offender_missing_sentence_case_info.nomis_offender_id, 485_637)
+    visit prison_confirm_allocation_path('LEI', offender_missing_sentence_case_info.nomis_offender_id, 485_926)
     click_button 'Complete allocation'
 
-    visit prison_pom_path('LEI', 485_637)
+    visit prison_pom_path('LEI', 485_926)
 
     expect(page).to have_css(".pom_cases_row_0", count: 1)
     expect(page).not_to have_css(".pom_cases_row_1")
@@ -51,7 +51,7 @@ feature "get poms list" do
         nomis_booking_id: booking,
         prison: 'LEI',
         allocated_at_tier: 'A',
-        created_by_username: 'PK000223',
+        created_by_username: 'MOIC_POM',
         primary_pom_nomis_id: 485_926,
         primary_pom_allocated_at: DateTime.now.utc,
         recommended_pom_type: 'prison',

--- a/spec/lib/hmpps_sso_spec.rb
+++ b/spec/lib/hmpps_sso_spec.rb
@@ -17,8 +17,8 @@ describe OmniAuth::Strategies::HmppsSso do
     context 'when #info' do
       it 'returns a hash with the username, active caseload, caseloads and email address' do
         leeds_prison = 'LEI'
-        username = 'PK000223'
-        staff_id = 485_637
+        username = 'MOIC_POM'
+        staff_id = 485_926
         caseloads = %w[LEI RNI]
         response = double(
           'staff_details',
@@ -43,8 +43,8 @@ describe OmniAuth::Strategies::HmppsSso do
 
       it 'sets active caseload from nomis caseloads if not present' do
         leeds_prison = 'LEI'
-        username = 'PK000223'
-        staff_id = 485_637
+        username = 'MOIC_POM'
+        staff_id = 485_926
         caseloads = [{ "caseLoadId" => "LEI" }, { "caseLoadId" => "PVI" }, { "caseLoadId" => "SWI" }, { "caseLoadId" => "VEI" }, { "caseLoadId" => "WEI" }]
         response = double(
           'staff_details',

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -9,11 +9,11 @@ describe AllocationService do
   end
 
   describe '#allocate_secondary', :queueing do
-    let(:kath_id) { 485_637 }
+    let(:moic_test_id) { 485_758 }
     let(:ross_id) { 485_926 }
     let(:nomis_offender_id) { 'G4273GI' }
     let(:primary_pom_id) { ross_id }
-    let(:secondary_pom_id) { kath_id }
+    let(:secondary_pom_id) { moic_test_id }
     let(:message) { 'Additional text' }
 
     let!(:allocation) {
@@ -31,7 +31,7 @@ describe AllocationService do
                                            message: message
         )
         expect(allocation.reload.secondary_pom_nomis_id).to eq(secondary_pom_id)
-        expect(allocation.reload.secondary_pom_name).to eq('POBEE-NORRIS, KATH')
+        expect(allocation.reload.secondary_pom_name).to eq('INTEGRATION-TESTS, MOIC')
       }.to change(enqueued_jobs, :count).by(2)
 
       primary_email_job, secondary_email_job = enqueued_jobs.last(2)
@@ -55,12 +55,12 @@ describe AllocationService do
         to match(
           hash_including(
             "message" => message,
-            "pom_name" => "Kath",
+            "pom_name" => "Moic",
             "offender_name" => "Abbella, Ozullirn",
             "nomis_offender_id" => "G4273GI",
             "responsibility" => "supporting",
             "responsible_pom_name" => 'Pom, Moic',
-            "pom_email" => "kath.pobee-norris@digital.justice.gov.uk",
+            "pom_email" => "ommiicc@digital.justice.gov.uk",
             "url" => "http://localhost:3000/prisons/LEI/caseload"
           ))
     end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EmailService do
     Allocation.new.tap do |a|
       a.primary_pom_nomis_id = 485_833
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
+      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
@@ -18,7 +18,7 @@ RSpec.describe EmailService do
     Allocation.new.tap { |a|
       a.primary_pom_nomis_id = 485_766
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
+      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
@@ -32,7 +32,7 @@ RSpec.describe EmailService do
     Allocation.new.tap { |a|
       a.primary_pom_nomis_id = 485_833
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
+      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
@@ -46,7 +46,7 @@ RSpec.describe EmailService do
       a.primary_pom_nomis_id = 485_833
       a.primary_pom_name = "Ricketts, Andrien"
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
+      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.secondary_pom_nomis_id = 485_926
       a.secondary_pom_name = "Pom, Moic"
@@ -62,7 +62,7 @@ RSpec.describe EmailService do
       a.primary_pom_nomis_id = 485_833
       a.primary_pom_name = "Ricketts, Andrien"
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'PK000223'
+      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.secondary_pom_nomis_id = nil
       a.secondary_pom_name = nil

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -15,7 +15,7 @@ describe Nomis::Client do
     it 'sets the Authorization header' do
       WebMock.stub_request(:get, /\w/).to_return(body: '{}')
 
-      username = 'PK000223'
+      username = 'MOIC_POM'
       route = "/elite2api/api/users/#{username}"
       client.get(route)
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -37,10 +37,7 @@ describe PrisonOffenderManagerService do
       it "can get a list of POMs",
          vcr: { cassette_name: :pom_service_get_poms_list } do
         expect(subject).to be_kind_of(Enumerable)
-        # 1 POM in T3 (Toby Retallick) is marked inactive, so expect one less active one
-        expect(subject.count { |pom| pom.status == 'active' }).to eq(subject.count - 1)
-        # would like these to both be true as integratopn test user has both positions
-        # expect(moic_integration_tests.prison_officer?).to eq(true)
+        expect(subject.count { |pom| pom.status == 'active' }).to eq(subject.count)
         expect(moic_integration_tests.probation_officer?).to eq(true)
       end
     end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -2,15 +2,15 @@ module FeaturesHelper
   # Signs in a user which historically has always been an SPO. For backwards
   # compatability this continues to mock sso for an SPO, but we should move
   # in future to one of the explicit signin_*_user methods below.
-  def signin_user(name = 'PK000223')
+  def signin_user(name = 'MOIC_POM')
     signin_spo_user(name)
   end
 
-  def signin_spo_user(name = 'PK000223')
+  def signin_spo_user(name = 'MOIC_POM')
     mock_sso_response(name, ['ROLE_ALLOC_MGR'])
   end
 
-  def signin_pom_user(name = 'PK000223')
+  def signin_pom_user(name = 'MOIC_POM')
     mock_sso_response(name, ['ROLE_ALLOC_CASE_MGR'])
   end
 


### PR DESCRIPTION
Replace signed_in user with MOIC_POM, instead of relying on team members so that the majority of tests continue to work when team member leaves