### PR TITLE
POM-707 different numbers between SPO caseload view and POM

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -3,7 +3,7 @@
 class PomsController < PrisonsApplicationController
   before_action :ensure_admin_user
 
-  # so that breadcrumb has staff member available
+  # so that breadcrumb has @pom available
   before_action :load_pom_staff_member, only: [:show, :edit]
 
   breadcrumb 'Prison Offender Managers',

--- a/app/models/nomis/prison_offender_manager.rb
+++ b/app/models/nomis/prison_offender_manager.rb
@@ -11,7 +11,7 @@ module Nomis
                   :schedule_type, :schedule_type_description,
                   :hours_per_week, :thumbnail_id, :emails,
                   :tier_a, :tier_b, :tier_c, :tier_d,
-                  :total_cases, :status, :working_pattern
+                  :status, :working_pattern
 
     attr_writer :position
 
@@ -39,19 +39,8 @@ module Nomis
       "#{position_description.split(' ').first} POM"
     end
 
-    def add_detail(pom_detail, prison)
-      allocations = Allocation.active_pom_allocations(
-        pom_detail.nomis_staff_id, prison).map(&:nomis_offender_id)
-      allocation_counts = CaseInformation.where(nomis_offender_id: allocations).
-        group_by(&:tier)
-
-      self.tier_a = allocation_counts.fetch('A', []).size
-      self.tier_b = allocation_counts.fetch('B', []).size
-      self.tier_c = allocation_counts.fetch('C', []).size
-      self.tier_d = allocation_counts.fetch('D', []).size
-      self.total_cases = [tier_a, tier_b, tier_c, tier_d].sum
-      self.status = pom_detail.status
-      self.working_pattern = pom_detail.working_pattern
+    def total_cases
+      [tier_a, tier_b, tier_c, tier_d].sum
     end
 
     def self.from_json(payload)

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -260,6 +260,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
 
     before do
       stub_offender(offender_no)
+      stub_offenders_for_prison(prison, [], [])
     end
 
     context 'when tier A offender' do

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe EarlyAllocationsController, type: :controller do
     stub_sso_data(prison, 'alice')
 
     stub_offender(nomis_offender_id)
-
     stub_poms(prison, poms)
+    stub_offenders_for_prison(prison, [], [])
 
     create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
   end

--- a/spec/controllers/poms_controller_spec.rb
+++ b/spec/controllers/poms_controller_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe PomsController, type: :controller do
   let(:prison) { build(:prison) }
+  let(:a_offenders) { build_list(:offender, 2) }
+  let(:b_offenders) { build_list(:offender, 4) }
+  let(:c_offenders) { build_list(:offender, 3) }
+  let(:d_offenders) { build_list(:offender, 1) }
 
   before do
     stub_sso_data(prison.code)
@@ -13,97 +17,75 @@ RSpec.describe PomsController, type: :controller do
       build(:pom, staffId: active.nomis_staff_id),
       build(:pom, staffId: unavailable.nomis_staff_id)
     ])
-    a1 = create(:case_information)
+    a1 = create(:case_information, tier: 'A', nomis_offender_id: a_offenders.first.offender_no)
     create(:allocation, nomis_offender_id: a1.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
 
-    a2 = create(:case_information)
+    a2 = create(:case_information, tier: 'A', nomis_offender_id: a_offenders.last.offender_no)
     create(:allocation, nomis_offender_id: a2.nomis_offender_id, primary_pom_nomis_id: inactive.nomis_staff_id, secondary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
 
-    b1 = create(:case_information, tier: 'B')
-    create(:allocation, nomis_offender_id: b1.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-    b2 = create(:case_information, tier: 'B')
-    create(:allocation, nomis_offender_id: b2.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-    b3 = create(:case_information, tier: 'B')
-    create(:allocation, nomis_offender_id: b3.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-    b4 = create(:case_information, tier: 'B')
-    create(:allocation, nomis_offender_id: b4.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-
-    c1 = create(:case_information, tier: 'C')
-    create(:allocation, nomis_offender_id: c1.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-    c2 = create(:case_information, tier: 'C')
-    create(:allocation, nomis_offender_id: c2.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-    c3 = create(:case_information, tier: 'C')
-    create(:allocation, nomis_offender_id: c3.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
-
-    d1 = create(:case_information, tier: 'D')
-    create(:allocation, nomis_offender_id: d1.nomis_offender_id, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
+    {
+      'B': b_offenders,
+      'C': c_offenders,
+      'D': d_offenders,
+    }.each do |tier, offenders|
+      offenders.map(&:offender_no).each do |offender_no|
+        create(:case_information, tier: tier.to_s, nomis_offender_id: offender_no)
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: active.nomis_staff_id, prison: prison.code)
+      end
+    end
   end
 
   render_views
 
-  it 'shows the correct counts on index' do
-    get :index, params: { prison_id: prison.code }
-
-    expect(response).to be_successful
-
-    expect(assigns(:inactive_poms).count).to eq(1)
-    expect(assigns(:active_poms).count).to eq(2)
-
-    active_pom = assigns(:active_poms).detect { |pom| pom.status == 'active' }
-
-    expect(active_pom.tier_a).to eq(2)
-    expect(active_pom.tier_b).to eq(4)
-    expect(active_pom.tier_c).to eq(3)
-    expect(active_pom.tier_d).to eq(1)
-
-    expect(active_pom.total_cases).to eq(10)
-  end
-
-  context 'when showing caseload' do
-    let(:staff_id) { PomDetail.where(status: 'active').first!.nomis_staff_id }
-    let(:offenderNos) { Allocation.all.map(&:nomis_offender_id).reverse }
+  context 'with an extra unsentenced offender' do
+    let(:active_staff_id) { PomDetail.where(status: 'active').first!.nomis_staff_id }
+    let(:unavailable_staff_id) { PomDetail.where(status: 'unavailable').first!.nomis_staff_id }
+    let(:offenderNos) { (a_offenders + b_offenders + c_offenders + d_offenders).map(&:offender_no) }
 
     before do
-      # This guy doesn't turn up in Prison#offenders, and hence doesn't show up on caseload
-      create(:allocation, primary_pom_nomis_id: staff_id, prison: prison.code)
+      # This guy doesn't turn up in Prison#offenders, and hence doesn't show up on caseload or stats
+      missing_offender = create(:case_information)
+      create(:allocation, nomis_offender_id: missing_offender.nomis_offender_id, primary_pom_nomis_id: active_staff_id, prison: prison.code)
 
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/#{staff_id}").
-        to_return(status: 200, body: { staffId: staff_id, lastName: 'LastName', firstName: 'FirstName' }.to_json, headers: {})
+      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/#{active_staff_id}").
+        to_return(body: { staffId: active_staff_id, lastName: 'LastName', firstName: 'FirstName' }.to_json)
 
-      offenders = [
-        { "bookingId": 754_207, "offenderNo": offenderNos.first, "firstName": "Alice", "lastName": "Aliceson",
-          "dateOfBirth": "1990-12-06", "age": 28, "categoryCode": "C", "imprisonmentStatus": "LIFE",
-          "convictedStatus": "Convicted", "latestLocationId": prison.code },
-        { "bookingId": 754_206, "offenderNo": offenderNos.last, "firstName": "Bob", "lastName": "Bibby",
-          "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison.code, "categoryCode": "D", "imprisonmentStatus": "SENT03",
-          "convictedStatus": "Convicted", "latestLocationId": prison.code }
-      ]
+      offenders = offenderNos.map.with_index { |nomis_id, index|
+        { "bookingId": 754_207 + index,
+          "offenderNo": nomis_id,
+          "dateOfBirth": "1990-12-06", "convictedStatus": "Convicted",
+          "categoryCode": "C", "imprisonmentStatus": "SENT03" }
+      }
 
-      bookings = [
-        { "bookingId": 754_207, "offenderNo": offenderNos.first, "firstName": "Indeter", "lastName": "Minate-Offender",
-          "agencyLocationId": prison.code,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" },
-          "dateOfBirth": "1953-04-15", "facialImageId": 1_399_838 },
-        { "bookingId": 754_206, "offenderNo": offenderNos.last, "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison.code,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" },
-          "dateOfBirth": "1953-04-15", "facialImageId": 1_399_838 }
-      ]
+      bookings = offenders.map { |offender|
+        { "bookingId": offender.fetch(:bookingId),
+                                   "offenderNo": offender.fetch(:offenderNo),
+                                   "agencyLocationId": prison.code,
+                "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
+                   "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
+                   "bookingId": 754_207, "sentenceStartDate": "2009-02-08",
+                   "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
+                   "releaseDate": "2012-03-17" } }
+      }
 
       stub_offenders_for_prison(prison.code, offenders, bookings)
     end
 
-    it 'shows the caseload on the show action' do
-      get :show, params: { prison_id: prison.code, nomis_staff_id: staff_id }
+    it 'omits the allocation which does not show up in Prison#offenders' do
+      get :index, params: { prison_id: prison.code }
       expect(response).to be_successful
-      expect(assigns(:allocations).count).to eq(2)
+
+      expect(assigns(:inactive_poms).count).to eq(1)
+      active_poms = assigns(:active_poms).map { |pom| { staff_id: pom.staff_id, tier_a: pom.tier_a, tier_b: pom.tier_b, tier_c: pom.tier_c, tier_d: pom.tier_d, total_cases: pom.total_cases } }
+
+      expect(active_poms).to match_array [{ staff_id: active_staff_id, tier_a: 2, tier_b: 4, tier_c: 3, tier_d: 1, total_cases: 10 },
+                                          { staff_id: unavailable_staff_id, tier_a: 0, tier_b: 0, tier_c: 0, tier_d: 0, total_cases: 0 }]
+    end
+
+    it 'shows the caseload on the show action' do
+      get :show, params: { prison_id: prison.code, nomis_staff_id: active_staff_id }
+      expect(response).to be_successful
+      expect(assigns(:allocations).map(&:tier)).to match_array(["A", 'A', "B", "B", "B", "B", "C", "C", "C", "D"])
     end
   end
 end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -116,6 +116,7 @@ describe PrisonOffenderManagerService do
 
       before do
         stub_poms('WSI', [dave, alice, billy, charles, eric])
+        stub_offenders_for_prison('WSI', [], [])
       end
 
       it 'removes duplicate staff ids, keeping the valid position' do


### PR DESCRIPTION
PrisonOffenderManagerService#get_poms_for(prison) circumvented Prison#offenders when getting allocation numbers for a POM. Hence allocations for offenders that are no longer sentenced, showed up vs actions that started from Prison#offenders. 
