### PR TITLE
fix flaky test - default sort is only by last name, not both names

### DIFF
--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -27,9 +27,9 @@ FactoryBot.define do
     firstName { Faker::Name.first_name }
     # We have some issues with corrupting the display
     # of names containing Mc or Du :-(
-    lastName do
-      Faker::Name.last_name.titleize
-    end
+    # also ensure uniqueness as duplicate last names can cause issues
+    # in tests, as ruby sort isn't stable by default
+    sequence(:lastName) { |c| "#{Faker::Name.last_name.titleize}_#{c}" }
     categoryCode { 'C' }
   end
 

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -39,7 +39,7 @@ feature "view POM's caseload" do
       map { |nomis_id, booking_id| attributes_for(:offender).merge(offenderNo: nomis_id, bookingId: booking_id) }
   }
   let(:sorted_offenders) {
-    offenders.sort_by { |o| "#{o.fetch(:lastName)}, #{o.fetch(:firstName)}" }
+    offenders.sort_by { |o| o.fetch(:lastName) }
   }
   let(:first_offender) { sorted_offenders.first }
   let(:moved_offender) { sorted_offenders.fourth }


### PR DESCRIPTION
while refactoing the POM caseload feature spec, the offenders were sorted lastname, firstname. The actual behaviour is sort by last name, so if the test produced 2 offenders with the same last name, there was a non-zero chance that the test would fail as the sort order for the test was different from the sort order of the code. This only happened a very few test runs