### PR TITLE
Add handover reason to debugging page

### DIFF
--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -106,17 +106,19 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Handover start date</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <% handover_date, reason =  @offender.handover_start_date %>
-        <%= format_date(handover_date) %>
-        <span class="handover-reason">(<%= reason %>)</span>
+        <%= format_date(@offender.handover_start_date, replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Responsibility handover date</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <% handover_date, reason = @offender.responsibility_handover_date %>
-        <%= format_date(handover_date, replacement: 'Unknown - missing MAPPA info') %>
-        <span class="handover-reason">(<%= reason %>)</span>
+        <%= format_date(@offender.responsibility_handover_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Reason for handover dates</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+        <%= @offender.handover_reason %>
       </td>
     </tr>
     </tbody>

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -12,7 +12,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 38)
+      expect(page).to have_css('tbody tr', count: 39)
       expect(page).to have_content("Not currently allocated")
 
       table_row = page.find(:css, 'tr.govuk-table__row#convicted', text: 'Convicted?')
@@ -34,7 +34,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 43)
+      expect(page).to have_css('tbody tr', count: 44)
 
       pom_table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
 


### PR DESCRIPTION
Whilst looking at preprod, I got confused by the fact that many offenders were coming up handover reasons of 'Unknown - Missing Mappa Info' even though I had selected offenders specifically with MAPPA levels. Turns out we had hard-coded the reason on the debugging page, even though the reason is extremely available - so this PR puts the reason for the Handover centre-stage, and removes the confusing 'Unknown - MAPPA info' message