### PR TITLE
fix defective factories

### DIFF
--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -22,7 +22,8 @@ FactoryBot.define do
     sequence(:nomis_offender_id) do |seq|
       number = seq / 26 + 1000
       letter = ('A'..'Z').to_a[seq % 26]
-      "T#{number}T#{letter}"
+      # This and the offender should produce different values to avoid clashes
+      "T#{number}C#{letter}"
     end
 
     association :team, code: '1234', name: 'A nice team'

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
   end
 
   factory :offender, class: 'Nomis::OffenderSummary' do
-    initialize_with { Nomis::OffenderSummary.from_json(attributes) }
+    initialize_with { Nomis::OffenderSummary.from_json(attributes.stringify_keys) }
 
     imprisonmentStatus { 'SENT03' }
     prisonId { 'LEI' }
@@ -19,7 +19,8 @@ FactoryBot.define do
     sequence(:offenderNo) do |seq|
       number = seq / 26 + 1000
       letter = ('A'..'Z').to_a[seq % 26]
-      "T#{number}T#{letter}"
+      # This and case_information should produce different values to avoid clashes
+      "T#{number}O#{letter}"
     end
     sequence(:bookingId) { |x| x + 700_000 }
     convictedStatus { 'Convicted' }


### PR DESCRIPTION
The new offender factory turned out to have a bug where it didn't populate any fields due to confusion between symbols and strings. 
Also change the id-generators in case_information and offender to use different name-spaces so that an offender clash can't be produced by accident