### PR TITLE
POM 752 - Enable 'delete' functionality for 'Teams' in Active Admin

### DIFF
--- a/app/admin/local_divisional_units.rb
+++ b/app/admin/local_divisional_units.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register LocalDivisionalUnit, as: 'LDU' do
+  actions :all, except: [:destroy]
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -2,12 +2,8 @@
 # ActiveAdmin.  you're either allowed in because you're considered to
 # be an SPO or you're not authorised to do anything.
 class MoicOAuth2Adapter < ActiveAdmin::AuthorizationAdapter
-  def authorized?(action, _subject = nil)
-    if action == :destroy
-      false
-    else
-      user.is_global_admin?
-    end
+  def authorized?(_action, _subject = nil)
+    user.is_global_admin?
   end
 end
 

--- a/spec/features/active_admin_feature_spec.rb
+++ b/spec/features/active_admin_feature_spec.rb
@@ -17,6 +17,9 @@ feature 'ActiveAdmin' do
   #   end
   # end
 
+  let(:ldu) { create(:local_divisional_unit) }
+  let!(:new_team) { create(:team, local_divisional_unit: ldu) }
+
   context 'when pom' do
     before do
       signin_pom_user
@@ -47,8 +50,45 @@ feature 'ActiveAdmin' do
     end
 
     it 'displays the dashboard' do
+      ci = create(:case_information, team: nil)
+      create(:allocation, nomis_offender_id: ci.nomis_offender_id)
+
       visit('/admin')
       expect(page).to have_http_status(:success)
+    end
+
+    context 'with teams' do
+      before do
+        visit('/admin/teams')
+      end
+
+      it 'displays the list of teams' do
+        expect(page).to have_http_status(:success)
+        expect(page).to have_content(new_team.name.to_s)
+      end
+
+      it 'can delete a team' do
+        within("#team_#{new_team.id}") do
+          click_link("Delete")
+        end
+
+        expect(page).to have_content('Team was successfully destroyed')
+      end
+    end
+
+    context 'with local divisional units' do
+      before do
+        visit('/admin/ldus')
+      end
+
+      it "displays the list of LDU's" do
+        expect(page).to have_http_status(:success)
+        expect(page).to have_content(ldu.name.to_s)
+      end
+
+      it 'cannot delete an ldu' do
+        expect(page).not_to have_link('Delete')
+      end
     end
   end
 end


### PR DESCRIPTION
Teams in active admin now has the delete action enabled
Disabled the delete action for LDU table in active admin