### PR TITLE
Skip blank rows in the nightly Delius import

### DIFF
--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -149,6 +149,8 @@ private
       # skip header row in row[0]
       next if index == 0
 
+      next if row.filter(&:present?).empty?
+
       record = {}
 
       # For each row, map the column to the appropriate column name


### PR DESCRIPTION
This commit patches a bug in the nightly Delius import where it was crashing when encountering blank rows in the XLSX spreadsheet. It turns out the Delius spreadsheet always tends to end with a blank row, so this was causing the import to fail in production.

This is a quick fix to patch the problem for the current implementation of the Delius XLSX file reader. We are aware of other bugs in the current implementation (see Jira ticket POM-739), so this is a temporary fix until that work is completed.