### PR TITLE
enable rspec -n to step through test failures

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.use_transactional_fixtures = false
+  config.example_status_persistence_file_path = 'tmp/example_status.txt'
   config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do


### PR DESCRIPTION
With a set of failing tests on a branch, rspec -n is a nice tool to run the tests and stop at the next failure - and to potentialy run only failures with --only-failures