### PR TITLE
refactor tests - stubbing zero offenders in a prison causes issues later

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -52,9 +52,9 @@ module Nomis
       data
     end
 
-    def post(route, body, extra_headers: {})
+    def post(route, body, queryparams: {}, extra_headers: {})
       response = request(
-        :post, route, extra_headers: extra_headers, body: body
+        :post, route, queryparams: queryparams, extra_headers: extra_headers, body: body
       )
 
       JSON.parse(response.body)

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -258,9 +258,12 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
 
     let(:offender_no) { 'G7806VO' }
 
+    let(:offender) { attributes_for(:offender, offenderNo: offender_no) }
+    let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+
     before do
       stub_offender(offender_no)
-      stub_offenders_for_prison(prison, [], [])
+      stub_offenders_for_prison(prison, [offender], [booking])
     end
 
     context 'when tier A offender' do

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -29,12 +29,15 @@ RSpec.describe EarlyAllocationsController, type: :controller do
   let(:s1_boolean_param_names) { [:convicted_under_terrorisom_act_2000, :high_profile, :serious_crime_prevention_order, :mappa_level_3, :cppc_case] }
   let(:s1_boolean_params) { s1_boolean_param_names.map { |p| [p, 'false'] }.to_h }
 
+  let(:offender) { attributes_for(:offender, offenderNo: nomis_offender_id) }
+  let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+
   before do
     stub_sso_data(prison, 'alice')
 
     stub_offender(nomis_offender_id)
     stub_poms(prison, poms)
-    stub_offenders_for_prison(prison, [], [])
+    stub_offenders_for_prison(prison, [offender], [booking])
 
     create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
   end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -113,10 +113,13 @@ describe PrisonOffenderManagerService do
               emails: ['test@digital.justice.org.uk']
         )
       }
+      let(:offender) { attributes_for(:offender) }
+      let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+
 
       before do
         stub_poms('WSI', [dave, alice, billy, charles, eric])
-        stub_offenders_for_prison('WSI', [], [])
+        stub_offenders_for_prison('WSI', [offender], [booking])
       end
 
       it 'removes duplicate staff ids, keeping the valid position' do

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -82,7 +82,7 @@ module ApiHelper
     # Get the booking ids provided
     booking_ids = offenders.map { |h| h.fetch(:bookingId) }
     stub_request(:post, elite2bookingsapi).with(body: booking_ids.to_json).
-      to_return(body: bookings.to_json, headers: {})
+      to_return(body: bookings.to_json)
   end
 
   def stub_multiple_offenders(offenders, bookings)


### PR DESCRIPTION
As a result of an earlier test refactor, some tests were stubbing a zero-length list of offenders. This was less than ideal, and caused problems later. This PR addresses those issues, taking the noise out of the affected story