### PR TITLE
POM-749 add validation for unique team codes and names

### DIFF
--- a/app/admin/local_divisional_units.rb
+++ b/app/admin/local_divisional_units.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register LocalDivisionalUnit, as: 'LDU' do
-  actions :all, except: [:destroy]
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
@@ -14,4 +13,19 @@ ActiveAdmin.register LocalDivisionalUnit, as: 'LDU' do
   #   permitted << :other if params[:action] == 'create' && current_user.admin?
   #   permitted
   # end
+  #
+  # Columns for index page
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :code
+    column :email_address
+    column 'Teams' do |ldu|
+      ldu.teams.size
+    end
+    column 'Created at', :created_at
+    column 'Updated at', :updated_at
+    actions
+  end
 end

--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -36,4 +36,14 @@ ActiveAdmin.register Team do
   filter :shadow_code
   filter :local_divisional_unit, collection: proc { LocalDivisionalUnit.order(:name) }
   filter :case_information_count, label: 'Offender count'
+
+  form do |_form|
+    inputs do
+      input :local_divisional_unit, collection: LocalDivisionalUnit.with_email_address.order(:name)
+      input :code
+      input :shadow_code
+      input :name
+    end
+    actions
+  end
 end

--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -132,9 +132,10 @@ private
       next unless active_ldu?(record[:ldu_code])
 
       UpdateTeamNameAndLduService.update(
-        team_code: record[:team_code],
-        team_name: record[:team],
-        ldu_code: record[:ldu_code]
+        team_code: record.fetch(:team_code),
+        team_name: record.fetch(:team),
+        ldu_code: record.fetch(:ldu_code),
+        ldu_name: record.fetch(:ldu)
       )
     end
   end

--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -103,6 +103,10 @@ private
   def process_decrypted_file(filename)
     Rails.logger.info('[DELIUS] Processing decrypted file')
     processor = Delius::Processor.new(filename)
+    # A key fact here is that update_team_names_and_ldus()
+    # only operates on 'active' records
+    # and update_shadow_team_associations() only operates on 'shadow'
+    # records - so their behaviours do not overlap.
     update_team_names_and_ldus(processor)
     update_shadow_team_associations(processor)
     upsert_delius_data_records(processor)

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -86,7 +86,9 @@ private
   end
 
   def map_team(team_code)
-    Team.find_by(shadow_code: team_code) || Team.find_by(code: team_code)
+    team = Team.find_by(shadow_code: team_code) || Team.find_by(code: team_code)
+    # don't map a team if it doesn't have an LDU
+    team if team&.local_divisional_unit.present?
   end
 
   def find_case_info(delius_record)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -23,7 +23,7 @@ class CaseInformation < ApplicationRecord
   validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }
   validates :nomis_offender_id, presence: true, uniqueness: true
 
-  validates :local_divisional_unit, :team, presence: true, unless: -> { manual_entry }
+  validates :team, presence: true, unless: -> { manual_entry }
 
   validates :welsh_offender, inclusion: {
     in: %w[Yes No],

--- a/app/models/local_divisional_unit.rb
+++ b/app/models/local_divisional_unit.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class LocalDivisionalUnit < ApplicationRecord
+  has_many :teams, dependent: :restrict_with_error
+
   validates :code, :name, presence: true
-  has_many :teams, dependent: :destroy
+
+  validates :code, uniqueness: true
 
   scope :without_email_address, -> { where(email_address: nil) }
   scope :with_email_address, -> { where.not(email_address: nil) }

--- a/app/models/local_divisional_unit.rb
+++ b/app/models/local_divisional_unit.rb
@@ -5,4 +5,5 @@ class LocalDivisionalUnit < ApplicationRecord
   has_many :teams, dependent: :destroy
 
   scope :without_email_address, -> { where(email_address: nil) }
+  scope :with_email_address, -> { where.not(email_address: nil) }
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class Team < ApplicationRecord
-  validates :name, :code, presence: true
+  validates :name, presence: true
 
   validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
-  validates :code, uniqueness: true, if: -> { nps? }
+  validates :code, uniqueness: true, if: -> { nps? && code.present? }
   validates :name, uniqueness: true, if: -> { nps? }
+
+  validate do |team|
+    unless team.code.present? || team.shadow_code.present?
+      team.errors.add(:code, 'can\'t be blank if shadow_code is blank')
+    end
+  end
 
   scope :nps, -> { where('teams.code like ?', 'N%') }
 
@@ -13,7 +19,7 @@ class Team < ApplicationRecord
     code&.starts_with?('N')
   end
 
-  belongs_to :local_divisional_unit
+  belongs_to :local_divisional_unit, optional: true
 
   has_many :case_information, dependent: :restrict_with_error, counter_cache: :case_information_count
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,7 +3,7 @@
 class Team < ApplicationRecord
   validates :name, :code, presence: true
 
-  validates :shadow_code, uniqueness: true, if: -> { nps? }
+  validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
   validates :code, uniqueness: true, if: -> { nps? }
   validates :name, uniqueness: true, if: -> { nps? }
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,7 +3,15 @@
 class Team < ApplicationRecord
   validates :name, :code, presence: true
 
+  validates :shadow_code, uniqueness: true, if: -> { nps? }
+  validates :code, uniqueness: true, if: -> { nps? }
+  validates :name, uniqueness: true, if: -> { nps? }
+
   scope :nps, -> { where('teams.code like ?', 'N%') }
+
+  def nps?
+    code&.starts_with?('N')
+  end
 
   belongs_to :local_divisional_unit
 

--- a/app/services/update_shadow_team_association_service.rb
+++ b/app/services/update_shadow_team_association_service.rb
@@ -1,46 +1,26 @@
+# frozen_string_literal: true
+
 class UpdateShadowTeamAssociationService
   def self.update(shadow_code:, shadow_name:)
-    new(shadow_code: shadow_code, shadow_name: shadow_name).update
-  end
+    active_name = shadow_name_to_active_name shadow_name
+    return if active_name.nil?
 
-  def initialize(shadow_code:, shadow_name:)
-    @shadow_code = shadow_code
-    @shadow_name = shadow_name
-    @team = find_active_team
-  end
-
-  def update
-    return if @team.nil?
-
-    if @team.shadow_code != @shadow_code
-      @team.update(shadow_code: @shadow_code)
+    Team.find_or_initialize_by(name: active_name).tap do |team|
+      team.shadow_code = shadow_code
+      team.save if team.changed?
     end
   end
 
 private
 
-  def shadow_name_to_active_name
-    match = @shadow_name.match(/^OMIC ?-? (.*)$/i)
+  def self.shadow_name_to_active_name shadow_name
+    match = shadow_name.match(/^OMIC ?-? (.*)$/i)
 
     if match.nil?
-      Rails.logger.error("This doesn't look like a shadow team name: '#{@shadow_name}'")
+      Rails.logger.error("This doesn't look like a shadow team name: '#{shadow_name}'")
       return nil
     end
 
     match[1]
-  end
-
-  def find_active_team
-    active_name = shadow_name_to_active_name
-    return if active_name.nil?
-
-    team = Team.find_by(name: active_name)
-
-    if team.nil?
-      Rails.logger.error("Couldn't find a team named '#{active_name}' to associate with shadow team '#{@shadow_name}'")
-      return nil
-    end
-
-    team
   end
 end

--- a/app/services/update_team_name_and_ldu_service.rb
+++ b/app/services/update_team_name_and_ldu_service.rb
@@ -1,42 +1,11 @@
 class UpdateTeamNameAndLduService
-  def self.update(team_code:, team_name:, ldu_code:)
-    new(team_code: team_code, team_name: team_name, ldu_code: ldu_code).update
-  end
-
-  def initialize(team_code:, team_name:, ldu_code:)
-    @team = Team.find_by(code: team_code)
-    @team_name = team_name
-    @ldu_code = ldu_code
-
-    Rails.logger.error("Couldn't find team with code #{team_code}") if @team.nil?
-  end
-
-  def update
-    return if @team.nil?
-
-    update_name if name_needs_updating?
-    update_ldu if ldu_needs_updating?
-    @team.save if @team.changed?
-  end
-
-private
-
-  def name_needs_updating?
-    @team.name != @team_name
-  end
-
-  def update_name
-    @team.name = @team_name
-  end
-
-  def ldu_needs_updating?
-    @team.local_divisional_unit&.code != @ldu_code
-  end
-
-  def update_ldu
-    ldu = LocalDivisionalUnit.find_by(code: @ldu_code)
-    return Rails.logger.error("Couldn't find LDU with code #{@ldu_code}") if ldu.nil?
-
-    @team.local_divisional_unit = ldu
+  def self.update(team_code:, team_name:, ldu_code:, ldu_name:)
+    ldu = LocalDivisionalUnit.find_or_create_by!(code: ldu_code) do |l|
+      l.name = ldu_name
+    end
+    Team.find_or_initialize_by(code: team_code).tap do |t|
+      t.assign_attributes(name: team_name, local_divisional_unit: ldu)
+      t.save if t.changed?
+    end
   end
 end

--- a/spec/factories/local_divisional_units.rb
+++ b/spec/factories/local_divisional_units.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :local_divisional_unit do
-    sequence(:code) do |seq| "LDU#{seq}" end
+    sequence(:code) { |seq| "LDU#{seq}" }
     name do 'An Uninteresting LDU' end
     email_address { Faker::Internet.email }
   end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -16,6 +16,6 @@ FactoryBot.define do
       sequence(:shadow_code) do |seq| "CS#{seq}" end
     end
 
-    association :local_divisional_unit, code: '123', name: "LDU Name", email_address: 'testldu@example.org'
+    association :local_divisional_unit
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,8 +1,20 @@
 FactoryBot.define do
   factory :team do
-    sequence(:code) do |seq| "N#{seq}" end
-    sequence(:shadow_code) do |seq| "SHAD#{seq}" end
-    name do 'The team' end
+    sequence(:code) do |seq| "NA#{seq}" end
+    sequence(:shadow_code) do |seq| "NS#{seq}" end
+    sequence(:name) { |seq|
+      "Team Number #{seq}"
+    }
+
+    trait :nps do
+      sequence(:code) do |seq| "NA#{seq}" end
+      sequence(:shadow_code) do |seq| "NS#{seq}" end
+    end
+
+    trait :crc do
+      sequence(:code) do |seq| "CA#{seq}" end
+      sequence(:shadow_code) do |seq| "CS#{seq}" end
+    end
 
     association :local_divisional_unit, code: '123', name: "LDU Name", email_address: 'testldu@example.org'
   end

--- a/spec/features/active_admin_feature_spec.rb
+++ b/spec/features/active_admin_feature_spec.rb
@@ -86,8 +86,8 @@ feature 'ActiveAdmin' do
         expect(page).to have_content(ldu.name.to_s)
       end
 
-      it 'cannot delete an ldu' do
-        expect(page).not_to have_link('Delete')
+      it 'can delete an ldu' do
+        expect(page).to have_link('Delete')
       end
     end
   end

--- a/spec/features/delius_process_data_feature_spec.rb
+++ b/spec/features/delius_process_data_feature_spec.rb
@@ -76,6 +76,9 @@ feature 'delius import scenarios', vcr: { cassette_name: :delius_import_scenario
       end
     end
 
+    #TODO: - I'm not sure if this scenario makes sense. Would we ever receive
+    # a delius extract record with team but no LDU? Think we might need to add
+    # validation to prevent this scenario occuring
     context 'without LDU' do
       let(:d1) { create(:delius_data, ldu: nil, ldu_code: nil) }
 
@@ -86,7 +89,7 @@ feature 'delius import scenarios', vcr: { cassette_name: :delius_import_scenario
       it 'displays the correct error message' do
         visit prison_case_information_path('LEI', d1.noms_no)
         within '.govuk-error-summary' do
-          expect(page).to have_content 'no local divisional unit (LDU) information found'
+          expect(page).to have_content 'no community team information found'
         end
       end
     end

--- a/spec/lib/ldu_email_importer_spec.rb
+++ b/spec/lib/ldu_email_importer_spec.rb
@@ -44,18 +44,4 @@ describe LDUEmailImporter do
     a4 = LocalDivisionalUnit.find_by(code: 'A4')
     expect(a4).to be_nil
   end
-
-  it "can update duplicates" do
-    create(:local_divisional_unit, code: 'A1', email_address: 'test@example.com')
-    create(:local_divisional_unit, code: 'A1', email_address: 'test@example.com')
-    create(:local_divisional_unit, code: 'A1', email_address: 'test@example.com')
-
-    described_class.import(file_path)
-
-    units = LocalDivisionalUnit.where(code: 'A1')
-    expect(units.count).to eq(3)
-    units.each { |unit|
-      expect(unit.email_address).to eq('test@example.com')
-    }
-  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,8 +3,13 @@ require 'rails_helper'
 RSpec.describe Team, type: :model do
   it {
     expect(subject).to validate_presence_of :name
-    expect(subject).to validate_presence_of :code
   }
+
+  it 'expects one of shadow code and code to be present' do
+    expect(build(:team, code: nil, shadow_code: nil)).not_to be_valid
+    expect(build(:team, code: 'N123', shadow_code: nil)).to be_valid
+    expect(build(:team, code: nil, shadow_code: 'N123')).to be_valid
+  end
 
   context 'when NPS' do
     before do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -5,4 +5,74 @@ RSpec.describe Team, type: :model do
     expect(subject).to validate_presence_of :name
     expect(subject).to validate_presence_of :code
   }
+
+  context 'when NPS' do
+    before do
+      create(:team, :nps)
+    end
+
+    let(:oldteam) { described_class.first }
+
+    context 'with a duplicate team code' do
+      let(:team) { build(:team, :nps, code: oldteam.code) }
+
+      it 'does not allow duplicate team codes' do
+        expect(team).not_to be_valid
+        expect(team.errors.count).to eq(1)
+        expect(team.errors.first).to eq([:code, "has already been taken"])
+      end
+    end
+
+    context 'with a duplicate shadow code' do
+      let(:team) { build(:team, :nps, shadow_code: oldteam.shadow_code) }
+
+      it 'does not allow duplicate team codes' do
+        expect(team).not_to be_valid
+        expect(team.errors.count).to eq(1)
+        expect(team.errors.first).to eq([:shadow_code, "has already been taken"])
+      end
+    end
+
+    context 'with a duplicate team name' do
+      let(:team) { build(:team, name: oldteam.name) }
+
+      it 'is not valid' do
+        expect(team).not_to be_valid
+        expect(team.errors.count).to eq(1)
+        expect(team.errors.first).to eq([:name, "has already been taken"])
+      end
+    end
+  end
+
+  context 'when CRC' do
+    before do
+      create(:team, :crc)
+    end
+
+    let(:oldteam) { described_class.first }
+
+    context 'with a duplicate team code' do
+      let(:team) { build(:team, :crc, code: oldteam.code) }
+
+      it 'allows duplicate team codes' do
+        expect(team).to be_valid
+      end
+    end
+
+    context 'with a duplicate shadow code' do
+      let(:team) { build(:team, :crc, shadow_code: oldteam.shadow_code) }
+
+      it 'is valid' do
+        expect(team).to be_valid
+      end
+    end
+
+    context 'with a duplicate team name' do
+      let(:team) { build(:team, :crc, name: oldteam.name) }
+
+      it 'is valid' do
+        expect(team).to be_valid
+      end
+    end
+  end
 end

--- a/spec/services/update_shadow_team_association_service_spec.rb
+++ b/spec/services/update_shadow_team_association_service_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe UpdateShadowTeamAssociationService do
   context "when no active team exists with a matching name" do
     let(:team_name) { 'Some other team name' }
 
-    it "logs an error" do
-      expect_message = "Couldn't find a team named 'Team 1' to associate with shadow team 'OMIC Team 1'"
-      expect(Rails.logger).to receive(:error).with(expect_message)
-      described_class.update(shadow_code: 'SHAD01', shadow_name: 'OMIC Team 1')
+    it "creates a new team" do
+      expect {
+        described_class.update(shadow_code: 'SHAD01', shadow_name: 'OMIC Team 1')
+      }.to change(Team, :count).by(1)
     end
   end
 end


### PR DESCRIPTION
As part of the tidying up of team data, this adds unique constraints to several team fields so that processing can be performed in the future without creating more of the duplicate records that we have seen so far