### PR TITLE
POM-759 add REDIS_URL to cronjob so that movements:process runs

### DIFF
--- a/deploy/preprod/cronjob.yaml
+++ b/deploy/preprod/cronjob.yaml
@@ -44,6 +44,11 @@ spec:
                   secretKeyRef:
                     name: allocation-rds-instance-output
                     key: postgres_user
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: elasticache-offender-management-allocation-manager-token-cache-preprod
+                    key: url
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1beta1

--- a/deploy/preprod/cronjob.yaml
+++ b/deploy/preprod/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: offender-manager-process-movements
 spec:
-  schedule: "*/20 * * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2

--- a/deploy/preprod/cronjob.yaml
+++ b/deploy/preprod/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: offender-manager-process-movements
 spec:
-  schedule: "30 * * * *"
+  schedule: "*/20 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2

--- a/deploy/preprod/cronjob.yaml
+++ b/deploy/preprod/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: offender-manager-process-movements
 spec:
-  schedule: "0 2 * * *"
+  schedule: "30 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
@@ -97,4 +97,9 @@ spec:
                     secretKeyRef:
                       name: allocation-rds-instance-output
                       key: postgres_user
+                - name: REDIS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: elasticache-offender-management-allocation-manager-token-cache-preprod
+                      key: url
           restartPolicy: OnFailure

--- a/deploy/production/cronjob.yaml
+++ b/deploy/production/cronjob.yaml
@@ -98,5 +98,10 @@ spec:
                     secretKeyRef:
                       name: allocation-rds-instance-output
                       key: postgres_user
+                - name: REDIS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: elasticache-offender-management-allocation-manager-token-cache-production
+                      key: url
           restartPolicy: OnFailure
 

--- a/deploy/production/cronjob.yaml
+++ b/deploy/production/cronjob.yaml
@@ -45,6 +45,11 @@ spec:
                   secretKeyRef:
                     name: allocation-rds-instance-output
                     key: postgres_user
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: elasticache-offender-management-allocation-manager-token-cache-production
+                    key: url
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1beta1


### PR DESCRIPTION
https://sentry.service.dsd.io/mojds/live1-allocation-manager-produ/issues/53354/

shows that the movement service job has not run for some time. This PR fixes it by introducing the REDIS_URL variable into the cronjob YAML file, which fails to load otherwise