### PR TITLE
POM-765 - improve handling of secondary non POMs

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -28,9 +28,11 @@ class AllocationsController < PrisonsApplicationController
     redirect_to prison_pom_non_pom_path(@prison.code, @pom.staff_id) unless @pom.pom_at?(@prison.code)
 
     secondary_pom_nomis_id = @allocation.secondary_pom_nomis_id
-    unless secondary_pom_nomis_id.nil?
-      @coworker = StaffMember.new(secondary_pom_nomis_id)
-      redirect_to prison_pom_non_pom_path(@prison.code, @coworker.staff_id) unless @coworker.pom_at?(@prison.code)
+    if secondary_pom_nomis_id.present?
+      coworker = StaffMember.new(secondary_pom_nomis_id)
+      if coworker.pom_at?(@prison.code)
+        @coworker = coworker
+      end
     end
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(active_prison_id, @prisoner.offender_no)
   end

--- a/app/views/coworking/_poms_table.html.erb
+++ b/app/views/coworking/_poms_table.html.erb
@@ -14,7 +14,7 @@
   </thead>
   <tbody class="govuk-table__body">
   <% poms.each_with_index do |pom, i| %>
-    <tr class="govuk-table__row prison_pom_row_<%= i %>">
+    <tr class="govuk-table__row <%= pom_type %>_pom_row_<%= i %>">
       <td aria-label="POM name" class="govuk-table__cell "><%= pom.full_name %></td>
       <td aria-label="Tier A cases" class="govuk-table__cell ">-</td>
       <td aria-label="Tier A cases" class="govuk-table__cell "><%= pom.tier_a %></td>

--- a/app/views/coworking/new.html.erb
+++ b/app/views/coworking/new.html.erb
@@ -12,14 +12,14 @@
 
 <h2 class="govuk-heading-s">Probation Officer POMs</h2>
 
-<%= render :partial => 'poms_table', :locals => { poms: @probation_poms } %>
+<%= render :partial => 'poms_table', :locals => { poms: @probation_poms, pom_type: 'probation' } %>
 
 <!-- Spacer -->
 <div class="govuk-grid-row"><div class="govuk-grid-column-full govuk-!-margin-top-4"></div></div>
 
 <h2 class="govuk-heading-s">Prison Officer POMs</h2>
 
-<%= render :partial => 'poms_table', :locals => { poms: @prison_poms } %>
+<%= render :partial => 'poms_table', :locals => { poms: @prison_poms, pom_type: 'prison' } %>
 
 <!-- Spacer -->
 <div class="govuk-grid-row"><div class="govuk-grid-column-full govuk-!-margin-top-4"></div></div>

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -4,45 +4,38 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
   let(:poms) {
     [
       build(:pom,
-            firstName: 'Alice',
-            position: RecommendationService::PRISON_POM,
+            :prison_officer,
             staffId: 1
       ),
       build(:pom,
-            firstName: 'Bob',
-            position: RecommendationService::PRISON_POM,
+            :prison_officer,
             staffId: 2
         ),
       build(:pom,
-            firstName: 'Clare',
-            position: RecommendationService::PROBATION_POM,
+            :probation_officer,
             staffId: 3,
             emails: ['pom3@prison.gov.uk']
         ),
       build(:pom,
-            firstName: 'Dave',
-            position: RecommendationService::PROBATION_POM,
+            :probation_officer,
             staffId: 4,
             emails: ['pom4@prison.gov.uk']
         )
     ]
   }
+  let(:prison) { build(:prison).code }
+  let(:offender_no) { build(:offender).offender_no }
 
   before do
-    stub_sso_data(prison, 'alice')
-
     stub_poms(prison, poms)
   end
 
-  context 'when user is a POM' do
-    let(:prison) { 'LEI' }
-    let(:offender_no) { 'G7806VO' }
-
+  context 'when user is a POM rather than an SPO' do
     before do
       stub_poms(prison, poms)
       stub_signed_in_pom(prison, 1, 'Alice')
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
-        to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
+        to_return(body: { staffId: 1 }.to_json)
     end
 
     it 'is not visible' do
@@ -51,241 +44,240 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
     end
   end
 
-  describe '#show' do
-    let(:prison) { 'WEI' }
+  context 'when user in SPO' do
+    before do
+      stub_sso_data(prison, 'alice')
+      stub_offender(offender_no)
+    end
 
-    context 'when POM has left' do
-      let(:offender_no) { 'G7806VO' }
-      let(:pom_staff_id) { 543_453 }
-      let(:poms) {
-        [build(:pom,
-               firstName: 'Alice',
-               position: RecommendationService::PRISON_POM,
-               staffId: 123
-         )]
-      }
+    describe '#show' do
+      let(:inactive_pom_staff_id) { 543_453 }
 
       before do
-        stub_offender(offender_no)
-        stub_poms(prison, poms)
-
         create(:case_information, nomis_offender_id: offender_no)
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: pom_staff_id)
-
-        stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/WEI/offender/G7806VO").
-          to_return(status: 200, body: { staffId: 123_456 }.to_json, headers: {})
+        stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/#{prison}/offender/#{offender_no}").
+          to_return(body: { staffId: 123_456 }.to_json)
       end
 
-      it 'redirects to the inactive POM page' do
-        get :show, params: { prison_id: prison, nomis_offender_id: offender_no }
-        expect(response).to redirect_to(prison_pom_non_pom_path(prison, pom_staff_id))
-      end
-    end
-  end
-
-  describe '#history' do
-    let(:prison) { 'AYI' }
-    let(:offender_no) { 'G1234VO' }
-    let(:pom_staff_id) { 1 }
-
-    before do
-      stub_offender(offender_no)
-      create(:case_information, nomis_offender_id: offender_no)
-
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/1").
-        to_return(status: 200, body: {}.to_json, headers: {})
-
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/MOIC_POM").
-        to_return(status: 200, body: { staffId: 3 }.to_json, headers: {})
-
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/4").
-        to_return(status: 200, body: {}.to_json, headers: {})
-
-      stub_pom_emails(5, [])
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/5").
-        to_return(status: 200, body: {}.to_json, headers: {})
-    end
-
-    context 'when DeliusDataJob has updated the COM name' do
-      # set DOB to 8 stars so that Delius matching ignores DoB
-      let!(:d1) { create(:delius_data, date_of_birth: '*' * 8, offender_manager: 'Mr Todd', noms_no: offender_no) }
-      let(:create_time) { 3.days.ago }
-      let(:create_date) { create_time.to_date }
-      let(:yesterday) { 1.day.ago.to_date }
-
-      context 'when create, delius, update' do
+      context 'when POM has left' do
         before do
-          x = create(:allocation, primary_pom_nomis_id: 1, allocated_at_tier: 'C',
-                                  nomis_offender_id: d1.noms_no,
-                                  created_at: create_time,
-                                  updated_at: create_time)
-          Timecop.travel 2.days.ago do
-            ProcessDeliusDataJob.perform_now offender_no
-          end
-          x.reload
-          Timecop.travel 1.day.ago do
-            x.update(allocated_at_tier: 'D')
-          end
+          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: inactive_pom_staff_id)
         end
 
-        it 'doesnt mess up the allocation history updated_at as we surface the value' do
-          get :history, params: { prison_id: prison, nomis_offender_id: d1.noms_no }
-          history = assigns(:history)
-          # one set of history as only 1 prison involved
-          expect(history.size).to eq(1)
-          # history is array of pairs - [prison, allocations]
-          expect(history.first.size).to eq(2)
-          expect(history.first.first).to eq 'LEI'
-
-          allocation_list = history.first.second
-          expect(allocation_list.size).to eq(2)
-          expect(allocation_list.map(&:updated_at).map(&:to_date)).to eq([yesterday, create_date])
+        it 'redirects to the inactive POM page' do
+          get :show, params: { prison_id: prison, nomis_offender_id: offender_no }
+          expect(response).to redirect_to(prison_pom_non_pom_path(prison, inactive_pom_staff_id))
         end
       end
 
-      context 'when delius updated' do
+      context 'with an inactive co-worker' do
         before do
-          create(:allocation, primary_pom_nomis_id: 1, allocated_at_tier: 'C',
-                              nomis_offender_id: d1.noms_no,
-                              created_at: create_time,
-                              updated_at: create_time)
-          Timecop.travel 2.days.ago do
-            ProcessDeliusDataJob.perform_now offender_no
-          end
-
-          stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/AYI/offender/G1234VO").
-            to_return(status: 200, body: { staffId: 123_456 }.to_json, headers: {})
+          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: 1, secondary_pom_nomis_id: inactive_pom_staff_id)
         end
 
-        it 'shows the correct date on the show page' do
-          get :show, params: { prison_id: prison, nomis_offender_id: d1.noms_no }
-          alloc = assigns(:allocation)
-          expect(alloc.updated_at.to_date).to eq(create_date)
+        it 'shows the page' do
+          get :show, params: { prison_id: prison, nomis_offender_id: offender_no }
+          expect(response).to have_http_status(:ok)
         end
       end
     end
 
-    context 'without DeliusDataJob' do
-      render_views
+    describe '#history' do
+      let(:pom_staff_id) { 1 }
 
-      context 'with an allocation' do
-        before do
-          allocation = create(:allocation,
-                              nomis_offender_id: offender_no,
-                              nomis_booking_id: 1,
-                              primary_pom_nomis_id: 4,
-                              allocated_at_tier: 'A',
-                              prison: 'PVI',
-                              recommended_pom_type: 'probation',
-                              event: Allocation::ALLOCATE_PRIMARY_POM,
-                              event_trigger: Allocation::USER,
-                              created_by_username: 'MOIC_POM'
-          )
+      before do
+        create(:case_information, nomis_offender_id: offender_no)
+
+        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/1").
+          to_return(status: 200, body: {}.to_json, headers: {})
+
+        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/MOIC_POM").
+          to_return(status: 200, body: { staffId: 3 }.to_json, headers: {})
+
+        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/4").
+          to_return(status: 200, body: {}.to_json, headers: {})
+
+        stub_pom_emails(5, [])
+        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/5").
+          to_return(status: 200, body: {}.to_json, headers: {})
+      end
+
+      context 'when DeliusDataJob has updated the COM name' do
+        # set DOB to 8 stars so that Delius matching ignores DoB
+        let!(:d1) { create(:delius_data, date_of_birth: '*' * 8, offender_manager: 'Mr Todd', noms_no: offender_no) }
+        let(:create_time) { 3.days.ago }
+        let(:create_date) { create_time.to_date }
+        let(:yesterday) { 1.day.ago.to_date }
+
+        context 'when create, delius, update' do
+          before do
+            x = create(:allocation, primary_pom_nomis_id: 1, allocated_at_tier: 'C',
+                       nomis_offender_id: d1.noms_no,
+                       created_at: create_time,
+                       updated_at: create_time)
+            Timecop.travel 2.days.ago do
+              ProcessDeliusDataJob.perform_now offender_no
+            end
+            x.reload
+            Timecop.travel 1.day.ago do
+              x.update(allocated_at_tier: 'D')
+            end
+          end
+
+          it 'doesnt mess up the allocation history updated_at as we surface the value' do
+            get :history, params: { prison_id: prison, nomis_offender_id: d1.noms_no }
+            history = assigns(:history)
+            # one set of history as only 1 prison involved
+            expect(history.size).to eq(1)
+            # history is array of pairs - [prison, allocations]
+            expect(history.first.size).to eq(2)
+            expect(history.first.first).to eq 'LEI'
+
+            allocation_list = history.first.second
+            expect(allocation_list.size).to eq(2)
+            expect(allocation_list.map(&:updated_at).map(&:to_date)).to eq([yesterday, create_date])
+          end
+        end
+
+        context 'when delius updated' do
+          before do
+            create(:allocation, primary_pom_nomis_id: 1, allocated_at_tier: 'C',
+                   nomis_offender_id: d1.noms_no,
+                   created_at: create_time,
+                   updated_at: create_time)
+            Timecop.travel 2.days.ago do
+              ProcessDeliusDataJob.perform_now offender_no
+            end
+
+            stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/#{prison}/offender/#{offender_no}").
+              to_return(body: { staffId: 123_456 }.to_json)
+          end
+
+          it 'shows the correct date on the show page' do
+            get :show, params: { prison_id: prison, nomis_offender_id: d1.noms_no }
+            alloc = assigns(:allocation)
+            expect(alloc.updated_at.to_date).to eq(create_date)
+          end
+        end
+      end
+
+      context 'without DeliusDataJob' do
+        render_views
+
+        context 'with an allocation' do
+          before do
+            allocation = create(:allocation,
+                                nomis_offender_id: offender_no,
+                                nomis_booking_id: 1,
+                                primary_pom_nomis_id: 4,
+                                allocated_at_tier: 'A',
+                                prison: 'PVI',
+                                recommended_pom_type: 'probation',
+                                event: Allocation::ALLOCATE_PRIMARY_POM,
+                                event_trigger: Allocation::USER,
+                                created_by_username: 'MOIC_POM'
+            )
+            allocation.update!(
+              primary_pom_nomis_id: 5,
+              prison: 'LEI',
+              event: Allocation::REALLOCATE_PRIMARY_POM,
+              event_trigger: Allocation::USER,
+              created_by_username: 'MOIC_POM'
+            )
+          end
+
+          it "Can get the allocation history for an offender", versioning: true do
+            get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
+            allocation_list = assigns(:history).to_a
+
+            expect(allocation_list.count).to eq(2)
+            # We get back a list of prison, allocation_array pairs
+            expect(allocation_list.map(&:size)).to eq([2, 2])
+            # Prisons are 1 each - LEI then PVI
+            expect(allocation_list.first.first).to eq('LEI')
+            expect(allocation_list.last.first).to eq('PVI')
+
+            # we have 2 1-element arrays
+            arrays = allocation_list.map { |al| al.second.first }
+            expect(arrays.size).to eq(2)
+
+            expect(arrays.first.nomis_offender_id).to eq(offender_no)
+            # expect to see reallocate event before allocate as the history is reversed
+            expect(arrays.first.event).to eq('reallocate_primary_pom')
+            expect(arrays.last.nomis_booking_id).to eq(1)
+          end
+        end
+      end
+
+      context 'with a different allocation' do
+        it "can get email addresses of POM's who have been allocated to an offender given the allocation history", versioning: true do
+          previous_primary_pom_nomis_id = 3
+          updated_primary_pom_nomis_id = 4
+          primary_pom_without_email_id = 5
+
+          allocation = create(
+            :allocation,
+            nomis_offender_id: offender_no,
+            prison: prison,
+            override_reasons: ['other'],
+            primary_pom_nomis_id: previous_primary_pom_nomis_id)
+
           allocation.update!(
-            primary_pom_nomis_id: 5,
-            prison: 'LEI',
-            event: Allocation::REALLOCATE_PRIMARY_POM,
-            event_trigger: Allocation::USER,
-            created_by_username: 'MOIC_POM'
+            primary_pom_nomis_id: updated_primary_pom_nomis_id,
+            event: Allocation::REALLOCATE_PRIMARY_POM
           )
-        end
 
-        it "Can get the allocation history for an offender", versioning: true do
+          allocation.update!(
+            primary_pom_nomis_id: primary_pom_without_email_id,
+            event: Allocation::REALLOCATE_PRIMARY_POM
+          )
+
+          allocation.update!(
+            primary_pom_nomis_id: updated_primary_pom_nomis_id,
+            event: Allocation::REALLOCATE_PRIMARY_POM
+          )
+
           get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
-          allocation_list = assigns(:history).to_a
+          pom_emails = assigns(:pom_emails)
 
-          expect(allocation_list.count).to eq(2)
-          # We get back a list of prison, allocation_array pairs
-          expect(allocation_list.map(&:size)).to eq([2, 2])
-          # Prisons are 1 each - LEI then PVI
-          expect(allocation_list.first.first).to eq('LEI')
-          expect(allocation_list.last.first).to eq('PVI')
-
-          # we have 2 1-element arrays
-          arrays = allocation_list.map { |al| al.second.first }
-          expect(arrays.size).to eq(2)
-
-          expect(arrays.first.nomis_offender_id).to eq(offender_no)
-          # expect to see reallocate event before allocate as the history is reversed
-          expect(arrays.first.event).to eq('reallocate_primary_pom')
-          expect(arrays.last.nomis_booking_id).to eq(1)
+          expect(pom_emails.count).to eq(3)
+          expect(pom_emails[primary_pom_without_email_id]).to eq(nil)
+          expect(pom_emails[updated_primary_pom_nomis_id]).to eq('pom4@prison.gov.uk')
+          expect(pom_emails[previous_primary_pom_nomis_id]).to eq('pom3@prison.gov.uk')
         end
       end
     end
 
-    context 'with a different allocation' do
-      it "can get email addresses of POM's who have been allocated to an offender given the allocation history", versioning: true do
-        previous_primary_pom_nomis_id = 3
-        updated_primary_pom_nomis_id = 4
-        primary_pom_without_email_id = 5
+    describe '#new' do
+      let(:offender) { attributes_for(:offender, offenderNo: offender_no) }
+      let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
 
-        allocation = create(
-          :allocation,
-          nomis_offender_id: offender_no,
-          prison: prison,
-          override_reasons: ['other'],
-          primary_pom_nomis_id: previous_primary_pom_nomis_id)
-
-        allocation.update!(
-          primary_pom_nomis_id: updated_primary_pom_nomis_id,
-          event: Allocation::REALLOCATE_PRIMARY_POM
-        )
-
-        allocation.update!(
-          primary_pom_nomis_id: primary_pom_without_email_id,
-          event: Allocation::REALLOCATE_PRIMARY_POM
-        )
-
-        allocation.update!(
-          primary_pom_nomis_id: updated_primary_pom_nomis_id,
-          event: Allocation::REALLOCATE_PRIMARY_POM
-        )
-
-        get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
-        pom_emails = assigns(:pom_emails)
-
-        expect(pom_emails.count).to eq(3)
-        expect(pom_emails[primary_pom_without_email_id]).to eq(nil)
-        expect(pom_emails[updated_primary_pom_nomis_id]).to eq('pom4@prison.gov.uk')
-        expect(pom_emails[previous_primary_pom_nomis_id]).to eq('pom3@prison.gov.uk')
+      before do
+        stub_offenders_for_prison(prison, [offender], [booking])
       end
-    end
-  end
 
-  describe '#new' do
-    let(:prison) { 'WSI' }
+      context 'when tier A offender' do
+        it 'serves recommended POMs' do
+          create(:case_information, nomis_offender_id: offender_no, tier: 'A')
 
-    let(:offender_no) { 'G7806VO' }
+          get :new, params: { prison_id: prison, nomis_offender_id: offender_no }
 
-    let(:offender) { attributes_for(:offender, offenderNo: offender_no) }
-    let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+          expect(response).to be_successful
 
-    before do
-      stub_offender(offender_no)
-      stub_offenders_for_prison(prison, [offender], [booking])
-    end
-
-    context 'when tier A offender' do
-      it 'serves recommended POMs' do
-        create(:case_information, nomis_offender_id: offender_no, tier: 'A')
-
-        get :new, params: { prison_id: prison, nomis_offender_id: offender_no }
-
-        expect(response).to be_successful
-
-        expect(assigns(:recommended_poms).map(&:first_name)).to match_array(%w[Clare Dave])
+          expect(assigns(:recommended_poms).map(&:first_name)).to match_array(poms.last(2).map(&:firstName))
+        end
       end
-    end
 
-    context 'when tier D offender' do
-      it 'serves recommended POMs' do
-        create(:case_information, nomis_offender_id: offender_no, tier: 'D')
+      context 'when tier D offender' do
+        it 'serves recommended POMs' do
+          create(:case_information, nomis_offender_id: offender_no, tier: 'D')
 
-        get :new, params: { prison_id: prison, nomis_offender_id: offender_no }
+          get :new, params: { prison_id: prison, nomis_offender_id: offender_no }
 
-        expect(response).to be_successful
+          expect(response).to be_successful
 
-        expect(assigns(:recommended_poms).map(&:first_name)).to match_array(%w[Alice Bob])
+          expect(assigns(:recommended_poms).map(&:first_name)).to match_array(poms.first(2).map(&:firstName))
+        end
       end
     end
   end

--- a/spec/controllers/coworking_controller_spec.rb
+++ b/spec/controllers/coworking_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CoworkingController, type: :controller do
+  context 'when there is an existing invalid co-worker' do
+    before do
+      stub_sso_data(prison, username)
+      stub_offender(offender_no)
+      stub_offenders_for_prison(prison, [offender], [booking])
+      stub_poms(prison, [primary_pom, new_secondary_pom])
+      stub_request(:get, "#{ApiHelper::T3}/staff/#{primary_pom.staffId}").
+        to_return(body: { 'firstName' => 'fred' }.to_json)
+      stub_request(:get, "#{ApiHelper::T3}/staff/#{new_secondary_pom.staffId}").
+        to_return(body: { 'firstName' => 'bill' }.to_json)
+      stub_request(:get, "#{ApiHelper::T3}/users/#{username}").
+        to_return(body: { 'staffId': user.staffId }.to_json)
+      stub_pom_emails(user.staffId, [])
+
+      create(:allocation, prison: prison,
+             nomis_offender_id: offender_no,
+             primary_pom_nomis_id: primary_pom.staffId,
+             secondary_pom_nomis_id: secondary_pom.staffId)
+    end
+
+    let(:username) { 'alice' }
+    let(:user) { build(:pom) }
+    let(:prison) { build(:prison).code }
+    let(:primary_pom) { build(:pom) }
+    let(:secondary_pom) { build(:pom) }
+    let(:new_secondary_pom) { build(:pom) }
+    let(:offender) { attributes_for(:offender) }
+    let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+    let(:offender_no) { offender.fetch(:offenderNo) }
+
+    it 'allocates' do
+      post :create, params: { prison_id: prison, coworking_allocations: { nomis_offender_id: offender_no, nomis_staff_id: new_secondary_pom.staffId } }
+      expect(response).to redirect_to(prison_summary_unallocated_path(prison))
+      expect(Allocation.find_by(nomis_offender_id: offender_no).secondary_pom_nomis_id).to eq(new_secondary_pom.staffId)
+    end
+  end
+end

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
   end
 
   class Elite2POM
-    attr_accessor :position, :staffId, :emails, :firstName, :lastName
+    attr_accessor :position, :staffId, :emails, :firstName, :lastName, :positionDescription
   end
 
   factory :pom, class: 'Elite2POM' do
@@ -29,6 +29,7 @@ FactoryBot.define do
 
     firstName { Faker::Name.first_name }
     lastName { Faker::Name.last_name }
+    positionDescription { Faker::Company.type }
 
     trait :probation_officer do
       position { 'PO' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,8 @@ SimpleCov.start 'rails' do
   add_group "Services", "app/services"
 
   # Try to set this to current coverage levels so that it never goes down after a PR
-  # 22 lines uncovered at 99.3% coverage
-  minimum_coverage 99.3
+  # 22 lines uncovered at 99.31% coverage
+  minimum_coverage 99.31
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.1
 end


### PR DESCRIPTION
If the co-working POM is no longer at the prison (possibly because the offender has been transferred) then remove the co-worker rather than sending the SPO off to the non-POM page