### PR TITLE
Revert crc handover display

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -15,7 +15,9 @@ class HandoverDateService
       date, reason = nps_handover_date(offender)
       HandoverData.new nps_start_date(offender), date, reason
     else
-      HandoverData.new crc_handover_date(offender), crc_handover_date(offender), 'CRC Case'
+      # This should really be crc_handover_date(offender) but fixing
+      # this show up other defects with handover calcs (with no case info)
+      HandoverData.new nil, crc_handover_date(offender), 'CRC Case'
     end
   end
 

--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CaseloadController, type: :controller do
       let(:case_allocation) { 'CRC' }
       let(:today_plus_13_weeks) { (Time.zone.today + 13.weeks).to_s }
 
-      it 'can pull back a CRC offender due for handover' do
+      pending 'can pull back a CRC offender due for handover' do
         get :handover_start, params: { prison_id: prison }
         expect(response).to be_successful
         expect(assigns(:upcoming_handovers).map(&:offender_no)).to match_array([offender.fetch(:offenderNo)])

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -70,15 +70,26 @@ RSpec.describe SummaryController, type: :controller do
     describe '#handover' do
       before do
         stub_movements
-        create(:allocation, nomis_offender_id: 'G4234GG')
-        create(:case_information, case_allocation: 'CRC', nomis_offender_id: 'G1234VV')
-        create(:allocation, nomis_offender_id: 'G1234VV')
       end
 
-      it 'returns CRC and NPS cases that are within the thirty day window' do
-        get :handovers, params: { prison_id: prison }
-        expect(response).to be_successful
-        expect(assigns(:offenders).map(&:offender_no)).to match_array(["G1234VV", "G4234GG"])
+      context 'when NPS case' do
+        it 'returns cases that are within the thirty day window' do
+          get :handovers, params: { prison_id: prison }
+          expect(response).to be_successful
+          expect(assigns(:offenders).map(&:offender_no)).to match_array(["G4234GG"])
+        end
+      end
+
+      context 'when CRC case' do
+        before do
+          create(:case_information, case_allocation: 'CRC', nomis_offender_id: 'G1234VV')
+        end
+
+        pending 'returns cases that are within the thirty day window' do
+          get :handovers, params: { prison_id: prison }
+          expect(response).to be_successful
+          expect(assigns(:offenders).map(&:offender_no)).to match_array(['G4234GG', "G1234VV"])
+        end
       end
     end
 


### PR DESCRIPTION
POM-718 uncovers another more insidious bug (POM-757) so revert the changes from master