### PR TITLE
POM-761 Sentry crash (Post recall release date)

### DIFF
--- a/app/models/nomis/sentence_detail.rb
+++ b/app/models/nomis/sentence_detail.rb
@@ -33,6 +33,8 @@ module Nomis
 
       return post_recall_release_date if @actual_parole_date.blank?
 
+      return @actual_parole_date if post_recall_release_date.blank?
+
       if @actual_parole_date.before?(post_recall_release_date)
         @actual_parole_date
       else

--- a/spec/models/nomis/sentence_detail_spec.rb
+++ b/spec/models/nomis/sentence_detail_spec.rb
@@ -102,6 +102,15 @@ describe Nomis::SentenceDetail, model: true do
       end
     end
 
+    context "when post_recall_release_date is not present" do
+      let(:actual_parole_date) { latest_date }
+      let(:nomis_post_recall_release_date) { no_date }
+
+      it "shows actual parole date" do
+        expect(subject.post_recall_release_date).to eq(latest_date)
+      end
+    end
+
     context "when actual_parole_date and post_recall_release_date are not present" do
       let(:actual_parole_date) { no_date }
       let(:nomis_post_recall_release_date) { no_date }


### PR DESCRIPTION
'post_recall_release_date' method fails in the scenario where the post_recall_release_date is blank but the actual_parole_date isn't blank.

The failure occurs because we are comparing a date (actual_parole_date) with nil, resulting in an ArgumentError - comparison of Date with nil (Sentry alerts).

This was affecting the following views:
SummaryController#unallocated
AllocationsController#new
AllocationsController#show
CaseloadController#allocated
PrisonController#show

This commit attempts to fix this issue by returning the actual_parole_date when the post_recall_release_date is blank before attempting any date comparisons.