### PR TITLE
POM - 760: Sentry production crash - SearchController#search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,6 +36,7 @@ private
   end
 
   def search_term
-    params['q'].strip
+    # defaults to an empty string if the key 'q' can't be found
+    params.fetch('q', '').strip
   end
 end


### PR DESCRIPTION
There are a number of occasions where Sentry is reporting 'NoMethodError - undefined method strip of nil:NilClass'. This is happening for some users when they are using the search query box.

Currently we are obtaining the query string using params['q'] and then performing the strip call, to remove any
whitespaces. This fails when params['q'] returns nil, because you can't use strip on nil.

This commit uses the fetch method instead to get the query string and provides a default value of an empty string if the
params key is not found. This way performing the strip call will not result in a NoMethodError.