### PR TITLE
POM-766 tidy up factories and stubs to improve test readability

### DIFF
--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -8,6 +8,8 @@ module Nomis
              :post_recall_release_date, :earliest_release_date,
              to: :sentence
 
+    delegate :indeterminate_sentence?, to: :@sentence_type
+
     attr_accessor :category_code, :date_of_birth
 
     attr_reader :first_name, :last_name, :booking_id,
@@ -53,13 +55,8 @@ module Nomis
       @sentence_type.code
     end
 
-    # sentence type may be nil if we are created as a stub
     def recalled?
-      @sentence_type.try(:recall_sentence?)
-    end
-
-    def indeterminate_sentence?
-      @sentence_type.try(:indeterminate_sentence?)
+      @sentence_type.recall_sentence?
     end
 
     def criminal_sentence?

--- a/app/models/nomis/offender_summary.rb
+++ b/app/models/nomis/offender_summary.rb
@@ -20,7 +20,7 @@ module Nomis
 
     def load_from_json(payload)
       @booking_id = payload.fetch('bookingId').to_i
-      @prison_id = payload['agencyId']
+      @prison_id = payload.fetch('agencyId')
       @facial_image_id = payload['facialImageId']&.to_i
 
       super(payload)

--- a/spec/controllers/coworking_controller_spec.rb
+++ b/spec/controllers/coworking_controller_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe CoworkingController, type: :controller do
   context 'when there is an existing invalid co-worker' do
     before do
       stub_sso_data(prison, username)
-      stub_offender(offender_no)
-      stub_offenders_for_prison(prison, [offender], [booking])
+      stub_offender(offender)
+      stub_offenders_for_prison(prison, [offender])
       stub_poms(prison, [primary_pom, new_secondary_pom])
       stub_request(:get, "#{ApiHelper::T3}/staff/#{primary_pom.staffId}").
         to_return(body: { 'firstName' => 'fred' }.to_json)
@@ -27,8 +27,7 @@ RSpec.describe CoworkingController, type: :controller do
     let(:primary_pom) { build(:pom) }
     let(:secondary_pom) { build(:pom) }
     let(:new_secondary_pom) { build(:pom) }
-    let(:offender) { attributes_for(:offender) }
-    let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+    let(:offender) { build(:nomis_offender) }
     let(:offender_no) { offender.fetch(:offenderNo) }
 
     it 'allocates' do

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -1,72 +1,40 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DebuggingController, type: :controller do
-  let(:prison) { 'WEI' }
-  let(:booking_id) { 'booking3' }
-  let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
-  let(:elite2listapi) { "#{elite2api}/locations/description/#{prison}/inmates?convictedStatus=Convicted&returnCategory=true" }
-  let(:elite2bookingsapi) { "#{elite2api}/offender-sentences/bookings" }
+  let(:prison) { build(:prison) }
+  let(:prison_id) { prison.code }
 
   before do
-    stub_sso_data(prison, 'user')
-    stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
-      with(
-        body: "[\"G7806VO\"]").
-      to_return(body: [].to_json)
+    stub_sso_data(prison_id)
   end
 
   context 'when debugging at a prison level' do
     it 'can show debugging information for an entire prison' do
-      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
-        to_return(status: 200, body: [].to_json)
+      stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=false&movementTypes=TRN").
+        to_return(body: [].to_json)
 
-      offenders = [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
-                     "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
-                     "age": 28, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                     "facialImageId": 1_392_829,
-                     "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
-                   { "bookingId": 754_206, "bookingNo": "K09212", "offenderNo": "G1234VV", "firstName": "ROSS",
-                     "lastName": "JONES", "dateOfBirth": "2004-02-02",
-                     "age": 15, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                     "facialImageId": 1_392_900,
-                     "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" },
-                   { "bookingId": 1, "bookingNo": "K09213", "offenderNo": "G1234XX", "firstName": "BOB",
-                     "lastName": "SMITH", "dateOfBirth": "1995-02-02",
-                     "age": 34, "agencyId": "WEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                     "facialImageId": 1_392_900,
-                     "categoryCode": "D", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }
+      offenders = [
+        build(:nomis_offender),
+        build(:nomis_offender, dateOfBirth: Time.zone.today - 15.years),
+        build(:nomis_offender, sentence: build(:nomis_sentence_detail, releaseDate: nil,
+                     paroleEligibilityDate: nil, homeDetentionCurfewEligibilityDate: nil, tariffDate: nil))
       ]
 
-      bookings = [
-        { "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "WEI",
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": "WEI",
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-      ]
+      stub_offenders_for_prison(prison_id, offenders)
 
-      stub_offenders_for_prison(prison, offenders, bookings)
-
-      get :prison_info, params: { prison_id: prison }
+      get :prison_info, params: { prison_id: prison_id }
       expect(response.status).to eq(200)
       expect(response).to be_successful
 
-      expect(assigns(:prison_title)).to eq('HMP Wealstun')
+      expect(assigns(:prison_title)).to eq(prison.name)
       expect(assigns(:filtered_offenders_count)).to eq(1)
       expect(assigns(:unfiltered_offenders_count)).to eq(3)
 
       filtered_offenders = assigns(:filtered)
       expect(filtered_offenders[:under18].count).to eq(1)
-      expect(filtered_offenders[:under18].first.first_name).to eq("ROSS")
+      expect(filtered_offenders[:under18].first.first_name).to eq(offenders.second.fetch(:firstName))
       expect(filtered_offenders[:unsentenced].count).to eq(1)
 
       summary = assigns(:summary)
@@ -82,21 +50,21 @@ RSpec.describe DebuggingController, type: :controller do
     let(:primary_pom_name) { 'Jenae Sporer' }
 
     it 'can show debugging information for a specific offender' do
-      stub_offender(offender_no, imprisonment_status: 'LIFE')
+      stub_offender(build(:nomis_offender, offenderNo: offender_no, imprisonmentStatus: 'LIFE'))
 
-      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false").
+      stub_request(:post, "#{ApiHelper::T3}/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false").
         with(
           body: "[\"G7806VO\"]").
-        to_return(status: 200, body: [{ offenderNo: offender_no,
+        to_return(body: [{ offenderNo: offender_no,
                                         fromAgency: "LEI",
-                                        toAgency: "WEI",
+                                        toAgency: prison_id,
                                         movementType: "TRN",
-                                        directionCode: "IN" }].to_json, headers: {})
+                                        directionCode: "IN" }].to_json)
 
       create(:case_information, nomis_offender_id: offender_no)
       create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: pom_staff_id, primary_pom_name: primary_pom_name)
 
-      get :debugging, params: { prison_id: prison, offender_no: offender_no }
+      get :debugging, params: { prison_id: prison_id, offender_no: offender_no }
 
       expect(response.status).to eq(200)
       expect(response).to be_successful
@@ -114,7 +82,7 @@ RSpec.describe DebuggingController, type: :controller do
       movements = assigns(:movements)
       expect(movements.movement_type).to eq "TRN"
       expect(movements.from_agency).to eq "LEI"
-      expect(movements.to_agency).to eq "WEI"
+      expect(movements.to_agency).to eq prison_id
     end
   end
 end

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -3,41 +3,32 @@
 require 'rails_helper'
 
 RSpec.describe EarlyAllocationsController, type: :controller do
-  let(:nomis_staff_id) { 444_555 }
-
-  let(:poms) {
-    [
-      build(:pom,
-            firstName: 'Alice',
-            position: RecommendationService::PRISON_POM,
-            staffId: nomis_staff_id,
-            emails: ['test@digital.justice.org.uk']
-      ),
-      build(:pom,
-            firstName: 'Bob',
-            position: RecommendationService::PRISON_POM,
-            staffId: 2,
-            emails: ['test@digital.justice.org.uk']
-      )
-    ]
-  }
-
   # any date less than 3 months in the past
   let(:valid_date) { Time.zone.today - 2.months }
-  let(:prison) { 'WEI' }
-  let(:nomis_offender_id) { 'B44455' }
   let(:s1_boolean_param_names) { [:convicted_under_terrorisom_act_2000, :high_profile, :serious_crime_prevention_order, :mappa_level_3, :cppc_case] }
   let(:s1_boolean_params) { s1_boolean_param_names.map { |p| [p, 'false'] }.to_h }
 
-  let(:offender) { attributes_for(:offender, offenderNo: nomis_offender_id) }
-  let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
+  let(:prison) { build(:prison).code }
+  let(:first_pom) { build(:pom) }
+  let(:nomis_staff_id) { first_pom.staffId }
+
+  let(:poms) {
+    [
+      first_pom,
+      build(:pom)
+    ]
+  }
+
+  let(:offender) { build(:nomis_offender) }
+  let(:nomis_offender_id) { offender.fetch(:offenderNo) }
 
   before do
     stub_sso_data(prison, 'alice')
 
-    stub_offender(nomis_offender_id)
+    stub_offender(offender)
     stub_poms(prison, poms)
-    stub_offenders_for_prison(prison, [offender], [booking])
+    stub_offenders_for_prison(prison, [offender])
+    create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
   end
 
   context 'with not ldu email address' do

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,30 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe SearchController, type: :controller do
-  # Need to use a different prison than LEI to prevent filling Rails cache with mock data }
-  let(:prison) { 'WEI' }
-  let(:booking_id) { 'booking3' }
-  let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
-  let(:elite2listapi) { "#{elite2api}/locations/description/#{prison}/inmates?convictedStatus=Convicted&returnCategory=true" }
-  let(:elite2bookingsapi) { "#{elite2api}/offender-sentences/bookings" }
+  let(:prison) { build(:prison).code }
+
+  let(:poms) {
+    [
+      build(:pom,
+            firstName: 'Alice',
+            position: RecommendationService::PRISON_POM,
+            staffId: 1
+      )
+    ]
+  }
+
+  before do
+    stub_poms(prison, poms)
+    stub_signed_in_pom(prison, 1, 'alice')
+  end
 
   context 'when user is a POM ' do
-    let(:poms) {
-      [
-        build(:pom,
-              firstName: 'Alice',
-              position: RecommendationService::PRISON_POM,
-              staffId: 1
-        )
-      ]
-    }
-
     before do
-      stub_poms(prison, poms)
       stub_signed_in_pom(prison, 1, 'alice')
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
-        with(headers: { 'Authorization' => 'Bearer token' }).
-        to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
     end
 
     it 'user is redirected to caseload' do
@@ -39,28 +35,8 @@ RSpec.describe SearchController, type: :controller do
     end
 
     it 'can search' do
-      offenders = [{ "bookingId": 754_207, "bookingNo": "K09211", "offenderNo": "G7806VO", "firstName": "ONGMETAIN",
-                     "lastName": "ABDORIA", "dateOfBirth": "1990-12-06",
-                     "age": 28, "agencyId": "LEI", "assignedLivingUnitId": 13_139, "assignedLivingUnitDesc": "E-5-004",
-                     "facialImageId": 1_392_829,
-                     "categoryCode": "C", "imprisonmentStatus": "LR", "alertsCodes": [], "alertsDetails": [], "convictedStatus": "Convicted" }]
-      bookings =  [{ "bookingId": 754_207, "offenderNo": "G4912VX", "firstName": "EASTZO", "lastName": "AUBUEL", "agencyLocationId": "LEI",
-                     "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                                         "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                                         "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                                         "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                                         "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-                     "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }]
-
-      stub_offenders_for_prison(prison, offenders, bookings)
-
-      stub_request(:get, "#{elite2api}/staff/roles/#{prison}/role/POM").
-        with(
-          headers: {
-            'Page-Limit' => '100',
-            'Page-Offset' => '0'
-          }).
-        to_return(status: 200, body: {}.to_json, headers: {})
+      offenders = build_list(:nomis_offender, 1)
+      stub_offenders_for_prison(prison, offenders)
 
       get :search, params: { prison_id: prison, q: 'Cal' }
       expect(response.status).to eq(200)

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SummaryController, type: :controller do
+  let(:prison) { build(:prison).code }
   let(:poms) {
     [
       build(:pom,
@@ -11,60 +14,42 @@ RSpec.describe SummaryController, type: :controller do
     ]
   }
 
-  let(:prison) { 'BRI' }
-
   before { stub_sso_data(prison, 'alice') }
 
-  context 'with 2 offenders' do
+  context 'with 4 offenders' do
     let(:today_plus_10) { (Time.zone.today + 10.days).to_s }
     let(:today_plus_13_weeks) { (Time.zone.today + 13.weeks).to_s }
 
     before do
       offenders = [
-        { "bookingId": 754_208, "offenderNo": "G7514GW", "firstName": "BOB", "lastName": "SMITH",
-          "dateOfBirth": "1995-02-02", "age": 34, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "LR" },
-        { "bookingId": 754_207, "offenderNo": "G1234GY", "firstName": "Indeter", "lastName": "Minate-Offender",
-          "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" },
-        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES",
-          "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" },
-        { "bookingId": 754_205, "offenderNo": "G4234GG", "firstName": "Fourth", "lastName": "Offender",
-          "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03" }
-      ]
-
-      bookings = [
-        { "bookingId": 754_208, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": today_plus_10,
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewActualDate": today_plus_10,
-                              "bookingId": 754_208, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-        { "bookingId": 754_207, "offenderNo": "G1234GY", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-        { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": today_plus_13_weeks,
-                              "licenceExpiryDate": "2014-02-07",
-                              "bookingId": 754_206, "sentenceStartDate": "2019-02-08",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-        { "bookingId": 754_205, "offenderNo": "G4234GG", "firstName": "Fourth", "lastName": "Offender", "agencyLocationId": prison,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": today_plus_10,
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewActualDate": today_plus_10,
-                              "bookingId": 754_205, "sentenceStartDate": "2019-02-08",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
+        build(:nomis_offender,
+              offenderNo: "G7514GW",
+              imprisonmentStatus: "LR",
+              lastName: 'SMITH',
+              sentence: build(:nomis_sentence_detail)),
+        build(:nomis_offender, offenderNo: "G1234GY", imprisonmentStatus: "LIFE",
+              lastName: 'Minate-Offender',
+              sentence: build(:nomis_sentence_detail,
+                              sentenceStartDate: "2009-02-08",
+                              automaticReleaseDate: "2011-01-28")),
+        build(:nomis_offender, offenderNo: "G1234VV",
+              lastName: 'JONES',
+              sentence: build(:nomis_sentence_detail,
+                              sentenceStartDate: "2019-02-08",
+                              automaticReleaseDate: today_plus_13_weeks)),
+        build(:nomis_offender, offenderNo: "G4234GG",
+              imprisonmentStatus: "SENT03",
+              firstName: "Fourth", lastName: "Offender",
+              sentence: build(:nomis_sentence_detail,
+                              automaticReleaseDate: today_plus_10,
+                              homeDetentionCurfewActualDate: today_plus_10,
+                              sentenceStartDate: "2019-02-08",
+              ))
       ]
 
       create(:case_information, case_allocation: 'NPS', nomis_offender_id: 'G4234GG')
 
-      stub_offenders_for_prison(prison, offenders, bookings)
+      stub_offenders_for_prison(prison, offenders)
     end
 
     describe '#handover' do
@@ -97,8 +82,8 @@ RSpec.describe SummaryController, type: :controller do
       before do
         stub_poms(prison, poms)
         stub_signed_in_pom(prison, 1, 'Alice')
-        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
-          to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
+        stub_request(:get, "#{ApiHelper::T3}/users/").
+          to_return(body: { staffId: 1 }.to_json)
       end
 
       it 'is not visible' do
@@ -109,17 +94,19 @@ RSpec.describe SummaryController, type: :controller do
 
     context 'without new arrivals' do
       before do
-        stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
+        stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=false&movementTypes=TRN").
           with(body: %w[G7514GW G1234GY G1234VV G4234GG].to_json).
-          to_return(status: 200, body: [{ offenderNo: 'G7514GW', toAgency: prison, createDateTime: Date.new(2018, 10, 1) },
-                                        { offenderNo: 'G1234VV', toAgency: prison, createDateTime: Date.new(2018, 9, 1) }].to_json)
+          to_return(body: [{ offenderNo: 'G7514GW', toAgency: prison, createDateTime: Date.new(2018, 10, 1) },
+                           { offenderNo: 'G1234VV', toAgency: prison, createDateTime: Date.new(2018, 9, 1) }].to_json)
       end
 
       it 'gets pending records' do
         get :pending, params: { prison_id: prison }
         # Expecting offender (2) to use sentenceStartDate as it is newer than last arrival date in prison
-        expect(assigns(:offenders).map(&:awaiting_allocation_for).map { |x| Time.zone.today - x }).
-          to match_array [Date.new(2009, 2, 8), Date.new(2018, 10, 1), Date.new(2019, 2, 8)]
+        off = assigns(:offenders).map { |o| [o.offender_no, Time.zone.today - o.awaiting_allocation_for] }.to_h
+        expect(off).to eq("G1234GY" => Date.new(2009, 2, 8),
+                  "G7514GW" => Date.new(2018, 10, 1),
+                  "G1234VV" => Date.new(2019, 2, 8))
       end
 
       it 'sorts ascending by default' do
@@ -136,38 +123,19 @@ RSpec.describe SummaryController, type: :controller do
   end
 
   context 'with enough offenders to page' do
-    let(:prison) { 'LEI' }
-    let(:range) { 0.upto(119) }
-    let(:offenders) {
-      range.map { |i|
-        { "bookingId": i, "offenderNo": "G#{10_000 - i}GW", "firstName": "Offen", "lastName": "DerNum#{i}",
-          "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" }
-      }
-    }
-    let(:bookings) {
-      range.map do |i|
-        { "bookingId": i, "offenderNo": "G#{10_000 - i}GW", "firstName": "Offen", "lastName": "DerNum#{i}", "agencyLocationId": prison,
-          "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                              "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                              "bookingId": 754_207, "sentenceStartDate": "2019-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                              "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                              "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-          "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-      end
-    }
+    let(:offenders) { build_list(:nomis_offender, 120) }
     let(:moves) {
-      range.map { |i| "G#{10_000 - i}GW" }
+      offenders.map { |o| o.fetch(:offenderNo) }
     }
     let(:summary_offenders) { assigns(:offenders) }
 
     render_views
 
     before do
-      stub_offenders_for_prison(prison, offenders, bookings)
-      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
+      stub_offenders_for_prison(prison, offenders)
+      stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=false&movementTypes=TRN").
         with(body: moves.to_json).
-        to_return(status: 200,
-                  body: moves.map { |offender_no| { offenderNo: offender_no, toAgency: prison, createDateTime: Date.new(2018, 10, 1) } }.to_json)
+        to_return(body: moves.map { |offender_no| { offenderNo: offender_no, toAgency: prison, createDateTime: Date.new(2018, 10, 1) } }.to_json)
     end
 
     it 'gets page 1 by default' do
@@ -201,23 +169,15 @@ RSpec.describe SummaryController, type: :controller do
     it 'handles trying to sort by missing field for allocated offenders' do
       # Allocated offenders do have to have their prison_arrival_date even if they don't use it
       # because we now need it to calculate the totals.
-      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
-        to_return(status: 200, body: [].to_json)
+      stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=false&movementTypes=TRN").
+        to_return(body: [].to_json)
 
       # When viewing allocated, cannot sort by awaiting_allocation_for as it is not available and is
       # meaningless in this context. We do not want to crash if passed a field that is not searchable
       # within a specific context.
       offender_id = 'G7514GW'
-      offenders = [{ "bookingId": 754_207, "offenderNo": offender_id, "firstName": "Indeter", "lastName": "Minate-Offender",
-                     "dateOfBirth": "1990-12-06", "age": 28, "agencyId": prison, "categoryCode": "C", "imprisonmentStatus": "LIFE" }]
-
-      bookings = [{ "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
-                    "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                                        "bookingId": 754_207, "sentenceStartDate": "2009-02-08",
-                                        "releaseDate": "2012-03-17" },
-                    "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-                    "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }]
-      stub_offenders_for_prison(prison, offenders, bookings)
+      offenders = [build(:nomis_offender, offenderNo: offender_id)]
+      stub_offenders_for_prison(prison, offenders)
 
       create(:case_information, nomis_offender_id: offender_id)
       create(:allocation, nomis_offender_id: offender_id, primary_pom_nomis_id: 234, prison: prison)
@@ -230,28 +190,16 @@ RSpec.describe SummaryController, type: :controller do
   describe 'new arrivals feature' do
     before do
       inmates = offenders.map { |offender|
-        {
-          bookingId: offender[:booking_id],
-          offenderNo: offender[:nomis_id],
-          dateOfBirth: 30.years.ago.strftime('%F'),
-          agencyId: offender[:prison_id]
-        }
+        build(:nomis_offender,
+              offenderNo: offender[:nomis_id],
+              sentence: build(:nomis_sentence_detail,
+                              sentenceStartDate: offender.fetch(:sentence_start_date).strftime('%F')))
       }
 
-      bookings = offenders.map { |offender|
-        {
-          bookingId: offender[:booking_id],
-          sentenceDetail: {
-            sentenceStartDate: offender[:sentence_start_date].strftime('%F'),
-            releaseDate: 30.years.from_now.strftime('%F')
-          }
-        }
-      }
+      stub_offenders_for_prison(prison, inmates)
 
-      stub_offenders_for_prison(prison, inmates, bookings)
-
-      stub_request(:post, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/movements/offenders?latestOnly=false&movementTypes=TRN").
-        to_return(status: 200, body: movements.to_json)
+      stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=false&movementTypes=TRN").
+        to_return(body: movements.to_json)
     end
 
     context 'with no movements and four offenders' do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -18,53 +18,13 @@ RSpec.describe TasksController, type: :controller do
     stub_poms(prison, pom)
     stub_signed_in_pom(prison, staff_id, username)
 
-    offenders = [
-      { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Alice", "lastName": "Aliceson",
-        "dateOfBirth": "1990-12-06", "age": 28, "categoryCode": "C", "imprisonmentStatus": "LIFE",
-        "convictedStatus": "Convicted", "latestLocationId": prison },
-      { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "Bob", "lastName": "Bibby",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03",
-        "convictedStatus": "Convicted", "latestLocationId": prison },
-      { "bookingId": 754_205, "offenderNo": "G1234AB", "firstName": "Carole", "lastName": "Caroleson",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03",
-        "convictedStatus": "Convicted", "latestLocationId": prison },
-      { "bookingId": 754_204, "offenderNo": "G1234GG", "firstName": "David", "lastName": "Davidson",
-        "dateOfBirth": "2001-02-02", "age": 18, "agencyId": prison, "categoryCode": "D", "imprisonmentStatus": "SENT03",
-        "convictedStatus": "Convicted", "latestLocationId": prison }
+    offenders = [build(:nomis_offender, imprisonmentStatus: 'LIFE', offenderNo: 'G7514GW', firstName: "Alice", lastName: "Aliceson"),
+                 build(:nomis_offender, offenderNo: 'G1234VV', firstName: "Bob", lastName: "Bibby"),
+                 build(:nomis_offender, offenderNo: 'G1234AB', firstName: "Carole", lastName: "Caroleson"),
+                 build(:nomis_offender, offenderNo: 'G1234GG', firstName: "David", lastName: "Davidson")
     ]
 
-    bookings = [
-      { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Indeter", "lastName": "Minate-Offender", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-      { "bookingId": 754_206, "offenderNo": "G1234VV", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-      { "bookingId": 754_205, "offenderNo": "G1234AB", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 },
-      { "bookingId": 754_204, "offenderNo": "G1234GG", "firstName": "ROSS", "lastName": "JONES", "agencyLocationId": prison,
-        "sentenceDetail": { "sentenceExpiryDate": "2014-02-16", "automaticReleaseDate": "2011-01-28",
-                            "licenceExpiryDate": "2014-02-07", "homeDetentionCurfewEligibilityDate": "2011-11-07",
-                            "bookingId": 754_207, "sentenceStartDate": "2009-02-08", "automaticReleaseOverrideDate": "2012-03-17",
-                            "nonDtoReleaseDate": "2012-03-17", "nonDtoReleaseDateType": "ARD", "confirmedReleaseDate": "2012-03-17",
-                            "releaseDate": "2012-03-17" }, "dateOfBirth": "1953-04-15", "agencyLocationDesc": "LEEDS (HMP)",
-        "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
-    ]
-
-    stub_offenders_for_prison(prison, offenders, bookings)
+    stub_offenders_for_prison(prison, offenders)
   end
 
   context 'when an SPO' do
@@ -100,7 +60,7 @@ RSpec.describe TasksController, type: :controller do
     end
 
     it 'can show offenders needing parole review date updates' do
-      stub_offender(offender_no, booking_number: 754_207, imprisonment_status: 'LIFE')
+      stub_offender(build(:nomis_offender, offenderNo: offender_no, imprisonmentStatus: 'LIFE'))
 
       get :index, params: { prison_id: prison }
 
@@ -122,7 +82,7 @@ RSpec.describe TasksController, type: :controller do
     before do
       test_strategy.switch!(:auto_delius_import, true)
 
-      stub_offender(offender_no, booking_number: 754_206)
+      stub_offender(build(:nomis_offender, offenderNo: offender_no))
 
       # Ensure only one of our offenders has missing data and that G7514GW (indeterminate) has a PRD
       create(:case_information, nomis_offender_id: offender_no, tier: 'A', mappa_level: 1, team: nil)

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -1,14 +1,4 @@
 FactoryBot.define do
-  class Elite2Booking
-    attr_reader :sentenceDetail
-
-    # rubocop:disable Naming/VariableName
-    def initialize(data)
-      @sentenceDetail = data[:sentenceDetail]
-    end
-    # rubocop:enable Naming/VariableName
-  end
-
   factory :offender, class: 'Nomis::Offender' do
     initialize_with { Nomis::Offender.from_json(attributes.stringify_keys) }
 
@@ -34,14 +24,31 @@ FactoryBot.define do
     categoryCode { 'C' }
   end
 
-  factory :booking, class: 'Elite2Booking' do
-    initialize_with do new(attributes) end
+  factory :nomis_offender, class: Hash do
+    initialize_with { attributes }
 
-    sequence(:sentenceDetail) { |seq|
-      {
-        'tariffDate' => Date.new(2032 + seq % 5, 3, 17) - (seq * 2).days,
-        'sentenceStartDate' => Date.new(2009, 2, 8)
-      }
-    }
+    imprisonmentStatus { 'SENT03' }
+    prisonId { 'LEI' }
+
+    # offender numbers are of the form <letter><4 numbers><2 letters>
+    sequence(:offenderNo) do |seq|
+      number = seq / 26 + 1000
+      letter = ('A'..'Z').to_a[seq % 26]
+      # This and case_information should produce different values to avoid clashes
+      "T#{number}O#{letter}"
+    end
+    convictedStatus { 'Convicted' }
+    dateOfBirth { Date.new(1990, 12, 6).to_s }
+    firstName { Faker::Name.first_name }
+    # We have some issues with corrupting the display
+    # of names containing Mc or Du :-(
+    # also ensure uniqueness as duplicate last names can cause issues
+    # in tests, as ruby sort isn't stable by default
+    sequence(:lastName) { |c| "#{Faker::Name.last_name.titleize}_#{c}" }
+    categoryCode { 'C' }
+
+    sentence do
+      association :nomis_sentence_detail
+    end
   end
 end

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -1,0 +1,35 @@
+FactoryBot.define do
+  factory :sentence_detail, class: 'Nomis::SentenceDetail' do
+    initialize_with { Nomis::SentenceDetail.from_json(attributes.stringify_keys) }
+
+    paroleEligibilityDate { "2011-01-28" }
+    releaseDate { "2011-01-28" }
+    sentenceStartDate { "2011-01-28" }
+    tariffDate { "2011-01-28" }
+    automaticReleaseDate { "2011-01-28" }
+    postRecallReleaseDate { "2011-01-28" }
+    conditionalReleaseDate { "2011-01-28" }
+    homeDetentionCurfewEligibilityDate { "2011-01-28" }
+    homeDetentionCurfewActualDate { "2011-01-28" }
+    actualParoleDate { "2011-01-28" }
+    licenceExpiryDate { "2011-01-28" }
+  end
+
+  factory :nomis_sentence_detail, class: Hash do
+    initialize_with {
+      # remove nil values from hash, so that SentenceDetail#from_json doesn't choke
+      attributes.reject { |_k, v| v.nil? }
+    }
+
+    releaseDate { "2031-01-19" }
+    sentenceStartDate { "2011-01-20" }
+    tariffDate { "2031-01-21" }
+    automaticReleaseDate { "2031-01-22" }
+    postRecallReleaseDate { "2031-01-23" }
+    conditionalReleaseDate { "2031-01-24" }
+    actualParoleDate { "2031-01-27" }
+  end
+end
+
+
+

--- a/spec/jobs/delius_import_job_spec.rb
+++ b/spec/jobs/delius_import_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DeliusImportJob, type: :job do
                    G4923UI G9577GE G2350UP G0686GT G5235GT G1955VA G7967UD G7142UL
                    G5497GU G3356GT]
     offenders.each { |offender|
-      stub_offender(offender)
+      stub_offender(build(:nomis_offender, offenderNo: offender))
     }
   end
 
@@ -37,7 +37,7 @@ RSpec.describe DeliusImportJob, type: :job do
 
   context 'when LDU and team names contain ampersands (&)' do
     before do
-      stub_offender('mangled nomis')
+      stub_offender(build(:nomis_offender, offenderNo: 'mangled nomis'))
     end
 
     it 'imports their names correctly' do

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -9,20 +9,19 @@ RSpec.describe MovementsOnDateJob, type: :job do
   end
 
   it 'deallocates' do
-    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new(
-                                                                  convicted_status: "Convicted",
-                                                                  date_of_birth: "Tue, 17 Sep 1991",
-                                                                  inprisonment_status: 'SENT03')
+    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new(convicted_status: "Convicted",
+    date_of_birth: "Tue, 17 Sep 1991",
+    inprisonment_status: 'SENT03')
     )
 
     stub_request(:get, "#{ApiHelper::T3}/movements?fromDateTime=2019-06-29T00:00&movementDate=2019-06-30").
-      to_return(status: 200, body: [
+      to_return(body: [
         { offenderNo: nomis_offender_id,
           fromAgency: "MDI",
           toAgency: "WEI",
           movementType: "ADM",
           directionCode: "IN"
-        }].to_json, headers: {})
+        }].to_json)
 
     expect(alloc.primary_pom_nomis_id).not_to be_nil
     expect(alloc.secondary_pom_nomis_id).not_to be_nil

--- a/spec/models/nomis/offender_spec.rb
+++ b/spec/models/nomis/offender_spec.rb
@@ -4,7 +4,7 @@ describe Nomis::Offender do
   describe '#handover_start_date' do
     context 'when in custody' do
       let(:offender) {
-        build(:offender).tap { |o|
+        build(:offender_summary).tap { |o|
           o.sentence = Nomis::SentenceDetail.new(automatic_release_date: Time.zone.today + 1.year,
                                                  sentence_start_date: Time.zone.today)
           o.load_case_information(build(:case_information, case_allocation: 'NPS', mappa_level: 0))
@@ -18,7 +18,7 @@ describe Nomis::Offender do
 
     context 'when COM responsible already' do
       let(:offender) {
-        build(:offender).tap { |o|
+        build(:offender_summary).tap { |o|
           o.sentence = Nomis::SentenceDetail.new
           o.load_case_information(build(:case_information))
         }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -39,12 +39,11 @@ RSpec.describe Team, type: :model do
     end
 
     context 'with a duplicate team name' do
-      let(:team) { build(:team, name: oldteam.name) }
+      let(:team) { build(:team, :nps, name: oldteam.name) }
 
       it 'is not valid' do
         expect(team).not_to be_valid
-        expect(team.errors.count).to eq(1)
-        expect(team.errors.first).to eq([:name, "has already been taken"])
+        expect(team.errors.to_a).to eq(["Name has already been taken"])
       end
     end
   end

--- a/spec/services/nomis/elite2/offender_api_spec.rb
+++ b/spec/services/nomis/elite2/offender_api_spec.rb
@@ -92,7 +92,7 @@ describe Nomis::Elite2::OffenderApi do
        vcr: { cassette_name: :offender_api_image_not_found } do
       booking_id = 1_153_753
       image_id = 1_340_556
-      uri = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/images/#{image_id}/data"
+      uri = "#{ApiHelper::T3}/images/#{image_id}/data"
 
       stub_request(:get, uri).to_return(status: 404)
 
@@ -107,7 +107,7 @@ describe Nomis::Elite2::OffenderApi do
        vcr: { cassette_name: :offender_api_image_use_default_image } do
       booking_id = 1_153_753
       image_id = 1_340_556
-      uri = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/images/#{image_id}/data"
+      uri = "#{ApiHelper::T3}/images/#{image_id}/data"
 
       WebMock.stub_request(:get, uri).to_return(body: "")
 
@@ -126,14 +126,13 @@ describe Nomis::Elite2::OffenderApi do
     it "uses the default image if no offender facialImageId found",
        vcr: { cassette_name: :offender_api_no_facial_image_id } do
       booking_id = 1_153_753
-      uri = "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/offender-sentences/bookings"
+      uri = "#{ApiHelper::T3}/offender-sentences/bookings"
 
       WebMock.stub_request(:post, uri).with(body: "[#{booking_id}]").to_return(
-        status: 200,
         body: [
           { "bookingId": 1_153_753,
             "dateOfBirth": "1953-04-15"
-        }].to_json, headers: {})
+        }].to_json)
 
       response = described_class.get_image(booking_id)
       expect(response).not_to be nil?

--- a/spec/services/nomis/keyworker/keyworker_api_spec.rb
+++ b/spec/services/nomis/keyworker/keyworker_api_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 describe Nomis::Keyworker::KeyworkerApi do
   before do
-    stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/LEI/offender/G4273GI").
-     to_return(status: 200, body: {
+    stub_request(:get, "#{ApiHelper::KEYWORKER_API_HOST}/key-worker/LEI/offender/G4273GI").
+     to_return(body: {
        staffId: 1,
        firstName: 'DOM',
        lastName: 'JONES'
      }.to_json)
-    stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/LEI/offender/GGGGGGG").
+    stub_request(:get, "#{ApiHelper::KEYWORKER_API_HOST}/key-worker/LEI/offender/GGGGGGG").
     to_return(status: 404)
   end
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe OffenderService do
-  let(:tier_map) { CaseInformationService.get_case_information('LEI') }
-
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     nomis_offender_id = 'G4273GI'
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -113,13 +113,11 @@ describe PrisonOffenderManagerService do
               emails: ['test@digital.justice.org.uk']
         )
       }
-      let(:offender) { attributes_for(:offender) }
-      let(:booking) { attributes_for(:booking, bookingId: offender.fetch(:bookingId)) }
-
+      let(:offender) { build(:nomis_offender) }
 
       before do
         stub_poms('WSI', [dave, alice, billy, charles, eric])
-        stub_offenders_for_prison('WSI', [offender], [booking])
+        stub_offenders_for_prison('WSI', [offender])
       end
 
       it 'removes duplicate staff ids, keeping the valid position' do
@@ -129,16 +127,14 @@ describe PrisonOffenderManagerService do
 
     describe '#get_pom_at' do
       context 'when pom not existing at a prison' do
-        let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
-
         before do
-          stub_request(:get, "#{elite2api}/staff/roles/LEI/role/POM").
+          stub_request(:get, "#{ApiHelper::T3}/staff/roles/LEI/role/POM").
             with(
               headers: {
                 'Page-Limit' => '100',
                 'Page-Offset' => '0'
               }).
-            to_return(status: 200, body: [
+            to_return(body: [
               { "staffId": 485_833, "firstName": "FRED", "lastName": "BLOGGS", "status": "ACTIVE", "gender": "F",
                 "dateOfBirth": "1980-01-01", "agencyId": "LEI", "agencyDescription": "Leeds (HMP)",
                 "fromDate": "2019-05-31", "position": "PRO", "positionDescription": "Prison Officer",
@@ -149,7 +145,7 @@ describe PrisonOffenderManagerService do
                 "position": "PRO", "positionDescription": "Prison Officer", "role": "POM",
                 "roleDescription": "Prison Offender Manager", "scheduleType": "FT", "scheduleTypeDescription": "Full Time",
                 "hoursPerWeek": 35 }
-            ].to_json, headers: {})
+            ].to_json)
         end
 
         it "raises" do

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 module AuthHelper
-  T3 = 'https://gateway.t3.nomis-api.hmpps.dsd.io'
   ACCESS_TOKEN = Struct.new(:access_token).new('an-access-token')
 
   def stub_auth_token
     allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
 
-    stub_request(:post, "#{T3}/auth/oauth/token?grant_type=client_credentials").
+    stub_request(:post, "#{ApiHelper::T3_HOST}/auth/oauth/token?grant_type=client_credentials").
       to_return(body: {
         "access_token": ACCESS_TOKEN.access_token,
         "token_type": "bearer",
@@ -22,9 +21,9 @@ module AuthHelper
                            'roles' => [role],
                            'caseloads' => [prison],
                            'username' => username }
-    stub_request(:get, "#{T3}/elite2api/api/users/#{username}").
-        to_return(status: 200, body: { 'staffId': 754_732 }.to_json)
-    stub_request(:get, "#{T3}/elite2api/api/staff/754732/emails").
-        to_return(status: 200, body: [].to_json)
+    stub_request(:get, "#{ApiHelper::T3}/users/#{username}").
+        to_return(body: { 'staffId': 754_732 }.to_json)
+    stub_request(:get, "#{ApiHelper::T3}/staff/754732/emails").
+        to_return(body: [].to_json)
   end
 end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -30,11 +30,11 @@ module FeaturesHelper
 
   def stub_spo_emails(staff_id)
     stub_request(:get, "#{ApiHelper::T3}/staff/#{staff_id}/emails").
-        to_return(status: 200, body: [].to_json)
+        to_return(body: [].to_json)
   end
 
   def stub_retrieve_spo_staff_id(staff_id, example_spo)
     stub_request(:get, "#{ApiHelper::T3}/users/#{example_spo}").
-        to_return(status: 200, body: { 'staffId': staff_id }.to_json)
+        to_return(body: { 'staffId': staff_id }.to_json)
   end
 end


### PR DESCRIPTION
Currently we have a number of tests which are very noisy and full of irrelevant detail. This PR attempts to address the main low-hanging fruit of this problem, which boiled down to:

1. signing in as a POm required 2 stub calls - it is now just one.
2. stub_offenders_for_prison required a set of 'bookings' with the sentences matched up with the offenders. This parameter has now beeing removed so that the test can focus on providing the offenders that it needs.
3. New factories have been created :nomis_offender and :nomis_sentence_detail that return a Hash that can be passed into the #load_from_json of the respective classes so that tests can just focus on the fields they require.