### PR TITLE
Pom511 Part 4 - DRY up controller using form objects

### DIFF
--- a/app/assets/javascripts/case_info.js
+++ b/app/assets/javascripts/case_info.js
@@ -16,16 +16,16 @@ $(document).on("turbolinks:load", function(){
         });
     }
 
-    if ($(".edit_case_information").length > 0){
-        if((document.getElementById('case_information_probation_service_scotland').checked) ||
-            (document.getElementById('case_information_probation_service_northern_ireland').checked)){
+    if ($(".new_edit_case_information").length > 0){
+        if((document.getElementById('edit_case_information_last_known_address_scotland').checked) ||
+            (document.getElementById('edit_case_information_last_known_address_northern_ireland').checked)){
                 hide_element();
         }
     }
 });
 
 function current_team() {
-    if ($(".edit_case_information").length > 0){
+    if ($(".new_edit_case_information").length > 0){
         let team_name = document.getElementById("chosen_team").innerText;
         if (team_name !== '') {
             return team_name

--- a/app/forms/edit_case_information.rb
+++ b/app/forms/edit_case_information.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class EditCaseInformation
+  include ActiveModel::Model
+
+  attr_accessor :last_known_location, :last_known_address, :tier, :case_allocation, :team
+
+  validates :last_known_address, inclusion: {
+    in: ['Scotland', 'Northern Ireland', 'Wales'],
+    allow_nil: false,
+    message: "You must say if the prisoner's last known address was in Northern Ireland, Scotland or Wales"
+  }, if: -> { last_known_location == 'Yes' }
+
+  validates :tier, inclusion: { in: %w[A B C D], message: "Select the prisoner's tier" }
+
+  validates :case_allocation, inclusion: {
+    in: %w[NPS CRC],
+    allow_nil: false,
+    message: 'Select the service provider for this case'
+  }
+
+  validates :team,
+            presence: { message: "You must select the prisoner's team" },
+            if: -> {
+                  last_known_location == 'No' ||
+                      last_known_address == 'Wales'
+                }
+
+  def probation_service
+    last_known_location == 'No' ? 'England' : last_known_address
+  end
+
+  def self.from_case_info case_info
+    new(
+      last_known_location: case_info.probation_service == 'England' ? 'No' : 'Yes',
+      last_known_address: case_info.probation_service,
+      tier: case_info.tier,
+      case_allocation: case_info.case_allocation
+    )
+  end
+end

--- a/app/forms/last_location.rb
+++ b/app/forms/last_location.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class LastLocation
+  include ActiveModel::Model
+
+  attr_accessor :nomis_offender_id, :last_known_location, :last_known_address
+
+  validates :last_known_location,
+            inclusion: {
+              in: %w[Yes No],
+              allow_nil: false,
+              message: "Select yes if the prisoner's last known address was in Northern Ireland, Scotland or Wales"
+            }
+
+  validates :last_known_address, inclusion: {
+    in: ['Scotland', 'Northern Ireland', 'Wales'],
+    allow_nil: false,
+    message: "You must say if the prisoner's last known address was in Northern Ireland, Scotland or Wales"
+  }, if: -> { last_known_location == 'Yes' }
+
+  def probation_service
+    last_known_location == 'No' ? 'England' : last_known_address
+  end
+end

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -111,6 +111,10 @@ private
     welsh_offender ? 'Wales' : 'England'
   end
 
+  def map_probation_service(welsh_offender)
+    welsh_offender ? 'Wales' : 'England'
+  end
+
   def map_tier(tier)
     tier[0] if tier.present?
   end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -13,7 +13,8 @@ class CaseInformation < ApplicationRecord
 
   scope :nps, -> { where(case_allocation: 'NPS') }
 
-  attr_accessor :last_known_location
+  before_validation :save_scottish_or_ni, if: -> { manual_entry && (probation_service == 'Scotland' || probation_service == 'Northern Ireland') }
+  before_validation :set_welsh_offender
 
   def local_divisional_unit
     team.try(:local_divisional_unit)
@@ -38,6 +39,8 @@ class CaseInformation < ApplicationRecord
 
   validates :tier, inclusion: { in: %w[A B C D N/A], message: "Select the prisoner's tier" }
 
+  validates :welsh_offender, inclusion: { in: %w[Yes No] }
+
   validates :case_allocation, inclusion: {
     in: %w[NPS CRC N/A],
     allow_nil: false,
@@ -52,46 +55,23 @@ class CaseInformation < ApplicationRecord
     in: ['Scotland', 'Northern Ireland', 'Wales', 'England'],
     allow_nil: false,
     message: "You must say if the prisoner's last known address was in Northern Ireland, Scotland or Wales"
-  }
+  }, if: -> { manual_entry }
 
-  def welsh_offender
-    probation_service == 'Wales' ? 'Yes' : 'No'
-  end
-
-  # We only want to validate last known location in forms
-  validates :last_known_location,
-            inclusion: {
-              in: %w[Yes No],
-              allow_nil: true,
-              message: "Select yes if the prisoner's last known address was in Northern Ireland, Scotland or Wales"
-            }, if: -> { manual_entry }
-
-  def scottish_or_ni?
-    return true if last_known_location == 'Yes' &&
-      (probation_service == 'Scotland' || probation_service == 'Northern Ireland')
-
-    false
-  end
+private
 
   def save_scottish_or_ni
-    self.tier = 'N/A'
-    self.case_allocation = 'N/A'
-    self.team = nil
+    assign_attributes(tier: 'N/A',
+                      case_allocation: 'N/A',
+                      team: nil)
   end
 
-  def english_or_welsh?
-    return true if last_known_location == 'No' || probation_service == 'Wales' || probation_service == 'England'
-
-    false
-  end
-
-  def english?
-    last_known_location == 'No'
-  end
-
-  def stage2_filled?
-    return false if tier.nil? || team.nil? || case_allocation.nil?
-
-    true
+  def set_welsh_offender
+    assign_attributes(
+      welsh_offender: if probation_service == 'Wales'
+                        'Yes'
+                      else
+                        'No'
+                      end
+    )
   end
 end

--- a/app/services/view_handover_email_addresses_summary.rb
+++ b/app/services/view_handover_email_addresses_summary.rb
@@ -24,8 +24,6 @@ class ViewHandoverEmailAddressesSummary
       :missing_delius_record
     elsif missing_team_link?(case_info)
       :missing_team_link
-    elsif missing_team_information?(case_info)
-      :missing_team_information
     elsif missing_local_divisional_unit?(case_info)
       :missing_local_divisional_unit
     elsif missing_email?(case_info)
@@ -41,10 +39,6 @@ class ViewHandoverEmailAddressesSummary
 
   def missing_team_link?(case_info)
     case_info.team_id.blank?
-  end
-
-  def missing_team_information?(case_info)
-    case_info.team.blank?
   end
 
   def missing_local_divisional_unit?(case_info)

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -1,6 +1,4 @@
-
-<%= form_for(@case_info, url: prison_case_information_path(@prison.code), method: :put, id: "case_info_form") do |form| %>
-  <%= form.hidden_field(:nomis_offender_id, value: @prisoner.offender_no) %>
+<%= form_for(@edit_case_info, url: prison_case_information_path(@prison.code), method: :put, id: "case_info_form") do |form| %>
   <%= hidden_field_tag("sort", params[:sort])%>
   <%= hidden_field_tag("page", params[:page]) %>
 
@@ -12,7 +10,7 @@
     <div class="govuk-form-group">
       <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
         <div class="govuk-radios__item">
-          <%= form.radio_button(:last_known_location, 'Yes', checked: @case_info.last_known_location == 'Yes', class: "govuk-radios__input", id:'last_known_location_yes', data: { aria_controls: "conditional-last_known_location_yes", aria_expanded: "true"} ) %>
+          <%= form.radio_button(:last_known_location, 'Yes', checked: @edit_case_info.last_known_location == 'Yes', class: "govuk-radios__input", id:'last_known_location_yes', data: { aria_controls: "conditional-last_known_location_yes", aria_expanded: "true"} ) %>
           <%= form.label :last_known_location, 'Yes', class: "govuk-label govuk-radios__label" %>
         </div>
 
@@ -24,23 +22,23 @@
 
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= form.radio_button(:probation_service, 'Scotland', checked: @case_info.probation_service == 'Scotland', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "hide_element()" ) %>
-                <%= form.label :probation_service, 'Scotland', class: "govuk-label govuk-radios__label" %>
+                <%= form.radio_button(:last_known_address, 'Scotland', checked: @edit_case_info.last_known_address == 'Scotland', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "hide_element()" ) %>
+                <%= form.label :last_known_address, 'Scotland', class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:probation_service, 'Northern Ireland', checked: @case_info.probation_service == 'Northern Ireland', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "hide_element()" ) %>
-                <%= form.label :probation_service, 'Northern Ireland', class: "govuk-label govuk-radios__label" %>
+                <%= form.radio_button(:last_known_address, 'Northern Ireland', checked: @edit_case_info.last_known_address == 'Northern Ireland', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "hide_element()" ) %>
+                <%= form.label :last_known_address, 'Northern Ireland', class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:probation_service, 'Wales', checked: @case_info.probation_service == 'Wales', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "show_element()" ) %>
-                <%= form.label :probation_service, 'Wales', class: "govuk-label govuk-radios__label" %>
+                <%= form.radio_button(:last_known_address, 'Wales', checked: @edit_case_info.last_known_address == 'Wales', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "show_element()" ) %>
+                <%= form.label :last_known_address, 'Wales', class: "govuk-label govuk-radios__label" %>
               </div>
             </div>
           </div>
         </div>
 
         <div class="govuk-radios__item">
-          <%= form.radio_button(:last_known_location, 'No', checked: @case_info.last_known_location == 'No', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "show_element()" ) %>
+          <%= form.radio_button(:last_known_location, 'No', checked: @edit_case_info.last_known_location == 'No', class: "govuk-radios__input", data: {behavior: "last-location"}, onclick: "show_element()" ) %>
           <%= form.label :last_known_location, 'No', class: "govuk-label govuk-radios__label" %>
         </div>
       </div>
@@ -54,11 +52,11 @@
 
         <div class="govuk-radios" data-module="govuk-radios">
           <div class="govuk-radios__item">
-            <%= form.radio_button(:case_allocation, 'NPS', checked: @case_info.case_allocation == 'NPS', class: "govuk-radios__input") %>
+            <%= form.radio_button(:case_allocation, 'NPS', checked: @edit_case_info.case_allocation == 'NPS', class: "govuk-radios__input") %>
             <%= form.label :case_allocation, 'National Probation Service (NPS)', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= form.radio_button(:case_allocation, 'CRC', checked: @case_info.case_allocation == 'CRC', class: "govuk-radios__input") %>
+            <%= form.radio_button(:case_allocation, 'CRC', checked: @edit_case_info.case_allocation == 'CRC', class: "govuk-radios__input") %>
             <%= form.label :case_allocation, 'Community Rehabilitation Company (CRC)', class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
@@ -71,19 +69,19 @@
 
         <div class="govuk-radios" data-module="govuk-radios">
           <div class="govuk-radios__item">
-            <%= form.radio_button(:tier, 'A', checked: @case_info.tier == 'A', class: "govuk-radios__input") %>
+            <%= form.radio_button(:tier, 'A', checked: @edit_case_info.tier == 'A', class: "govuk-radios__input") %>
             <%= form.label :tier, 'A', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= form.radio_button(:tier, 'B', checked: @case_info.tier == 'B', class: "govuk-radios__input") %>
+            <%= form.radio_button(:tier, 'B', checked: @edit_case_info.tier == 'B', class: "govuk-radios__input") %>
             <%= form.label :tier, 'B', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= form.radio_button(:tier, 'C', checked: @case_info.tier == 'C', class: "govuk-radios__input") %>
+            <%= form.radio_button(:tier, 'C', checked: @edit_case_info.tier == 'C', class: "govuk-radios__input") %>
             <%= form.label :tier, 'C', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= form.radio_button(:tier, 'D', checked: @case_info.tier == 'D', class: "govuk-radios__input") %>
+            <%= form.radio_button(:tier, 'D', checked: @edit_case_info.tier == 'D', class: "govuk-radios__input") %>
             <%= form.label :tier, 'D', class: "govuk-label govuk-radios__label" %>
           </div>
         </div>

--- a/app/views/case_information/_last_known_location.html.erb
+++ b/app/views/case_information/_last_known_location.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@case_info, url: prison_case_information_index_path(@prison.code), method: form_method) do |form| %>
+<%= form_for(@last_location, url: prison_case_information_index_path(@prison.code), method: form_method) do |form| %>
   <%= form.hidden_field(:nomis_offender_id, value: @prisoner.offender_no) %>
   <%= hidden_field_tag("sort", params[:sort])%>
   <%= hidden_field_tag("page", params[:page]) %>
@@ -24,16 +24,16 @@
 
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <%= form.radio_button(:probation_service, 'Scotland', class: "govuk-radios__input" ) %>
-                <%= form.label :probation_service, 'Scotland - to be managed by Scottish probation', class: "govuk-label govuk-radios__label" %>
+                <%= form.radio_button(:last_known_address, 'Scotland', class: "govuk-radios__input" ) %>
+                <%= form.label :last_known_address, 'Scotland - to be managed by Scottish probation', class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:probation_service, 'Northern Ireland', class: "govuk-radios__input" ) %>
-                <%= form.label :probation_service, 'Northern Ireland - to be managed by Northern Irish probation', class: "govuk-label govuk-radios__label" %>
+                <%= form.radio_button(:last_known_address, 'Northern Ireland', class: "govuk-radios__input" ) %>
+                <%= form.label :last_known_address, 'Northern Ireland - to be managed by Northern Irish probation', class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios__item">
-                <%= form.radio_button(:probation_service, 'Wales', class: "govuk-radios__input" ) %>
-                <%= form.label :probation_service, 'Wales', class: "govuk-label govuk-radios__label" %>
+                <%= form.radio_button(:last_known_address, 'Wales', class: "govuk-radios__input" ) %>
+                <%= form.label :last_known_address, 'Wales', class: "govuk-label govuk-radios__label" %>
               </div>
             </div>
           </div>

--- a/app/views/case_information/edit.html.erb
+++ b/app/views/case_information/edit.html.erb
@@ -1,7 +1,7 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
-<% if @case_info.errors.count > 0 %>
-  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>
+<% if @edit_case_info.errors.count > 0 %>
+  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @edit_case_info.errors } %>
 <% end %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Case information</h1>

--- a/app/views/case_information/missing_info.html.erb
+++ b/app/views/case_information/missing_info.html.erb
@@ -11,8 +11,7 @@
 
 <%= form_for(@case_info, url: prison_case_information_index_path(@prison.code), method: :post) do |form| %>
   <%= form.hidden_field(:nomis_offender_id, value: @prisoner.offender_no) %>
-  <%= form.hidden_field(:last_known_location, value: params.dig(:case_information, :last_known_location)) %>
-  <%= form.hidden_field(:probation_service, value: params.dig(:case_information, :probation_service)) %>
+  <%= form.hidden_field(:probation_service, value: @case_info.probation_service) %>
   <%= hidden_field_tag("sort", params[:sort])%>
   <%= hidden_field_tag("page", params[:page]) %>
   <%= hidden_field_tag("stage", 'missing_info') %>

--- a/app/views/case_information/new.html.erb
+++ b/app/views/case_information/new.html.erb
@@ -1,7 +1,7 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
-<% if @case_info.errors.count > 0 %>
-  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>
+<% if @last_location.errors.count > 0 %>
+  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @last_location.errors } %>
 <% end %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Case information</h1>

--- a/lib/tasks/backfill_probation_service.rake
+++ b/lib/tasks/backfill_probation_service.rake
@@ -6,7 +6,7 @@ namespace :backfill do
   desc 'Back-fill case_information#probation_service from welsh_offender'
   task probation_service: :environment do
     CaseInformation.where(probation_service: nil).find_each do |ci|
-      ci.update!(probation_service: (ci.welsh_offender == 'Yes') ? 'Wales' : 'England')
+      ci.update!(probation_service: ci.welsh_offender ? 'Wales' : 'England')
     end
   end
 end

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -39,7 +39,8 @@ feature 'case information feature' do
     context "when the offender is Scottish or Northern Irish" do
       context 'when the form has errors' do
         let(:offender_id) { 'G1821VA' }
-        let(:error_msg) { "You must say if the prisoner's last known address was in Northern Ireland, Scotland or Wales" }
+        let(:error_msg) { "Select yes if the prisoner's last known address was in Northern Ireland, Scotland or Wales" }
+        let(:error_msg2) { "You must say if the prisoner's last known address was in Northern Ireland, Scotland or Wales" }
 
         before do
           signin_user
@@ -47,7 +48,7 @@ feature 'case information feature' do
           expect(page).to have_current_path new_prison_case_information_path('LEI', offender_id)
         end
 
-        it 'complains if the user does not select any radio buttons', :raven_intercept_exception,
+        it 'complains if the user does not select any radio buttons',
            vcr: { cassette_name: :case_information_missing_all } do
           click_button 'Continue'
           expect(CaseInformation.count).to eq(0)
@@ -55,12 +56,11 @@ feature 'case information feature' do
         end
 
         it 'complains if the user selects the yes radio button, but does not select a country',
-           :raven_intercept_exception,
            vcr: { cassette_name: :case_information_missing_country } do
           choose('last_known_location_yes')
           click_button 'Continue'
           expect(CaseInformation.count).to eq(0)
-          expect(page).to have_content(error_msg)
+          expect(page).to have_content(error_msg2)
         end
       end
 
@@ -78,7 +78,7 @@ feature 'case information feature' do
           end
 
           visit new_prison_case_information_path('LEI', offenders[index])
-          choose_country(country: country)
+          choose_country(country: country, prefix: 'last_location')
 
           expect { click_button 'Continue' }.to change(enqueued_jobs, :size).by(0)
           expect(page).not_to have_css(".notification")
@@ -92,7 +92,7 @@ feature 'case information feature' do
     end
 
     context "when the offender is Welsh or considered English", js: true do
-      it 'shows error messages when second page of form not filled', :raven_intercept_exception,
+      it 'shows error messages when second page of form not filled',
          vcr: { cassette_name: :case_information_missing_error_messages } do
         signin_user
         visit prison_summary_pending_path('LEI')
@@ -102,8 +102,8 @@ feature 'case information feature' do
           click_link 'Edit'
         end
 
-        visit new_prison_case_information_path('LEI', nomis_offender_id)
-        choose_country(country: "England")
+        # visit new_prison_case_information_path('LEI', nomis_offender_id)
+        choose_country(country: "England", prefix: 'last_location')
         click_button('Continue')
 
         # attempt to save form without filling in the additional fields
@@ -125,15 +125,15 @@ feature 'case information feature' do
           within "#edit_#{nomis_offender_id}" do
             click_link 'Edit'
           end
-          visit new_prison_case_information_path('LEI', nomis_offender_id)
+          # visit new_prison_case_information_path('LEI', nomis_offender_id)
         end
 
         it 'enqueue emails to LDU and SPO when email addresses present',
            vcr: { cassette_name: :case_information_send_emails_to_ldu_and_spo } do
-          choose_country(country: 'England')
+          choose_country(country: 'England', prefix: 'last_location')
           click_button 'Continue'
 
-          second_page_form(case_alloc: 'nps', tier: 'a', team_option: 'NPS - England')
+          second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'a', team_option: 'NPS - England')
           email_expectations(button_name: 'Continue',
                              emails: %w[EnglishNPS@example.com spo_user@digital-justice.uk],
                              spo_notice: 'This is a copy of the email sent to the LDU for your records',
@@ -147,10 +147,10 @@ feature 'case information feature' do
 
         it 'when there is no LDU email address, send email to SPO only',
            vcr: { cassette_name: :case_information_no_ldu_email } do
-          choose_country(country: 'England')
+          choose_country(country: 'England', prefix: 'last_location')
           click_button 'Continue'
 
-          second_page_form(case_alloc: 'nps', tier: 'a', team_option: 'NPS - England 2')
+          second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'a', team_option: 'NPS - England 2')
           email_expectations(button_name: 'Continue',
                              emails: %w[spo_user@digital-justice.uk],
                              spo_notice: "We were unable to send an email to English LDU 2 as we do not have their "\
@@ -171,12 +171,12 @@ feature 'case information feature' do
           expectations(probation_service: 'England', tier: 'A', team: 'NPS - England 2', case_allocation: 'NPS')
         end
 
-        it 'when there is no SPO email address, send email to LDU only', :raven_intercept_exception,
+        it 'when there is no SPO email address, send email to LDU only',
            vcr: { cassette_name: :case_information_no_spo_email } do
-          choose_country(country: 'England')
+          choose_country(country: 'England', prefix: 'last_location')
           click_button 'Continue'
 
-          second_page_form(case_alloc: 'nps', tier: 'a', team_option: 'NPS - England')
+          second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'a', team_option: 'NPS - England')
           user_details.email_address = []
 
           expect {
@@ -198,10 +198,10 @@ feature 'case information feature' do
 
         it 'when there are no email addresses for LDU or SPO, no email sent', :raven_intercept_exception,
            vcr: { cassette_name: :case_information_no_ldu_or_spo_email } do
-          choose_country(country: 'England')
+          choose_country(country: 'England', prefix: 'last_location')
           click_button 'Continue'
 
-          second_page_form(case_alloc: 'nps', tier: 'a', team_option: 'NPS - England 2')
+          second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'a', team_option: 'NPS - England 2')
           user_details.email_address = []
 
           expect {
@@ -228,27 +228,28 @@ feature 'case information feature' do
 
   context 'when updating an offenders case information', js: true do
     context 'when offender is Scottish or Northern Irish' do
-      it 'can be changed to England or Wales', :raven_intercept_exception,
+      it 'can be changed to England or Wales',
          vcr: { cassette_name: :case_information_update_when_scottish_or_ni } do
         old_countries = ['Northern Ireland', 'Scotland']
         new_countries = %w[England Wales]
         offenders = [nomis_offender_id, other_nomis_offender_id]
+        offenders.each { |o| create(:case_information, nomis_offender_id: o) }
         signin_user
 
         old_countries.each_with_index do |country, index|
-          visit new_prison_case_information_path('LEI', offenders[index])
-          choose_country(country: country)
-          click_button 'Continue'
-
+          # visit new_prison_case_information_path('LEI', offenders[index])
+          # choose_country(country: country)
+          # click_button 'Continue'
+          CaseInformation.find_by!(nomis_offender_id: offenders[index]).update!(probation_service: country)
           visit edit_prison_case_information_path('LEI', offenders[index])
           expect(page).not_to have_css("div.optional-case-info")
 
           if new_countries[index] == 'England'
-            choose('case_information_last_known_location_no', visible: false)
-            second_page_form(case_alloc: 'crc', tier: 'd', team_option: 'NPS - England')
+            choose('edit_case_information_last_known_location_no', visible: false)
+            second_page_form(prefix: 'edit_case_information', case_alloc: 'crc', tier: 'd', team_option: 'NPS - England')
           else
-            choose('case_information_probation_service_wales', visible: false)
-            second_page_form(case_alloc: 'nps', tier: 'b', team_option: 'NPS - Wales')
+            choose('edit_case_information_last_known_address_wales', visible: false)
+            second_page_form(prefix: 'edit_case_information', case_alloc: 'nps', tier: 'b', team_option: 'NPS - Wales')
           end
 
           click_button 'Update'
@@ -259,22 +260,19 @@ feature 'case information feature' do
       end
 
       it 'complains if tier, case_allocation or team not selected when changing to England or Wales',
-         :raven_intercept_exception,
          vcr: { cassette_name: :case_information_update_validation_errors } do
         signin_user
-        visit new_prison_case_information_path('LEI', nomis_offender_id)
-        choose_country(country: 'Scotland')
-        click_button 'Continue'
+        create(:case_information, nomis_offender_id: nomis_offender_id, probation_service: 'Scotland', team: nil)
 
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
-        choose('case_information_last_known_location_no', visible: false)
+        choose('edit_case_information_last_known_location_no', visible: false)
 
         expect(page).to have_css("div.optional-case-info")
         click_button 'Update'
 
-        expect(page).to have_content("You must select the prisoner's team")
         expect(page).to have_content("Select the prisoner's tier")
         expect(page).to have_content("Select the service provider for this case")
+        expect(page).to have_content("You must select the prisoner's team")
         expectations(probation_service: 'Scotland', tier: 'N/A', team: nil, case_allocation: 'N/A')
       end
     end
@@ -288,23 +286,23 @@ feature 'case information feature' do
 
         old_countries.each_with_index do |country, index|
           visit new_prison_case_information_path('LEI', offenders[index])
-          choose_country(country: country)
+          choose_country(country: country, prefix: 'last_location')
           click_button 'Continue'
 
           if country == 'England'
-            second_page_form(case_alloc: 'nps', tier: 'c', team_option: 'NPS - England')
+            second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'c', team_option: 'NPS - England')
           else
-            second_page_form(case_alloc: 'crc', tier: 'd', team_option: 'NPS - Wales')
+            second_page_form(prefix: 'case_information', case_alloc: 'crc', tier: 'd', team_option: 'NPS - Wales')
           end
           click_button 'Continue'
           visit edit_prison_case_information_path('LEI', offenders[index])
           expect(page).to have_css("div.optional-case-info")
 
           if country == 'England'
-            choose_country(country: 'Scotland')
+            choose_country(country: 'Scotland', prefix: 'edit_case_information')
           else
-            choose_country(country: 'England')
-            second_page_form(case_alloc: 'crc', tier: 'a', team_option: 'NPS - England')
+            choose_country(country: 'England', prefix: 'edit_case_information')
+            second_page_form(prefix: 'edit_case_information', case_alloc: 'crc', tier: 'a', team_option: 'NPS - England')
           end
           click_button 'Update'
         end
@@ -312,14 +310,14 @@ feature 'case information feature' do
         group_expectations(probation_services: %w[Scotland England], tiers: %w[N/A A], teams: [nil, 'NPS - England'], case_allocs: %w[N/A CRC])
       end
 
-      it 'complains if country not selected when changing to another country', :raven_intercept_exception,
+      it 'complains if country not selected when changing to another country',
          vcr: { cassette_name: :case_information_update_location_validation_errors } do
         signin_user
         visit new_prison_case_information_path('LEI', nomis_offender_id)
 
-        choose_country(country: 'England')
+        choose_country(country: 'England', prefix: 'last_location')
         click_button 'Continue'
-        second_page_form(case_alloc: 'crc', tier: 'd', team_option: 'NPS - England')
+        second_page_form(prefix: 'case_information', case_alloc: 'crc', tier: 'd', team_option: 'NPS - England')
         click_button 'Continue'
 
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
@@ -342,15 +340,15 @@ feature 'case information feature' do
         visit new_prison_case_information_path('LEI', nomis_offender_id)
       end
 
-      it 'does not send email if team_id has not been updated',
+      it 'does not send email if team has not been updated', :js,
          vcr: { cassette_name: :case_information_update_email_not_triggered_when_team_not_changed } do
-        choose_country(country: 'Wales')
+        choose_country(country: 'Wales', prefix: 'last_location')
         click_button 'Continue'
-        second_page_form(case_alloc: 'nps', tier: 'b', team_option: 'NPS - Wales')
+        second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'b', team_option: 'NPS - Wales')
         click_button 'Continue'
 
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
-        choose('case_information_tier_c', visible: false)
+        choose('edit_case_information_tier_c', visible: false)
 
         expect {
           click_button 'Update'
@@ -361,15 +359,15 @@ feature 'case information feature' do
         expectations(probation_service: 'Wales', tier: 'C', team: 'NPS - Wales', case_allocation: 'NPS')
       end
 
-      it 'does not send email if probation_service changed to Scotland or Northern Ireland', :raven_intercept_exception,
+      it 'does not send email if last_known_address changed to Scotland or Northern Ireland',
          vcr: { cassette_name: :case_information_update_email_not_triggered_when_probation_scotland_or_ni } do
-        choose_country(country: 'Wales')
+        choose_country(country: 'Wales', prefix: 'last_location')
         click_button 'Continue'
-        second_page_form(case_alloc: 'nps', tier: 'b', team_option: 'NPS - Wales')
+        second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'b', team_option: 'NPS - Wales')
         click_button 'Continue'
 
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
-        choose_country(country: 'Northern Ireland')
+        choose_country(country: 'Northern Ireland', prefix: 'edit_case_information')
 
         expect {
           click_button 'Update'
@@ -378,11 +376,11 @@ feature 'case information feature' do
         expect(page).not_to have_css(".alert")
       end
 
-      it 'does not send email when updating team has the same ldu', :raven_intercept_exception,
+      it 'does not send email when updating team has the same ldu',
          vcr: { cassette_name: :case_information_update_email_not_triggered_when_updated_team_has_same_ldu } do
-        choose_country(country: 'England')
+        choose_country(country: 'England', prefix: 'last_location')
         click_button 'Continue'
-        second_page_form(case_alloc: 'nps', tier: 'b', team_option: 'NPS - England')
+        second_page_form(prefix: 'case_information', case_alloc: 'nps', tier: 'b', team_option: 'NPS - England')
         click_button 'Continue'
 
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
@@ -398,15 +396,16 @@ feature 'case information feature' do
         expectations(probation_service: 'England', tier: 'B', team: 'NPS - England 3', case_allocation: 'NPS')
       end
 
-      it 'will send an email when probation_service changed to England or Wales from Scotland or Northern Ireland',
-         :raven_intercept_exception,
+      it 'will send an email when last_known_address changed to England or Wales from Scotland or Northern Ireland',
          vcr: { cassette_name: :case_information_update_email_sent_when_probation_changed_from_scot_or_ni } do
-        choose_country(country: 'Northern Ireland')
-        click_button 'Continue'
+        # choose_country(country: 'Northern Ireland', prefix: 'last_location')
+        # click_button 'Continue'
+        create(:case_information, nomis_offender_id: nomis_offender_id, probation_service: 'Northern Ireland')
+
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
 
-        choose_country(country: 'Wales')
-        second_page_form(case_alloc: 'crc', tier: 'b', team_option: 'NPS - Wales')
+        choose_country(country: 'Wales', prefix: 'edit_case_information')
+        second_page_form(prefix: 'edit_case_information', case_alloc: 'crc', tier: 'b', team_option: 'NPS - Wales')
 
         email_expectations(button_name: 'Update',
                            emails: %w[WalesNPS@example.com spo_user@digital-justice.uk],
@@ -421,17 +420,17 @@ feature 'case information feature' do
         expectations(probation_service: 'Wales', tier: 'B', team: 'NPS - Wales', case_allocation: 'CRC')
       end
 
-      it 'will send an email when updating team which has a different ldu', :raven_intercept_exception,
+      it 'will send an email when updating team which has a different ldu',
          vcr: { cassette_name: :case_information_update_email_sent_when_updated_team_has_different_ldu } do
-        choose_country(country: 'Wales')
+        choose_country(country: 'Wales', prefix: 'last_location')
         click_button 'Continue'
-        second_page_form(case_alloc: 'crc', tier: 'd', team_option: 'NPS - Wales')
+        second_page_form(prefix: 'case_information', case_alloc: 'crc', tier: 'd', team_option: 'NPS - Wales')
         click_button 'Continue'
 
         visit edit_prison_case_information_path('LEI', nomis_offender_id)
 
-        choose_country(country: 'England')
-        second_page_form(case_alloc: 'nps', tier: 'a', team_option: 'NPS - England 3')
+        choose_country(country: 'England', prefix: 'edit_case_information')
+        second_page_form(prefix: 'edit_case_information', case_alloc: 'nps', tier: 'a', team_option: 'NPS - England 3')
 
         email_expectations(button_name: 'Update',
                            emails: %w[EnglishNPS@example.com spo_user@digital-justice.uk],
@@ -463,7 +462,7 @@ feature 'case information feature' do
     expect(page).to have_selector('h1', text: 'Add missing information')
   end
 
-  it 'returns to previously paginated page after saving', :raven_intercept_exception,
+  it 'returns to previously paginated page after saving',
      vcr: { cassette_name: :case_information_return_to_previously_paginated_page } do
     signin_user
     visit prison_summary_pending_path('LEI', sort: "last_name desc", page: 3)
@@ -472,7 +471,7 @@ feature 'case information feature' do
       click_link 'Edit'
     end
     expect(page).to have_selector('h1', text: 'Case information')
-    choose_country(country: 'Scotland')
+    choose_country(country: 'Scotland', prefix: 'last_location')
     click_button 'Continue'
     expect(current_url).to have_content("/prisons/LEI/summary/pending?page=3&sort=last_name+desc")
   end
@@ -534,19 +533,19 @@ feature 'case information feature' do
     expect(CaseInformation.last.tier).to eq(tiers.last)
   end
 
-  def second_page_form(case_alloc:, tier:, team_option:)
-    choose("case_information_case_allocation_#{case_alloc}", visible: false) unless case_alloc.nil?
-    choose("case_information_tier_#{tier}", visible: false) unless tier.nil?
+  def second_page_form(prefix:, case_alloc:, tier:, team_option:)
+    choose("#{prefix}_case_allocation_#{case_alloc}", visible: false) unless case_alloc.nil?
+    choose("#{prefix}_tier_#{tier}", visible: false) unless tier.nil?
     page.execute_script("document.getElementsByName('input-autocomplete')[0].value='#{team_option}'")
   end
 
-  def choose_country(country:)
+  def choose_country(country:, prefix:)
     if country == 'England'
-      choose('case_information_last_known_location_no', visible: false)
+      choose("#{prefix}_last_known_location_no", visible: false)
     else
       choose('last_known_location_yes', visible: false)
       area = country.downcase.tr(" ", "_")
-      probation = "case_information_probation_service_" + area
+      probation = "#{prefix}_last_known_address_" + area
       choose(probation, visible: false)
     end
   end

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe CaseInformation, type: :model do
       end
     end
 
-    context 'without manual flag, it is still required' do
+    context 'without manual flag, it is not required' do
       it 'does not raise an error when not present' do
-        expect(build(:case_information, probation_service: nil, manual_entry: false)).not_to be_valid
+        expect(build(:case_information, probation_service: nil, manual_entry: false)).to be_valid
       end
     end
   end
@@ -123,32 +123,6 @@ RSpec.describe CaseInformation, type: :model do
       context 'with Scotland or Northern Ireland offender' do
         it 'is valid without team' do
           expect(build(:case_information, team: nil, probation_service: 'Northern Ireland')).to be_valid
-        end
-      end
-    end
-  end
-
-  context 'with last_known_location' do
-    context 'without manual flag' do
-      it 'will be valid' do
-        expect(build(:case_information, manual_entry: false, last_known_location: nil)).to be_valid
-      end
-    end
-
-    context 'with manual flag' do
-      it 'is valid if nil' do
-        expect(build(:case_information, manual_entry: true, last_known_location: nil)).to be_valid
-      end
-
-      # only values accepted are nil, Yes or No
-      context 'when value is not Yes or No' do
-        subject {
-          build(:case_information, manual_entry: true, last_known_location: 'Maybe')
-        }
-
-        it 'gives the correct message if value not in Yes or No' do
-          expect(subject).not_to be_valid
-          expect(subject.errors.messages).to eq(last_known_location: ["Select yes if the prisoner's last known address was in Northern Ireland, Scotland or Wales"])
         end
       end
     end

--- a/spec/services/view_handover_email_addresses_summary_spec.rb
+++ b/spec/services/view_handover_email_addresses_summary_spec.rb
@@ -65,26 +65,6 @@ describe ViewHandoverEmailAddressesSummary do
     end
   end
 
-  context 'with an offender that has case information with an orphaned team link' do
-    let(:offenders) { [double(offender_no: 1)] }
-
-    before do
-      create(:case_information, :no_team, nomis_offender_id: 1, team_id: 1)
-      Team.destroy_all
-    end
-
-    it 'returns the right counts' do
-      expect(result).to eq(
-        has_email_address: 0,
-        missing_delius_record: 0,
-        missing_team_link: 0,
-        missing_team_information: 1,
-        missing_local_divisional_unit: 0,
-        missing_local_divisional_unit_email: 0
-                        )
-    end
-  end
-
   context 'with an offender that cannot be linked to a local divisional unit' do
     let(:offenders) { [double(offender_no: 1)] }
 


### PR DESCRIPTION
POM-511 has quite a lot of duplicated code in the case_information_controller. 

This PR attempts to deal with this, creating a couple of 'form objects' to handle the 'new' and 'edit' forms (which are different in shape to CaseInformation model)