### PR TITLE
Pom767 handovers without caseinfo crc

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -90,7 +90,7 @@ private
   end
 
   def prisoner(nomis_id)
-    @prisoner ||= OffenderService.get_offender(nomis_id)
+    @prisoner ||= OffenderPresenter.new(OffenderService.get_offender(nomis_id), nil)
   end
 
   def nomis_offender_id_from_url

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -24,7 +24,7 @@ class PrisonersController < PrisonsApplicationController
       @secondary_pom_name = helpers.fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
     end
 
-    @pom_responsibility = pom_responsibility
+    @pom_responsibility = @prisoner.pom_responsibility
     @keyworker = Nomis::Keyworker::KeyworkerApi.get_keyworker(
       active_prison_id, @prisoner.offender_no
     )
@@ -46,27 +46,6 @@ class PrisonersController < PrisonsApplicationController
   end
 
 private
-
-  def pom_responsibility
-    @pom_responsibility ||= overridden_responsibility || calculated_responsibility
-  end
-
-  def overridden_responsibility
-    override = Responsibility.find_by(nomis_offender_id: @offender.offender_no)
-    return nil if override.nil?
-
-    if override.value == Responsibility::PRISON
-      ResponsibilityService::RESPONSIBLE.to_s
-    else
-      ResponsibilityService::SUPPORTING.to_s
-    end
-  end
-
-  def calculated_responsibility
-    ResponsibilityService.calculate_pom_responsibility(
-      @offender
-    )
-  end
 
   def id_for_show_action
     params[:id]

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -11,10 +11,14 @@ module OffenderHelper
   end
 
   def case_owner_label(offender)
-    if offender.pom_responsibility.custody?
-      'Custody'
+    if offender.pom_responsibility
+      if offender.pom_responsibility.custody?
+        'Custody'
+      else
+        'Community'
+      end
     else
-      'Community'
+      'Unknown'
     end
   end
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -3,14 +3,6 @@
 class Allocation < ApplicationRecord
   has_paper_trail ignore: [:com_name]
 
-  has_one :case_information,
-          primary_key: :nomis_offender_id,
-          foreign_key: :nomis_offender_id,
-          inverse_of: :allocation,
-          # allocation(histories) are never destroyed in the normal cycle,
-          # they are kept in case offender returns to the system
-          dependent: :restrict_with_exception
-
   ALLOCATE_PRIMARY_POM = 0
   REALLOCATE_PRIMARY_POM = 1
   ALLOCATE_SECONDARY_POM = 2

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -3,6 +3,14 @@
 class Allocation < ApplicationRecord
   has_paper_trail ignore: [:com_name]
 
+  has_one :case_information,
+          primary_key: :nomis_offender_id,
+          foreign_key: :nomis_offender_id,
+          inverse_of: :allocation,
+          # allocation(histories) are never destroyed in the normal cycle,
+          # they are kept in case offender returns to the system
+          dependent: :restrict_with_exception
+
   ALLOCATE_PRIMARY_POM = 0
   REALLOCATE_PRIMARY_POM = 1
   ALLOCATE_SECONDARY_POM = 2

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -15,6 +15,12 @@ class CaseInformation < ApplicationRecord
 
   before_validation :set_probation_service
 
+  belongs_to :allocation,
+             foreign_key: :nomis_offender_id,
+             primary_key: :nomis_offender_id,
+             inverse_of: :case_information,
+             optional: true
+
   def local_divisional_unit
     team.try(:local_divisional_unit)
   end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -15,12 +15,6 @@ class CaseInformation < ApplicationRecord
 
   before_validation :set_probation_service
 
-  belongs_to :allocation,
-             foreign_key: :nomis_offender_id,
-             primary_key: :nomis_offender_id,
-             inverse_of: :case_information,
-             optional: true
-
   def local_divisional_unit
     team.try(:local_divisional_unit)
   end

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -160,7 +160,7 @@ module Nomis
       @team.try(:name)
     end
 
-    def case_information=(record)
+    def load_case_information(record)
       return if record.blank?
 
       @case_information = record

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -86,7 +86,7 @@ private
         sentencing = sentence_details[offender.booking_id]
         offender.sentence = sentencing if sentencing.present?
 
-        offender.case_information = mapped_tiers[offender.offender_no]
+        offender.load_case_information(mapped_tiers[offender.offender_no])
       }
     end
   end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -86,8 +86,7 @@ private
         sentencing = sentence_details[offender.booking_id]
         offender.sentence = sentencing if sentencing.present?
 
-        case_info_record = mapped_tiers[offender.offender_no]
-        offender.load_case_information(case_info_record)
+        offender.case_information = mapped_tiers[offender.offender_no]
       }
     end
   end

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OffenderPresenter
-  attr_reader :offender, :responsibility
+  attr_reader :responsibility
 
   delegate :offender_no, :first_name, :last_name, :booking_id,
            :indeterminate_sentence?, :sentence_type_code, :describe_sentence,

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -10,17 +10,33 @@ class OffenderPresenter
            :home_detention_curfew_eligibility_date, :home_detention_curfew_actual_date,
            :tariff_date,
            :date_of_birth, :release_date, :parole_eligibility_date,
-           :welsh_offender, :case_allocation, :earliest_release_date,
+           :welsh_offender, :earliest_release_date,
            :category_code, :conditional_release_date, :automatic_release_date,
            :awaiting_allocation_for, :allocated_pom_name, :allocation_date, :allocated_com_name,
            :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
-           :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
+           :prison_arrival_date,
            :licence_expiry_date, :post_recall_release_date,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level, to: :@offender
 
   def initialize(offender, responsibility)
     @offender = offender
     @responsibility = responsibility
+  end
+
+  def handover_reason
+    @offender.handover_reason if @offender.has_case_information?
+  end
+
+  def handover_start_date
+    @offender.handover_start_date if @offender.has_case_information?
+  end
+
+  def responsibility_handover_date
+    @offender.responsibility_handover_date if @offender.has_case_information?
+  end
+
+  def case_allocation
+    @offender.case_allocation if @offender.has_case_information?
   end
 
   def pom_responsibility
@@ -33,7 +49,7 @@ class OffenderPresenter
       else
         ResponsibilityService::SUPPORTING
       end
-    else
+    elsif @offender.has_case_information?
       @offender.pom_responsibility
     end
   end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -5,7 +5,7 @@ class OffenderService
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
       next false if o.nil?
 
-      o.case_information = CaseInformation.find_by(nomis_offender_id: offender_no)
+      o.load_case_information(CaseInformation.find_by(nomis_offender_id: offender_no))
 
       sentence_detail = get_sentence_details([o.booking_id])
       if sentence_detail.present? && sentence_detail.key?(o.booking_id)

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -5,8 +5,7 @@ class OffenderService
     Nomis::Elite2::OffenderApi.get_offender(offender_no).tap { |o|
       next false if o.nil?
 
-      record = CaseInformation.find_by(nomis_offender_id: offender_no)
-      o.load_case_information(record)
+      o.case_information = CaseInformation.find_by(nomis_offender_id: offender_no)
 
       sentence_detail = get_sentence_details([o.booking_id])
       if sentence_detail.present? && sentence_detail.key?(o.booking_id)

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -73,6 +73,8 @@ private
   end
 
   def self.approaching_handover?(offender)
+    return false unless offender.has_case_information?
+
     today = Time.zone.today
     thirty_days_time = today + 30.days
 

--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe CaseloadController, type: :controller do
 
       # Need to create history records because AllocatedOffender#new_case? doesn't cope otherwise
       offenders.each do |offender|
+        create(:case_information, nomis_offender_id: offender.fetch(:offenderNo))
         alloc = create(:allocation, nomis_offender_id: offender.fetch(:offenderNo), primary_pom_nomis_id: staff_id, prison: prison)
         alloc.update!(primary_pom_nomis_id: staff_id,
                       event: Allocation::REALLOCATE_PRIMARY_POM,

--- a/spec/controllers/coworking_controller_spec.rb
+++ b/spec/controllers/coworking_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe CoworkingController, type: :controller do
         to_return(body: { 'staffId': user.staffId }.to_json)
       stub_pom_emails(user.staffId, [])
 
+      create(:case_information, nomis_offender_id: offender_no)
       create(:allocation, prison: prison,
              nomis_offender_id: offender_no,
              primary_pom_nomis_id: primary_pom.staffId,

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
 
   context 'with a good ldu complete with email address' do
     before do
-      create(:case_information, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
+      create(:case_information, nomis_offender_id: nomis_offender_id)
       create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
     end
 

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe EarlyAllocationsController, type: :controller do
     stub_offender(nomis_offender_id)
     stub_poms(prison, poms)
     stub_offenders_for_prison(prison, [offender], [booking])
-
-    create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
   end
 
   context 'with not ldu email address' do
@@ -48,6 +46,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
 
     before do
       create(:case_information, nomis_offender_id: nomis_offender_id, team: team)
+      create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
     end
 
     it 'goes to the dead end' do
@@ -61,6 +60,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
   context 'with a good ldu complete with email address' do
     before do
       create(:case_information, nomis_offender_id: nomis_offender_id)
+      create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
     end
 
     context 'when stage 1' do

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
 
   context 'with a good ldu complete with email address' do
     before do
-      create(:case_information, nomis_offender_id: nomis_offender_id)
+      create(:case_information, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
       create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -64,25 +64,30 @@ RSpec.describe TasksController, type: :controller do
         "internalLocationDesc": "A-4-013", "facialImageId": 1_399_838 }
     ]
 
-    # Allocate all of the offenders to this POM
-    offenders.each do |offender|
-      create(:allocation, nomis_offender_id: offender[:offenderNo], primary_pom_nomis_id: staff_id, prison: prison)
-    end
-
     stub_offenders_for_prison(prison, offenders, bookings)
   end
 
   context 'when showing parole review date pom tasks' do
     let(:offender_no) { 'G7514GW' }
 
-    it 'can show offenders needing parole review date updates' do
-      stub_offender(offender_no, booking_number: 754_207, imprisonment_status: 'LIFE')
-
+    before do
+      # Allocate all of the offenders to this POM
       # Make sure that we don't generate missing nDelius data by mistake
       create(:case_information, nomis_offender_id: offender_no, tier: 'A')
+      create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id, prison: prison)
+
       create(:case_information, nomis_offender_id: 'G1234VV', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G1234VV', primary_pom_nomis_id: staff_id, prison: prison)
+
       create(:case_information, nomis_offender_id: 'G1234AB', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G1234AB', primary_pom_nomis_id: staff_id, prison: prison)
+
       create(:case_information, nomis_offender_id: 'G1234GG', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G1234GG', primary_pom_nomis_id: staff_id, prison: prison)
+    end
+
+    it 'can show offenders needing parole review date updates' do
+      stub_offender(offender_no, booking_number: 754_207, imprisonment_status: 'LIFE')
 
       get :index, params: { prison_id: prison }
 
@@ -103,6 +108,21 @@ RSpec.describe TasksController, type: :controller do
 
     before do
       test_strategy.switch!(:auto_delius_import, true)
+
+      stub_offender(offender_no, booking_number: 754_206)
+
+      # Ensure only one of our offenders has missing data and that G7514GW (indeterminate) has a PRD
+      create(:case_information, nomis_offender_id: offender_no, tier: 'A', mappa_level: 1, team: nil)
+      create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id, prison: prison)
+
+      create(:case_information,  nomis_offender_id: 'G1234AB', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G1234AB', primary_pom_nomis_id: staff_id, prison: prison)
+
+      create(:case_information, nomis_offender_id: 'G1234GG', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G1234GG', primary_pom_nomis_id: staff_id, prison: prison)
+
+      create(:case_information,  nomis_offender_id: 'G7514GW', tier: 'A', mappa_level: 1, parole_review_date: next_week)
+      create(:allocation, nomis_offender_id: 'G7514GW', primary_pom_nomis_id: staff_id, prison: prison)
     end
 
     after do
@@ -110,14 +130,6 @@ RSpec.describe TasksController, type: :controller do
     end
 
     it 'can show offenders needing nDelius updates' do
-      stub_offender(offender_no, booking_number: 754_206)
-
-      # Ensure only one of our offenders has missing data and that G7514GW (indeterminate) has a PRD
-      create(:case_information, nomis_offender_id: offender_no, tier: 'A', team: nil)
-      create(:case_information, nomis_offender_id: 'G1234AB', tier: 'A', mappa_level: 1)
-      create(:case_information, nomis_offender_id: 'G1234GG', tier: 'A', mappa_level: 1)
-      create(:case_information, nomis_offender_id: 'G7514GW', tier: 'A', mappa_level: 1, parole_review_date: next_week)
-
       get :index, params: { prison_id: prison }
 
       expect(response).to be_successful
@@ -136,6 +148,7 @@ RSpec.describe TasksController, type: :controller do
     it 'can show offenders needing early allocation decision updates' do
       offender_nos.each do |offender_no|
         create(:case_information, nomis_offender_id: offender_no, tier: 'A', mappa_level: 1, parole_review_date: next_week)
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id, prison: prison)
       end
 
       create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: test_offender_no)
@@ -156,12 +169,19 @@ RSpec.describe TasksController, type: :controller do
     let(:offender_nos) { %w[G1234AB G1234GG G7514GW G1234VV] }
     let(:test_offender_no) { 'G1234AB' }
 
-    it 'can show multiple types at once' do
+    before do
       # One offender (G1234VV) should have missing case info and one should have no PRD
       create(:case_information, nomis_offender_id: 'G1234AB', tier: 'A', mappa_level: 1, parole_review_date: next_week)
-      create(:case_information, nomis_offender_id: 'G1234GG', tier: 'A', mappa_level: 1, parole_review_date: next_week)
-      create(:case_information, nomis_offender_id: 'G7514GW', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G1234AB', primary_pom_nomis_id: staff_id, prison: prison)
 
+      create(:case_information, nomis_offender_id: 'G1234GG', tier: 'A', mappa_level: 1, parole_review_date: next_week)
+      create(:allocation, nomis_offender_id: 'G1234GG', primary_pom_nomis_id: staff_id, prison: prison)
+
+      create(:case_information, nomis_offender_id: 'G7514GW', tier: 'A', mappa_level: 1)
+      create(:allocation, nomis_offender_id: 'G7514GW', primary_pom_nomis_id: staff_id, prison: prison)
+    end
+
+    it 'can show multiple types at once' do
       # One offender should have a pending early allocation
       create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: test_offender_no)
       create(:early_allocation, :stage2, :skip_validate, nomis_offender_id: test_offender_no)
@@ -175,11 +195,6 @@ RSpec.describe TasksController, type: :controller do
     end
 
     it 'can sort the results' do
-      # One offender (G1234VV) should have missing case info and one should have no PRD
-      create(:case_information, nomis_offender_id: 'G1234AB', tier: 'A', mappa_level: 1, parole_review_date: next_week)
-      create(:case_information, nomis_offender_id: 'G1234GG', tier: 'A', mappa_level: 1, parole_review_date: next_week)
-      create(:case_information, nomis_offender_id: 'G7514GW', tier: 'A', mappa_level: 1)
-
       # Two offenders should have a pending early allocation
       create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: 'G1234AB')
       create(:early_allocation, :stage2, :skip_validate, nomis_offender_id: 'G1234AB')

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -47,5 +47,9 @@ FactoryBot.define do
     prison do
       'LEI'
     end
+
+    case_information do
+      build(:case_information, nomis_offender_id: nomis_offender_id)
+    end
   end
 end

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
     end
 
     primary_pom_name do
-      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+      "#{Faker::Name.last_name}, #{Faker::Name.first_name}"
     end
 
     primary_pom_allocated_at do

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -47,9 +47,5 @@ FactoryBot.define do
     prison do
       'LEI'
     end
-
-    case_information do
-      build(:case_information, nomis_offender_id: nomis_offender_id)
-    end
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -17,6 +17,7 @@ feature 'Allocation' do
 
   let!(:case_information) {
     create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'No')
+    create(:case_information, nomis_offender_id: never_allocated_offender)
   }
 
   before do

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -11,6 +11,7 @@ feature 'Inactive POM' do
     before do
       signin_user
 
+      create(:case_information, nomis_offender_id: nomis_offender_id)
       create(
         :allocation,
         nomis_offender_id: nomis_offender_id,

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -18,6 +18,7 @@ feature 'View a prisoner profile page' do
 
   context 'with an allocation' do
     let!(:alloc) {
+      create(:case_information, nomis_offender_id: 'G7998GJ')
       create(:allocation, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637', primary_pom_name: 'Pobno, Kath')
     }
 
@@ -64,7 +65,7 @@ feature 'View a prisoner profile page' do
        vcr: { cassette_name: :show_offender_community_info_full } do
       ldu = create(:local_divisional_unit, name: 'An LDU', email_address: 'test@example.com')
       team = create(:team, name: 'A team', local_divisional_unit: ldu)
-      alloc.case_information.update(team: team)
+      CaseInformation.find_by(nomis_offender_id: alloc.nomis_offender_id).update(team: team)
 
       alloc.update(com_name: 'Bob Smith')
 
@@ -80,7 +81,7 @@ feature 'View a prisoner profile page' do
        vcr: { cassette_name: :show_offender_community_info_partial } do
       ldu = create(:local_divisional_unit, name: 'An LDU', email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
-      alloc.case_information.update(team: team)
+      CaseInformation.find_by(nomis_offender_id: alloc.nomis_offender_id).update(team: team)
 
       visit prison_prisoner_path('LEI', 'G7998GJ')
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -64,10 +64,7 @@ feature 'View a prisoner profile page' do
        vcr: { cassette_name: :show_offender_community_info_full } do
       ldu = create(:local_divisional_unit, name: 'An LDU', email_address: 'test@example.com')
       team = create(:team, name: 'A team', local_divisional_unit: ldu)
-      create(:case_information,
-             nomis_offender_id: alloc.nomis_offender_id,
-             team: team
-      )
+      alloc.case_information.update(team: team)
 
       alloc.update(com_name: 'Bob Smith')
 
@@ -83,10 +80,7 @@ feature 'View a prisoner profile page' do
        vcr: { cassette_name: :show_offender_community_info_partial } do
       ldu = create(:local_divisional_unit, name: 'An LDU', email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
-      create(:case_information,
-             nomis_offender_id: alloc.nomis_offender_id,
-             team: team
-      )
+      alloc.case_information.update(team: team)
 
       visit prison_prisoner_path('LEI', 'G7998GJ')
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -54,15 +54,14 @@ feature 'View a prisoner profile page' do
       expect(page.response_headers['Content-Type']).to eq('image/jpg')
     end
 
-    it "has a link to the allocation history",
-       :versioning, vcr: { cassette_name: :link_to_allocation_history } do
+    it "has a link to the allocation history", :versioning, vcr: { cassette_name: :link_to_allocation_history } do
       visit prison_prisoner_path('LEI', 'G7998GJ')
       click_link "View"
       expect(page).to have_content('Prisoner allocation')
     end
 
     it "has community information when present",
-       :raven_intercept_exception, vcr: { cassette_name: :show_offender_community_info_full } do
+       vcr: { cassette_name: :show_offender_community_info_full } do
       ldu = create(:local_divisional_unit, name: 'An LDU', email_address: 'test@example.com')
       team = create(:team, name: 'A team', local_divisional_unit: ldu)
       create(:case_information,
@@ -81,7 +80,7 @@ feature 'View a prisoner profile page' do
     end
 
     it "has some community information when present",
-       :raven_intercept_exception, vcr: { cassette_name: :show_offender_community_info_partial } do
+       vcr: { cassette_name: :show_offender_community_info_partial } do
       ldu = create(:local_divisional_unit, name: 'An LDU', email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
       create(:case_information,

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 feature "get poms list" do
   let!(:offender_missing_sentence_case_info) { create(:case_information, nomis_offender_id: 'G1247VX') }
 
-  it "shows the page", vcr: { cassette_name: :show_poms_feature_list } do
+  before do
     signin_user
+  end
 
+  it "shows the page", vcr: { cassette_name: :show_poms_feature_list } do
     visit prison_poms_path('LEI')
 
     expect(page).to have_css(".govuk-table", count: 4)
@@ -18,8 +20,6 @@ feature "get poms list" do
   end
 
   it "handles missing sentence data", vcr: { cassette_name: :show_poms_feature_missing_sentence } do
-    signin_user('MOIC_POM')
-
     visit prison_confirm_allocation_path('LEI', offender_missing_sentence_case_info.nomis_offender_id, 485_926)
     click_button 'Complete allocation'
 
@@ -31,8 +31,6 @@ feature "get poms list" do
   end
 
   it "allows viewing a POM", vcr: { cassette_name: :show_poms_feature_view } do
-    signin_user
-
     visit "/prisons/LEI/poms/485926"
 
     expect(page).to have_css(".govuk-button", count: 1)
@@ -43,9 +41,8 @@ feature "get poms list" do
   end
 
   it "can sort offenders allocated to a POM", vcr: { cassette_name: :show_poms_feature_view_sorting } do
-    signin_user
-
     [['G7806VO', 754_207], ['G2911GD', 1_175_317]].each do |offender_id, booking|
+      create(:case_information, nomis_offender_id: offender_id)
       AllocationService.create_or_update(
         nomis_offender_id: offender_id,
         nomis_booking_id: booking,
@@ -88,8 +85,6 @@ feature "get poms list" do
   end
 
   it "allows editing a POM", vcr: { cassette_name: :show_poms_feature_edit } do
-    signin_user
-
     visit "/prisons/LEI/poms/485926/edit"
 
     expect(page).to have_css(".govuk-button", count: 1)

--- a/spec/features/spo_handover_cases_feature_spec.rb
+++ b/spec/features/spo_handover_cases_feature_spec.rb
@@ -7,7 +7,9 @@ feature "SPO viewing upcoming handover cases" do
     before do
       allow_any_instance_of(Nomis::OffenderBase).to receive_messages(
         handover_start_date: handover_start_date,
-        responsibility_handover_date: responsibility_handover_date
+        responsibility_handover_date: responsibility_handover_date,
+        case_allocation: 'NPS',
+        has_case_information?: true
       )
       signin_spo_user
       visit prison_summary_handovers_path(prison)

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -49,8 +49,8 @@ context 'when NOMIS is missing information' do
 
           stub_offenders_for_prison(prison_code, stub_offenders, stub_bookings)
 
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
-          create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id,
+                 case_information: build(:case_information, case_allocation: 'NPS'))
         end
 
         it 'does not error' do
@@ -96,8 +96,8 @@ context 'when NOMIS is missing information' do
 
         stub_offenders_for_prison(prison_code, stub_offender, stub_bookings)
 
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
-        create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id,
+               case_information: build(:case_information, case_allocation: 'NPS'))
       end
 
       it 'does not error' do
@@ -194,13 +194,12 @@ context 'when NOMIS is missing information' do
         stub_request(:get, "#{stub_keyworker_host}/key-worker/#{prison_code}/offender/#{offender_no}").
           to_return(status: 200, body: {}.to_json)
 
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
-        create(
-          :case_information,
-          nomis_offender_id: offender_no,
-          case_allocation: 'NPS',
-          welsh_offender: welsh
-        )
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id,
+               case_information: build(
+                 :case_information,
+                 case_allocation: 'NPS',
+                 welsh_offender: welsh
+        ))
       end
 
       describe 'the pom details page' do

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -49,8 +49,8 @@ context 'when NOMIS is missing information' do
 
           stub_offenders_for_prison(prison_code, stub_offenders, stub_bookings)
 
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id,
-                 case_information: build(:case_information, case_allocation: 'NPS'))
+          create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
         end
 
         it 'does not error' do
@@ -96,8 +96,8 @@ context 'when NOMIS is missing information' do
 
         stub_offenders_for_prison(prison_code, stub_offender, stub_bookings)
 
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id,
-               case_information: build(:case_information, case_allocation: 'NPS'))
+        create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
       end
 
       it 'does not error' do
@@ -194,12 +194,8 @@ context 'when NOMIS is missing information' do
         stub_request(:get, "#{stub_keyworker_host}/key-worker/#{prison_code}/offender/#{offender_no}").
           to_return(status: 200, body: {}.to_json)
 
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id,
-               case_information: build(
-                 :case_information,
-                 case_allocation: 'NPS',
-                 welsh_offender: welsh
-        ))
+        create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS', probation_service: (welsh == 'Yes') ? "Wales" : 'England')
+        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
       end
 
       describe 'the pom details page' do

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe SearchHelper do
 
     it "will change to allocate if there is no allocation" do
       offender = Nomis::Offender.new(
-        offender_no: 'A',
-        tier: 'A'
-      )
+        offender_no: 'A').tap { |o|
+        o.load_case_information(build(:case_information, tier: 'A'))
+      }
       text, _link = cta_for_offender('LEI', offender)
       expect(text).to eq('<a href="/prisons/LEI/allocations/A/new">Allocate</a>')
     end
@@ -22,9 +22,9 @@ RSpec.describe SearchHelper do
     it "will change to view if there is an allocation" do
       offender = Nomis::Offender.new(
         offender_no: 'A',
-        tier: 'A',
         allocated_pom_name: 'Bob'
-      )
+      ).tap { |o| o.load_case_information(build(:case_information, tier: 'A')) }
+
       text, _link = cta_for_offender('LEI', offender)
       expect(text).to eq('<a href="/prisons/LEI/allocations/A">View</a>')
     end

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when duplicate NOMIS ids exist' do
       let!(:d1) {
         create(:delius_data, noms_no: nomis_offender_id, team_code: team.code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
       let!(:d2) {
         create(:delius_data, noms_no: nomis_offender_id, team_code: team.code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'flags up the duplicate IDs' do
@@ -42,7 +42,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when on the happy path' do
       let!(:d1) {
         create(:delius_data, team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'creates case information' do
@@ -57,28 +57,28 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
       let!(:com_name) { 'Bob Smith' }
       let!(:d1) {
         create(:delius_data, offender_manager: com_name, team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
+      let!(:allocation) { create(:allocation, nomis_offender_id: d1.noms_no) }
 
       it 'does no update if no allocation' do
-        alloc = Allocation.find_by(nomis_offender_id: d1.noms_no)
+        alloc = Allocation.find_by(nomis_offender_id: offender_id)
         expect(alloc).to be_nil
 
         expect {
           described_class.perform_now d1.noms_no
         }.to change(CaseInformation, :count).by(1)
 
-        alloc = Allocation.find_by(nomis_offender_id: d1.noms_no)
+        alloc = Allocation.find_by(nomis_offender_id: offender_id)
         expect(alloc).to be_nil
       end
 
       it 'updates existing allocation without new version' do
-        allocation = create(:allocation, nomis_offender_id: d1.noms_no)
         expect(allocation.version).to be_nil
 
         expect {
           described_class.perform_now d1.noms_no
-        }.not_to change(CaseInformation, :count)
+        }.to change(CaseInformation, :count).by(1)
 
         allocation.reload
         expect(allocation.version).to be_nil
@@ -89,7 +89,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when offender is not convicted' do
       let!(:d1) {
         create(:delius_data, noms_no: remand_nomis_offender_id, team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'does not case information' do
@@ -102,7 +102,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when tier contains extra characters' do
       let!(:d1) {
         create(:delius_data, tier: 'B1', team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'creates case information' do
@@ -116,7 +116,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when tier is invalid' do
       let!(:d1) {
         create(:delius_data, tier: 'X', team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'does not creates case information' do
@@ -130,7 +130,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
       context 'without delius mappa' do
         let!(:d1) {
           create(:delius_data, mappa: 'N', team_code: team.shadow_code, team: team.name,
-                               ldu_code: ldu.code, ldu: ldu.name)
+                 ldu_code: ldu.code, ldu: ldu.name)
         }
 
         it 'creates case information with mappa level 0' do
@@ -144,7 +144,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
       context 'with delius mappa' do
         let!(:d1) {
           create(:delius_data, mappa: 'Y', mappa_levels: mappa_levels, team_code: team.shadow_code, team: team.name,
-                               ldu_code: ldu.code, ldu: ldu.name)
+                 ldu_code: ldu.code, ldu: ldu.name)
         }
 
         context 'with delius mappa data is 1' do
@@ -185,7 +185,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when tier is missing' do
       let!(:d1) {
         create(:delius_data, tier: nil, team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'does not creates case information' do
@@ -198,7 +198,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when invalid service provider' do
       let!(:d1) {
         create(:delius_data, provider_code: 'X123', team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'does not creates case information' do
@@ -211,7 +211,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when date contains 8 stars' do
       let!(:d1) {
         create(:delius_data, date_of_birth: '*' * 8, team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'creates a new case information record' do
@@ -224,7 +224,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when date invalid' do
       let!(:d1) {
         create(:delius_data, date_of_birth: 'ohdearieme', team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
 
       it 'creates an error record' do
@@ -241,7 +241,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
     context 'when case information already present' do
       let!(:d1) {
         create(:delius_data, tier: 'C', team_code: team.shadow_code, team: team.name,
-                             ldu_code: ldu.code, ldu: ldu.name)
+               ldu_code: ldu.code, ldu: ldu.name)
       }
       let!(:c1) { create(:case_information, tier: 'B', nomis_offender_id: d1.noms_no, crn: d1.crn) }
 
@@ -263,7 +263,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
       context 'when on the happy path' do
         let!(:d1) {
           create(:delius_data, team_code: team.shadow_code, team: team.name,
-                               ldu_code: ldu.code, ldu: ldu.name)
+                 ldu_code: ldu.code, ldu: ldu.name)
         }
 
         it 'creates case information' do
@@ -282,7 +282,7 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
       context 'when on the happy path' do
         let!(:d1) {
           create(:delius_data, team_code: team.shadow_code, team: team.name,
-                               ldu_code: ldu.code, ldu: ldu.name)
+                 ldu_code: ldu.code, ldu: ldu.name)
         }
 
         it 'creates case information' do

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -59,26 +59,26 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
         create(:delius_data, offender_manager: com_name, team_code: team.shadow_code, team: team.name,
                              ldu_code: ldu.code, ldu: ldu.name)
       }
-      let!(:allocation) { create(:allocation, nomis_offender_id: d1.noms_no) }
 
       it 'does no update if no allocation' do
-        alloc = Allocation.find_by(nomis_offender_id: offender_id)
+        alloc = Allocation.find_by(nomis_offender_id: d1.noms_no)
         expect(alloc).to be_nil
 
         expect {
           described_class.perform_now d1.noms_no
         }.to change(CaseInformation, :count).by(1)
 
-        alloc = Allocation.find_by(nomis_offender_id: offender_id)
+        alloc = Allocation.find_by(nomis_offender_id: d1.noms_no)
         expect(alloc).to be_nil
       end
 
       it 'updates existing allocation without new version' do
+        allocation = create(:allocation, nomis_offender_id: d1.noms_no)
         expect(allocation.version).to be_nil
 
         expect {
           described_class.perform_now d1.noms_no
-        }.to change(CaseInformation, :count).by(1)
+        }.not_to change(CaseInformation, :count)
 
         allocation.reload
         expect(allocation.version).to be_nil

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -16,17 +16,20 @@ RSpec.describe Allocation, type: :model do
     end
 
     let!(:c1) {
-      create(:allocation, case_information: build(:case_information, team: nil))
+      ci1 = create(:case_information, team: nil)
+      create(:allocation, nomis_offender_id: ci1.nomis_offender_id)
     }
     let!(:c2) {
       ldu = create(:local_divisional_unit, email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
-      create(:allocation, case_information: build(:case_information, team: team))
+      ci2 = create(:case_information, team: team)
+      create(:allocation, nomis_offender_id: ci2.nomis_offender_id)
     }
     let!(:c3) {
       ldu = create(:local_divisional_unit, email_address: 'someone@example.com')
       team = create(:team, local_divisional_unit: ldu)
-      create(:allocation, case_information: build(:case_information, team: team))
+      ci3 = create(:case_information, team: team)
+      create(:allocation, nomis_offender_id: ci3.nomis_offender_id)
     }
 
     it 'picks up NPS allocations without emails' do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -16,20 +16,17 @@ RSpec.describe Allocation, type: :model do
     end
 
     let!(:c1) {
-      ci1 = create(:case_information, team: nil)
-      create(:allocation, nomis_offender_id: ci1.nomis_offender_id)
+      create(:allocation, case_information: build(:case_information, team: nil))
     }
     let!(:c2) {
       ldu = create(:local_divisional_unit, email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
-      ci2 = create(:case_information, team: team)
-      create(:allocation, nomis_offender_id: ci2.nomis_offender_id)
+      create(:allocation, case_information: build(:case_information, team: team))
     }
     let!(:c3) {
       ldu = create(:local_divisional_unit, email_address: 'someone@example.com')
       team = create(:team, local_divisional_unit: ldu)
-      ci3 = create(:case_information, team: team)
-      create(:allocation, nomis_offender_id: ci3.nomis_offender_id)
+      create(:allocation, case_information: build(:case_information, team: team))
     }
 
     it 'picks up NPS allocations without emails' do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Allocation, type: :model do
       it 'removes them as the primary pom\'s from all allocations' do
         described_class.deallocate_primary_pom(nomis_staff_id, allocation.prison)
 
-        deallocation = described_class.find_by(nomis_offender_id: nomis_offender_id)
+        deallocation = described_class.find_by!(nomis_offender_id: nomis_offender_id)
 
         expect(deallocation.primary_pom_nomis_id).to be_nil
         expect(deallocation.primary_pom_name).to be_nil
@@ -102,6 +102,8 @@ RSpec.describe Allocation, type: :model do
     describe 'when an offender moves prison', versioning: true, vcr: { cassette_name: :allocation_deallocate_offender }  do
       it 'removes the primary pom details in an Offender\'s allocation' do
         nomis_offender_id = 'G2911GD'
+        create(:case_information, nomis_offender_id: nomis_offender_id)
+
         movement_type = Allocation::OFFENDER_TRANSFERRED
         params = {
           nomis_offender_id: nomis_offender_id,
@@ -132,6 +134,8 @@ RSpec.describe Allocation, type: :model do
     describe 'when an offender gets released from prison', versioning: true, vcr: { cassette_name: :allocation_deallocate_offender_released }  do
       it 'removes the primary pom details in an Offender\'s allocation' do
         nomis_offender_id = 'G2911GD'
+        create(:case_information, nomis_offender_id: nomis_offender_id)
+
         movement_type = Allocation::OFFENDER_RELEASED
         params = {
           nomis_offender_id: nomis_offender_id,

--- a/spec/models/nomis/offender_spec.rb
+++ b/spec/models/nomis/offender_spec.rb
@@ -7,8 +7,7 @@ describe Nomis::Offender do
         build(:offender).tap { |o|
           o.sentence = Nomis::SentenceDetail.new(automatic_release_date: Time.zone.today + 1.year,
                                                  sentence_start_date: Time.zone.today)
-          o.case_allocation = 'NPS'
-          o.mappa_level = 0
+          o.load_case_information(build(:case_information, case_allocation: 'NPS', mappa_level: 0))
         }
       }
 
@@ -18,7 +17,12 @@ describe Nomis::Offender do
     end
 
     context 'when COM responsible already' do
-      let(:offender) { build(:offender).tap { |o| o.sentence = Nomis::SentenceDetail.new } }
+      let(:offender) {
+        build(:offender).tap { |o|
+          o.sentence = Nomis::SentenceDetail.new
+          o.load_case_information(build(:case_information))
+        }
+      }
 
       it 'doesnt has a value' do
         expect(offender.handover_start_date).to eq(nil)

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -18,6 +18,7 @@ describe AllocationService do
     let(:message) { 'Additional text' }
 
     let!(:allocation) {
+      create(:case_information, nomis_offender_id: nomis_offender_id)
       create(:allocation,
              nomis_offender_id: nomis_offender_id,
              primary_pom_nomis_id: primary_pom_id,
@@ -95,6 +96,7 @@ describe AllocationService do
 
     context 'when one already exists' do
       before do
+        create(:case_information, nomis_offender_id: nomis_offender_id)
         create(:allocation, nomis_offender_id: nomis_offender_id)
       end
 

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe EmailService do
   include ActiveJob::TestHelper
 
+  before do
+    create(:case_information, nomis_offender_id: 'G2911GD')
+  end
+
   let(:allocation) {
     Allocation.new.tap do |a|
       a.primary_pom_nomis_id = 485_833

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -2,18 +2,27 @@ require 'rails_helper'
 
 describe RecommendationService do
   let(:tierA) {
-    build(:offender_summary, tier: 'A', sentence: Nomis::SentenceDetail.new(
-      sentence_start_date: Time.zone.today,
-      automatic_release_date: Time.zone.today + 15.months))
+    build(:offender_summary,
+          sentence: Nomis::SentenceDetail.new(
+            sentence_start_date: Time.zone.today,
+            automatic_release_date: Time.zone.today + 15.months)).tap { |o|
+      o.load_case_information(build(:case_information, tier: 'A'))
+    }
   }
   let(:tierD) {
-    build(:offender_summary, tier: 'D', sentence: Nomis::SentenceDetail.new(
-      sentence_start_date: Time.zone.today,
-      automatic_release_date: Time.zone.today + 10.months))
+    build(:offender_summary,
+          sentence: Nomis::SentenceDetail.new(
+            sentence_start_date: Time.zone.today,
+            automatic_release_date: Time.zone.today + 10.months)).tap { |o|
+      o.load_case_information(build(:case_information, tier: 'D'))
+    }
   }
 
   let(:tierA_and_immigration_case) {
-    build(:offender_summary, tier: 'A', inprisonment_status: 'DET', sentence: Nomis::SentenceDetail.new)
+    build(:offender_summary,
+          inprisonment_status: 'DET', sentence: Nomis::SentenceDetail.new).tap { |o|
+      o.load_case_information(build(:case_information, tier: 'A'))
+    }
   }
 
   it "can determine the best type of POM for Tier A" do


### PR DESCRIPTION
Currently any offender without case_information data is in danger of being considered a 'CRC' case because the 'case_allocation' field in Nomis::OffenderBase can be set to nil. This PR changes that relationship so this is no longer possible, and fixes the main point in the codebase (SummaryController) which was in danger of creating this mis-calculation