### PR TITLE
use yarn install to install NPM modules everywhere consistently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,11 +146,8 @@ jobs:
             - allocation-manager-v2-{{ checksum "Gemfile.lock" }}
             - allocation-manager-v2-
       - run:
-          name: Update npm
-          command: 'sudo npm install -g npm@latest'
-      - run:
           name: Install GOV.UK frontend modules
-          command: npm install
+          command: yarn install
       - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
       - save_cache:
           key: allocation-manager-v2-{{ checksum "Gemfile.lock" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN \
     -y \
     --no-install-recommends \
     yarn=1.10.1-1 \
-  && yarn add govuk-frontend
+  && yarn install
 
 COPY Gemfile Gemfile.lock package.json ./
 


### PR DESCRIPTION
Some NPM (& yarn) strangeness found after discussions about NPM vs YARN. 

This PR tidies up and makes sure that we use yarn everywhere and do so consistently and correctly