### PR TITLE
Fixup tests missing VCR tags

### DIFF
--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -149,13 +149,13 @@ feature "view an offender's allocation information", :versioning do
       end
     end
 
-    context 'without auto_delius_import enabled' do
+    context 'without auto_delius_import enabled', vcr: { cassette_name: :allocation_auto_delius_off } do
       it 'displays change links' do
         expect(page).to have_content 'Change'
       end
     end
 
-    context 'with auto_delius_import enabled' do
+    context 'with auto_delius_import enabled', vcr: { cassette_name: :allocation_auto_delius_on } do
       let(:test_strategy) { Flipflop::FeatureSet.current.test! }
 
       before do

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "ChangeParoleReviewDates", :versioning, type: :feature do
     signin_user
   end
 
-  it 'updates the date' do
+  it 'updates the date',  vcr: { cassette_name: :change_parole_date } do
     visit prison_allocation_path('LEI', nomis_offender_id)
 
     click_link 'Update'
@@ -26,7 +26,7 @@ RSpec.feature "ChangeParoleReviewDates", :versioning, type: :feature do
     expect(case_info.reload.parole_review_date).to eq(Date.new(year, 5, 13))
   end
 
-  it 'bounces properly' do
+  it 'bounces properly', vcr: { cassette_name: :change_parole_date_bounce } do
     visit prison_allocation_path('LEI', nomis_offender_id)
 
     click_link 'Update'

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -72,7 +72,7 @@ feature 'Provide debugging information for our team to use' do
     end
   end
 
-  context 'when debugging at a prison level' do
+  context 'when debugging at a prison level', vcr: { cassette_name: :debugging_prison_level } do
     it 'displays a dashboard' do
       signin_user
       visit prison_debugging_prison_path('LEI')

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -177,6 +177,9 @@ feature "view POM's caseload" do
 
   it 'allows a POM to view the prisoner profile page for a specific offender' do
     signin_pom_user
+    stub_offender(first_offender.fetch(:offenderNo))
+    stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/LEI/offender/#{first_offender.fetch(:offenderNo)}").
+      to_return(body: { staffId: 485_572, firstName: "DOM", lastName: "BULL" }.to_json)
     visit prison_caseload_index_path(prison)
 
     expected_name = "#{first_offender.fetch(:lastName)}, #{first_offender.fetch(:firstName)}"

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -12,7 +12,7 @@ feature 'Search for offenders' do
       test_strategy.switch!(:auto_delius_import, false)
     end
 
-    it 'shows update not edit' do
+    it 'shows update not edit', vcr: { cassette_name: :search_update_edit } do
       signin_user
       visit prison_summary_allocated_path('LEI')
 
@@ -33,7 +33,7 @@ feature 'Search for offenders' do
       test_strategy.switch!(:auto_delius_import, false)
     end
 
-    it 'shows update not edit' do
+    it 'shows update not edit', vcr: { cassette_name: :search_update_edit_no_delius } do
       signin_user
       visit prison_summary_allocated_path('LEI')
 


### PR DESCRIPTION
The recent changes to Elite2 API resulted in a number of test failures due to a lack of recording interactions in certain tests with VCR.
This PR fixes up those tests so that they now use VCR to record their interactions, which should result in quicker local tests as no-one is now going to Elite2 in 'local' mode unless they are changing the interactions with the Elite2 API.