### PR TITLE
POM-511 Part 1a - add probation_service column

### DIFF
--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -13,6 +13,8 @@ class CaseInformation < ApplicationRecord
 
   scope :nps, -> { where(case_allocation: 'NPS') }
 
+  before_validation :set_probation_service
+
   def local_divisional_unit
     team.try(:local_divisional_unit)
   end
@@ -43,4 +45,16 @@ class CaseInformation < ApplicationRecord
   # nil means MAPPA level is completely unknown.
   # 0 means MAPPA level is known to be not relevant for offender
   validates :mappa_level, inclusion: { in: [0, 1, 2, 3], allow_nil: true }
+
+  validates :probation_service, inclusion: {
+    in: ['Wales', 'England'],
+    allow_nil: false
+  }
+
+private
+
+  def set_probation_service
+    self.probation_service = 'England' if welsh_offender == 'No'
+    self.probation_service = 'Wales' if welsh_offender == 'Yes'
+  end
 end

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -16,9 +16,11 @@ module Nomis
     attr_accessor :crn,
                   :allocated_pom_name, :case_allocation,
                   :allocated_com_name,
-                  :welsh_offender, :tier, :parole_review_date,
+                  :tier, :parole_review_date,
                   :sentence, :mappa_level,
                   :ldu, :team
+
+    attr_reader :welsh_offender
 
     def convicted?
       convicted_status == 'Convicted'

--- a/db/migrate/20200304155347_add_probation_service_to_case_information.rb
+++ b/db/migrate/20200304155347_add_probation_service_to_case_information.rb
@@ -1,0 +1,5 @@
+class AddProbationServiceToCaseInformation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :case_information, :probation_service, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_165050) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date "parole_review_date"
+    t.string "probation_service"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id", unique: true
     t.index ["team_id"], name: "index_case_information_on_team_id"
   end

--- a/lib/tasks/backfill_probation_service.rake
+++ b/lib/tasks/backfill_probation_service.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :backfill do
+  desc 'Back-fill case_information#probation_service from welsh_offender'
+  task probation_service: :environment do
+    CaseInformation.where(probation_service: nil).find_each do |ci|
+      ci.update!(probation_service: ci.welsh_offender ? 'Wales' : 'England')
+    end
+  end
+end


### PR DESCRIPTION
This creates the new probation_service column in case_information, adds a task to back-fill it from welsh_offender and starts to populate it for all new and edited case information records