### PR TITLE
Pom511 Part1b - stop using welsh_offender column

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -51,7 +51,7 @@ class CaseInformationController < PrisonsApplicationController
     @case_info = CaseInformation.create(
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
-      welsh_offender: case_information_params[:welsh_offender],
+      probation_service: case_information_params[:probation_service],
       case_allocation: case_information_params[:case_allocation],
       manual_entry: true
     )
@@ -99,7 +99,7 @@ private
 
   def case_information_params
     params.require(:case_information).
-      permit(:nomis_offender_id, :tier, :case_allocation, :welsh_offender,
+      permit(:nomis_offender_id, :tier, :case_allocation, :probation_service,
              :parole_review_date_dd, :parole_review_date_mm, :parole_review_date_yyyy)
   end
 

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -79,7 +79,7 @@ private
         tier: map_tier(delius_record.tier),
         team: team,
         case_allocation: delius_record.service_provider,
-        welsh_offender: map_welsh_offender(delius_record.welsh_offender?),
+        probation_service: map_probation_service(delius_record.welsh_offender?),
         mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
       )
     end
@@ -107,8 +107,8 @@ private
     end
   end
 
-  def map_welsh_offender(welsh_offender)
-    welsh_offender ? 'Yes' : 'No'
+  def map_probation_service(welsh_offender)
+    welsh_offender ? 'Wales' : 'England'
   end
 
   def map_tier(tier)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -13,8 +13,6 @@ class CaseInformation < ApplicationRecord
 
   scope :nps, -> { where(case_allocation: 'NPS') }
 
-  before_validation :set_probation_service
-
   def local_divisional_unit
     team.try(:local_divisional_unit)
   end
@@ -50,13 +48,11 @@ class CaseInformation < ApplicationRecord
 
   validates :probation_service, inclusion: {
     in: ['Wales', 'England'],
-    allow_nil: false
+    allow_nil: false,
+    message: 'Select yes if the prisoner’s last known address was in Wales'
   }
 
-private
-
-  def set_probation_service
-    self.probation_service = 'England' if welsh_offender == 'No'
-    self.probation_service = 'Wales' if welsh_offender == 'Yes'
+  def welsh?
+    probation_service == 'Wales'
   end
 end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -27,11 +27,6 @@ class CaseInformation < ApplicationRecord
 
   validates :team, presence: true, unless: -> { manual_entry }
 
-  validates :welsh_offender, inclusion: {
-    in: %w[Yes No],
-    allow_nil: false,
-    message: 'Select yes if the prisoner’s last known address was in Wales'
-  }
   # Don't think this is as simple as allowing nil. In the specific case of Scot/NI
   # prisoners it makes sense to have N/A (as this is genuine) but not otherwise
   validates :tier, inclusion: { in: %w[A B C D N/A], message: 'Select the prisoner’s tier' }

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -142,7 +142,7 @@ module Nomis
 
       @tier = record.tier
       @case_allocation = record.case_allocation
-      @welsh_offender = record.welsh_offender == 'Yes'
+      @welsh_offender = record.welsh?
       @crn = record.crn
       @mappa_level = record.mappa_level
       @ldu = record.local_divisional_unit

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -4,7 +4,7 @@
     <%= hidden_field_tag("sort", params[:sort])%>
     <%= hidden_field_tag("page", params[:page]) %>
 
-    <div class="govuk-form-group <% if @case_info.errors[:welsh_offender].present? %>govuk-form-group--error<% end %>">
+    <div class="govuk-form-group <% if @case_info.errors[:probation_service].present? %>govuk-form-group--error<% end %>">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-2">
           Was this prisoner's last known address in Wales?
@@ -13,20 +13,20 @@
           Only prisoners with a Welsh address will be allocated a responsible<br/> prison or probation POM.
         </p>
 
-        <% if @case_info.errors[:welsh_offender].present? %>
+        <% if @case_info.errors[:probation_service].present? %>
           <span class="govuk-error-message">
-            <%= @case_info.errors[:welsh_offender].first %>
+            <%= @case_info.errors[:probation_service].first %>
           </span>
         <% end %>
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[welsh_offender]", 'Yes', @case_info.welsh_offender == 'Yes', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[welsh_offender]", 'Yes', class: "govuk-label govuk-radios__label" %>
+            <%= radio_button_tag("case_information[probation_service]", 'Wales', @case_info.probation_service == 'Wales', class: "govuk-radios__input") %>
+            <%= label_tag "case_information[probation_service]", 'Yes', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[welsh_offender]", 'No', @case_info.welsh_offender == 'No', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[welsh_offender]", "No", class: "govuk-label govuk-radios__label" %>
+            <%= radio_button_tag("case_information[probation_service]", 'England', @case_info.probation_service == 'England', class: "govuk-radios__input") %>
+            <%= label_tag "case_information[probation_service]", "No", class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,33 +76,33 @@ team3 = Team.find_or_create_by!(
 # responsibility override workflow
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G7658UL') do |info|
-    info.tier = 'A'
-    info.case_allocation = 'NPS'
-    info.welsh_offender = 'Yes'
-    info.manual_entry =  true
-    info.team_id = team1.id
+  info.tier = 'A'
+  info.case_allocation = 'NPS'
+  info.manual_entry =  true
+  info.team_id = team1.id
+  info.probation_service = "Wales"
 end
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G7517GF') do |info|
   info.tier = 'B'
-    info.case_allocation = 'NPS'
-    info.welsh_offender = 'Yes'
-    info.manual_entry = true
-    info.team_id = team2.id
+  info.case_allocation = 'NPS'
+  info.manual_entry = true
+  info.team_id = team2.id
+  info.probation_service = "Wales"
 end
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G3536UF') do |info|
   info.tier = 'A'
   info.case_allocation = 'NPS'
-  info.welsh_offender = 'No'
   info.manual_entry = true
   info.team_id = team2.id
+  info.probation_service = "England"
 end
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G2260UO') do |info|
   info.tier = 'B'
   info.case_allocation = 'NPS'
-  info.welsh_offender = 'No'
   info.manual_entry = true
   info.team_id = team3.id
+  info.probation_service = "England"
 end

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -22,14 +22,13 @@ class OnboardPrison
       end
 
       # Create a CaseInformation .....
-      CaseInformation.find_or_create_by(
-        nomis_offender_id: offender_id,
-        welsh_offender: record[:welsh_offender] ? 'Yes' : 'No',
-        tier: record[:tier],
-        case_allocation: record[:provider_cd],
-        crn: record[:crn],
-        manual_entry: true
-      )
+      CaseInformation.find_or_create_by(nomis_offender_id: offender_id) do |ci|
+        ci.tier = record[:tier]
+        ci.case_allocation = record[:provider_cd]
+        ci.crn = record[:crn]
+        ci.probation_service = record[:welsh_offender] ? 'England' : 'Wales'
+        ci.manual_entry = true
+      end
 
       @additions += 1
     }

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -6,10 +6,6 @@ FactoryBot.define do
       'A'
     end
 
-    welsh_offender do
-      'Yes'
-    end
-
     case_allocation do
       'NPS'
     end
@@ -28,6 +24,15 @@ FactoryBot.define do
 
     association :team, code: '1234', name: 'A nice team'
 
-    crn { Faker::Alphanumeric.alpha(number: 10) }
+    crn do Faker::Alphanumeric.alpha(number: 10) end
+
+    probation_service do
+      'Wales'
+    end
+
+    trait :no_team do
+      probation_service { 'Scotland' }
+      team { nil }
+    end
   end
 end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -16,7 +16,7 @@ feature 'Allocation' do
   }
 
   let!(:case_information) {
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'No')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', probation_service: 'England')
     create(:case_information, nomis_offender_id: never_allocated_offender)
   }
 

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -14,7 +14,7 @@ feature 'case information feature' do
     end
     visit new_prison_case_information_path('LEI', nomis_offender_id)
 
-    choose('case_information_welsh_offender_Yes')
+    choose('case_information_probation_service_Wales')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'
@@ -91,7 +91,7 @@ feature 'case information feature' do
 
     signin_user
     visit new_prison_case_information_path('LEI', nomis_offender_id)
-    choose('case_information_welsh_offender_No')
+    choose('case_information_probation_service_England')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'
@@ -100,7 +100,7 @@ feature 'case information feature' do
 
     expect(page).to have_content('Case information')
     expect(page).to have_content('G1821VA')
-    choose('case_information_welsh_offender_No')
+    choose('case_information_probation_service_England')
     choose('case_information_case_allocation_CRC')
     click_button 'Update'
 
@@ -123,7 +123,7 @@ feature 'case information feature' do
     end
     expect(page).to have_selector('h1', text: 'Case information')
 
-    choose('case_information_welsh_offender_No')
+    choose('case_information_probation_service_England')
     choose('case_information_case_allocation_NPS')
     choose('case_information_tier_A')
     click_button 'Save'

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -67,7 +67,7 @@ feature "view POM's caseload" do
       create(:case_information, nomis_offender_id: nomis_offender_id)
       create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, nomis_booking_id: nomis_booking_id)
     end
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', probation_service: 'Wales')
     create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, nomis_booking_id: 1_153_753)
 
     offenders.last(15).each do |o|

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -145,7 +145,7 @@ context 'when NOMIS is missing information' do
           :case_information,
           nomis_offender_id: offender_no,
           case_allocation: 'NPS',
-          welsh_offender: welsh
+          probation_service: welsh == 'Yes' ? 'Wales' : 'England'
         )
       end
 

--- a/spec/lib/onboard_prison_spec.rb
+++ b/spec/lib/onboard_prison_spec.rb
@@ -17,13 +17,13 @@ describe OnboardPrison do
              nomis_offender_id: 'G5054VN',
              tier: 'A',
              case_allocation: 'NPS',
-             welsh_offender: 'Yes'
+             probation_service: 'Wales'
       )
       create(:case_information,
              nomis_offender_id: 'G9468UN',
              tier: 'C',
              case_allocation: 'CRC',
-             welsh_offender: 'Yes'
+             probation_service: 'Wales'
       )
 
       op = described_class.new('PVI', offender_ids, nil)

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe CaseInformation, type: :model do
       build(:case_information, tier: nil)
     }
 
-    it 'gives the correct message' do
+    it 'gives the correct error message' do
       expect(subject).not_to be_valid
       expect(subject.errors.messages).to eq(tier: ['Select the prisoner’s tier'])
     end
@@ -77,6 +77,25 @@ RSpec.describe CaseInformation, type: :model do
   context 'with null manual flag' do
     it 'wont be valid' do
       expect(build(:case_information, manual_entry: nil)).not_to be_valid
+    end
+  end
+
+  context 'when probation service' do
+    subject {
+      build(:case_information, probation_service: nil)
+    }
+
+    it 'gives the correct validation error message' do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages).
+        to eq(probation_service: ["Select yes if the prisoner’s last known address was in Wales"])
+    end
+
+    it 'allows England, Wales' do
+      ['England', 'Wales'].each do |service|
+        subject.probation_service = service
+        expect(subject).to be_valid
+      end
     end
   end
 end

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -6,7 +6,7 @@ describe CaseInformationService do
            nomis_offender_id: 'X1000XX',
            tier: 'A',
            case_allocation: 'NPS',
-           welsh_offender: 'Yes'
+           probation_service: 'Wales'
     )
   }
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -4,7 +4,7 @@ describe OffenderService do
   it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
     nomis_offender_id = 'G4273GI'
 
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_offender: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', probation_service: 'Wales')
     offender = described_class.get_offender(nomis_offender_id)
 
     expect(offender).to be_kind_of(Nomis::OffenderBase)


### PR DESCRIPTION
This PR stops using the old welsh_offender column, as this data can now be calculated by using the new probation_service column. Before this PR can be deployed, the rake task backfill:probation_service needs to be run so that all the case_information records have probation_service populated 