### PR TITLE
POM-766 Part 1 - remove unused methods

### DIFF
--- a/app/models/nomis/offender.rb
+++ b/app/models/nomis/offender.rb
@@ -4,19 +4,17 @@ module Nomis
   class Offender < OffenderBase
     include Deserialisable
 
-    attr_accessor :gender,
-                  :main_offence,
-                  :nationalities,
-                  :noms_id,
-                  :prison_id
+    attr_accessor :main_offence
 
-    attr_reader :reception_date
+    attr_reader :reception_date, :prison_id
 
-    def initialize(fields = nil)
+    def initialize(fields = {})
       # Allow this object to be reconstituted from a hash, we can't use
       # from_json as the one passed in will already be using the snake case
       # names whereas from_json is expecting the elite2 camelcase names.
-      fields.each { |k, v| public_send("#{k}=", v) } if fields.present?
+      fields.each do |k, v|
+        instance_variable_set("@#{k}", v)
+      end
     end
 
     def self.from_json(payload)
@@ -26,11 +24,7 @@ module Nomis
     end
 
     def load_from_json(payload)
-      @gender = payload['gender']
       @booking_id = payload['latestBookingId']&.to_i
-      @main_offence = payload['mainOffence']
-      @nationalities = payload['nationalities']
-      @noms_id = payload['nomsId']
       @prison_id = payload['latestLocationId']
       @reception_date = deserialise_date(payload, 'receptionDate')
 

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -8,19 +8,16 @@ module Nomis
              :post_recall_release_date, :earliest_release_date,
              to: :sentence
 
-    attr_accessor :convicted_status, :booking_id,
-                  :category_code, :offender_no, :date_of_birth,
-                  :first_name, :last_name
+    attr_accessor :category_code, :date_of_birth
 
-    # Custom attributes
-    attr_accessor :crn,
-                  :allocated_pom_name, :case_allocation,
-                  :allocated_com_name,
-                  :tier, :parole_review_date,
-                  :sentence, :mappa_level,
-                  :ldu, :team
+    attr_reader :first_name, :last_name, :booking_id,
+                :offender_no, :convicted_status
 
-    attr_reader :welsh_offender
+    attr_accessor :sentence, :allocated_pom_name, :allocated_com_name, :case_allocation, :mappa_level, :tier
+
+    attr_reader :crn,
+                :welsh_offender, :parole_review_date,
+                :ldu, :team
 
     def convicted?
       convicted_status == 'Convicted'
@@ -123,7 +120,7 @@ module Nomis
       # method from it's own internal from_json
       @first_name = payload['firstName']
       @last_name = payload['lastName']
-      @offender_no = payload['offenderNo']
+      @offender_no = payload.fetch('offenderNo')
       @convicted_status = payload['convictedStatus']
       @sentence_type = SentenceType.new(payload['imprisonmentStatus'])
       @category_code = payload['categoryCode']

--- a/app/models/nomis/offender_summary.rb
+++ b/app/models/nomis/offender_summary.rb
@@ -4,12 +4,9 @@ module Nomis
   class OffenderSummary < OffenderBase
     include Deserialisable
 
-    attr_accessor :aliases
-
-    # custom attributes
     attr_accessor :allocation_date, :prison_arrival_date
 
-    attr_reader :prison_id
+    attr_reader :prison_id, :facial_image_id
 
     def awaiting_allocation_for
       (Time.zone.today - prison_arrival_date.to_date).to_i
@@ -22,9 +19,9 @@ module Nomis
     end
 
     def load_from_json(payload)
-      @aliases = payload['aliases']
-      @booking_id = payload['bookingId']&.to_i
+      @booking_id = payload.fetch('bookingId').to_i
       @prison_id = payload['agencyId']
+      @facial_image_id = payload['facialImageId']&.to_i
 
       super(payload)
     end

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -40,8 +40,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
 
     before do
       stub_poms(prison, poms)
-      stub_sso_pom_data(prison, 'alice')
-      stub_signed_in_pom(1, 'Alice')
+      stub_signed_in_pom(prison, 1, 'Alice')
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
         to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
     end

--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe CaseloadController, type: :controller do
 
   before do
     stub_poms(prison, poms)
-    stub_sso_pom_data(prison, 'alice')
-    stub_signed_in_pom(staff_id, 'alice')
+    stub_signed_in_pom(prison, staff_id, 'alice')
   end
 
   describe '#handover_start' do

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,26 +1,29 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DashboardController, type: :controller do
-  describe '#index' do
-    let(:prison) { 'LEI' }
-    let(:poms) {
-      [
-        build(:pom,
-              firstName: 'Alice',
-              position: RecommendationService::PRISON_POM,
-              staffId: 1
+  let(:prison) { build(:prison).code }
+  let(:poms) {
+    [
+      build(:pom,
+            firstName: 'Alice',
+            position: RecommendationService::PRISON_POM,
+            staffId: 1
       )
-      ]
-    }
+    ]
+  }
 
+  before do
+    stub_poms(prison, poms)
+  end
+
+  describe '#index' do
     context 'when logged in as POM' do
       render_views
 
       before do
-        stub_auth_token
-        stub_poms(prison, poms)
-        stub_sso_pom_data(prison, 'alice')
-        stub_signed_in_pom(1, 'alice')
+        stub_signed_in_pom(prison, 1, 'alice')
       end
 
       it 'shows me only Manage case tasks' do
@@ -48,12 +51,9 @@ RSpec.describe DashboardController, type: :controller do
       render_views
 
       before do
-        stub_poms(prison, poms)
         stub_sso_data(prison, 'alice')
-        stub_signed_in_pom(1, 'Alice')
-        stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
-          with(headers: { 'Authorization' => 'Bearer token' }).
-          to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
+        stub_request(:get, "#{ApiHelper::T3}/users/").
+          to_return(body: { staffId: 1 }.to_json)
       end
 
       it 'shows me only SPO tasks' do

--- a/spec/controllers/poms_controller_spec.rb
+++ b/spec/controllers/poms_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PomsController, type: :controller do
       missing_offender = create(:case_information)
       create(:allocation, nomis_offender_id: missing_offender.nomis_offender_id, primary_pom_nomis_id: active_staff_id, prison: prison.code)
 
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/#{active_staff_id}").
+      stub_request(:get, "#{ApiHelper::T3}/staff/#{active_staff_id}").
         to_return(body: { staffId: active_staff_id, lastName: 'LastName', firstName: 'FirstName' }.to_json)
 
       offenders = offenderNos.map.with_index { |nomis_id, index|

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe SearchController, type: :controller do
 
     before do
       stub_poms(prison, poms)
-      stub_sso_pom_data(prison, 'alice')
-      stub_signed_in_pom(1, 'Alice')
+      stub_signed_in_pom(prison, 1, 'Alice')
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
         with(headers: { 'Authorization' => 'Bearer token' }).
         to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -96,8 +96,7 @@ RSpec.describe SummaryController, type: :controller do
     context 'when user is a POM' do
       before do
         stub_poms(prison, poms)
-        stub_sso_pom_data(prison, 'alice')
-        stub_signed_in_pom(1, 'Alice')
+        stub_signed_in_pom(prison, 1, 'Alice')
         stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
           to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
       end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe TasksController, type: :controller do
   let(:next_week) { Time.zone.today + 7.days }
 
   before do
-    stub_sso_pom_data(prison, username)
-
     stub_poms(prison, pom)
-    stub_signed_in_pom(staff_id, username)
+    stub_signed_in_pom(prison, staff_id, username)
 
     offenders = [
       { "bookingId": 754_207, "offenderNo": "G7514GW", "firstName": "Alice", "lastName": "Aliceson",

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -23,9 +23,12 @@ FactoryBot.define do
   end
 
   factory :pom, class: 'Elite2POM' do
-    position do 'PRO' end
-    sequence(:emails) do |x| ["staff#{x}@justice.gov.uk"]  end
-    sequence(:staffId) do |x| x + 1  end
+    position { 'PRO' }
+    sequence(:emails) { |x| ["staff#{x}@justice.gov.uk"]  }
+    sequence(:staffId) { |x| x + 1000  }
+
+    firstName { Faker::Name.first_name }
+    lastName { Faker::Name.last_name }
 
     trait :probation_officer do
       position { 'PO' }

--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   class Elite2Prison
-    attr_accessor :code
+    attr_accessor :code, :name
   end
 
   factory :prison, class: 'Elite2Prison' do
@@ -9,5 +9,7 @@ FactoryBot.define do
       codes = PrisonService.prison_codes
       codes[c % codes.size]
     end
+
+    name { PrisonService.name_for(code) }
   end
 end

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -3,20 +3,19 @@ require 'rails_helper'
 RSpec.describe MovementsOnDateJob, type: :job do
   let(:nomis_offender_id) { 'G3462VT' }
   let!(:alloc) { create(:allocation, nomis_offender_id: nomis_offender_id, secondary_pom_nomis_id: 123_435, prison: 'MDI') }
-  let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
 
   before do
     stub_auth_token
   end
 
   it 'deallocates' do
-    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap { |o|
-      o.convicted_status = "Convicted"
-      o.date_of_birth = "Tue, 17 Sep 1991"
-      o.inprisonment_status = 'SENT03'
-    })
+    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new(
+                                                                  convicted_status: "Convicted",
+                                                                  date_of_birth: "Tue, 17 Sep 1991",
+                                                                  inprisonment_status: 'SENT03')
+    )
 
-    stub_request(:get, "#{elite2api}/movements?fromDateTime=2019-06-29T00:00&movementDate=2019-06-30").
+    stub_request(:get, "#{ApiHelper::T3}/movements?fromDateTime=2019-06-29T00:00&movementDate=2019-06-30").
       to_return(status: 200, body: [
         { offenderNo: nomis_offender_id,
           fromAgency: "MDI",

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
   end
 
   it 'does not send an email if the offender case_information is not NPS' do
-    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap { |o|
-      o.prison_id = open_prison_code
-      o.offender_no =  nomis_offender_id
-      o.case_allocation = 'CRC'
-    })
+    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new(
+                                                                  case_allocation: 'CRC',
+                                                                  prison_id: open_prison_code,
+                                                                  offender_no:  nomis_offender_id
+    ))
     described_class.perform_now(movement_json)
 
     email_job = enqueued_jobs.first
@@ -53,11 +53,10 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
   end
 
   it 'does not send an email when no LDU email address' do
-    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap { |o|
-      o.prison_id = open_prison_code
-      o.offender_no =  nomis_offender_id
-      o.case_allocation = 'NPS'
-    })
+    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new(
+                                                                  case_allocation: 'NPS',
+                                                                  prison_id: open_prison_code,
+                                                                  offender_no: nomis_offender_id))
 
     described_class.perform_now(movement_json)
 
@@ -66,14 +65,14 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
   end
 
   it 'sends an email when there was no previous allocation' do
-    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap { |o|
-      o.prison_id = open_prison_code
-      o.offender_no =  nomis_offender_id
-      o.case_allocation = 'NPS'
-      o.ldu = LocalDivisionalUnit.new.tap { |l| l.email_address = 'ldu@local.local' }
-      o.first_name = 'First'
-      o.last_name = 'Last'
-    })
+    allow(OffenderService).to receive(:get_offender).
+      and_return(Nomis::Offender.new(prison_id: open_prison_code,
+                                     offender_no: nomis_offender_id,
+                                     first_name: 'First',
+                                     last_name: 'Last',
+                                     case_allocation: 'NPS',
+                                     ldu: LocalDivisionalUnit.new.tap { |l| l.email_address = 'ldu@local.local' }
+                                     ))
 
     fakejob = double
     allow(fakejob).to receive(:deliver_later)
@@ -91,14 +90,12 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
   end
 
   it 'can use previous allocation details where they exist', versioning: true do
-    allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap { |o|
-      o.prison_id = open_prison_code
-      o.offender_no =  nomis_offender_id
-      o.case_allocation = 'NPS'
-      o.ldu = LocalDivisionalUnit.new.tap { |l| l.email_address = 'ldu@local.local' }
-      o.first_name = 'First'
-      o.last_name = 'Last'
-    })
+    allow(OffenderService).to receive(:get_offender).
+      and_return(Nomis::Offender.new(prison_id: open_prison_code,
+                                     offender_no: nomis_offender_id,
+                                     first_name: 'First',
+                                     last_name: 'Last', case_allocation: 'NPS',
+                                     ldu: LocalDivisionalUnit.new.tap { |l| l.email_address = 'ldu@local.local' }))
 
     # Create an allocation where the offender is allocated, and then deallocate so we can
     # test finding the last pom that was allocated to this offender ....

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -148,9 +148,7 @@ describe MovementService do
       # who were moved were not de-allocated (as they should never have been allocated).  This
       # optimisation has come back to bite us as it is entirely possible someone who is allocated
       # could be switched to remand immediately, so now we expect this to succeed.
-      allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new.tap { |o|
-        o.convicted_status = "Remand"
-      })
+      allow(OffenderService).to receive(:get_offender).and_return(Nomis::Offender.new(convicted_status: "Remand"))
       processed = described_class.process_movement(transfer_in)
       expect(processed).to be true
     end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module ApiHelper
-  T3 = 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api'
+  T3_HOST = Rails.configuration.nomis_oauth_host
+  T3 = "#{T3_HOST}/elite2api/api"
 
   def stub_offender(nomis_id, booking_number: 754_165, imprisonment_status: 'SENT03', dob: "1985-03-19")
     stub_request(:get, "#{T3}/prisoners/#{nomis_id}").
@@ -50,13 +51,14 @@ module ApiHelper
 
   def stub_pom_emails(staff_id, emails)
     stub_request(:get, "#{T3}/staff/#{staff_id}/emails").
-      to_return(status: 200, body: emails.to_json)
+      to_return(body: emails.to_json)
   end
 
-  def stub_signed_in_pom(staff_id, username)
+  def stub_signed_in_pom(prison, staff_id, username)
     stub_auth_token
+    stub_sso_data(prison, username, 'ROLE_ALLOC_CASE_MGR')
     stub_request(:get, "#{T3}/users/#{username}").
-      to_return(status: 200, body: { 'staffId': staff_id }.to_json)
+      to_return(body: { 'staffId': staff_id }.to_json)
   end
 
   def stub_offenders_for_prison(prison, offenders, bookings)

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -2,32 +2,24 @@
 
 module AuthHelper
   T3 = 'https://gateway.t3.nomis-api.hmpps.dsd.io'
-  ACCESS_TOKEN = 'an access token'
+  ACCESS_TOKEN = Struct.new(:access_token).new('an-access-token')
 
   def stub_auth_token
-    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(OpenStruct.new(access_token: ACCESS_TOKEN))
+    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
 
     stub_request(:post, "#{T3}/auth/oauth/token?grant_type=client_credentials").
-      to_return(status: 200, body: {
-        "access_token": ACCESS_TOKEN,
+      to_return(body: {
+        "access_token": ACCESS_TOKEN.access_token,
         "token_type": "bearer",
         "expires_in": 1199,
         "scope": "readwrite"
-      }.to_json, headers: {})
+      }.to_json)
   end
 
-  def stub_sso_data(prison, username = 'user')
-    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(OpenStruct.new(access_token: 'token'))
+  def stub_sso_data(prison, username = 'user', role = 'ROLE_ALLOC_MGR')
+    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
     session[:sso_data] = { 'expiry' => Time.zone.now + 1.day,
-                           'roles' => ['ROLE_ALLOC_MGR'],
-                           'caseloads' => [prison],
-                           'username' => username }
-  end
-
-  def stub_sso_pom_data(prison, username)
-    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(OpenStruct.new(access_token: 'token'))
-    session[:sso_data] = { 'expiry' => Time.zone.now + 1.day,
-                           'roles' => ['ROLE_ALLOC_CASE_MGR'],
+                           'roles' => [role],
                            'caseloads' => [prison],
                            'username' => username }
   end


### PR DESCRIPTION
After reviewing POM-766, I thought it was better to split it into 2 PRs.
This first one should be simple and straightforward to merge, the second is more invasive on existing tests so I wanted to keep it seperate to help avoid merge and rebase issues