### PR TITLE
Pom 746 debugging page fields

### DIFF
--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -32,6 +32,7 @@ private
     return redirect_to('/401') if caseloads.nil? || !caseloads.include?(active_prison_id)
 
     @prison = Prison.new(active_prison_id)
+    @caseloads = caseloads
   end
 
   def pom_at_active_prison?

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -199,7 +199,7 @@
       </td>
     </tr>
     <tr class="govuk-table__row" id="licence-expiry-date">
-      <td class="govuk-table__cell">Sentence/ license end date</td>
+      <td class="govuk-table__cell">Sentence/ licence end date</td>
       <td class="govuk-table__cell table_cell__left_align">
         <%= format_date(@offender.licence_expiry_date, replacement: 'N/A') %>
       </td>

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -23,7 +23,7 @@
   </p>
   <% else %>
 
-<div class="govuk-!-margin-top-1">
+<div class="govuk-!-margin-top-1" id="prisoner-information">
   <table class="govuk-table">
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
@@ -124,7 +124,7 @@
     </tbody>
   </table>
 
-  <table class="govuk-table">
+  <table class="govuk-table" id="sentence-information">
     <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <td class="govuk-table__header govuk-!-width-one-half" scope="row">Sentence information</td>
@@ -190,6 +190,18 @@
       <td class="govuk-table__cell">Tariff date</td>
       <td class="govuk-table__cell table_cell__left_align">
         <%= format_date(@offender.tariff_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="post-recall-release-date">
+      <td class="govuk-table__cell">Post recall release date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.post_recall_release_date, replacement: 'N/A') %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="licence-expiry-date">
+      <td class="govuk-table__cell">Sentence/ license end date</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@offender.licence_expiry_date, replacement: 'N/A') %>
       </td>
     </tr>
     </tbody>

--- a/app/views/layouts/_prison_switcher.html.erb
+++ b/app/views/layouts/_prison_switcher.html.erb
@@ -1,4 +1,4 @@
-<% if show_prison_switcher?(caseloads) %>
+<% if show_prison_switcher?(@caseloads) %>
   <div class="govuk-phase-banner govuk-width-container app-site-
   width-container govuk-!-padding-bottom-0 prison-switcher">
       <h2 class="govuk-heading-m govuk-!-margin-0 govuk-!-padding-0">

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -44,4 +44,29 @@ FactoryBot.define do
       }
     }
   end
+
+  factory :offender_detail, class: 'Nomis::Offender' do
+    initialize_with { Nomis::Offender.from_json(attributes.stringify_keys) }
+
+    imprisonmentStatus { 'SENT03' }
+    prisonId { 'LEI' }
+
+    # offender numbers are of the form <letter><4 numbers><2 letters>
+    sequence(:offenderNo) do |seq|
+      number = seq / 26 + 1000
+      letter = ('A'..'Z').to_a[seq % 26]
+      # This and case_information should produce different values to avoid clashes
+      "T#{number}O#{letter}"
+    end
+    sequence(:bookingId) { |x| x + 700_000 }
+    convictedStatus { 'Convicted' }
+    dateOfBirth { Date.new(1990, 12, 6).to_s }
+    firstName { Faker::Name.first_name }
+    # We have some issues with corrupting the display
+    # of names containing Mc or Du :-(
+    # also ensure uniqueness as duplicate last names can cause issues
+    # in tests, as ruby sort isn't stable by default
+    sequence(:lastName) { |c| "#{Faker::Name.last_name.titleize}_#{c}" }
+    categoryCode { 'C' }
+  end
 end

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -44,29 +44,4 @@ FactoryBot.define do
       }
     }
   end
-
-  factory :offender_detail, class: 'Nomis::Offender' do
-    initialize_with { Nomis::Offender.from_json(attributes.stringify_keys) }
-
-    imprisonmentStatus { 'SENT03' }
-    prisonId { 'LEI' }
-
-    # offender numbers are of the form <letter><4 numbers><2 letters>
-    sequence(:offenderNo) do |seq|
-      number = seq / 26 + 1000
-      letter = ('A'..'Z').to_a[seq % 26]
-      # This and case_information should produce different values to avoid clashes
-      "T#{number}O#{letter}"
-    end
-    sequence(:bookingId) { |x| x + 700_000 }
-    convictedStatus { 'Convicted' }
-    dateOfBirth { Date.new(1990, 12, 6).to_s }
-    firstName { Faker::Name.first_name }
-    # We have some issues with corrupting the display
-    # of names containing Mc or Du :-(
-    # also ensure uniqueness as duplicate last names can cause issues
-    # in tests, as ruby sort isn't stable by default
-    sequence(:lastName) { |c| "#{Faker::Name.last_name.titleize}_#{c}" }
-    categoryCode { 'C' }
-  end
 end

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -72,7 +72,7 @@ feature 'Provide debugging information for our team to use' do
     end
   end
 
-  context 'when debugging at a prison level' do
+  context 'when debugging at a prison level', vcr: { cassette_name: :debugging_prison_level } do
     it 'displays a dashboard' do
       signin_user
       visit prison_debugging_prison_path('LEI')

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -12,7 +12,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 39)
+      expect(page).to have_css('tbody tr', count: 40)
       expect(page).to have_content("Not currently allocated")
 
       table_row = page.find(:css, 'tr.govuk-table__row#convicted', text: 'Convicted?')
@@ -34,7 +34,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 44)
+      expect(page).to have_css('tbody tr', count: 45)
 
       pom_table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
 

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -12,7 +12,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 40)
+      expect(page).to have_css('tbody tr', count: 41)
       expect(page).to have_content("Not currently allocated")
 
       table_row = page.find(:css, 'tr.govuk-table__row#convicted', text: 'Convicted?')
@@ -34,7 +34,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 45)
+      expect(page).to have_css('tbody tr', count: 46)
 
       pom_table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
 

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -72,7 +72,7 @@ feature 'Provide debugging information for our team to use' do
     end
   end
 
-  context 'when debugging at a prison level', vcr: { cassette_name: :debugging_prison_level } do
+  context 'when debugging at a prison level' do
     it 'displays a dashboard' do
       signin_user
       visit prison_debugging_prison_path('LEI')

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -1,14 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe "debugging/debugging", type: :view do
+  let(:offender) do
+    offender = build(:offender, firstName: 'John', lastName: 'Dory')
+    offender.sentence = Nomis::SentenceDetail.new(
+      sentence_start_date: Time.zone.today,
+      automatic_release_date: Time.zone.today + 10.months,
+      tariff_date: Date.new(2033, 8, 1),
+      nomis_post_recall_release_date: Date.new(2028, 11, 8),
+      licence_expiry_date: Date.new(2025, 10, 7))
+    return offender
+  end
+
+  let(:prison) { build(:prison) }
+
   describe "debugging/debugging.html.erb" do
     it "displays offender full_name" do
-      offender = build(:offender_detail, firstName: 'John', lastName: 'Dory')
-      offender.sentence = Nomis::SentenceDetail.new(
-        sentence_start_date: Time.zone.today,
-        automatic_release_date: Time.zone.today + 10.months)
-      prison = build(:prison)
-
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
 
@@ -21,13 +28,6 @@ RSpec.describe "debugging/debugging", type: :view do
 
   describe "debugging/debugging.html.erb" do
     it "displays tariff date" do
-      offender = build(:offender_detail)
-      offender.sentence = Nomis::SentenceDetail.new(
-        sentence_start_date: Time.zone.today,
-        automatic_release_date: Time.zone.today + 10.months,
-        tariff_date: Date.new(2033, 8, 1))
-      prison = build(:prison)
-
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
 
@@ -38,13 +38,6 @@ RSpec.describe "debugging/debugging", type: :view do
     end
 
     it "displays post recall release date" do
-      offender = build(:offender_detail)
-      offender.sentence = Nomis::SentenceDetail.new(
-        sentence_start_date: Time.zone.today,
-        automatic_release_date: Time.zone.today + 10.months,
-        nomis_post_recall_release_date: Date.new(2028, 11, 8))
-      prison = build(:prison)
-
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
 
@@ -55,13 +48,6 @@ RSpec.describe "debugging/debugging", type: :view do
     end
 
     it "displays licence end date" do
-      offender = build(:offender_detail)
-      offender.sentence = Nomis::SentenceDetail.new(
-        sentence_start_date: Time.zone.today,
-        automatic_release_date: Time.zone.today + 10.months,
-        licence_expiry_date: Date.new(2025, 10, 7))
-      prison = build(:prison)
-
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
 

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe "debugging/debugging", type: :view do
+
+  describe "debugging/debugging.html.erb" do
+
+    it "displays offender full_name" do
+      offender = build(:offender_detail, firstName:'John', lastName: 'Dory')
+      offender.sentence = Nomis::SentenceDetail.new(
+        sentence_start_date: Time.zone.today,
+        automatic_release_date: Time.zone.today + 10.months)
+      prison = build(:prison)
+
+      assign(:offender, OffenderPresenter.new(offender, nil))
+      assign(:prison, prison)
+  
+      render
+      page = Nokogiri::HTML(rendered)
+      full_name = page.css('#prisoner-information').css('#name').first
+      expect(full_name.text).to match /Dory, John/
+    end
+  end
+
+  describe "debugging/debugging.html.erb" do
+
+    it "displays tariff date" do
+      offender = build(:offender_detail)
+      offender.sentence = Nomis::SentenceDetail.new(
+        sentence_start_date: Time.zone.today,
+        automatic_release_date: Time.zone.today + 10.months,
+        tariff_date: Date.new(2033, 8, 1))
+      prison = build(:prison)
+      
+      assign(:offender, OffenderPresenter.new(offender, nil))
+      assign(:prison, prison)
+      
+      render
+      page = Nokogiri::HTML(rendered)
+      tariff_date = page.css('#sentence-information').css('#tariff-date').first
+      expect(tariff_date.text).to match '01/08/2033'
+    end
+
+    it "displays post recall release date" do
+      offender = build(:offender_detail)
+      offender.sentence = Nomis::SentenceDetail.new(
+        sentence_start_date: Time.zone.today,
+        automatic_release_date: Time.zone.today + 10.months,
+        nomis_post_recall_release_date: Date.new(2028, 11, 8))
+      prison = build(:prison)
+      
+      assign(:offender, OffenderPresenter.new(offender, nil))
+      assign(:prison, prison)
+
+      render
+      page = Nokogiri::HTML(rendered)
+      post_recall_release_date = page.css('#sentence-information').css('#post-recall-release-date').first
+      expect(post_recall_release_date.text).to match '08/11/2028'
+    end
+
+    it "displays licence end date" do
+      offender = build(:offender_detail)
+      offender.sentence = Nomis::SentenceDetail.new(
+        sentence_start_date: Time.zone.today,
+        automatic_release_date: Time.zone.today + 10.months, 
+        licence_expiry_date: Date.new(2025, 10, 7))
+      prison = build(:prison)
+      
+      assign(:offender, OffenderPresenter.new(offender, nil))
+      assign(:prison, prison)
+
+      render
+      page = Nokogiri::HTML(rendered)
+      licence_expiry_date = page.css('#sentence-information').css('#licence-expiry-date').first
+
+      expect(licence_expiry_date.text).to match '07/10/2025'
+    end
+  end
+end

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe "debugging/debugging", type: :view do
-
   describe "debugging/debugging.html.erb" do
-
     it "displays offender full_name" do
-      offender = build(:offender_detail, firstName:'John', lastName: 'Dory')
+      offender = build(:offender_detail, firstName: 'John', lastName: 'Dory')
       offender.sentence = Nomis::SentenceDetail.new(
         sentence_start_date: Time.zone.today,
         automatic_release_date: Time.zone.today + 10.months)
@@ -13,16 +11,15 @@ RSpec.describe "debugging/debugging", type: :view do
 
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
-  
+
       render
       page = Nokogiri::HTML(rendered)
       full_name = page.css('#prisoner-information').css('#name').first
-      expect(full_name.text).to match /Dory, John/
+      expect(full_name.text).to match(/Dory, John/)
     end
   end
 
   describe "debugging/debugging.html.erb" do
-
     it "displays tariff date" do
       offender = build(:offender_detail)
       offender.sentence = Nomis::SentenceDetail.new(
@@ -30,10 +27,10 @@ RSpec.describe "debugging/debugging", type: :view do
         automatic_release_date: Time.zone.today + 10.months,
         tariff_date: Date.new(2033, 8, 1))
       prison = build(:prison)
-      
+
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
-      
+
       render
       page = Nokogiri::HTML(rendered)
       tariff_date = page.css('#sentence-information').css('#tariff-date').first
@@ -47,7 +44,7 @@ RSpec.describe "debugging/debugging", type: :view do
         automatic_release_date: Time.zone.today + 10.months,
         nomis_post_recall_release_date: Date.new(2028, 11, 8))
       prison = build(:prison)
-      
+
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
 
@@ -61,10 +58,10 @@ RSpec.describe "debugging/debugging", type: :view do
       offender = build(:offender_detail)
       offender.sentence = Nomis::SentenceDetail.new(
         sentence_start_date: Time.zone.today,
-        automatic_release_date: Time.zone.today + 10.months, 
+        automatic_release_date: Time.zone.today + 10.months,
         licence_expiry_date: Date.new(2025, 10, 7))
       prison = build(:prison)
-      
+
       assign(:offender, OffenderPresenter.new(offender, nil))
       assign(:prison, prison)
 


### PR DESCRIPTION
This commit exposes two additional date fields in the ‘offence’ table on Debugging page