### PR TITLE
Pom757 redux

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 class CaseloadController < PrisonsApplicationController
-  before_action :ensure_pom
-  before_action :load_pom
+  before_action :ensure_signed_in_pom_is_this_pom, :load_pom
 
   breadcrumb -> { 'Your caseload' },
-             -> { prison_caseload_index_path(active_prison_id) }
+             -> { prison_staff_caseload_index_path(active_prison_id, staff_id) }
   breadcrumb -> { 'New cases' },
-             -> { new_prison_caseload_path(active_prison_id) }, only: [:new]
+             -> { new_prison_staff_caseload_path(active_prison_id, staff_id) }, only: [:new]
   breadcrumb -> { 'Cases close to handover' },
-             -> { prison_caseload_handover_start_path(active_prison_id) },
+             -> { prison_staff_caseload_handover_start_path(active_prison_id, staff_id) },
              only: [:handover_start]
 
   def index
@@ -84,13 +83,21 @@ private
   end
 
   def load_pom
-    @pom = PrisonOffenderManagerService.get_signed_in_pom_details(
-      current_user,
-      active_prison_id
-    )
+    @pom = StaffMember.new(params[:staff_id])
+  end
+
+  def ensure_signed_in_pom_is_this_pom
+    user = Nomis::Elite2::UserApi.user_details(current_user)
+    unless staff_id == user.staff_id || current_user_is_spo?
+      redirect_to '/401'
+    end
   end
 
   def page
     params.fetch('page', 1).to_i
+  end
+
+  def staff_id
+    params[:staff_id].to_i
   end
 end

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -5,7 +5,7 @@ class PrisonersController < PrisonsApplicationController
   before_action :load_offender, only: [:show]
 
   breadcrumb 'Your caseload',
-             -> { prison_caseload_index_path(active_prison_id) }, only: [:show]
+             -> { prison_staff_caseload_index_path(active_prison_id, @staff_id) }, only: [:show]
   breadcrumb -> { @offender.full_name },
              -> { '' }, only: [:show]
 

--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -3,7 +3,7 @@
 # This class is inherited by all controllers under the /prisons route
 # so that they have @prison and active_prison_id available
 class PrisonsApplicationController < ApplicationController
-  before_action :authenticate_user, :check_prison_access
+  before_action :authenticate_user, :check_prison_access, :load_staff_id
 
 protected
 
@@ -37,5 +37,10 @@ private
   def pom_at_active_prison?
     user = Nomis::Elite2::UserApi.user_details(current_user)
     StaffMember.new(user.staff_id).pom_at?(active_prison_id)
+  end
+
+  def load_staff_id
+    user = Nomis::Elite2::UserApi.user_details(current_user)
+    @staff_id = user.staff_id
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,7 @@ class SearchController < PrisonsApplicationController
     # and instead they should be redirected to the caseload search instead. If a user
     # is both SPO _and_ POM then we'll let them do an actionable search.
     unless current_user_is_spo?
-      redirect_to(prison_caseload_index_path(q: search_term)) && return
+      redirect_to(prison_staff_caseload_index_path(active_prison_id, @staff_id, q: search_term)) && return
     end
 
     @q = search_term

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -70,7 +70,7 @@ class EmailService
 private
 
   def url
-    @url ||= Rails.application.routes.url_helpers.prison_caseload_index_url(@allocation.prison)
+    @url ||= Rails.application.routes.url_helpers.prison_staff_caseload_index_url(@allocation.prison, @pom.staff_id)
   end
 
   def current_responsibility

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -18,7 +18,7 @@
       <div class="govuk-body">New cases</div>
       <div class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24 new-cases-count">
         <% if @new_cases_count > 0 %>
-          <%= link_to "#{@new_cases_count}", new_prison_caseload_path(@prison.code), class:"govuk-link"%>
+          <%= link_to "#{@new_cases_count}", new_prison_staff_caseload_path(@prison.code), class:"govuk-link"%>
         <% else %>
           0
         <% end %>
@@ -29,7 +29,7 @@
       <div class="govuk-body">Cases close to handover</div>
       <div class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-24 upcoming-handover-count">
         <% if @pending_handover_count > 0 %>
-          <%= link_to "#{@pending_handover_count}", prison_caseload_handover_start_path(@prison.code), class:"govuk-link"%>
+          <%= link_to "#{@pending_handover_count}", prison_staff_caseload_handover_start_path(@prison.code), class:"govuk-link"%>
         <% else %>
           0
         <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -72,7 +72,7 @@
     <div class="govuk-grid-column-one-third">
       <div class="wrapper">
         <h1 class="govuk-heading-s">
-          <%= link_to "See your caseload", prison_caseload_index_path(@prison.code), class:"govuk-link" %>
+          <%= link_to "See your caseload", prison_staff_caseload_index_path(@prison.code, @staff_id ), class:"govuk-link" %>
         </h1>
         <p class="govuk-body">All prisoners allocated to you.</p>
       </div>
@@ -80,7 +80,7 @@
     <div class="govuk-grid-column-one-third">
       <div class="wrapper">
         <h1 class="govuk-heading-s">
-          <%= link_to "See new allocations", new_prison_caseload_path(@prison.code), class:"govuk-link" %>
+          <%= link_to "See new allocations", new_prison_staff_caseload_path(@prison.code, @staff_id), class:"govuk-link" %>
         </h1>
         <p class="govuk-body">Prisoners allocated to you in the last seven days.</p>
       </div>
@@ -88,7 +88,7 @@
     <div class="govuk-grid-column-one-third">
       <div class="wrapper">
         <h1 class="govuk-heading-s">
-          <%= link_to "See cases close to handover", prison_caseload_handover_start_path(@prison.code), class:"govuk-link" %>
+          <%= link_to "See cases close to handover", prison_staff_caseload_handover_start_path(@prison.code, @staff_id), class:"govuk-link" %>
         </h1>
         <p class="govuk-body">All cases for start of handover to the community in the next thirty days</p>
       </div>

--- a/app/views/poms/_search_box.html.erb
+++ b/app/views/poms/_search_box.html.erb
@@ -1,5 +1,5 @@
 <div class="search-box">
-  <%= form_tag(prison_caseload_index_path(@prison.code), method: :get, id: "search_form") do %>
+  <%= form_tag(prison_staff_caseload_index_path(@prison.code), method: :get, id: "search_form") do %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <label class="govuk-label" for="q">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,10 @@ Rails.application.routes.draw do
   resources :prisons do
     resources :prisons, only: :index
     resources :dashboard, only: :index
-    resources :caseload, only: %i[ index new]
-    get('/caseload/handover_start' => 'caseload#handover_start', as: 'caseload_handover_start')
+    resources :staff do
+      resources :caseload, only: %i[ index new]
+      get('/caseload/handover_start' => 'caseload#handover_start', as: 'caseload_handover_start')
+    end
 
     resources :prisoners, only: [:show] do
       scope :format => true, :constraints => { :format => 'jpg' } do

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
     before do
       stub_poms(prison, poms)
       stub_sso_pom_data(prison, 'alice')
-      stub_signed_in_pom(1, 'Alice')
+      stub_signed_in_pom(1, 'alice')
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
         to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
     end
@@ -96,7 +96,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/1").
         to_return(status: 200, body: {}.to_json, headers: {})
 
-      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/MOIC_POM").
+      stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/alice").
         to_return(status: 200, body: { staffId: 3 }.to_json, headers: {})
 
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/staff/4").

--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -3,12 +3,17 @@ require 'rails_helper'
 RSpec.describe CaseloadController, type: :controller do
   let(:prison) { build(:prison).code }
   let(:staff_id) { 456_987 }
+  let(:not_signed_in) { 123_456 }
   let(:poms) {
     [
-      build(:pom,
-            firstName: 'Alice',
-            staffId:  staff_id,
-            position: RecommendationService::PRISON_POM)
+        build(:pom,
+              firstName: 'Alice',
+              staffId:  staff_id,
+              position: RecommendationService::PRISON_POM),
+        build(:pom,
+              firstName: 'John',
+              staffId:  not_signed_in,
+              position: RecommendationService::PRISON_POM)
     ]
   }
 
@@ -28,6 +33,10 @@ RSpec.describe CaseloadController, type: :controller do
     let(:offender) { attributes_for(:offender) }
 
     context 'when NPS' do
+      before do
+        stub_sso_data(prison, 'alice')
+      end
+
       let(:today_plus_36_weeks) { (Time.zone.today + 36.weeks).to_s }
       let(:bookings) {
         [offender].map { |o|
@@ -40,7 +49,7 @@ RSpec.describe CaseloadController, type: :controller do
       let(:case_allocation) { 'NPS' }
 
       it 'can pull back a NPS offender due for handover' do
-        get :handover_start, params: { prison_id: prison }
+        get :handover_start, params: { prison_id: prison, staff_id: staff_id }
         expect(response).to be_successful
         expect(assigns(:upcoming_handovers).map(&:offender_no)).to match_array([offender.fetch(:offenderNo)])
       end
@@ -59,7 +68,7 @@ RSpec.describe CaseloadController, type: :controller do
       let(:today_plus_13_weeks) { (Time.zone.today + 13.weeks).to_s }
 
       pending 'can pull back a CRC offender due for handover' do
-        get :handover_start, params: { prison_id: prison }
+        get :handover_start, params: { prison_id: prison, staff_id: staff_id }
         expect(response).to be_successful
         expect(assigns(:upcoming_handovers).map(&:offender_no)).to match_array([offender.fetch(:offenderNo)])
       end
@@ -90,17 +99,52 @@ RSpec.describe CaseloadController, type: :controller do
     end
 
     describe '#index' do
-      it 'returns the caseload' do
-        get :index, params: { prison_id: prison }
-        expect(response).to be_successful
+      before do
+        stub_sso_data(prison, 'alice')
+      end
 
-        expect(assigns(:allocations).map(&:nomis_offender_id)).to match_array(offenders.map { |o| o.fetch(:offenderNo) })
+      context 'when user is an SPO' do
+        before do
+          stub_sso_data(prison, 'alice')
+        end
+
+        it 'returns the caseload for an SPO' do
+          get :index, params: { prison_id: prison, staff_id: staff_id }
+          expect(response).to be_successful
+
+          expect(assigns(:allocations).map(&:nomis_offender_id)).to match_array(offenders.map { |o| o.fetch(:offenderNo) })
+        end
+      end
+
+      context 'when user is a different POM to the one signed in' do
+        before do
+          stub_signed_in_pom(staff_id, 'alice')
+          stub_sso_pom_data(prison, 'alice')
+        end
+
+        it 'cant see the caseload' do
+          get :index, params: { prison_id: prison, staff_id: not_signed_in }
+          expect(response).to redirect_to('/401')
+        end
+      end
+
+      context 'when user is the signed in POM' do
+        it 'returns the caseload' do
+          get :index, params: { prison_id: prison, staff_id: staff_id }
+          expect(response).to be_successful
+
+          expect(assigns(:allocations).map(&:nomis_offender_id)).to match_array(offenders.map { |o| o.fetch(:offenderNo) })
+        end
       end
     end
 
     describe '#new' do
+      before do
+        stub_sso_data(prison, 'alice')
+      end
+
       it 'returns the caseload' do
-        get :new, params: { prison_id: prison }
+        get :new, params: { prison_id: prison, staff_id: staff_id }
         expect(response).to be_successful
 
         expect(assigns(:new_cases).map(&:nomis_offender_id)).to match_array(offenders.map { |o| o.fetch(:offenderNo) })

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SearchController, type: :controller do
-  # Need to use a different prison than LEI to prevent filling Rails cache with mock data
+  # Need to use a different prison than LEI to prevent filling Rails cache with mock data }
   let(:prison) { 'WEI' }
   let(:booking_id) { 'booking3' }
   let(:elite2api) { 'https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api' }
@@ -22,7 +22,7 @@ RSpec.describe SearchController, type: :controller do
     before do
       stub_poms(prison, poms)
       stub_sso_pom_data(prison, 'alice')
-      stub_signed_in_pom(1, 'Alice')
+      stub_signed_in_pom(1, 'alice')
       stub_request(:get, "https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api/api/users/").
         with(headers: { 'Authorization' => 'Bearer token' }).
         to_return(status: 200, body: { staffId: 1 }.to_json, headers: {})
@@ -30,7 +30,7 @@ RSpec.describe SearchController, type: :controller do
 
     it 'user is redirected to caseload' do
       get :search, params: { prison_id: prison, q: 'Cal' }
-      expect(response).to redirect_to(prison_caseload_index_path(q: 'Cal'))
+      expect(response).to redirect_to(prison_staff_caseload_index_path(prison, 1, q: 'Cal'))
     end
   end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -74,6 +74,19 @@ RSpec.describe TasksController, type: :controller do
     stub_offenders_for_prison(prison, offenders, bookings)
   end
 
+  context 'when an SPO' do
+    before do
+      stub_sso_data(prison)
+    end
+
+    it 'return a 401' do
+      get :index, params: { prison_id: prison }
+
+      expect(response).to redirect_to '/401'
+    end
+  end
+
+
   context 'when showing parole review date pom tasks' do
     let(:offender_no) { 'G7514GW' }
 

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocations } do
   let(:nomis_staff_id) { 485_926 }
-
   # This booking id is the latest one for the offender in T3
   let(:nomis_offender_id) { 'G4273GI' }
   let(:booking_id) { 1_153_753 }
@@ -17,8 +16,9 @@ feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocat
     create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id, nomis_booking_id: booking_id)
 
     signin_pom_user
+    signin_spo_user
 
-    visit prison_caseload_index_path(prison)
+    visit prison_staff_caseload_index_path(prison, nomis_staff_id)
 
     # assert that our setup created a caseload record
     expect(page).to have_content("Showing 1 - 1 of 1 results")

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -77,7 +77,7 @@ feature "view POM's caseload" do
     before do
       signin_pom_user
 
-      visit prison_caseload_index_path('LEI')
+      visit prison_staff_caseload_index_path('LEI', nomis_staff_id)
     end
 
     it 'displays paginated cases for a specific POM' do
@@ -157,7 +157,7 @@ feature "view POM's caseload" do
   context 'when looking at handover start' do
     before {
       signin_pom_user
-      visit prison_caseload_index_path('LEI')
+      visit prison_staff_caseload_index_path('LEI', nomis_staff_id)
     }
 
     it 'shows the number of upcoming handovers' do
@@ -180,7 +180,7 @@ feature "view POM's caseload" do
     stub_offender(first_offender.fetch(:offenderNo))
     stub_request(:get, "https://keyworker-api-dev.prison.service.justice.gov.uk/key-worker/LEI/offender/#{first_offender.fetch(:offenderNo)}").
       to_return(body: { staffId: 485_572, firstName: "DOM", lastName: "BULL" }.to_json)
-    visit prison_caseload_index_path(prison)
+    visit prison_staff_caseload_index_path(prison, nomis_staff_id)
 
     expected_name = "#{first_offender.fetch(:lastName)}, #{first_offender.fetch(:firstName)}"
 
@@ -195,7 +195,7 @@ feature "view POM's caseload" do
   it 'can sort all cases that have been allocated to a specific POM in the last week', :versioning do
     # Sign in as a POM
     signin_pom_user
-    visit prison_caseload_index_path('LEI')
+    visit  prison_staff_caseload_index_path('LEI', nomis_staff_id)
     within('.new-cases-count') do
       click_link('1')
     end
@@ -216,11 +216,5 @@ feature "view POM's caseload" do
     within('.offender_row_20') do
       expect(find('.prisoner-name').text).to eq(expected_name)
     end
-  end
-
-  it 'stops staff without the POM role from viewing the my caseload page', vcr: { cassette_name: :non_pom_caseload }  do
-    signin_user('NON_POM_GEN')
-    visit prison_caseload_index_path('LEI')
-    expect(page).to have_current_path('/401')
   end
 end

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -54,7 +54,7 @@ context 'when NOMIS is missing information' do
         end
 
         it 'does not error' do
-          visit prison_caseload_index_path(prison_code)
+          visit prison_staff_caseload_index_path(prison_code, staff_id)
 
           expect(page).to have_content('Showing 1 - 1 of 1 results')
         end
@@ -134,7 +134,7 @@ context 'when NOMIS is missing information' do
       it 'does not error' do
         create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
 
-        visit prison_caseload_handover_start_path(prison_code)
+        visit prison_staff_caseload_handover_start_path(prison_code, staff_id)
 
         expect(page).to have_content('All cases for start of handover to the community in the next 30 days')
       end
@@ -147,7 +147,11 @@ context 'when NOMIS is missing information' do
         with(query: { grant_type: 'client_credentials' }).
         to_return(status: 200, body: {}.to_json)
 
-      signin_spo_user('example SPO')
+      signin_spo_user('example_SPO')
+      stub_request(:get, "#{ApiHelper::T3}/users/example_SPO").
+          to_return(status: 200, body: { 'staffId': 754_732 }.to_json)
+      stub_request(:get, "#{ApiHelper::T3}/staff/754732/emails").
+          to_return(status: 200, body: [].to_json)
     end
 
     context 'with an NPS offender with an indeterminate sentence, but no release dates' do

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -47,7 +47,7 @@ describe AllocationService do
             "nomis_offender_id" => "G4273GI",
             "pom_email" => "pom@digital.justice.gov.uk",
             "pom_name" => "Moic",
-            "url" => "http://localhost:3000/prisons/LEI/caseload"
+            "url" => "http://localhost:3000/prisons/LEI/staff/485926/caseload"
           ))
 
       # message telling co-working POM who the Primary POM is.
@@ -61,7 +61,7 @@ describe AllocationService do
             "responsibility" => "supporting",
             "responsible_pom_name" => 'Pom, Moic',
             "pom_email" => "ommiicc@digital.justice.gov.uk",
-            "url" => "http://localhost:3000/prisons/LEI/caseload"
+            "url" => "http://localhost:3000/prisons/LEI/staff/485758/caseload"
           ))
     end
   end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -47,7 +47,7 @@ describe AllocationService do
             "nomis_offender_id" => "G4273GI",
             "pom_email" => "pom@digital.justice.gov.uk",
             "pom_name" => "Moic",
-            "url" => "http://localhost:3000/prisons/LEI/staff/485926/caseload"
+            "url" => "http://localhost:3000/prisons/LEI/staff/#{primary_pom_id}/caseload"
           ))
 
       # message telling co-working POM who the Primary POM is.
@@ -61,7 +61,7 @@ describe AllocationService do
             "responsibility" => "supporting",
             "responsible_pom_name" => 'Pom, Moic',
             "pom_email" => "ommiicc@digital.justice.gov.uk",
-            "url" => "http://localhost:3000/prisons/LEI/staff/485758/caseload"
+            "url" => "http://localhost:3000/prisons/LEI/staff/#{secondary_pom_id}/caseload"
           ))
     end
   end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe EmailService do
         offender_name: "Ahmonis, Imanjah",
         offender_no: "G2911GD",
         prison: 'HMP Leeds',
-        url: 'http://localhost:3000/prisons/LEI/caseload'
+        url: 'http://localhost:3000/prisons/LEI/staff/485833/caseload'
       ).and_return OpenStruct.new(deliver_later: true)
 
       expect(PomMailer).to receive(:new_allocation_email).with(
@@ -162,7 +162,7 @@ RSpec.describe EmailService do
         offender_name: "Ahmonis, Imanjah",
         offender_no: "G2911GD",
         message: '',
-        url: 'http://localhost:3000/prisons/LEI/caseload'
+        url: 'http://localhost:3000/prisons/LEI/staff/485833/caseload'
       ).and_return OpenStruct.new(deliver_later: true)
 
       described_class.

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -57,6 +57,7 @@ module ApiHelper
     stub_auth_token
     stub_request(:get, "#{T3}/users/#{username}").
       to_return(status: 200, body: { 'staffId': staff_id }.to_json)
+    stub_pom_emails(staff_id, [])
   end
 
   def stub_offenders_for_prison(prison, offenders, bookings)

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -58,7 +58,6 @@ module ApiHelper
     stub_auth_token
     stub_sso_data(prison, username, 'ROLE_ALLOC_CASE_MGR')
     stub_request(:get, "#{T3}/users/#{username}").
-
       to_return(status: 200, body: { 'staffId': staff_id }.to_json)
     stub_pom_emails(staff_id, [])
   end

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -22,6 +22,10 @@ module AuthHelper
                            'roles' => ['ROLE_ALLOC_MGR'],
                            'caseloads' => [prison],
                            'username' => username }
+    stub_request(:get, "#{T3}/elite2api/api/users/#{username}").
+        to_return(status: 200, body: { 'staffId': 754_732 }.to_json)
+    stub_request(:get, "#{T3}/elite2api/api/staff/754732/emails").
+        to_return(status: 200, body: [].to_json)
   end
 
   def stub_sso_pom_data(prison, username)

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -16,7 +16,7 @@ module AuthHelper
       }.to_json)
   end
 
-  def stub_sso_data(prison, username = 'user', role = 'ROLE_ALLOC_MGR')
+  def stub_sso_data(prison, username = 'user', _role = 'ROLE_ALLOC_MGR')
     allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
     session[:sso_data] = { 'expiry' => Time.zone.now + 1.day,
                            'roles' => ['ROLE_ALLOC_MGR'],

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -27,4 +27,14 @@ module FeaturesHelper
 
     OmniAuth.config.add_mock(:hmpps_sso, hmpps_sso_response)
   end
+
+  def stub_spo_emails(staff_id)
+    stub_request(:get, "#{ApiHelper::T3}/staff/#{staff_id}/emails").
+        to_return(status: 200, body: [].to_json)
+  end
+
+  def stub_retrieve_spo_staff_id(staff_id, example_spo)
+    stub_request(:get, "#{ApiHelper::T3}/users/#{example_spo}").
+        to_return(status: 200, body: { 'staffId': staff_id }.to_json)
+  end
 end


### PR DESCRIPTION
This PR alters the url for the caseload of the pom so that the staff_id is now visible in the url. This means that the SPO users (e.g. admins) are now able to get visibility on the POM's caseload page too. It also means this feature can now be tested and supported properly.