### PR TITLE
don't click on invisible things in feature tests

### DIFF
--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -49,8 +49,10 @@ feature 'Allocation' do
 
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
-    within('.not_recommended_pom_row_0', visible:  false) do
-      click_link('Allocate', visible:  false)
+    find('.govuk-details__summary-text').click
+
+    within('.not_recommended_pom_row_0') do
+      click_link('Allocate')
     end
 
     expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
@@ -73,8 +75,10 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: :override_allocation_feature_validate_reasons } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
-    within('.not_recommended_pom_row_0', visible:  false) do
-      click_link('Allocate', visible:  false)
+    find('.govuk-details__summary-text').click
+
+    within('.not_recommended_pom_row_0') do
+      click_link('Allocate')
     end
 
     expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
@@ -87,8 +91,10 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate missing Other detail', vcr: { cassette_name: :override_allocation_feature_validate_other } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
-    within('.not_recommended_pom_row_0', visible:  false) do
-      click_link('Allocate', visible:  false)
+    find('.govuk-details__summary-text').click
+
+    within('.not_recommended_pom_row_0') do
+      click_link('Allocate')
     end
 
     expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
@@ -102,8 +108,10 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate missing suitability detail', vcr: { cassette_name: :override_suitability_allocation_feature } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
-    within('.not_recommended_pom_row_0', visible:  false) do
-      click_link('Allocate', visible:  false)
+    find('.govuk-details__summary-text').click
+
+    within('.not_recommended_pom_row_0') do
+      click_link('Allocate')
     end
 
     expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
@@ -117,8 +125,10 @@ feature 'Allocation' do
   scenario 'overriding an allocation can validate the reason text area character limit', vcr: { cassette_name: :override_allocation__character_count_feature } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
-    within('.not_recommended_pom_row_0', visible:  false) do
-      click_link('Allocate', visible:  false)
+    find('.govuk-details__summary-text').click
+
+    within('.not_recommended_pom_row_0') do
+      click_link('Allocate')
     end
 
     expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,10 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
+
+  config.before(:each, :js) do
+    page.driver.browser.manage.window.resize_to(1280,3072)
+  end
   
   config.before(:each, :raven_intercept_exception) do
     Rails.configuration.sentry_dsn = 'https://test.com'


### PR DESCRIPTION
We have a handful of feature tests that click on 'visible: false' items. IMHO this is an anti-pattern (at least for feature tests) as it reflects doing something that an actual user can't do. 
This PR removes these, and makes the browser window nice and tall so that we can always find things on the page 