### PR TITLE
POM-771 Remove deprecated APIs for Kubernetes version 1.16

### DIFF
--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: allocation-manager

--- a/deploy/preprod/ingress.yaml
+++ b/deploy/preprod/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: allocation-manager

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: allocation-manager

--- a/deploy/production/ingress.yaml
+++ b/deploy/production/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: allocation-manager

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: allocation-manager

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: allocation-manager


### PR DESCRIPTION
The MOJ Cloud Platform is being upgraded from Kubernetes 1.15 to 1.16.

To maintain compatibility with this new version, I've replaced use of deprecated APIs with equivalent current APIs.

I did this by following documentation in the Cloud Platform user guide:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html