### PR TITLE
Pom763 fixup sort helper

### DIFF
--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -1,84 +1,69 @@
 # frozen_string_literal: true
 
 module SortHelper
-  # rubocop:disable Rails/HelperInstanceVariable
-  class Sorter
-    include ActionView::Helpers::TagHelper
-
-    DEFAULT_SORT = 'last_name'
-
-    def initialize(url)
-      @uri = URI.parse(url)
-
-      @query = Rack::Utils.parse_query(@uri.query)
-      @current_sort_field = @query['sort']
-    end
-
-    def link_for_field(field_name)
-      @query['sort'] = if @current_sort_field.present? && @current_sort_field.start_with?(field_name)
-        # Check if name is already in query, and invert the search if it is
-                         "#{field_name} #{invert_sort_parameter(@current_sort_field)}"
-                       else
-        # If it isn't, choose the appropriate default
-                         "#{field_name} #{default_direction(field_name)}"
-                       end
-
-      @uri.query = Rack::Utils.build_query(@query)
-      @uri.to_s
-    end
-
-    def arrow_for_field(field_name)
-      if field_name == DEFAULT_SORT && @current_sort_field.blank?
-        return asc_tag
-      end
-
-      return '' if @current_sort_field.blank?
-      return '' unless @current_sort_field.start_with?(field_name)
-
-      if @current_sort_field.end_with?('asc')
-        asc_tag
-      else
-        desc_tag
-      end
-    end
-
-  private
-
-    def default_direction(field_name)
-      return 'desc' if @current_sort_field.blank? && field_name == DEFAULT_SORT
-
-      'asc'
-    end
-
-    def asc_tag
-      content_tag(:span, '&#9650'.html_safe, class: 'sort-arrow')
-    end
-
-    def desc_tag
-      content_tag(:span, '&#9660'.html_safe, class: 'sort-arrow')
-    end
-
-    def invert_sort_parameter(param)
-      return 'desc' if param.end_with?('asc')
-
-      'asc'
-    end
-    # rubocop:enable Rails/HelperInstanceVariable
-  end
+  DEFAULT_SORT = 'last_name'
 
   def sort_link(field_name)
-    sorter.link_for_field(field_name)
+    link_for_field(field_name, URI.parse(request.original_url))
   end
 
   def sort_arrow(field_name)
-    sorter.arrow_for_field(field_name)
+    arrow_for_field(field_name, URI.parse(request.original_url))
   end
 
 private
 
-  # rubocop:disable Rails/HelperInstanceVariable
-  def sorter
-    @sorter ||= Sorter.new(request.original_url)
+  def link_for_field(field_name, uri)
+    query = Rack::Utils.parse_query(uri.query)
+    current_sort_field = query['sort']
+
+    query['sort'] = if current_sort_field.present? && current_sort_field.start_with?(field_name)
+                      # Check if name is already in query, and invert the search if it is
+                      "#{field_name} #{invert_sort_parameter(current_sort_field)}"
+                    else
+                      # If it isn't, choose the appropriate default
+                      "#{field_name} #{default_direction(field_name, current_sort_field)}"
+                    end
+
+    uri.query = Rack::Utils.build_query(query)
+    uri.to_s
   end
-  # rubocop:enable Rails/HelperInstanceVariable
+
+  def arrow_for_field(field_name, uri)
+    query = Rack::Utils.parse_query(uri.query)
+    current_sort_field = query['sort']
+
+    if field_name == DEFAULT_SORT && current_sort_field.blank?
+      return asc_tag
+    end
+
+    return '' if current_sort_field.blank?
+    return '' unless current_sort_field.start_with?(field_name)
+
+    if current_sort_field.end_with?('asc')
+      asc_tag
+    else
+      desc_tag
+    end
+  end
+
+  def default_direction(field_name, current_sort_field)
+    return 'desc' if current_sort_field.blank? && field_name == DEFAULT_SORT
+
+    'asc'
+  end
+
+  def asc_tag
+    content_tag(:span, '&#9650'.html_safe, class: 'sort-arrow')
+  end
+
+  def desc_tag
+    content_tag(:span, '&#9660'.html_safe, class: 'sort-arrow')
+  end
+
+  def invert_sort_parameter(param)
+    return 'desc' if param.end_with?('asc')
+
+    'asc'
+  end
 end


### PR DESCRIPTION
We have been getting strange errors in Sentry to do with sorting. It looks like a multi-threading issue - having a persistent variable in a helper (which is just a module). It's very hard to reproduce - I thought I could do it trivially, but there are 5 pods which could each have their own copy of the variable, so it's pretty difficult. This PR just converts the module back to a 'plain old module' with no member variables - and removes the rubucop warnings against such things. 
https://sentry.service.dsd.io/mojds/live1-allocation-manager-produ/issues/41019/