### PR TITLE
Pom750 parallel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,12 +211,12 @@ jobs:
       - run:
           name: Setup database
           command: |
-            bundle exec rake db:setup
+            bundle exec rake parallel:setup[4]
       - run:
           name: Run tests
           command: |
             cc-test-reporter before-build
-            bundle exec rake
+            bundle exec rake parallel:spec[4]
             cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
           environment:
             ALLOCATION_MANAGER_HOST: https://allocation-manager-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/Gemfile
+++ b/Gemfile
@@ -44,13 +44,14 @@ gem 'activeadmin'
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
+  gem 'parallel_tests'
   gem 'rubocop'
   gem 'rubocop-rspec'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-govuk'
-  gem 'dotenv-rails'
   # needed to support Rails 6.0
   gem 'rspec-rails', '~> 4.0.0.beta2'
   gem 'rswag-specs'
@@ -76,16 +77,14 @@ group :test do
 end
 
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'web-console', '>= 3.3.0'
-
-  gem 'rack-mini-profiler'
-  gem 'flamegraph'
-  gem 'stackprof'
-  gem 'memory_profiler'
-  gem 'binding_of_caller'
   gem 'better_errors'
+  gem 'binding_of_caller'
+  gem 'flamegraph'
+  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'memory_profiler'
+  gem 'rack-mini-profiler'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'stackprof'
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,6 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.6)
@@ -243,6 +242,8 @@ GEM
       activerecord (>= 4.2)
       request_store (~> 1.1)
     parallel (1.19.2)
+    parallel_tests (3.1.0)
+      parallel
     parser (2.7.1.4)
       ast (~> 2.4.1)
     pdf-core (0.7.0)
@@ -427,11 +428,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.1)
     vcr (5.1.0)
-    web-console (4.0.2)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -486,6 +482,7 @@ DEPENDENCIES
   memory_profiler
   omniauth-oauth2
   paper_trail
+  parallel_tests
   pg
   prawn-rails
   prometheus_exporter
@@ -522,7 +519,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   vcr
-  web-console (>= 3.3.0)
   webmock
   zendesk_api
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
 
 test:
   <<: *default
-  database: offender-management-allocation-manager_test
+  database: offender-management-allocation-manager_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   <<: *default


### PR DESCRIPTION
This PR introduces the paralllel_tests gem. It runs in circle with parallelism 4 - setting it to default fails miserably for some unknown reason. The resulting build runs in around 6 minutes rather than 20, and reduces our circle footprint (including the move from docker medium -> small) by a factor of 6. 
Native Rails 6 test parallelism is thread-based, which RSpec doesn't support (yet). This gem uses process-based parallelism, which is much kess invasive.
The result should be that we go from No5 project for circle usage (3%) to around 0.5% and hopefully not a blip on anyone's radar.