### PR TITLE
Prison factory should only do closed prisons by default

### DIFF
--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
+  CLOSED_PRISON_CODES = PrisonService.prison_codes.reject { |x|
+    PrisonService::OPEN_PRISON_CODES.include?(x) || PrisonService::ENGLISH_HUB_PRISON_CODES.include?(x)
+  }
   class Elite2Prison
     attr_accessor :code, :name
   end
@@ -6,8 +9,7 @@ FactoryBot.define do
   factory :prison, class: 'Elite2Prison' do
     # rotate around every closed prison - open prisons have different rules
     sequence(:code) do |c|
-      codes = PrisonService.prison_codes.reject { |x| PrisonService::OPEN_PRISON_CODES.include?(x) }
-      codes[c % codes.size]
+      CLOSED_PRISON_CODES[c % CLOSED_PRISON_CODES.size]
     end
 
     name { PrisonService.name_for(code) }

--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   end
 
   factory :prison, class: 'Elite2Prison' do
-    # rotate around every prison - can't use arbitrary codes as we sometimes lookup names in PrisonService
+    # rotate around every closed prison - open prisons have different rules
     sequence(:code) do |c|
-      codes = PrisonService.prison_codes
+      codes = PrisonService.prison_codes.reject { |x| PrisonService::OPEN_PRISON_CODES.include?(x) }
       codes[c % codes.size]
     end
 


### PR DESCRIPTION
This PR fixes a defect in the prisons factory - it should only produce closed prisons by default, as open prisons have subtlely different rules which can cause surprises in tests