### PR TITLE
changes to support rubocop-rails 2.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,8 @@ GEM
       rubocop-rspec (~> 1.28)
     rubocop-performance (1.6.1)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.4.2)
+    rubocop-rails (2.5.2)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     rubocop-rspec (1.37.1)

--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -106,7 +106,7 @@ private
     begin
       yield record
     rescue StandardError => e
-      Raven.extra_context [:team_code, :team].map { |field| [field, record.fetch(field)] }.to_h
+      Raven.extra_context([:team_code, :team].index_with { |field| record.fetch(field) })
       Raven::capture_exception(e)
     end
   end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -25,7 +25,7 @@ class Prison
   end
 
   def allocations_for(staff_id)
-    offender_hash = offenders.map { |o| [o.offender_no, o] }.to_h
+    offender_hash = offenders.index_by(&:offender_no)
     allocations = Allocation.
       where(nomis_offender_id: offender_hash.keys).
       active_pom_allocations(staff_id, @code)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -76,12 +76,9 @@ class AllocationService
   end
 
   def self.active_allocations(nomis_offender_ids, prison)
-    Allocation.active(nomis_offender_ids, prison).map { |a|
-      [
-        a[:nomis_offender_id],
-        a
-      ]
-    }.to_h
+    Allocation.active(nomis_offender_ids, prison).index_by { |a|
+      a[:nomis_offender_id]
+    }
   end
 
   def self.previously_allocated_poms(nomis_offender_id)
@@ -96,7 +93,7 @@ class AllocationService
   def self.allocation_history_pom_emails(history)
     pom_ids = history.map { |h| [h.primary_pom_nomis_id, h.secondary_pom_nomis_id] }.flatten.compact.uniq
 
-    pom_ids.map { |pom_id|  [pom_id, PrisonOffenderManagerService.get_pom_emails(pom_id).first] }.to_h
+    pom_ids.index_with { |pom_id| PrisonOffenderManagerService.get_pom_emails(pom_id).first }
   end
 
   def self.create_override(params)

--- a/app/services/case_information_service.rb
+++ b/app/services/case_information_service.rb
@@ -3,8 +3,6 @@
 class CaseInformationService
   def self.get_case_information(offender_ids)
     CaseInformation.includes(:early_allocations, team: :local_divisional_unit).
-      where(nomis_offender_id: offender_ids).map { |case_info|
-      [case_info.nomis_offender_id, case_info]
-    }.to_h
+      where(nomis_offender_id: offender_ids).index_by(&:nomis_offender_id)
   end
 end

--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -41,7 +41,7 @@ module Nomis
             }
           }
           # return a hash of offender_no => [Nomis::Movement]
-          movements.map { |m| [m.first.offender_no, m] }.to_h
+          movements.index_by { |m| m.first.offender_no }
         end
       end
     end

--- a/app/services/prison_service.rb
+++ b/app/services/prison_service.rb
@@ -129,7 +129,7 @@ class PrisonService
     PrisonInfo.new('WTI', 'HMP Whatton', :england),
     PrisonInfo.new('WWI', 'HMP Wandsworth', :england),
     PrisonInfo.new('WYI', 'HMP/YOI Wetherby', :england)
-  ].index_by(&:code)
+  ].index_by(&:code).freeze
 
   PRIVATE_ENGLISH_PRISON_CODES = %w[ACI ASI DNI DGI FBI LGI OWI NLI PBI RHI TSI].freeze
 

--- a/app/services/prison_service.rb
+++ b/app/services/prison_service.rb
@@ -129,7 +129,7 @@ class PrisonService
     PrisonInfo.new('WTI', 'HMP Whatton', :england),
     PrisonInfo.new('WWI', 'HMP Wandsworth', :england),
     PrisonInfo.new('WYI', 'HMP/YOI Wetherby', :england)
-  ].map { |p| [p.code, p] }.to_h
+  ].index_by(&:code)
 
   PRIVATE_ENGLISH_PRISON_CODES = %w[ACI ASI DNI DGI FBI LGI OWI NLI PBI RHI TSI].freeze
 
@@ -166,9 +166,7 @@ class PrisonService
   end
 
   def self.prisons_from_list(codelist)
-    prisons = codelist.each_with_object({}) { |code, hash|
-      hash[code] = PRISONS[code]&.name
-    }
+    prisons = codelist.index_with { |code| PRISONS[code]&.name }
     prisons.compact.sort_by { |_code, prison| prison }.to_h
   end
 end

--- a/db/migrate/20200803135050_add_unique_index_to_ldu_code.rb
+++ b/db/migrate/20200803135050_add_unique_index_to_ldu_code.rb
@@ -1,0 +1,15 @@
+class AddUniqueIndexToLduCode < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :local_divisional_units, :code
+    change_table :local_divisional_units do |t|
+      t.index :code, unique: true
+    end
+  end
+
+  def down
+    remove_index :local_divisional_units, :code
+    change_table :local_divisional_units do |t|
+      t.index :code, unique: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_165050) do
+ActiveRecord::Schema.define(version: 2020_08_03_135050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_165050) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email_address"
-    t.index ["code"], name: "index_local_divisional_units_on_code"
+    t.index ["code"], name: "index_local_divisional_units_on_code", unique: true
   end
 
   create_table "overrides", force: :cascade do |t|

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -45,6 +45,6 @@ private
   def list_to_lookup(delius_records)
     return {} if delius_records.blank?
 
-    Hash[delius_records.collect { |record| [record[:noms_no], record] }]
+    delius_records.index_by { |record| record[:noms_no] }
   end
 end

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
   # any date less than 3 months in the past
   let(:valid_date) { Time.zone.today - 2.months }
   let(:s1_boolean_param_names) { [:convicted_under_terrorisom_act_2000, :high_profile, :serious_crime_prevention_order, :mappa_level_3, :cppc_case] }
-  let(:s1_boolean_params) { s1_boolean_param_names.map { |p| [p, 'false'] }.to_h }
+  let(:s1_boolean_params) { s1_boolean_param_names.index_with { 'false' } }
 
   let(:prison) { build(:prison).code }
   let(:first_pom) { build(:pom) }
@@ -95,7 +95,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
          :other_reason]
       }
 
-      let(:s2_boolean_params) { s2_boolean_param_names.map { |p| [p, 'false'] }.to_h }
+      let(:s2_boolean_params) { s2_boolean_param_names.index_with { |_p| 'false' }.to_h }
 
       it 'is ineligible if <24 months is false but extremism_separation is true' do
         post :create, params: {


### PR DESCRIPTION
Rails 6 has some nice methods to replace <array>.map { |x| [x, x.thing] }.to_h. 
This update encourages us to use them.