### PR TITLE
Speed up probation_service database backfill task

### DIFF
--- a/lib/tasks/backfill_probation_service.rake
+++ b/lib/tasks/backfill_probation_service.rake
@@ -5,8 +5,7 @@ require 'rake'
 namespace :backfill do
   desc 'Back-fill case_information#probation_service from welsh_offender'
   task probation_service: :environment do
-    CaseInformation.where(probation_service: nil).find_each do |ci|
-      ci.update!(probation_service: (ci.welsh_offender == 'Yes') ? 'Wales' : 'England')
-    end
+    CaseInformation.where(probation_service: nil, welsh_offender: 'Yes').update_all(probation_service: 'Wales')
+    CaseInformation.where(probation_service: nil, welsh_offender: 'No').update_all(probation_service: 'England')
   end
 end


### PR DESCRIPTION
The `backfill:probation_service` rake task sets the value of probation_service field based on the value of welsh_offender column.

This was previously done by looping through each record individually and performing a write to the database for each record. This isn't efficient. Given the number of records we need to backfill, this command would take a long time to complete.

Instead, I've updated the task to use 'update all'. This performs a SQL UPDATE statement, which will update all records at once – no need for us to read/write each record individually.