### PR TITLE
fixed test failing on Mon Aug 17th 2020 due to date issue

### DIFF
--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -325,7 +325,7 @@ describe ResponsibilityService do
           end
 
           context 'when a determinate NPS offender with parole eligibility' do
-            let(:sentence_start_date) { Date.parse('15-09-2019') }
+            let(:sentence_start_date) { Time.zone.today - 10.months }
             let(:offender) {
               OpenStruct.new  nps_case?: true,
                               welsh_offender: false,


### PR DESCRIPTION
On Mon 17th Aug 2020, a test started failing due to a hard-coded date in the past.
This PR changes that date to be dynamic based oin today's date so it is unlikely to fail again