### PR TITLE
POM-789 improved query performance by using explicit 'in' queries

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -48,8 +48,8 @@ class Allocation < ApplicationRecord
   scope :active, lambda { |nomis_offender_ids, prison|
     where.not(
       primary_pom_nomis_id: nil
-      ).where(
-        nomis_offender_id: nomis_offender_ids, prison: prison
+      ).where(prison: prison).where(
+        'nomis_offender_id in (?)', nomis_offender_ids
       )
   }
 

--- a/app/services/case_information_service.rb
+++ b/app/services/case_information_service.rb
@@ -3,7 +3,7 @@
 class CaseInformationService
   def self.get_case_information(offender_ids)
     CaseInformation.includes(:early_allocations, team: :local_divisional_unit).
-      where(nomis_offender_id: offender_ids).map { |case_info|
+      where('nomis_offender_id in (?)', offender_ids).map { |case_info|
       [case_info.nomis_offender_id, case_info]
     }.to_h
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,8 +16,11 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
   # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
+  # Run rails dev:cache to toggle caching.~
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true


### PR DESCRIPTION
This PR appears to improve the actual performance of MOIC by at least 100% by converting a couple of 'where' statements to explicit 'in' queries. 
We still appear to have a slow analytics rendering (800 ms) in development mode.
Once deployed, the analytics overhead goes away and we get a 1000% speedup (a factor of 10)