### PR TITLE
POM-793 wrong allocation record retrieved in show action

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -56,7 +56,7 @@ class EarlyAllocationsController < PrisonsApplicationController
   end
 
   def show
-    @early_assignment = EarlyAllocation.find_by!(offender_id_from_url)
+    @early_assignment = EarlyAllocation.where(offender_id_from_url).last
 
     respond_to do |format|
       format.pdf {

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe EarlyAllocationsController, type: :controller do
     create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
   end
 
+  describe '#show' do
+    before do
+      create(:case_information, nomis_offender_id: nomis_offender_id, early_allocations: build_list(:early_allocation, 5))
+    end
+
+    it 'shows the most recent' do
+      get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id }, format: :pdf
+      expect(assigns(:early_assignment)).to eq(CaseInformation.last.early_allocations.last)
+    end
+  end
+
   context 'with not ldu email address' do
     let(:ldu) { create(:local_divisional_unit, email_address: nil) }
     let(:team) { create(:team, local_divisional_unit: ldu) }


### PR DESCRIPTION
Turned out that when multiple early allocation assessments had been done, the link on the success page accessed a random one rather than the most recent one. Hence this PR fixes both POM-793 and POM-794 as they were symptoms of the same defect.