### PR TITLE
Resolve Prometheus Exporter errors in Heroku logs

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,20 +1,23 @@
 if Rails.env.production?
   Sidekiq.configure_server do |config|
-    config.on :startup do
-      require 'prometheus_exporter/instrumentation'
-      PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
-    end
+    # Configure Prometheus Exporter
+    if ENV['PROMETHEUS_METRICS']&.strip == 'on'
+      config.on :startup do
+        require 'prometheus_exporter/instrumentation'
+        PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+      end
 
-    at_exit do
-      PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
-    end
+      at_exit do
+        PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
+      end
 
-    config.server_middleware do |chain|
-      require 'prometheus_exporter/instrumentation'
-      chain.add PrometheusExporter::Instrumentation::Sidekiq
-    end
+      config.server_middleware do |chain|
+        require 'prometheus_exporter/instrumentation'
+        chain.add PrometheusExporter::Instrumentation::Sidekiq
+      end
 
-    config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+      config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+    end
 
     config.redis = {
       url: Rails.configuration.redis_url.to_s,

--- a/config/puma_prod.rb
+++ b/config/puma_prod.rb
@@ -9,14 +9,17 @@ rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'production'
 
-after_worker_boot do
-  require 'prometheus_exporter/instrumentation'
-  require 'prometheus_exporter/client'
-  PrometheusExporter::Instrumentation::Puma.start
-  PrometheusExporter::Instrumentation::Process.start(type: 'web')
+# Configure Prometheus Exporter
+if ENV['PROMETHEUS_METRICS']&.strip == 'on'
+  after_worker_boot do
+    require 'prometheus_exporter/instrumentation'
+    require 'prometheus_exporter/client'
+    PrometheusExporter::Instrumentation::Puma.start
+    PrometheusExporter::Instrumentation::Process.start(type: 'web')
 
-  PrometheusExporter::Instrumentation::ActiveRecord.start(
-    custom_labels: { type: 'puma_worker' },
-    config_labels: [:database, :host]
-  )
+    PrometheusExporter::Instrumentation::ActiveRecord.start(
+      custom_labels: { type: 'puma_worker' },
+      config_labels: [:database, :host]
+    )
+  end
 end


### PR DESCRIPTION
We set environment variable `PROMETHEUS_METRICS=on` when we want to log metrics using Prometheus Exporter. However, even when that variable wasn't set, Puma (web server) and Sidekiq workers (job queue) were still attempting to initialise a connection to a local Prometheus Exporter server.

We don't record metrics to Prometheus in Heroku, and therefore don't run a local Promethus Exporter server. But since the application was still trying to connect to the server regardless of the environment variable not being set, it was resulting in the following error being logged repeatedly in the app logs, at a rate of about two entries per second:

```
Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394
```

This commit adjusts the Puma and Sidekiq configurations so they don't attempt to connect to Prometheus Exporter when `PROMETHEUS_METRICS=on` is not set in the environment. This significantly reduces log noise in Heroku.