### PR TITLE
Make offender stubs more consistent

### DIFF
--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -8,12 +8,7 @@ module ApiHelper
   def stub_offender(offender)
     booking_number = 1
     stub_request(:get, "#{T3}/prisoners/#{offender.fetch(:offenderNo)}").
-      to_return(body: [{ offenderNo: offender.fetch(:offenderNo),
-                                      gender: 'Male',
-                                      convictedStatus: 'Convicted',
-                                      latestBookingId: booking_number,
-                                      imprisonmentStatus: offender.fetch(:imprisonmentStatus),
-                                      dateOfBirth: offender.fetch(:dateOfBirth) }].to_json)
+      to_return(body: [offender.except(:sentence).merge('latestBookingId' => booking_number)].to_json)
 
     stub_request(:post, "#{T3}/offender-sentences/bookings").
       with(


### PR DESCRIPTION
The `stub_offender` and `stub_offenders_for_prison` spec helper methods were producing different stubs.

This commit fixes that by making `stub_offender` return the entire `offender` object which was passed in, rather than just stubbing some of the expected fields.

`stub_offenders_for_prison` already does this, meaning both stubs now give equivalent responses for the given offender.

---

This was done as part of some work on a feature spec for the POM-511 ticket. However I've pulled it out into a separate PR to reduce unnecessary noise in PR #1263.