### PR TITLE
Stub Keyworker API, and allow individual POM stub

### DIFF
--- a/spec/factories/keyworker.rb
+++ b/spec/factories/keyworker.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :keyworker, class: Hash do
+    initialize_with { attributes }
+
+    sequence(:staffId) { |x| x + 1000  }
+    firstName { Faker::Name.first_name }
+    lastName { Faker::Name.last_name }
+  end
+end

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -19,13 +19,14 @@ FactoryBot.define do
   end
 
   class Elite2POM
-    attr_accessor :position, :staffId, :emails, :firstName, :lastName, :positionDescription
+    attr_accessor :position, :staffId, :emails, :firstName, :lastName, :positionDescription, :status
   end
 
   factory :pom, class: 'Elite2POM' do
     position { 'PRO' }
     sequence(:emails) { |x| ["staff#{x}@justice.gov.uk"]  }
     sequence(:staffId) { |x| x + 1000  }
+    status { 'ACTIVE' }
 
     firstName { Faker::Name.first_name }
     lastName { Faker::Name.last_name }

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -50,6 +50,11 @@ module ApiHelper
       to_return(body: emails.to_json)
   end
 
+  def stub_pom(pom)
+    stub_request(:get, "#{T3}/staff/#{pom.staffId}").
+      to_return(body: pom.to_json)
+  end
+
   def stub_signed_in_pom(prison, staff_id, username)
     stub_auth_token
     stub_sso_data(prison, username, 'ROLE_ALLOC_CASE_MGR')

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -102,6 +102,11 @@ module ApiHelper
       to_return(body: bookings.to_json)
   end
 
+  def stub_keyworker(prison_code, offender_id, keyworker)
+    stub_request(:get, "#{KEYWORKER_API_HOST}/key-worker/#{prison_code}/offender/#{offender_id}").
+      to_return(body: keyworker.to_json)
+  end
+
   def reload_page
     visit current_path
   end


### PR DESCRIPTION
This PR adds two new stub methods:

- `stub_keyworker`
- `stub_pom`

Read individual commit messages for descriptions of each.

---

This PR was split out of work carried out on POM-511 / PR #1263.