### PR TITLE
Configure CircleCI to use `main` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ references:
         ${login}
         docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
         docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
-        if [ "${CIRCLE_BRANCH}" == "master" ]; then
+        if [ "${CIRCLE_BRANCH}" == "main" ]; then
           docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
         fi
@@ -347,34 +347,34 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - preproduction
       - deploy_staging:
           requires:
             - build_and_push_docker_image
           filters:
             branches:
-              only: master
+              only: main
       - test_staging:
           requires:
             - build_and_push_docker_image
             - deploy_staging
           filters:
             branches:
-              only: master
+              only: main
       - deploy_production_approval:
           type: approval
           requires:
             - test_staging
           filters:
             branches:
-              only: master
+              only: main
       - deploy_production:
           requires:
             - deploy_production_approval
           filters:
             branches:
-              only: master
+              only: main
       - deploy_preprod:
           requires:
             - build_and_push_docker_image


### PR DESCRIPTION
We've renamed the `master` branch to `main`. This commit updates the CircleCI configuration to use this new branch instead of `master`.