### PR TITLE
Pom795 reinstate flipflop

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def ensure_global_admin_user
+    unless sso_identity.is_global_admin?
+      redirect_to '/401'
+    end
+  end
+
   def default_prison_code
     sso_identity.default_prison_code
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module OffenderManagementAllocationClient
     config.active_model.i18n_customize_full_message = true
     # Before filter for Flipflop dashboard. Replace with a lambda or method name
     # defined in ApplicationController to implement access control.
-    config.flipflop.dashboard_access_filter = -> { :current_user_is_spo? }
+    config.flipflop.dashboard_access_filter = :ensure_global_admin_user
 
     config.load_defaults 6.0
     config.exceptions_app = routes

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,8 @@
 Rails.application.configure do
   # Before filter for Flipflop dashboard. Replace with a lambda or method name
   # defined in ApplicationController to implement access control.
-  config.flipflop.dashboard_access_filter = nil
+  # don't override this here - we want to test that we have implemented the access controls correctly
+  # config.flipflop.dashboard_access_filter = nil
 
   # Settings specified here will take precedence over those in config/application.rb.
   config.notify_api_key = ENV['TEST_NOTIFY_API_KEY']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,4 +106,6 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+
+  mount Flipflop::Engine => "/flip-flop-admin"
 end

--- a/spec/features/admin_feature_spec.rb
+++ b/spec/features/admin_feature_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
-feature 'ActiveAdmin' do
+feature 'admin urls' do
   # This works as expected (i.e. it sends the user to login)
   # but doesn't work in test-land for some unknown reason
-  # context 'unauthorised' do
+  # context 'without login' do
   #   before do
   #     OmniAuth.config.test_mode = false
   #   end
+  #
   #   after do
   #     OmniAuth.config.test_mode = true
   #   end
   #
-  #   scenario 'unauthorised' do
+  #   xit 'is unauthorised' do
   #     visit('/admin')
   #     expect(page).to have_http_status(:unauthorized)
   #   end
@@ -19,6 +20,7 @@ feature 'ActiveAdmin' do
 
   let(:ldu) { create(:local_divisional_unit) }
   let!(:new_team) { create(:team, local_divisional_unit: ldu) }
+  let(:admin_urls) { ['/admin', '/flip-flop-admin'] }
 
   context 'when pom' do
     before do
@@ -26,8 +28,11 @@ feature 'ActiveAdmin' do
     end
 
     it 'is unauthorised' do
-      visit('/admin')
-      expect(page).to have_http_status(:unauthorized)
+      admin_urls.each do |admin_url|
+        visit(admin_url)
+
+        expect(page).to have_http_status(:unauthorized)
+      end
     end
   end
 
@@ -37,8 +42,11 @@ feature 'ActiveAdmin' do
     end
 
     it 'is unauthorised' do
-      visit('/admin')
-      expect(page).to have_http_status(:unauthorized)
+      admin_urls.each do |admin_url|
+        visit(admin_url)
+
+        expect(page).to have_http_status(:unauthorized)
+      end
     end
   end
 
@@ -47,6 +55,14 @@ feature 'ActiveAdmin' do
       signin_global_admin_user
       ci = create(:case_information, team: nil)
       create(:allocation, nomis_offender_id: ci.nomis_offender_id)
+    end
+
+    it 'is ok' do
+      admin_urls.each do |admin_url|
+        visit(admin_url)
+
+        expect(page).to have_http_status(:ok)
+      end
     end
 
     it 'displays the dashboard' do


### PR DESCRIPTION
FlipFlop admin was removed a while back as it wasn't secured properly

This PR re-instates it, secures it properly and adds a test to demonstrate that it is secured.