### PR TITLE
fix parallel tests config

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ SimpleCov.start 'rails' do
   maximum_coverage_drop 0.5
 
   # Increase the merge timeout as tests sometimes take longer than the default 10 mins
+  # 1200 seconds is 20 minutes
   merge_timeout 1200
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,9 +13,11 @@ SimpleCov.start 'rails' do
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 
-  # Increase the merge timeout as tests sometimes take longer than the default 10 mins
+  # Increase the merge timeout for circle:ci
+  # as tests sometimes take longer than the default 10 mins
+
   # 1200 seconds is 20 minutes
-  merge_timeout 1200
+  merge_timeout 1200 if ENV['CIRCLE_ARTIFACTS']
 end
 
 if ENV['CIRCLE_ARTIFACTS']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,8 @@ SimpleCov.start 'rails' do
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 
-  # Needed for parallel specs
-  command_name "specs" + (ENV['TEST_ENV_NUMBER'] || '')
+  # Increase the merge timeout as tests sometimes take longer than the default 10 mins
+  merge_timeout 1200
 end
 
 if ENV['CIRCLE_ARTIFACTS']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ SimpleCov.start 'rails' do
   minimum_coverage 99.34
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
+
+  # Needed for parallel specs
+  command_name "specs" + (ENV['TEST_ENV_NUMBER'] || '')
 end
 
 if ENV['CIRCLE_ARTIFACTS']


### PR DESCRIPTION
Turns out that we managed to omit a piece of configuration when we created parallel specs.
This PR hoping fixes the flakey tests that have been bothering us a bit on circle:ci