### PR TITLE
Alter parallelism to try to improve build reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
 
   test_container_config: &test_container_config
-    resource_class: small
+    resource_class: medium
     docker:
       - image: circleci/ruby:2.6.3-node-browsers
         environment:
@@ -20,6 +20,7 @@ references:
           PGUSER: ubuntu
           RACK_ENV: test
           VCR: 1
+          PARALLEL_TEST_PROCESSORS: 6
       - image: circleci/postgres:10.5-alpine
         environment:
           POSTGRES_USER: ubuntu
@@ -212,12 +213,12 @@ jobs:
       - run:
           name: Setup database
           command: |
-            bundle exec rake parallel:setup[3]
+            bundle exec rake parallel:setup
       - run:
           name: Run tests
           command: |
             cc-test-reporter before-build
-            bundle exec rake parallel:spec[3]
+            bundle exec rake parallel:spec
             cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
           environment:
             ALLOCATION_MANAGER_HOST: https://allocation-manager-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ references:
           PGUSER: ubuntu
           RACK_ENV: test
           VCR: 1
-          PARALLEL_TEST_PROCESSORS: 6
+          PARALLEL_TEST_PROCESSORS: 7
       - image: circleci/postgres:10.5-alpine
         environment:
           POSTGRES_USER: ubuntu


### PR DESCRIPTION
POM-714 only got over the line by changing the circle:ci parallelism from 4 to 3. 
This PR appears to show that we can use parallelism 7 with a Medium container to good effect.
I theorise that we are sometimes running out of RAM on the small container - using a 'medium' container seems to allow us greater headroom whilst producing reasonable results [~6m30 vs ~12m test run time]