### PR TITLE
POM-824 use null object when responsibility calculation is unknown

### DIFF
--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -11,11 +11,7 @@ module OffenderHelper
   end
 
   def case_owner_label(offender)
-    if offender.pom_responsibility.custody?
-      'Custody'
-    else
-      'Community'
-    end
+    offender.pom_responsibility.case_owner
   end
 
   def last_event(allocation)

--- a/app/models/nomis/offender_base.rb
+++ b/app/models/nomis/offender_base.rb
@@ -158,7 +158,7 @@ module Nomis
   private
 
     def handover
-      @handover ||= if pom_responsibility&.custody?
+      @handover ||= if pom_responsibility.custody?
                       HandoverDateService.handover(self)
                     else
                       HandoverDateService::NO_HANDOVER_DATE

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -9,6 +9,7 @@ class ResponsibilityService
 
   RESPONSIBLE = Responsibility.new 'Responsible', true
   SUPPORTING = Responsibility.new 'Supporting', false
+  UNKNOWN = Responsibility.new 'Unknown', false
   COWORKING = 'Co-Working'
   NPS = 'NPS'
 
@@ -65,7 +66,7 @@ private
         release_date ||= possible_dates.compact.min
       end
 
-      return nil if release_date.blank?
+      return UNKNOWN if release_date.blank?
 
       expected_time_in_custody_gt_10_months = release_date > offender.sentence_start_date + 10.months
       handover_date_in_future = HandoverDateService.handover(offender).handover_date > Time.zone.today
@@ -107,7 +108,7 @@ private
         release_date ||= possible_dates.compact.min
       end
 
-      return nil if release_date.blank?
+      return UNKNOWN if release_date.blank?
 
       handover_date_in_future = HandoverDateService.handover(offender).handover_date > Time.zone.today
       if handover_date_in_future && release_date >= cutoff
@@ -136,10 +137,10 @@ private
 
   private
 
-    def english_prepolicy_rules(offender)
-      private_cutoff = '1 Jun 2021'.to_date
-      public_cutoff = '15 Feb 2021'.to_date
+    PRIVATE_CUTOFF = '1 Jun 2021'.to_date.freeze
+    PUBLIC_CUTOFF = '15 Feb 2021'.to_date.freeze
 
+    def english_prepolicy_rules(offender)
       release_date = offender.parole_eligibility_date
 
       if offender.indeterminate_sentence?
@@ -149,9 +150,9 @@ private
         release_date ||= possible_dates.compact.min
       end
 
-      return nil if release_date.blank?
+      return UNKNOWN if release_date.blank?
 
-      cutoff = hub_or_private?(offender) ? private_cutoff : public_cutoff
+      cutoff = hub_or_private?(offender) ? PRIVATE_CUTOFF : PUBLIC_CUTOFF
 
       handover_date_in_future = HandoverDateService.handover(offender).handover_date > Time.zone.today
 
@@ -189,7 +190,7 @@ private
            offender.conditional_release_date,
            offender.home_detention_curfew_eligibility_date].compact.min
 
-      return nil if earliest_release_date.nil?
+      return UNKNOWN if earliest_release_date.nil?
 
       if earliest_release_date > DateTime.now.utc.to_date + 12.weeks
         RESPONSIBLE

--- a/app/services/responsibility_service.rb
+++ b/app/services/responsibility_service.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class ResponsibilityService
-  Responsibility = Struct.new(:description, :custody?) do
+  Responsibility = Struct.new(:description, :custody?, :case_owner) do
     def to_s
       description
     end
   end
 
-  RESPONSIBLE = Responsibility.new 'Responsible', true
-  SUPPORTING = Responsibility.new 'Supporting', false
-  UNKNOWN = Responsibility.new 'Unknown', false
+  RESPONSIBLE = Responsibility.new 'Responsible', true, 'Custody'
+  SUPPORTING = Responsibility.new 'Supporting', false, 'Community'
+  UNKNOWN = Responsibility.new 'Unknown', false, 'Unknown'
   COWORKING = 'Co-Working'
   NPS = 'NPS'
 

--- a/spec/services/responsibility_service_spec.rb
+++ b/spec/services/responsibility_service_spec.rb
@@ -232,7 +232,7 @@ describe ResponsibilityService do
 
               it 'will return no responsibility' do
                 expect(described_class.calculate_pom_responsibility(offender)).
-                  to be_nil
+                  to eq ResponsibilityService::UNKNOWN
               end
             end
           end
@@ -319,7 +319,7 @@ describe ResponsibilityService do
 
               it 'will return no responsibility' do
                 expect(described_class.calculate_pom_responsibility(offender)).
-                  to be_nil
+                  to eq ResponsibilityService::UNKNOWN
               end
             end
           end
@@ -528,7 +528,7 @@ describe ResponsibilityService do
 
               it 'will return no responsibility' do
                 expect(described_class.calculate_pom_responsibility(offender)).
-                  to be_nil
+                  to eq ResponsibilityService::UNKNOWN
               end
             end
           end


### PR DESCRIPTION
Elmley has been having a crash when looking at the allocations summary recently due to some questionable data
This PR fixes this by making the ResponsibilityService always return an object (even if the answer is 'Unknown')