### PR TITLE
POM-823 only load latest movement for ROTL calculations

### DIFF
--- a/app/services/nomis/elite2/movement_api.rb
+++ b/app/services/nomis/elite2/movement_api.rb
@@ -61,7 +61,7 @@ module Nomis
         data = Rails.cache.fetch(cache_key,
                                  expires_in: Rails.configuration.cache_expiry) do
           e2_client.post(route, offender_nos,
-                         queryparams: { latestOnly: false, movementTypes: types }).
+                         queryparams: { latestOnly: true, movementTypes: types }).
             group_by { |x| x['offenderNo'] }.values
         end
 

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -68,7 +68,7 @@ module ApiHelper
     # and if you provide a booking, that the id matches between the offender and booking hashes.
     elite2listapi = "#{T3}/locations/description/#{prison}/inmates?convictedStatus=Convicted&returnCategory=true"
     elite2bookingsapi = "#{T3}/offender-sentences/bookings"
-    elite2latestmove = "#{T3}/movements/offenders?latestOnly=false&movementTypes=TAP"
+    elite2latestmove = "#{T3}/movements/offenders?latestOnly=true&movementTypes=TAP"
 
     # Stub the call that will get the total number of records
     stub_request(:get, elite2listapi).to_return(


### PR DESCRIPTION
The ROTL code pulls every (temporary) movement for each offender - resulting in large amounts of wasted download data.
This showed up in Grafana on release (and in the VCR cassettes which went from 200Mb to 1.8Gb) but the fix has only just been identified