### PR TITLE
add increased merge timeout on circle:ci due to merge failures

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ SimpleCov.start 'rails' do
   minimum_coverage 99.34
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
+
+  # set merge_timeout to 30 minutes on circle:ci
+  merge_timeout 1800 if ENV['CIRCLECI']
 end
 
 if ENV['CIRCLE_ARTIFACTS']


### PR DESCRIPTION
The individual SimpleCov coverage files that are merged in rake parallel:spec have a default lifetime of 10 minutes.
If the tests take significantly longer than that, then the earliest coverage file is likely to be invalid resulting in a build failure.

This PR increases that merge timeout to 30 minutes on circle:ci  