### PR TITLE
Pom825 huntercombe broken due to 400 offenders

### DIFF
--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
     initialize_with { attributes }
 
     imprisonmentStatus { 'SENT03' }
-    prisonId { 'LEI' }
+    agencyId { 'LEI' }
 
     # offender numbers are of the form <letter><4 numbers><2 letters>
     sequence(:offenderNo) do |seq|
@@ -65,5 +65,7 @@ FactoryBot.define do
     sentence do
       association :nomis_sentence_detail
     end
+
+    sequence(:bookingId) { |c| c + 100_000 }
   end
 end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -2,21 +2,73 @@ require 'rails_helper'
 
 RSpec.describe Prison, type: :model do
   describe '#offenders' do
-    let(:offenders) { described_class.new("LEI").offenders }
+    subject { described_class.new("LEI").offenders }
 
     it "get first page of offenders for a specific prison",
        vcr: { cassette_name: :offender_service_offenders_by_prison_first_page_spec } do
-      offender_array = offenders.first(9)
+      offender_array = subject.first(9)
       expect(offender_array).to be_kind_of(Array)
       expect(offender_array.length).to eq(9)
       expect(offender_array.first).to be_kind_of(Nomis::OffenderSummary)
     end
 
     it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
-      offender_array = offenders.to_a
+      offender_array = subject.to_a
       expect(offender_array).to be_kind_of(Array)
       expect(offender_array.length).to be > 800
       expect(offender_array.first).to be_kind_of(Nomis::OffenderSummary)
+    end
+
+    context 'when there are exactly 200 offenders' do
+      let(:offenders) { build_list(:nomis_offender, 200) }
+
+      before do
+        stub_auth_token
+        stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+          with(
+            headers: {
+              'Page-Limit' => '1',
+              'Page-Offset' => '1',
+            }).
+          to_return(
+            body: {}.to_json,
+            headers: { 'Total-Records' => '200' }
+          )
+        stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+          with(
+            headers: {
+              'Page-Limit' => '200',
+              'Page-Offset' => '0',
+            }).
+          to_return(body: offenders.to_json)
+
+        # stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/movements/offenders?latestOnly=false&movementTypes=TAP").
+        #   with(body: offenders.map { |o| o.fetch(:offenderNo) }.to_json).
+        #   to_return(body: [].to_json)
+        stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/movements/offenders?latestOnly=false&movementTypes=TAP").
+          to_return(body: [].to_json)
+
+        stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+          with(
+            headers: {
+              'Page-Limit' => '200',
+              'Page-Offset' => '200',
+            }).
+          to_return(body: [].to_json)
+
+        # stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/movements/offenders?latestOnly=false&movementTypes=TAP").
+        #   with(body: [].to_json).
+        #   to_return(body: [].to_json)
+
+        bookings = offenders.map { |offender| { 'bookingId' => offender.fetch(:bookingId), 'sentenceDetail' => offender.fetch(:sentence) } }
+        stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/offender-sentences/bookings").
+          with(body: offenders.map { |o| o.fetch(:bookingId) }.to_json).
+          to_return(body: bookings.to_json)
+      end
+
+      it 'fetches one page only' do
+        expect(subject.count).to eq(200)
+      end
     end
   end
 end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -24,17 +24,7 @@ RSpec.describe Prison, type: :model do
 
       before do
         stub_auth_token
-        stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
-          with(
-            headers: {
-              'Page-Limit' => '1',
-              'Page-Offset' => '1',
-            }).
-          to_return(
-            body: {}.to_json,
-            headers: { 'Total-Records' => '200' }
-          )
-        stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+        stub_request(:get, "#{ApiHelper::T3}/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
           with(
             headers: {
               'Page-Limit' => '200',
@@ -42,26 +32,12 @@ RSpec.describe Prison, type: :model do
             }).
           to_return(body: offenders.to_json)
 
-        # stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/movements/offenders?latestOnly=false&movementTypes=TAP").
-        #   with(body: offenders.map { |o| o.fetch(:offenderNo) }.to_json).
-        #   to_return(body: [].to_json)
-        stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/movements/offenders?latestOnly=false&movementTypes=TAP").
+        stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=true&movementTypes=TAP").
+          with(body: offenders.map { |o| o.fetch(:offenderNo) }.to_json).
           to_return(body: [].to_json)
-
-        stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
-          with(
-            headers: {
-              'Page-Limit' => '200',
-              'Page-Offset' => '200',
-            }).
-          to_return(body: [].to_json)
-
-        # stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/movements/offenders?latestOnly=false&movementTypes=TAP").
-        #   with(body: [].to_json).
-        #   to_return(body: [].to_json)
 
         bookings = offenders.map { |offender| { 'bookingId' => offender.fetch(:bookingId), 'sentenceDetail' => offender.fetch(:sentence) } }
-        stub_request(:post, "https://api-dev.prison.service.justice.gov.uk/api/offender-sentences/bookings").
+        stub_request(:post, "#{ApiHelper::T3}/offender-sentences/bookings").
           with(body: offenders.map { |o| o.fetch(:bookingId) }.to_json).
           to_return(body: bookings.to_json)
       end


### PR DESCRIPTION
Our pagination code had yet another defect hiding in it - when the nunber of offenders was an exact multiple of the page size, we went for one extra request. This used to be harmless, but after the movement fetching was introduced for ROTLs, it becomes dehabilitating as the request for movements for [] returns a 400 status from the movement API