### PR TITLE
POM-829 offender Ids have to conform to 'A0000AA' format

### DIFF
--- a/spec/services/nomis/elite2/offender_api_spec.rb
+++ b/spec/services/nomis/elite2/offender_api_spec.rb
@@ -80,13 +80,14 @@ describe Nomis::Elite2::OffenderApi do
       expect(response).to eq('C')
     end
 
-    it 'returns nil if unable to find prisoner',
-       vcr: { cassette_name: :offender_api_null_offender_spec  } do
-      noms_id = 'AAA22D'
+    context 'when unable to find prisoner', vcr: { cassette_name: :offender_api_null_offender_spec } do
+      let(:noms_id) { 'A2222DD' }
 
-      response = described_class.get_offender(noms_id)
+      it 'returns nil' do
+        response = described_class.get_offender(noms_id)
 
-      expect(response).to be_nil
+        expect(response).to be_nil
+      end
     end
   end
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -14,11 +14,15 @@ describe OffenderService do
     expect(offender.case_allocation).to eq 'CRC'
   end
 
-  it "returns nil if offender record not found", vcr: { cassette_name: :offender_service_single_offender_not_found_spec } do
-    nomis_offender_id = 'AAA121212CV4G4GGVV'
+  context 'when offender record not found', vcr: { cassette_name: :offender_service_single_offender_not_found_spec } do
+    let(:nomis_offender_id) { 'C4443CV' }
 
-    offender = described_class.get_offender(nomis_offender_id)
-    expect(offender).to be_nil
+    it "returns nil" do
+      nomis_offender_id = 'C4443CV'
+
+      offender = described_class.get_offender(nomis_offender_id)
+      expect(offender).to be_nil
+    end
   end
 
   describe "#set_allocated_pom_name" do


### PR DESCRIPTION
It seems that Prison API dev has just changed its error behaviour around non-conformant NOMIS IDs - it was allowing the and returning 404, now it seems that it is returning a 400 error