### PR TITLE
fix a mis-feature in movement factory

### DIFF
--- a/spec/factories/movement.rb
+++ b/spec/factories/movement.rb
@@ -18,8 +18,9 @@ FactoryBot.define do
       'LEI'
     end
 
+    # This should be far enough in the past so that the offender isn't considered a 'new arrival' by default
     sequence(:createDateTime) do |seq|
-      (Time.zone.today - seq.days).to_s
+      (Time.zone.today - 1.year - seq.days).to_s
     end
 
     toAgency do


### PR DESCRIPTION
Movement Factory creates a very recent movement by default (it ca be as recent a yesterday) which can cause tests to fail as the codebase will consider the offender a 'recent arrival' in e.g. the summary screens.