### PR TITLE
POM-809 allow same name to exist in NPS and CRC worlds

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,11 +5,14 @@ class Team < ApplicationRecord
 
   validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
   validates :code, uniqueness: true, if: -> { nps? && code.present? }
-  validates :name, uniqueness: true, if: -> { nps? }
 
   validate do |team|
     unless team.code.present? || team.shadow_code.present?
       team.errors.add(:code, 'can\'t be blank if shadow_code is blank')
+    end
+
+    if team.name.present? && team.nps? && Team.nps.where(name: team.name).any? { |t| t.id != team.id }
+      team.errors.add(:name, :taken)
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe Team, type: :model do
         expect(team.errors.to_a).to eq(["Name has already been taken"])
       end
     end
+
+    context 'with a duplicate CRC team name' do
+      let(:team) { create(:team, :crc, name: oldteam.name) }
+
+      it 'is valid' do
+        expect(team).to be_valid
+        expect(oldteam).to be_valid
+      end
+    end
   end
 
   context 'when CRC' do


### PR DESCRIPTION
Allow 'Leamington' to exist in both NPS and CRC worlds by loosening the uniqueness validation slightly.
Previously a CRC 'Leamington' would prevent an NPS 'Leamington' from being saved, but saving a CRC 'Leamington' (with no uniqueness check) after an NPS version would mysteriously make the existing saved NPS 'Leamington' record invalid