### PR TITLE
POM-831 search API not always returning same data as Prison API

### DIFF
--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -118,13 +118,14 @@ module Nomis
 
     private
 
-      def self.get_recall_flags(offenders)
+      def self.get_recall_flags(offender_nos)
         search_route = '/prisoner-numbers'
-        search_key = "#{search_route}_#{Digest::SHA256.hexdigest(offenders.to_s)}"
-        Rails.cache.fetch(search_key,
-                          expires_in: Rails.configuration.cache_expiry) {
-          search_client.post(search_route, prisonerNumbers: offenders)
-        }.map { |prisoner| [prisoner.fetch('prisonerNumber'), { 'recall' => prisoner.fetch('recall', false) }] }.to_h
+        search_key = "#{search_route}_#{Digest::SHA256.hexdigest(offender_nos.to_s)}"
+        search_result = Rails.cache.fetch(search_key,
+                                          expires_in: Rails.configuration.cache_expiry) {
+                          search_client.post(search_route, prisonerNumbers: offender_nos)
+                        }.index_by { |prisoner| prisoner.fetch('prisonerNumber') }
+        offender_nos.index_with { |_nomis_id| { 'recall' => search_result.fetch('recall', false) } }
       end
 
       def self.paging_headers(page_size, page_offset)

--- a/app/services/nomis/elite2/offender_api.rb
+++ b/app/services/nomis/elite2/offender_api.rb
@@ -125,7 +125,7 @@ module Nomis
                                           expires_in: Rails.configuration.cache_expiry) {
                           search_client.post(search_route, prisonerNumbers: offender_nos)
                         }.index_by { |prisoner| prisoner.fetch('prisonerNumber') }
-        offender_nos.index_with { |_nomis_id| { 'recall' => search_result.fetch('recall', false) } }
+        offender_nos.index_with { |nomis_id| { 'recall' => search_result.fetch(nomis_id, {}).fetch('recall', false) } }
       end
 
       def self.paging_headers(page_size, page_offset)

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -19,6 +19,44 @@ RSpec.describe Prison, type: :model do
       expect(offender_array.first).to be_kind_of(Nomis::OffenderSummary)
     end
 
+    context 'when the search API misses someone' do
+      let(:offenders) { build_list(:nomis_offender, 10) }
+      let(:offender_nos) { offenders.map { |o| o.fetch(:offenderNo) } }
+
+      before do
+        stub_auth_token
+        stub_request(:get, "#{ApiHelper::T3}/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+          with(
+            headers: {
+              'Page-Limit' => '200',
+              'Page-Offset' => '0',
+            }).
+          to_return(body: offenders.to_json)
+
+        stub_request(:post, "#{ApiHelper::T3_SEARCH}/prisoner-numbers").
+          with(
+            body: { prisonerNumbers: offender_nos }.to_json
+          ).
+          to_return(body: offenders.first(2).map { |o|
+            { prisonerNumber: o.fetch(:offenderNo),
+              recall: o.fetch(:recall) }
+          }                          .to_json)
+
+        stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=true&movementTypes=TAP").
+          with(body: offender_nos.to_json).
+          to_return(body: [].to_json)
+
+        bookings = offenders.map { |offender| { 'bookingId' => offender.fetch(:bookingId), 'sentenceDetail' => offender.fetch(:sentence) } }
+        stub_request(:post, "#{ApiHelper::T3}/offender-sentences/bookings").
+          with(body: offenders.map { |o| o.fetch(:bookingId) }.to_json).
+          to_return(body: bookings.to_json)
+      end
+
+      it 'doesnt crash' do
+        expect(subject.count).to eq(10)
+      end
+    end
+
     context 'when there are exactly 200 offenders' do
       let(:offenders) { build_list(:nomis_offender, 200) }
       let(:offender_nos) { offenders.map { |o| o.fetch(:offenderNo) } }

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -19,8 +19,21 @@ RSpec.describe Prison, type: :model do
       expect(offender_array.first).to be_kind_of(Nomis::OffenderSummary)
     end
 
+    context 'when recall flag set' do
+      let(:offenders) { build_list(:nomis_offender, 2, recall: true) }
+
+      before do
+        stub_auth_token
+        stub_offenders_for_prison('LEI', offenders)
+      end
+
+      it 'populates the recall flag' do
+        expect(subject.map(&:recalled?)).to eq [true, true]
+      end
+    end
+
     context 'when the search API misses someone' do
-      let(:offenders) { build_list(:nomis_offender, 10) }
+      let(:offenders) { build_list(:nomis_offender, 5, recall: true) }
       let(:offender_nos) { offenders.map { |o| o.fetch(:offenderNo) } }
 
       before do
@@ -52,8 +65,8 @@ RSpec.describe Prison, type: :model do
           to_return(body: bookings.to_json)
       end
 
-      it 'doesnt crash' do
-        expect(subject.count).to eq(10)
+      it 'returns falses when missing' do
+        expect(subject.map(&:recalled?)).to eq([true, true, false, false, false])
       end
     end
 


### PR DESCRIPTION
It seems that the Prisoner Search API doesn't always return the data it has been asked for - even if the list of offenders has just been returned from the Prison API.
This fixes this problem, by assuming that the recall flag is false in this case