### PR TITLE
Banner notification for recalls POM-828

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
-//= link @ministryofjustice/frontend/moj/assets/images/icon-close-cross-black.svg
+//= link_tree ../../../node_modules/@ministryofjustice/frontend/moj/assets/images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/notifications/service_notifications.yaml
+++ b/app/notifications/service_notifications.yaml
@@ -28,3 +28,10 @@
 
 ---
 notifications:
+  - id: recall-badges-09-2020
+    start_date: 08/09/2020
+    role:
+      - POM
+      - SPO
+    end_date: 18/09/2020
+    text: "<b>NEW FEATURE:</b> Prisoners on recall can now be identified by the 'Recall' badge shown on their case details page. <a href='/whats-new'>Read more</a>"

--- a/app/views/layouts/_service_notification_banner.html.erb
+++ b/app/views/layouts/_service_notification_banner.html.erb
@@ -3,7 +3,7 @@
       <div class="govuk-width-container app-site-width-container">
         <div class="service_banner">
           <button onclick="cancelThisNotification(this)" type="button" class="close-service-notification" id="<%= "ServiceNotifications." + service_alert['id'] %>">
-            <%= image_tag('icon-close-cross-black.svg', alt:"close notification", class: "close-button") %>
+            <%= image_tag(asset_path('@ministryofjustice/frontend/moj/assets/images/icon-close-cross-black.svg'), alt:"close notification", class: "close-button") %>
           </button>
           <p><%= raw(service_alert['text']) %></p>
         </div>


### PR DESCRIPTION
This PR should fix the issues with the close icon button on banner notifications. The problem appeared to have been the path that was previously used resulted in `Asset not found` error. This PR has been tested in the Heroku deployment and now works

**Screenshot from Heroku deployment**
<img width="1680" alt="Screen Shot 2020-09-10 at 16 08 43" src="https://user-images.githubusercontent.com/10685841/92752022-71de9f00-f380-11ea-8853-690570e1536b.png">
