### PR TITLE
POM-815 match team to an existing shadow-only if there is one

### DIFF
--- a/app/services/update_team_name_and_ldu_service.rb
+++ b/app/services/update_team_name_and_ldu_service.rb
@@ -5,9 +5,16 @@ class UpdateTeamNameAndLduService
     ldu = LocalDivisionalUnit.find_or_create_by!(code: ldu_code) do |l|
       l.name = ldu_name
     end
-    Team.find_or_initialize_by(code: team_code).tap do |t|
-      t.assign_attributes(name: team_name, local_divisional_unit: ldu)
-      t.save! if t.changed?
+    # If there is a code-less team with this name, match to it as it used to be a 'shadow-only' team
+    existing_team = Team.find_by(name: team_name)
+    if existing_team.present? && existing_team.code.nil?
+      existing_team.assign_attributes(code: team_code, local_divisional_unit: ldu)
+      existing_team.save! if existing_team.changed?
+    else
+      Team.find_or_initialize_by(code: team_code).tap do |team|
+        team.assign_attributes(name: team_name, local_divisional_unit: ldu)
+        team.save! if team.changed?
+      end
     end
   end
 end

--- a/spec/services/update_team_name_and_ldu_service_spec.rb
+++ b/spec/services/update_team_name_and_ldu_service_spec.rb
@@ -102,4 +102,22 @@ RSpec.describe UpdateTeamNameAndLduService do
       }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken')
     end
   end
+
+  context 'when a shadow team of the same name exists' do
+    before do
+      create(:team, code: nil, local_divisional_unit: nil)
+      create(:local_divisional_unit)
+    end
+
+    let(:ldu) { LocalDivisionalUnit.last }
+
+    let(:team) { Team.last }
+    let(:team_code) { 'NTTR2' }
+
+    it 'matches, and updates the LDU' do
+      described_class.update(team_code: team_code, team_name: team.name, ldu_code: ldu.code, ldu_name: ldu.name)
+      expect(team.reload.attributes.symbolize_keys.except(:id, :case_information_count, :created_at, :updated_at)).
+        to eq(attributes_for(:team, shadow_code: team.shadow_code, code: team_code, name: team.name, local_divisional_unit_id: ldu.id))
+    end
+  end
 end


### PR DESCRIPTION
In the current DeliusImportJob, if a shadow team is created first (i.e. one with just a shadow code and a name) then if/when the actual team shows up, it fails to match to it as the real team matching is done purely by code. This PR spots this case, and matches the team up by name instead.