### PR TITLE
Pom813 ldu team codes only allow alpha-numerics

### DIFF
--- a/app/jobs/delius_import_job.rb
+++ b/app/jobs/delius_import_job.rb
@@ -115,9 +115,9 @@ private
     processor.select { |record| active_ldu?(record.fetch(:ldu_code)) }.uniq { |r| r.fetch(:team_code) }.each do |rec|
       process_record_logging_errors(rec) do |record|
         UpdateTeamNameAndLduService.update(
-          team_code: record.fetch(:team_code),
+          team_code: record.fetch(:team_code).strip,
           team_name: record.fetch(:team),
-          ldu_code: record.fetch(:ldu_code),
+          ldu_code: record.fetch(:ldu_code).strip,
           ldu_name: record.fetch(:ldu)
         )
       end
@@ -127,7 +127,7 @@ private
       process_record_logging_errors(rec) do |record|
         UpdateShadowTeamAssociationService.update(
           shadow_name: record.fetch(:team),
-          shadow_code: record.fetch(:team_code)
+          shadow_code: record.fetch(:team_code).strip
         )
       end
     end

--- a/app/models/local_divisional_unit.rb
+++ b/app/models/local_divisional_unit.rb
@@ -3,9 +3,8 @@
 class LocalDivisionalUnit < ApplicationRecord
   has_many :teams, dependent: :restrict_with_error
 
-  validates :code, :name, presence: true
-
-  validates :code, uniqueness: true
+  validates :name, presence: true
+  validates :code, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9]+\z/ }
 
   scope :without_email_address, -> { where(email_address: nil) }
   scope :with_email_address, -> { where.not(email_address: nil) }

--- a/app/models/local_divisional_unit.rb
+++ b/app/models/local_divisional_unit.rb
@@ -4,7 +4,7 @@ class LocalDivisionalUnit < ApplicationRecord
   has_many :teams, dependent: :restrict_with_error
 
   validates :name, presence: true
-  validates :code, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9]+\z/ }
+  validates :code, presence: true, uniqueness: true, format: { with: Team::TEAM_LDU_CODE_REGEX }
 
   scope :without_email_address, -> { where(email_address: nil) }
   scope :with_email_address, -> { where.not(email_address: nil) }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,11 +4,13 @@ class Team < ApplicationRecord
   TEAM_LDU_CODE_REGEX = /\A[a-zA-Z0-9]+\z/.freeze
 
   validates :name, presence: true
-  validates :code, format: { with: TEAM_LDU_CODE_REGEX }, unless: -> { code.blank? }
-  validates :shadow_code, format: { with: TEAM_LDU_CODE_REGEX }, unless: -> { shadow_code.blank? }
+  validates :name, uniqueness: true, if: -> { nps? }
 
-  validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
+  validates :code, format: { with: TEAM_LDU_CODE_REGEX }, unless: -> { code.blank? }
   validates :code, uniqueness: true, if: -> { nps? && code.present? }
+
+  validates :shadow_code, format: { with: TEAM_LDU_CODE_REGEX }, unless: -> { shadow_code.blank? }
+  validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
 
   validate do |team|
     unless team.code.present? || team.shadow_code.present?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class Team < ApplicationRecord
+  TEAM_LDU_CODE_REGEX = /\A[a-zA-Z0-9]+\z/.freeze
+
   validates :name, presence: true
-  validates :code, format: { with: /\A[a-zA-Z0-9]+\z/, allow_nil: true }
+  validates :code, format: { with: TEAM_LDU_CODE_REGEX }, unless: -> { code.blank? }
+  validates :shadow_code, format: { with: TEAM_LDU_CODE_REGEX }, unless: -> { shadow_code.blank? }
 
   validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
   validates :code, uniqueness: true, if: -> { nps? && code.present? }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,6 +2,7 @@
 
 class Team < ApplicationRecord
   validates :name, presence: true
+  validates :code, format: { with: /\A[a-zA-Z0-9]+\z/, allow_nil: true }
 
   validates :shadow_code, uniqueness: true, if: -> { nps? && shadow_code.present? }
   validates :code, uniqueness: true, if: -> { nps? && code.present? }
@@ -22,6 +23,9 @@ class Team < ApplicationRecord
     code&.starts_with?('N')
   end
 
+  # This should strictly be a non-optional association, but without it we
+  # will just attach the a shadow-only team to the 'OMIC Responsibility' team.
+  # Maybe that's what we should do?
   belongs_to :local_divisional_unit, optional: true
 
   has_many :case_information, dependent: :restrict_with_error, counter_cache: :case_information_count

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,9 +5,10 @@ class Team < ApplicationRecord
 
   class NpsUniquenessValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
+      scope = Team.nps
       if record.new_record?
-        record.errors.add(attribute, :taken) if Team.nps.find_by(attribute => value).present?
-      elsif Team.nps.where(attribute => value).where.not(id: record.id).any?
+        record.errors.add(attribute, :taken) if scope.find_by(attribute => value).present?
+      elsif scope.where(attribute => value).where.not(id: record.id).any?
         record.errors.add(attribute, :taken)
       end
     end

--- a/spec/jobs/delius_import_job_spec.rb
+++ b/spec/jobs/delius_import_job_spec.rb
@@ -56,4 +56,12 @@ RSpec.describe DeliusImportJob, type: :job do
       subject.process_decrypted_file([ldu_code: 'N01OMIC', ldu: 'An LDU', team_code: 'SHAD01', team: bad_shadow_name])
     end
   end
+
+  context 'with tabs on the end of the team code' do
+    it 'still works correctly due to stripping' do
+      expect {
+        subject.process_decrypted_file([ldu_code: 'N50LDU', ldu: 'An LDU', team_code: "NN01\t", team: 'Team Name'])
+      }.to change(Team, :count).by(1)
+    end
+  end
 end

--- a/spec/models/local_divisional_unit_spec.rb
+++ b/spec/models/local_divisional_unit_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe LocalDivisionalUnit, type: :model do
   describe '#code' do
     let(:ldu) { build(:local_divisional_unit, code: code) }
 
+    context 'with blank' do
+      let(:code) { '' }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+      end
+    end
+
     context 'with non-alpha' do
       let(:code) { "ND4\t" }
 

--- a/spec/models/local_divisional_unit_spec.rb
+++ b/spec/models/local_divisional_unit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe LocalDivisionalUnit, type: :model do
@@ -6,4 +8,32 @@ RSpec.describe LocalDivisionalUnit, type: :model do
     expect(subject).to validate_presence_of :code
     expect(subject).not_to validate_presence_of :email_address
   }
+
+  describe '#code' do
+    let(:ldu) { build(:local_divisional_unit, code: code) }
+
+    context 'with non-alpha' do
+      let(:code) { "ND4\t" }
+
+      it 'is invalid' do
+        expect(ldu).not_to be_valid
+      end
+    end
+
+    context 'with upper-case and numbers' do
+      let(:code) { 'ND143A' }
+
+      it 'is valid' do
+        expect(ldu).to be_valid
+      end
+    end
+
+    context 'with lower-case and numbers' do
+      let(:code) { 'nd143a' }
+
+      it 'is valid' do
+        expect(ldu).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -11,6 +11,34 @@ RSpec.describe Team, type: :model do
     expect(build(:team, code: nil, shadow_code: 'N123')).to be_valid
   end
 
+  describe '#code' do
+    subject { build(:team, code: code) }
+
+    context 'with non-alpha' do
+      let(:code) { "ND4\t" }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context 'with upper-case and numbers' do
+      let(:code) { 'ND143A' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with lower-case and numbers' do
+      let(:code) { 'nd143a' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+
   context 'when NPS' do
     before do
       create(:team, :nps)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -14,6 +14,50 @@ RSpec.describe Team, type: :model do
   describe '#code' do
     subject { build(:team, code: code) }
 
+    context 'with blank' do
+      let(:code) { '' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with non-alpha' do
+      let(:code) { "ND4\t" }
+
+      it 'is invalid' do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context 'with upper-case and numbers' do
+      let(:code) { 'ND143A' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with lower-case and numbers' do
+      let(:code) { 'nd143a' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+
+  describe '#shadow_code' do
+    subject { build(:team, shadow_code: code) }
+
+    context 'with blank' do
+      let(:code) { '' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
     context 'with non-alpha' do
       let(:code) { "ND4\t" }
 

--- a/spec/services/update_shadow_team_association_service_spec.rb
+++ b/spec/services/update_shadow_team_association_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UpdateShadowTeamAssociationService do
   end
 
   context "when the team has a different shadow code" do
-    let(:team_shadow_code) { 'A_DIFFERENT_SHADOW_CODE' }
+    let(:team_shadow_code) { 'SHAD02' }
 
     it "updates the team's shadow code" do
       described_class.update(shadow_code: 'SHAD01', shadow_name: 'OMIC NPS - Team 1')


### PR DESCRIPTION
It appears that our data feed sometimes includes tab characters in the 'code' field which leads to a lot of weird behaviour - if nothing else it makes it look as though duplicates are possible, This PR remedies that situation by preventing it 