### PR TITLE
Pom812 match active team by name

### DIFF
--- a/spec/services/update_team_name_and_ldu_service_spec.rb
+++ b/spec/services/update_team_name_and_ldu_service_spec.rb
@@ -95,17 +95,17 @@ RSpec.describe UpdateTeamNameAndLduService do
     end
 
     let(:ldu) { build(:local_divisional_unit) }
+    let(:team) { Team.last }
 
-    it 'errors' do
-      expect {
-        described_class.update(team_code: 'NTTR2', team_name: 'A team', ldu_code: ldu.code, ldu_name: ldu.name)
-      }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken')
+    it 'matches to the existing team and updates the code' do
+      described_class.update(team_code: 'NTTR2', team_name: 'A team', ldu_code: ldu.code, ldu_name: ldu.name)
+      expect(team.code).to eq('NTTR2')
     end
   end
 
   context 'when a shadow team of the same name exists' do
     before do
-      create(:team, code: nil, local_divisional_unit: nil)
+      create(:team, code: '', local_divisional_unit: nil)
       create(:local_divisional_unit)
     end
 


### PR DESCRIPTION
When nDelius data is re-jigged, we can end up trying to create a new team with the same name but a different code. 
This PR changes that so that we match the team and update the code.