### PR TITLE
Pom 805 bug allocation reallocation 2

### DIFF
--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -28,26 +28,24 @@ private
   end
 
   def redirect_on_success
-    previously_allocated = AllocationService.previously_allocated_poms(
-      override_params[:nomis_offender_id]
-    )
+    allocation = AllocationService.current_allocation_for(override_params[:nomis_offender_id])
 
-    if previously_allocated.empty?
-      redirect_to prison_confirm_allocation_path(
-        active_prison_id,
-        override_params[:nomis_offender_id],
-        override_params[:nomis_staff_id],
-        sort: params[:sort],
-        page: params[:page]
-      )
-    else
+    if allocation.present? && allocation.active?
       redirect_to prison_confirm_reallocation_path(
         active_prison_id,
         override_params[:nomis_offender_id],
         override_params[:nomis_staff_id],
         sort: params[:sort],
         page: params[:page]
-      )
+                  )
+    else
+      redirect_to prison_confirm_allocation_path(
+        active_prison_id,
+        override_params[:nomis_offender_id],
+        override_params[:nomis_staff_id],
+        sort: params[:sort],
+        page: params[:page]
+                  )
     end
   end
 

--- a/app/views/allocations/_allocate_primary_pom.html.erb
+++ b/app/views/allocations/_allocate_primary_pom.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-timeline__item">
   <div class="moj-timeline__header">
-    <h2 class="moj-timeline__title">Prisoner allocation</h2>
+    <h2 class="moj-timeline__title">Prisoner allocated</h2>
   </div>
 
   <div class="moj-timeline__description">Prisoner allocated to <%= pom_name.titleize %>

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -8,7 +8,8 @@
       <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
       <div class="moj-timeline">
           <% allocations.each_with_index do |allocation, i| %>
-            <% if allocation.event == 'allocate_primary_pom' %>
+<!-- It is size-1 because the list is displayed backwards -->
+            <% if allocation.event == 'allocate_primary_pom' || i == allocations.size-1 %>
               <%= render :partial => "allocate_primary_pom",
                          :locals => { allocation: allocation,
                                       pom_name: allocation.primary_pom_name,

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -51,5 +51,48 @@ FactoryBot.define do
     updated_at do
       DateTime.now.utc
     end
+
+    trait :primary do
+      event {Allocation::ALLOCATE_PRIMARY_POM}
+      event_trigger { Allocation::USER }
+      primary_pom_nomis_id { 123_456}
+      primary_pom_name {"#{Faker::Name.last_name}, #{Faker::Name.first_name}"}
+      secondary_pom_nomis_id { nil }
+      secondary_pom_name { nil }
+    end
+
+    trait :release do
+      event { Allocation::DEALLOCATE_RELEASED_OFFENDER }
+      event_trigger {Allocation::OFFENDER_RELEASED}
+      primary_pom_nomis_id { nil}
+      primary_pom_name { nil }
+      secondary_pom_nomis_id { nil }
+      secondary_pom_name { nil }
+    end
+
+    trait :transfer do
+      event { Allocation::DEALLOCATE_PRIMARY_POM }
+      event_trigger {Allocation::OFFENDER_RELEASED}
+      primary_pom_nomis_id { nil}
+      primary_pom_name { nil }
+      secondary_pom_nomis_id { nil }
+      secondary_pom_name { nil }
+    end
+
+    trait :reallocation do
+      event {Allocation::REALLOCATE_PRIMARY_POM}
+      event_trigger { Allocation::USER }
+      primary_pom_nomis_id { 123_456}
+      primary_pom_name {"#{Faker::Name.last_name}, #{Faker::Name.first_name}"}
+      secondary_pom_nomis_id { nil }
+      secondary_pom_name { nil }
+    end
+
+    trait :override do
+      override_detail {Faker::Lorem.sentence}
+      suitability_detail {Faker::Lorem.sentence}
+      override_reasons { ["suitability"] }
+    end
+
   end
 end

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -120,7 +120,7 @@ feature 'Allocation History' do
         ['.moj-timeline__title', "Prisoner reallocated"],
         ['.moj-timeline__description', "Prisoner reallocated to #{history1.primary_pom_name.titleize} - (email address not found) Tier: #{history1.allocated_at_tier}"],
         ['.moj-timeline__date', formatted_date_for(history1).to_s],
-        ['.moj-timeline__title', "Prisoner allocation"],
+        ['.moj-timeline__title', "Prisoner allocated"],
         ['.moj-timeline__description', "Prisoner allocated to #{history2.primary_pom_name.titleize} - #{prison_pom[:email]} Tier: #{history2.allocated_at_tier}"],
         ['.moj-timeline__date', formatted_date_for(history2).to_s],
         ['.moj-timeline__description', "Prisoner allocated to #{hist_allocate_secondary.secondary_pom_name.titleize} - #{probation_pom[:email]} Tier: #{hist_allocate_secondary.allocated_at_tier}"],
@@ -132,7 +132,7 @@ feature 'Allocation History' do
         ['.moj-timeline__title', "Prisoner reallocated"],
         ['.moj-timeline__description', "Prisoner reallocated to #{history6.primary_pom_name.titleize} - #{probation_pom_2[:email]} Tier: #{history6.allocated_at_tier}"],
         ['.moj-timeline__date', "#{formatted_date_for(history6)} by #{history6.created_by_name.titleize}"],
-        ['.moj-timeline__title', "Prisoner allocation"],
+        ['.moj-timeline__title', "Prisoner allocated"],
         ['.moj-timeline__description', "Prisoner allocated to #{history.last.primary_pom_name.titleize} - #{probation_pom[:email]} Tier: #{history.last.allocated_at_tier}"],
         ['.moj-timeline__description', "Probation POM allocated instead of recommended Prison POM", "Reason(s):", "- Prisoner assessed as suitable for a prison POM despite tiering calculation", "Too high risk"],
         ['.moj-timeline__date', "#{formatted_date_for(history.last)} by #{history.last.created_by_name.titleize}"]

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -58,7 +58,7 @@ feature 'View a prisoner profile page' do
     it "has a link to the allocation history", :versioning, vcr: { cassette_name: :link_to_allocation_history } do
       visit prison_prisoner_path('LEI', 'G7998GJ')
       click_link "View"
-      expect(page).to have_content('Prisoner allocation')
+      expect(page).to have_content('Prisoner allocated')
     end
 
     it "has community information when present",

--- a/spec/views/allocations/allocation_history.html.erb_spec.rb
+++ b/spec/views/allocations/allocation_history.html.erb_spec.rb
@@ -17,4 +17,25 @@ RSpec.describe "allocations/history", type: :view do
       expect(page.css('#override-reason-reallocation').text).to include 'Continuity'
     end
   end
+
+  # Their is a fix in this view to display incorrect data correctly due to a bug created in the Override Controller. Unfortunately this bad data
+  # can not be altered so to get around this it has been modified at the view level.
+  context 'when a prisoner has moved to another prison' do
+    before do
+      assign(:prisoner, build(:offender))
+      assign(:pom_emails, {})
+      assign(:history, [build(:allocation, :primary, prison: prison_one),
+                        build(:allocation, :transfer, prison: prison_one),
+                        build(:allocation, :reallocation, :override, prison: prison_two)])
+    end
+
+    let(:prison_one) { build(:prison).code }
+    let(:prison_two) { build(:prison).code }
+    let(:page) { Nokogiri::HTML(rendered) }
+
+    it 'displays an allocation label in the allocation history' do
+      render
+      expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Prisoner allocated", "Prisoner unallocated", "Prisoner allocated"]
+    end
+  end
 end


### PR DESCRIPTION
When a prisoner is deallocated at a prison due to transfer the next allocation should be: ALLOCATION (not re-allocation as is now) So when there is a deallocation - the next step should be Allocation and then Re-allocation until the De-allocation of a case when the journey starts again. 

This bug was discovered and corrected in the Override Controller. However, this bug created bad data that could not be altered with the bug fix. To get around this the data has been modified at the view level to ensure that allocation is always displayed when an offender has been transferred to a new prison.