### PR TITLE
Add support for PUT and DELETE calls to HMPPS API client

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -68,6 +68,12 @@ module Nomis
       JSON.parse(response.body)
     end
 
+    def delete(route, queryparams: {}, extra_headers: {})
+      request(
+        :delete, route, queryparams: queryparams, extra_headers: extra_headers
+      )
+    end
+
   private
 
     def request(method, route, queryparams: {}, extra_headers: {}, body: nil)

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -60,16 +60,24 @@ module Nomis
       JSON.parse(response.body)
     end
 
+    def put(route, body, queryparams: {}, extra_headers: {})
+      response = request(
+        :put, route, queryparams: queryparams, extra_headers: extra_headers, body: body
+      )
+
+      JSON.parse(response.body)
+    end
+
   private
 
     def request(method, route, queryparams: {}, extra_headers: {}, body: nil)
       @connection.send(method) do |req|
         req.url(@root + route)
         req.headers['Authorization'] = "Bearer #{token.access_token}"
-        req.headers['Content-Type'] = 'application/json' if method == :post
+        req.headers['Content-Type'] = 'application/json' unless body.nil?
         req.headers.merge!(extra_headers)
         req.params.update(queryparams)
-        req.body = body.to_json if body.present? && method == :post
+        req.body = body.to_json unless body.nil?
       end
     rescue Faraday::ConnectionFailed => e
       AllocationManager::ExceptionHandler.capture_exception(e)

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -7,6 +7,14 @@ describe Nomis::Client do
   let(:access_token) { "access_token" }
   let(:valid_token) { Nomis::Oauth::Token.new(access_token: access_token) }
 
+  let(:auth_header) {
+    {
+      headers: {
+        'Authorization': "Bearer #{access_token}"
+      }
+    }
+  }
+
   before do
     allow(token_service).to receive(:valid_token).and_return(valid_token)
   end
@@ -20,11 +28,7 @@ describe Nomis::Client do
       client.get(route)
 
       expect(WebMock).to have_requested(:get, /\w/).
-        with(
-          headers: {
-            'Authorization': "Bearer #{access_token}"
-          }
-      )
+        with(auth_header)
     end
   end
 
@@ -125,11 +129,7 @@ describe Nomis::Client do
 
       it 'performs an authenticated GET request' do
         expect(WebMock).to have_requested(:get, stub_url).
-          with(
-            headers: {
-              'Authorization': "Bearer #{access_token}"
-            }
-          )
+          with(auth_header)
       end
 
       include_examples 'handles JSON response'
@@ -151,11 +151,7 @@ describe Nomis::Client do
 
       it 'performs an authenticated POST request' do
         expect(WebMock).to have_requested(:post, stub_url).
-          with(
-            headers: {
-              'Authorization': "Bearer #{access_token}"
-            }
-          )
+          with(auth_header)
       end
 
       it 'encodes the request body as JSON' do
@@ -187,11 +183,7 @@ describe Nomis::Client do
 
       it 'performs an authenticated PUT request' do
         expect(WebMock).to have_requested(:put, stub_url).
-          with(
-            headers: {
-              'Authorization': "Bearer #{access_token}"
-            }
-          )
+          with(auth_header)
       end
 
       it 'encodes the request body as JSON' do
@@ -205,6 +197,20 @@ describe Nomis::Client do
       end
 
       include_examples 'handles JSON response'
+    end
+
+    describe '#delete' do
+      before do
+        WebMock.stub_request(:delete, stub_url).
+          to_return(status: 200)
+
+        client.delete(route)
+      end
+
+      it 'performs an authenticated DELETE request' do
+        expect(WebMock).to have_requested(:delete, stub_url).
+          with(auth_header)
+      end
     end
   end
 end

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -97,4 +97,114 @@ describe Nomis::Client do
         to raise_error(Nomis::Client::APIError, 'Failed to connect to nosuchhost')
     end
   end
+
+  describe 'instance method' do
+    let(:route) { '/api/some/endpoint' }
+    let(:stub_url) { api_host + route }
+    let(:response_body) { '{"key": "value", "success": true}' }
+
+    shared_examples 'handles JSON response' do
+      it 'decodes the response JSON' do
+        expect(response).to be_a(Hash)
+        expect(response).to eq JSON.parse(response_body)
+      end
+    end
+
+    describe '#get' do
+      let(:response) do
+        client.get(route)
+      end
+
+      before do
+        WebMock.stub_request(:get, stub_url).
+          to_return(body: response_body)
+
+        # Trigger the request
+        response
+      end
+
+      it 'performs an authenticated GET request' do
+        expect(WebMock).to have_requested(:get, stub_url).
+          with(
+            headers: {
+              'Authorization': "Bearer #{access_token}"
+            }
+          )
+      end
+
+      include_examples 'handles JSON response'
+    end
+
+    describe '#post' do
+      let(:request_body) { { id: 123, someKey: 'Some value' } }
+      let(:response) do
+        client.post(route, request_body)
+      end
+
+      before do
+        WebMock.stub_request(:post, stub_url).
+          to_return(body: response_body)
+
+        # Trigger the request
+        response
+      end
+
+      it 'performs an authenticated POST request' do
+        expect(WebMock).to have_requested(:post, stub_url).
+          with(
+            headers: {
+              'Authorization': "Bearer #{access_token}"
+            }
+          )
+      end
+
+      it 'encodes the request body as JSON' do
+        expect(WebMock).to have_requested(:post, stub_url).
+          with(
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: request_body.to_json
+          )
+      end
+
+      include_examples 'handles JSON response'
+    end
+
+    describe '#put' do
+      let(:request_body) { { id: 123, someKey: 'Some value' } }
+      let(:response) do
+        client.put(route, request_body)
+      end
+
+      before do
+        WebMock.stub_request(:put, stub_url).
+          to_return(body: response_body)
+
+        # Trigger the request
+        response
+      end
+
+      it 'performs an authenticated PUT request' do
+        expect(WebMock).to have_requested(:put, stub_url).
+          with(
+            headers: {
+              'Authorization': "Bearer #{access_token}"
+            }
+          )
+      end
+
+      it 'encodes the request body as JSON' do
+        expect(WebMock).to have_requested(:put, stub_url).
+          with(
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: request_body.to_json
+          )
+      end
+
+      include_examples 'handles JSON response'
+    end
+  end
 end


### PR DESCRIPTION
This Pull Request adds support for `PUT` and `DELETE` API calls to the `Nomis::Client` class, which is what we use when calling HMPPS APIs.

This will be needed for pushing data into the Community API in POM-81 and POM-788.

It also adds unit tests for each of the methods `get`, `post`, `put` and `delete` to more explicitly cover what they do (e.g. auto encoding and decoding of JSON, setting the correct Content-Type headers, etc.)