### PR TITLE
Link to live container diagram in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A service for allocating Prisoners to Prisoner Offender Managers (POMs).
 This is a Ruby on Rails application that exposes an interface for Prison staff
 to manage the allocation of POMs to Prisoners.
 
+[![auto-updating container diagram](https://static.structurizr.com/workspace/56937/diagrams/omic-container.png)](https://structurizr.com/share/56937/diagrams#omic-container)
+
+👆 edit in [hmpps-architecture-as-code](https://github.com/ministryofjustice/hmpps-architecture-as-code/blob/9990e7fbb3aa545208d2ebc40104f6f3d5a9813d/src/main/kotlin/model/OffenderManagementInCustody.kt)
+
 ### Dependencies
 
 - [Nomis Oauth2 Server](https://github.com/ministryofjustice/nomis-oauth2-server) - for logging into the application


### PR DESCRIPTION
This container diagram is maintained in a central architecture model repository.

If any of the components in the diagram change, the diagram will reflect it (eventually, after Github's cache expires).

An auto-refreshing diagram makes it easier to reflect the current state than hand-drawing :)

**Screenshot**

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/1526295/94916358-73dede00-04a6-11eb-915e-ede32e460d77.png">

