### PR TITLE
Remove nomis_sentence_detail factory

### DIFF
--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CaseloadController, type: :controller do
       end
 
       let(:today_plus_36_weeks) { (Time.zone.today + 36.weeks).to_s }
-      let(:offender) { build(:nomis_offender, sentence: build(:nomis_sentence_detail, paroleEligibilityDate: today_plus_36_weeks)) }
+      let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, paroleEligibilityDate: today_plus_36_weeks)) }
       let(:case_allocation) { 'NPS' }
 
       it 'can pull back a NPS offender due for handover' do
@@ -49,7 +49,7 @@ RSpec.describe CaseloadController, type: :controller do
     end
 
     context 'when CRC' do
-      let(:offender) { build(:nomis_offender, sentence: build(:nomis_sentence_detail, automaticReleaseDate: today_plus_13_weeks)) }
+      let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, automaticReleaseDate: today_plus_13_weeks)) }
       let(:case_allocation) { 'CRC' }
       let(:today_plus_13_weeks) { (Time.zone.today + 13.weeks).to_s }
 

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DebuggingController, type: :controller do
       offenders = [
         build(:nomis_offender),
         build(:nomis_offender, dateOfBirth: Time.zone.today - 15.years),
-        build(:nomis_offender, sentence: build(:nomis_sentence_detail, releaseDate: nil,
+        build(:nomis_offender, sentence: attributes_for(:sentence_detail, releaseDate: nil,
                      paroleEligibilityDate: nil, homeDetentionCurfewEligibilityDate: nil, tariffDate: nil))
       ]
 

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -17,24 +17,24 @@ RSpec.describe SummaryController, type: :controller do
               offenderNo: "G7514GW",
               imprisonmentStatus: "LR",
               lastName: 'SMITH',
-              sentence: build(:nomis_sentence_detail)),
+              sentence: attributes_for(:sentence_detail, sentenceStartDate: "2011-01-20")),
         build(:nomis_offender, offenderNo: "G1234GY", imprisonmentStatus: "LIFE",
               lastName: 'Minate-Offender',
-              sentence: build(:nomis_sentence_detail,
-                              sentenceStartDate: "2009-02-08",
-                              automaticReleaseDate: "2011-01-28")),
+              sentence: attributes_for(:sentence_detail,
+                                       sentenceStartDate: "2009-02-08",
+                                       automaticReleaseDate: "2011-01-28")),
         build(:nomis_offender, offenderNo: "G1234VV",
               lastName: 'JONES',
-              sentence: build(:nomis_sentence_detail,
-                              sentenceStartDate: "2019-02-08",
-                              automaticReleaseDate: today_plus_13_weeks)),
+              sentence: attributes_for(:sentence_detail,
+                                       sentenceStartDate: "2019-02-08",
+                                       automaticReleaseDate: today_plus_13_weeks)),
         build(:nomis_offender, offenderNo: "G4234GG",
               imprisonmentStatus: "SENT03",
               firstName: "Fourth", lastName: "Offender",
-              sentence: build(:nomis_sentence_detail,
-                              automaticReleaseDate: today_plus_10,
-                              homeDetentionCurfewActualDate: today_plus_10,
-                              sentenceStartDate: "2019-02-08",
+              sentence: attributes_for(:sentence_detail,
+                                       automaticReleaseDate: today_plus_10,
+                                       homeDetentionCurfewActualDate: today_plus_10,
+                                       sentenceStartDate: "2019-02-08",
               ))
       ]
 
@@ -193,8 +193,8 @@ RSpec.describe SummaryController, type: :controller do
       inmates = offenders.map { |offender|
         build(:nomis_offender,
               offenderNo: offender[:nomis_id],
-              sentence: build(:nomis_sentence_detail,
-                              sentenceStartDate: offender.fetch(:sentence_start_date).strftime('%F')))
+              sentence: attributes_for(:sentence_detail,
+                                       sentenceStartDate: offender.fetch(:sentence_start_date).strftime('%F')))
       }
 
       stub_offenders_for_prison(prison, inmates)

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
     recall { false }
 
     sentence do
-      association :nomis_sentence_detail
+      attributes_for :sentence_detail
     end
 
     sequence(:bookingId) { |c| c + 100_000 }

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
       HmppsApi::SentenceDetail.from_json(values_hash)
     end
 
+    # 1 day after policy start in Wales
     sentenceStartDate { '2019-02-05' }
     releaseDate { "2021-01-28" }
     automaticReleaseDate { "2022-01-28" }
@@ -15,21 +16,6 @@ FactoryBot.define do
     conditionalReleaseDate { "2022-01-28" }
     actualParoleDate { "2021-01-28" }
     licenceExpiryDate { "2021-01-28" }
-  end
-
-  factory :nomis_sentence_detail, class: Hash do
-    initialize_with {
-      # remove nil values from hash, so that SentenceDetail#from_json doesn't choke
-      attributes.reject { |_k, v| v.nil? }
-    }
-
-    sentenceStartDate { "2011-01-20" }
-    releaseDate { "2031-01-19" }
-    tariffDate { "2031-01-21" }
-    automaticReleaseDate { "2031-01-22" }
-    postRecallReleaseDate { "2031-01-23" }
-    conditionalReleaseDate { "2031-01-24" }
-    actualParoleDate { "2031-01-27" }
   end
 end
 

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -215,11 +215,11 @@ private
     stub_pom_emails(1, [])
 
     stub_offender(build(:nomis_offender, offenderNo: offender_no,
-                        sentence: build(:nomis_sentence_detail,
-                                        sentenceStartDate: sentence_start_date,
-                                        conditionalReleaseDate: conditional_release_date,
-                                        automaticReleaseDate: automatic_release_date,
-                                        homeDetentionCurfewEligibilityDate: hdced
+                        sentence: attributes_for(:sentence_detail,
+                                                 sentenceStartDate: sentence_start_date,
+                                                 conditionalReleaseDate: conditional_release_date,
+                                                 automaticReleaseDate: automatic_release_date,
+                                                 homeDetentionCurfewEligibilityDate: hdced
                                         )))
 
     stub_request(:get, "#{ApiHelper::T3}/staff/roles/LEI/role/POM").

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -36,8 +36,10 @@ feature "view POM's caseload" do
       map { |nomis_id, booking_id|
       build(:nomis_offender,
             offenderNo: nomis_id,
-            sentence: build(:nomis_sentence_detail,
-                            tariffDate: Time.zone.today + booking_id.minutes))
+            sentence: attributes_for(:sentence_detail,
+                                     automaticReleaseDate: "2031-01-22",
+                                     conditionalReleaseDate: "2031-01-24",
+                                     tariffDate: Time.zone.today + booking_id.minutes))
     }
   }
   let(:sorted_offenders) {

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -32,9 +32,9 @@ context 'when NOMIS is missing information' do
         before do
           stub_offenders = [build(:nomis_offender, offenderNo: offender_no,
                                   imprisonmentStatus: 'SEC91',
-                                  sentence: build(:nomis_sentence_detail,
-                                                  releaseDate: 30.years.from_now.iso8601,
-                                 sentenceStartDate: Time.zone.now.iso8601))]
+                                  sentence: attributes_for(:sentence_detail,
+                                                           releaseDate: 30.years.from_now.iso8601,
+                                                           sentenceStartDate: Time.zone.now.iso8601))]
 
           stub_offenders_for_prison(prison_code, stub_offenders)
 
@@ -52,7 +52,10 @@ context 'when NOMIS is missing information' do
 
     describe 'the prisoner page' do
       before do
-        offender = build(:nomis_offender, offenderNo: offender_no, sentence: build(:nomis_sentence_detail, conditionalReleaseDate: Time.zone.today + 22.months))
+        offender = build(:nomis_offender, offenderNo: offender_no,
+                         sentence: attributes_for(:sentence_detail,
+                                                  automaticReleaseDate: Time.zone.today + 3.years,
+                                                  conditionalReleaseDate: Time.zone.today + 22.months))
 
         stub_request(:get, "#{ApiHelper::T3}/staff/#{staff_id}").
           to_return(body: { staffId: staff_id, firstName: "TEST", lastName: "MOIC" }.to_json)

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -108,7 +108,13 @@ module ApiHelper
                         }
                       }.to_json)
 
-    bookings = booking_ids.zip(offenders).map { |booking_id, offender| { 'bookingId' => booking_id, 'sentenceDetail' => offender.fetch(:sentence) } }
+    bookings = booking_ids.zip(offenders).map do |booking_id, offender|
+      {
+          'bookingId' => booking_id,
+          'sentenceDetail' => offender.fetch(:sentence).reject { |_k, v| v.nil? }
+      }
+    end
+
     stub_request(:post, elite2bookingsapi).with(body: booking_ids.to_json).
       to_return(body: bookings.to_json)
 


### PR DESCRIPTION
The factory :nomis_sentence_detail is an danger of introducing duplication with :sentence_detail (which is involved with the same entity in MOIC).
This PR converts all usages of the :nomis_sentence_detail factory to attributes_for(:sentence_detail) and deletes the factory