### PR TITLE
POM-846 Early Allocation content changes

### DIFF
--- a/app/views/early_allocations/_stage1.html.erb
+++ b/app/views/early_allocations/_stage1.html.erb
@@ -1,4 +1,7 @@
-<%= form_for(@early_assignment, url: prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id), method: form_method) do |f| %>
+<%= form_for(@early_assignment,
+             url: prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id),
+             method: form_method,
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
   <%= render :partial => "/shared/field_errors", :locals => { form: f, errors: @early_assignment.errors } %>
 
   <h1 class="govuk-heading-xl govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
@@ -35,7 +38,7 @@
 
   <%= render partial: 'yes_no_boolean_field', locals: {
       form: f,
-      heading_text: 'Does this prisoner need to be managed as a Multi-Agency Public Protection (MAPPA) level 3 case?',
+      heading_text: 'Is this prisoner likely to meet criteria for Multi-Agency Public Protection (MAPPA) level 3 management?',
       hint_text: 'If a MAPPA assessment has not taken place, give the most likely answer, or ask for an assessment to be carried out by the community probation team',
       errors: @early_assignment.errors,
       fieldname: :mappa_level_3
@@ -43,7 +46,7 @@
 
   <%= render partial: 'yes_no_boolean_field', locals: {
       form: f,
-      heading_text: 'Is this likely to be a Critical Protection Case (CPPC)?',
+      heading_text: 'Is prisoner likely to meet criteria for a referral for CPPC registration and has an \'in principle\' decision? (see <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">Equip</a> for guidance)',
       hint_text: 'This usually means it is also a Multi-Agency Public Protection (MAPPA) level 3 case. See Equip for more about CPPC cases.',
       errors: @early_assignment.errors,
       fieldname: :cppc_case

--- a/app/views/early_allocations/_stage2.html.erb
+++ b/app/views/early_allocations/_stage2.html.erb
@@ -1,4 +1,7 @@
-<%= form_for(@early_assignment, url: prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id), method: form_method) do |form| %>
+<%= form_for(@early_assignment,
+             url: prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id),
+             method: form_method,
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <%= render :partial => "/shared/field_errors", :locals => { form: form, errors: @early_assignment.errors } %>
 
   <h1 class="govuk-heading-xl govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>

--- a/app/views/early_allocations/_stage2.html.erb
+++ b/app/views/early_allocations/_stage2.html.erb
@@ -32,24 +32,12 @@
           </div>
           <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
                id="show-when-extremism-true">
-            <fieldset class="govuk-fieldset">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                <h1 class="govuk-fieldset__heading">Are they due for release in the next 24 months or less?</h1>
-              </legend>
-
-              <%= render partial: 'error', locals: { form: form, errors: @early_assignment.errors, fieldname: :due_for_release_in_less_than_24months }%>
-
-              <div class="govuk-radios">
-                <div class="govuk-radios__item">
-                  <%= form.radio_button(:due_for_release_in_less_than_24months, true, class: "govuk-radios__input") %>
-                  <%= form.label "due_for_release_in_lessthan_24months_true", 'Yes', class: "govuk-label govuk-radios__label" %>
-                </div>
-                <div class="govuk-radios__item">
-                  <%= form.radio_button(:due_for_release_in_less_than_24months, false, class: "govuk-radios__input") %>
-                  <%= form.label "due_for_release_in_lessthan_24months_false", 'No', class: "govuk-label govuk-radios__label" %>
-                </div>
-              </div>
-            </fieldset>
+            <%= render 'yes_no_boolean_field',
+                       form: form,
+                       fieldname: :due_for_release_in_less_than_24months,
+                       heading_text: 'Are they due for release in the next 24 months or less?',
+                       hint_text: ''
+            %>
           </div>
         </div>
         <div class="govuk-radios__item">

--- a/app/views/early_allocations/_yes_no_boolean_field.html.erb
+++ b/app/views/early_allocations/_yes_no_boolean_field.html.erb
@@ -1,22 +1,8 @@
-<div class="govuk-form-group">
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-      <h1 class="govuk-fieldset__heading"><%= heading_text %></h1>
-    </legend>
-
-    <span class="govuk-hint"><%= hint_text %></span>
-
-    <%= render partial: 'error', locals: { errors: errors, fieldname: fieldname, form: form }%>
-
-    <div class="govuk-radios">
-      <div class="govuk-radios__item">
-        <%= form.radio_button(fieldname, true, class: "govuk-radios__input") %>
-        <%= form.label "#{fieldname}_true", 'Yes', class: "govuk-label govuk-radios__label" %>
-      </div>
-      <div class="govuk-radios__item">
-        <%= form.radio_button(fieldname, false, class: "govuk-radios__input") %>
-        <%= form.label "#{fieldname}_false", 'No', class: "govuk-label govuk-radios__label" %>
-      </div>
-    </div>
-  </fieldset>
-</div>
+<%= form.govuk_collection_radio_buttons(
+        fieldname,
+        [OpenStruct.new(name: 'Yes', value: true), OpenStruct.new(name: 'No', value: false)],
+        :value,
+        :name,
+        hint_text: hint_text,
+        legend: { text: heading_text.html_safe }
+    ) %>

--- a/app/views/early_allocations/_yes_no_boolean_field.html.erb
+++ b/app/views/early_allocations/_yes_no_boolean_field.html.erb
@@ -4,5 +4,5 @@
         :value,
         :name,
         hint_text: hint_text,
-        legend: { text: heading_text.html_safe }
+        legend: { text: heading_text.html_safe, size: 's' }
     ) %>

--- a/app/views/early_allocations/new.html.erb
+++ b/app/views/early_allocations/new.html.erb
@@ -2,4 +2,9 @@
   <%= render '/layouts/prison_switcher' %>
 <% end %>
 
+<p class="govuk-body">
+  For further guidance on Early Allocation referral please see
+  <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">EQuiP</a>
+</p>
+
 <%= render 'stage1', form_method: :post %>

--- a/app/views/early_allocations/stage3.html.erb
+++ b/app/views/early_allocations/stage3.html.erb
@@ -2,7 +2,8 @@
   <%= render '/layouts/prison_switcher' %>
 <% end %>
 
-<%= form_for(@early_assignment, url: discretionary_prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id)) do |form| %>
+<%= form_for(@early_assignment,
+             url: discretionary_prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id)) do |form| %>
 
   <%= render :partial => "/shared/field_errors", :locals => { form: form, errors: @early_assignment.errors } %>
 

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -57,7 +57,7 @@ feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocat
         scenario 'error case' do
           expect(page).to have_css('.govuk-error-message')
           expect(page).to have_css('#early_allocation_oasys_risk_assessment_date_error')
-          expect(page).to have_css('#early_allocation_high_profile_error')
+          expect(page).to have_css('#early-allocation-high-profile-error')
           within '.govuk-error-summary' do
             expect(page).to have_text 'You must say if this case is \'high profile\''
             click_link 'You must say if this case is \'high profile\''
@@ -115,10 +115,10 @@ feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocat
         context 'with discretionary path' do
           before do
             find('#early_allocation_extremism_separation_false').click
-            find('#early_allocation_high_risk_of_serious_harm_false').click
-            find('#early_allocation_mappa_level_2_false').click
-            find('#early_allocation_pathfinder_process_false').click
-            find('#early_allocation_other_reason_true').click
+            find('#early-allocation-high-risk-of-serious-harm-field').click
+            find('#early-allocation-mappa-level-2-field').click
+            find('#early-allocation-pathfinder-process-field').click
+            find('#early-allocation-other-reason-true-field').click
 
             click_button 'Continue'
             expect(page).not_to have_text 'The community probation team will make a decision'
@@ -166,10 +166,10 @@ feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocat
 
         scenario 'not eligible due to all answers false' do
           find('#early_allocation_extremism_separation_false').click
-          find('#early_allocation_high_risk_of_serious_harm_false').click
-          find('#early_allocation_mappa_level_2_false').click
-          find('#early_allocation_pathfinder_process_false').click
-          find('#early_allocation_other_reason_false').click
+          find('#early-allocation-high-risk-of-serious-harm-field').click
+          find('#early-allocation-mappa-level-2-field').click
+          find('#early-allocation-pathfinder-process-field').click
+          find('#early-allocation-other-reason-field').click
 
           click_button 'Continue'
           expect(page).to have_text 'Not eligible for early allocation'
@@ -219,11 +219,11 @@ feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocat
     fill_in id: 'early_allocation_oasys_risk_assessment_date_mm', with: valid_date.month
     fill_in id: 'early_allocation_oasys_risk_assessment_date_yyyy', with: valid_date.year
 
-    find('#early_allocation_convicted_under_terrorisom_act_2000_true').click
-    find('#early_allocation_high_profile_false').click
-    find('#early_allocation_serious_crime_prevention_order_false').click
-    find('#early_allocation_mappa_level_3_false').click
-    find('#early_allocation_cppc_case_false').click
+    find('#early-allocation-convicted-under-terrorisom-act-2000-true-field').click
+    find('#early-allocation-high-profile-field').click
+    find('#early-allocation-serious-crime-prevention-order-field').click
+    find('#early-allocation-mappa-level-3-field').click
+    find('#early-allocation-cppc-case-field').click
   end
 
   def stage1_stage2_answers
@@ -231,10 +231,10 @@ feature "early allocation", type: :feature, vcr: { cassette_name: :early_allocat
     fill_in id: 'early_allocation_oasys_risk_assessment_date_mm', with: valid_date.month
     fill_in id: 'early_allocation_oasys_risk_assessment_date_yyyy', with: valid_date.year
 
-    find('#early_allocation_convicted_under_terrorisom_act_2000_false').click
-    find('#early_allocation_high_profile_false').click
-    find('#early_allocation_serious_crime_prevention_order_false').click
-    find('#early_allocation_mappa_level_3_false').click
-    find('#early_allocation_cppc_case_false').click
+    find('#early-allocation-convicted-under-terrorisom-act-2000-field').click
+    find('#early-allocation-high-profile-field').click
+    find('#early-allocation-serious-crime-prevention-order-field').click
+    find('#early-allocation-mappa-level-3-field').click
+    find('#early-allocation-cppc-case-field').click
   end
 end


### PR DESCRIPTION
This PR introduces 2 small content changes to the Early Allocation forms.

As this was touching early allocatikon views, I took the opportunity to refactor the yes_no_boolean partial to use the govuk_formbuilder gem - which involved effectively deleting a large amount of custom view code and replacing it with a single call.