### PR TITLE
replace signin_user method with signin_spo_user

### DIFF
--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -21,7 +21,7 @@ feature 'Allocation' do
   }
 
   before do
-    signin_user
+    signin_spo_user
   end
 
   scenario 'accepting a recommended allocation', versioning: true, vcr: { cassette_name: :create_new_allocation_feature } do

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -109,7 +109,7 @@ feature 'Allocation History' do
     hist_allocate_secondary = history[5]
     history6 = history[6]
 
-    signin_user
+    signin_spo_user
     visit prison_allocation_history_path('LEI', nomis_offender_id)
 
     stub_const("TESTS", [

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -19,7 +19,7 @@ feature "view an offender's allocation information", :versioning do
   let(:offender_no) { "G4273GI" }
 
   before do
-    signin_user
+    signin_spo_user
   end
 
   context 'when offender does not have a key worker assigned' do

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'summary summary feature' do
   before do
-    signin_user
+    signin_spo_user
   end
 
   describe 'awaiting summary table' do

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -5,7 +5,7 @@ feature 'case information feature' do
     # This NOMIS id needs to appear on the first page of 'missing information'
     nomis_offender_id = 'G2911GD'
 
-    signin_user
+    signin_spo_user
     visit prison_summary_pending_path('LEI')
 
     expect(page).to have_content('Add missing information')
@@ -30,7 +30,7 @@ feature 'case information feature' do
 
   it "clicking back link after viewing prisoner's case information, returns back the same paginated page",
      vcr: { cassette_name: :case_information_back_link }, js: true do
-    signin_user
+    signin_spo_user
     visit prison_summary_pending_path('LEI', page: 3)
 
     within ".govuk-table tr:first-child td:nth-child(5)" do
@@ -45,7 +45,7 @@ feature 'case information feature' do
   it 'complains if allocation data is missing', vcr: { cassette_name: :case_information_missing_case_feature } do
     nomis_offender_id = 'G1821VA'
 
-    signin_user
+    signin_spo_user
     visit new_prison_case_information_path('LEI', nomis_offender_id)
     expect(page).to have_current_path new_prison_case_information_path('LEI', nomis_offender_id)
 
@@ -60,7 +60,7 @@ feature 'case information feature' do
   it 'complains if all data is missing', vcr: { cassette_name: :case_information_missing_all_feature } do
     nomis_offender_id = 'G1821VA'
 
-    signin_user
+    signin_spo_user
     visit new_prison_case_information_path('LEI', nomis_offender_id)
     expect(page).to have_current_path new_prison_case_information_path('LEI', nomis_offender_id)
 
@@ -75,7 +75,7 @@ feature 'case information feature' do
   it 'complains if tier data is missing', vcr: { cassette_name: :case_information_missing_tier_feature } do
     nomis_offender_id = 'G1821VA'
 
-    signin_user
+    signin_spo_user
     visit new_prison_case_information_path('LEI', nomis_offender_id)
     expect(page).to have_current_path new_prison_case_information_path('LEI', nomis_offender_id)
 
@@ -89,7 +89,7 @@ feature 'case information feature' do
   it 'allows editing case information for a prisoner', vcr: { cassette_name: :case_information_editing_feature } do
     nomis_offender_id = 'G1821VA'
 
-    signin_user
+    signin_spo_user
     visit new_prison_case_information_path('LEI', nomis_offender_id)
     choose('case_information_welsh_offender_No')
     choose('case_information_case_allocation_NPS')
@@ -115,7 +115,7 @@ feature 'case information feature' do
 
   it 'returns to previously paginated page after saving',
      vcr: { cassette_name: :case_information_return_to_previously_paginated_page } do
-    signin_user
+    signin_spo_user
     visit prison_summary_pending_path('LEI', sort: "last_name desc", page: 3)
 
     within ".govuk-table tr:first-child td:nth-child(5)" do
@@ -135,7 +135,7 @@ feature 'case information feature' do
      vcr: { cassette_name: :case_information_no_update_feature } do
     # When auto-delius is on there should be no update link to modify the case info
     # as it may not exist yet. We run this test with an indeterminate and a determine offender
-    signin_user
+    signin_spo_user
 
     # Indeterminate offender
     nomis_offender_id = 'G0806GQ'

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "ChangeParoleReviewDates", :versioning, type: :feature do
   let(:yesterday) { Time.zone.yesterday }
 
   before do
-    signin_user
+    signin_spo_user
   end
 
   it 'updates the date',  vcr: { cassette_name: :change_parole_date } do

--- a/spec/features/contact_us_feature_spec.rb
+++ b/spec/features/contact_us_feature_spec.rb
@@ -11,7 +11,7 @@ feature 'Getting help' do
   end
 
   it 'shows a pre-filled contact form when a user is signed in', vcr: { cassette_name: :help_logged_in } do
-    signin_user('MOIC_POM')
+    signin_spo_user('MOIC_POM')
     visit '/'
     click_link 'Contact us'
 

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -19,7 +19,7 @@ feature 'Co-working', :versioning do
   end
 
   before(:each) do
-    signin_user
+    signin_spo_user
 
     create(:case_information, nomis_offender_id: nomis_offender_id)
   end

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -5,7 +5,7 @@ feature 'Provide debugging information for our team to use' do
 
   context 'when debugging an individual offender' do
     it 'returns information for an unallocated offender', vcr: { cassette_name: :debugging_feature } do
-      signin_user
+      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -27,7 +27,7 @@ feature 'Provide debugging information for our team to use' do
              nomis_offender_id: nomis_offender_id,
              primary_pom_name: "Rossana Spinka"
              )
-      signin_user
+      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -50,7 +50,7 @@ feature 'Provide debugging information for our team to use' do
     end
 
     it 'can handle an incorrect offender number', vcr: { cassette_name: :debugging_incorrect_offender_feature } do
-      signin_user
+      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -61,7 +61,7 @@ feature 'Provide debugging information for our team to use' do
     end
 
     it 'can handle no offender number being entered', vcr: { cassette_name: :debugging_no_offender_feature } do
-      signin_user
+      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -74,7 +74,7 @@ feature 'Provide debugging information for our team to use' do
 
   context 'when debugging at a prison level', vcr: { cassette_name: :debugging_prison_level } do
     it 'displays a dashboard' do
-      signin_user
+      signin_spo_user
       visit prison_debugging_prison_path('LEI')
 
       expect(page).to have_text("Prison Debugging")

--- a/spec/features/delius_process_data_feature_spec.rb
+++ b/spec/features/delius_process_data_feature_spec.rb
@@ -15,7 +15,7 @@ feature 'delius import scenarios', vcr: { cassette_name: :delius_import_scenario
   end
 
   before do
-    signin_user
+    signin_spo_user
   end
 
   context 'when one delius record' do

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -10,7 +10,7 @@ feature "edit a POM's details" do
 
     create(:pom_detail, nomis_staff_id: fulltime_pom_id, working_pattern: 1)
 
-    signin_user
+    signin_spo_user
   end
 
   it "setting unavailable shows selected on re-edit", vcr: { cassette_name: :edit_poms_unavailable_check } do

--- a/spec/features/feedback_feature_spec.rb
+++ b/spec/features/feedback_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'feedback' do
   it 'provides a link to the feedback form', vcr: { cassette_name: :feedback_link } do
-    signin_user('MOIC_POM')
+    signin_spo_user('MOIC_POM')
 
     visit '/'
 

--- a/spec/features/help_feature_spec.rb
+++ b/spec/features/help_feature_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Help' do
   context 'when accessing help page' do
     it 'provides a link to the help pages', vcr: { cassette_name: :help_link } do
-      signin_user('MOIC_POM')
+      signin_spo_user('MOIC_POM')
 
       visit '/'
       expect(page).to have_link('Help', href: '/help')

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -9,7 +9,7 @@ feature 'Inactive POM' do
     let(:active_pom) { 485_926 }
 
     before do
-      signin_user
+      signin_spo_user
 
       create(
         :allocation,

--- a/spec/features/prison_switching_feature_spec.rb
+++ b/spec/features/prison_switching_feature_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 feature 'Switching prisons' do
   it 'Shows the switcher if the user has more than one prison',
      vcr: { cassette_name: :prison_switching_feature_many_prisons_spec } do
-    signin_user
+    signin_spo_user
     visit root_path
 
     expect(page).to have_css('h2', text: 'HMP Leeds')
   end
 
   it 'shows dashboard links if there is no referrer', vcr: { cassette_name: :nav_to_prison_switcher } do
-    signin_user
+    signin_spo_user
 
     visit root_path
 
@@ -27,7 +27,7 @@ feature 'Switching prisons' do
 
   it 'Shows the list of prisons I can switch to',
      vcr: { cassette_name: :prison_switching_feature_list_spec }do
-    signin_user
+    signin_spo_user
     visit root_path
 
     click_link('Switch prison')
@@ -38,7 +38,7 @@ feature 'Switching prisons' do
 
   it 'Changes my prison when I choose one',
      vcr: { cassette_name: :prison_switching_feature_change_prisons_spec }do
-    signin_user
+    signin_spo_user
     visit root_path
 
     click_link('Switch prison')
@@ -50,7 +50,7 @@ feature 'Switching prisons' do
 
   it 'Can remember where I was',
      vcr: { cassette_name: :prison_switching_feature_remember_prison_spec } do
-    signin_user
+    signin_spo_user
     visit prison_poms_path('LEI')
 
     expect(page).to have_css('h2', text: 'HMP Leeds')

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'View a prisoner profile page' do
   before do
-    signin_user
+    signin_spo_user
   end
 
   context 'without allocation' do

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -4,7 +4,7 @@ feature 'Responsibility override', :versioning do
   include ActiveJob::TestHelper
 
   before do
-    signin_user
+    signin_spo_user
   end
 
   let(:offender_id) { 'G8060UF' }

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -13,7 +13,7 @@ feature 'Search for offenders' do
     end
 
     it 'shows update not edit', vcr: { cassette_name: :search_update_edit } do
-      signin_user
+      signin_spo_user
       visit prison_summary_allocated_path('LEI')
 
       expect(page).to have_text('See allocations')
@@ -34,7 +34,7 @@ feature 'Search for offenders' do
     end
 
     it 'shows update not edit', vcr: { cassette_name: :search_update_edit_no_delius } do
-      signin_user
+      signin_spo_user
       visit prison_summary_allocated_path('LEI')
 
       expect(page).to have_text('See allocations')
@@ -48,7 +48,7 @@ feature 'Search for offenders' do
   end
 
   it 'Can search from the dashboard', vcr: { cassette_name: :dashboard_search_feature } do
-    signin_user
+    signin_spo_user
     visit root_path
 
     expect(page).to have_text('Dashboard')
@@ -60,7 +60,7 @@ feature 'Search for offenders' do
   end
 
   it 'Can search from the Allocations summary page', vcr: { cassette_name: :allocated_search_feature } do
-    signin_user
+    signin_spo_user
     visit prison_summary_allocated_path('LEI')
 
     expect(page).to have_text('See allocations')
@@ -72,7 +72,7 @@ feature 'Search for offenders' do
   end
 
   it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: :waiting_allocation_search_feature } do
-    signin_user
+    signin_spo_user
     visit prison_summary_unallocated_path('LEI')
 
     expect(page).to have_text('Make allocations')
@@ -84,7 +84,7 @@ feature 'Search for offenders' do
   end
 
   it 'Can search from the Missing Information summary page', vcr: { cassette_name: :missing_info_search_feature } do
-    signin_user
+    signin_spo_user
     visit  prison_summary_pending_path('LEI')
 
     expect(page).to have_text('Make allocations')

--- a/spec/features/service_notification_feature_spec.rb
+++ b/spec/features/service_notification_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Service Notification' do
   before do
-    signin_user
+    signin_spo_user
   end
 
   it 'does not display service notification if none exist',

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -4,7 +4,7 @@ feature "get poms list" do
   let!(:offender_missing_sentence_case_info) { create(:case_information, nomis_offender_id: 'G1247VX') }
 
   before do
-    signin_user
+    signin_spo_user
   end
 
   it "shows the page", vcr: { cassette_name: :show_poms_feature_list } do

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -7,7 +7,7 @@ describe AllocationService do
 
   before do
     # needed as create_or_update calls a NOMIS API
-    signin_user
+    signin_spo_user
   end
 
   describe '#allocate_secondary', :queueing do

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -1,11 +1,6 @@
-module FeaturesHelper
-  # Signs in a user which historically has always been an SPO. For backwards
-  # compatability this continues to mock sso for an SPO, but we should move
-  # in future to one of the explicit signin_*_user methods below.
-  def signin_user(name = 'MOIC_POM')
-    signin_spo_user(name)
-  end
+# frozen_string_literal: true
 
+module FeaturesHelper
   def signin_spo_user(name = 'MOIC_POM')
     mock_sso_response(name, ['ROLE_ALLOC_MGR'])
   end


### PR DESCRIPTION
There is a legacy method signin_user which is effetcively an alias for signin_spo_user.
This PR removes the legacy method, and replaces all occurrences of it with signin_spo_user