### PR TITLE
POM-834 map unallocated and inactive COM names to nil

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -68,7 +68,14 @@ private
     allocation = Allocation.find_by(nomis_offender_id: delius_record.noms_no)
     return if allocation.blank?
 
-    allocation.update(com_name: delius_record.offender_manager)
+    com_name = if ['Unallocated', 'Inactive'].any? { |pattern| delius_record.offender_manager.include?(pattern) }
+                 nil
+               else
+                 delius_record.offender_manager
+               end
+
+    allocation.assign_attributes(com_name: com_name)
+    allocation.save! if allocation.changed?
   end
 
   def map_delius_to_case_info(delius_record)


### PR DESCRIPTION
nDelius produces quite a few 'fake' COM names in it's data extract. MOIC need to know real soon whether a COM has been allocated or not. 
This PR fixes up the mapping so that inactive and unallocated COM names are mapped to nil in MOIC