### PR TITLE
Use new nomis role

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AllocationsController < PrisonsApplicationController
-  before_action :ensure_admin_user
+  before_action :ensure_spo_user
 
   delegate :update, to: :create
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,14 +23,14 @@ class ApplicationController < ActionController::Base
     sso_identity.current_user_is_spo?
   end
 
-  def ensure_admin_user
+  def ensure_spo_user
     unless current_user_is_spo?
       redirect_to '/401'
     end
   end
 
-  def ensure_global_admin_user
-    unless sso_identity.is_global_admin?
+  def ensure_admin_user
+    unless sso_identity.current_user_is_admin?
       redirect_to '/401'
     end
   end

--- a/app/controllers/concerns/sso_identity.rb
+++ b/app/controllers/concerns/sso_identity.rb
@@ -1,4 +1,10 @@
+# frozen_string_literal: true
+
 class SsoIdentity
+  POM_ROLE = 'ROLE_ALLOC_CASE_MGR'
+  SPO_ROLE = 'ROLE_ALLOC_MGR'
+  ADMIN_ROLE = 'ROLE_MOIC_ADMIN'
+
   def initialize(session)
     @sso_identity = session[:sso_data]
   end
@@ -16,17 +22,17 @@ class SsoIdentity
   end
 
   def current_user_is_spo?
-    roles.include?('ROLE_ALLOC_MGR')
+    roles.include?(SPO_ROLE)
   end
 
+  # This role is granted to the service team to give them 'admin' priviledges
+  # such as editing teams and changing switch values
   def is_global_admin?
-    # TODO - change this to roles.include?('ROLE_MOIC_ADMIN') (or whatever name is chosen)
-    # once the name has been agreed and the role has been set up in T3/preprod/production
-    current_user_is_spo? && caseloads.size == PrisonService.prison_codes.size
+    roles.include?(ADMIN_ROLE)
   end
 
   def current_user_is_pom?
-    roles.include?('ROLE_ALLOC_CASE_MGR')
+    roles.include?(POM_ROLE)
   end
 
   def default_prison_code

--- a/app/controllers/concerns/sso_identity.rb
+++ b/app/controllers/concerns/sso_identity.rb
@@ -27,7 +27,7 @@ class SsoIdentity
 
   # This role is granted to the service team to give them 'admin' priviledges
   # such as editing teams and changing switch values
-  def is_global_admin?
+  def current_user_is_admin?
     roles.include?(ADMIN_ROLE)
   end
 

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PomsController < PrisonsApplicationController
-  before_action :ensure_admin_user
+  before_action :ensure_spo_user
 
   # so that breadcrumb has @pom available
   before_action :load_pom_staff_member, only: [:show, :edit]

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SummaryController < PrisonsApplicationController
-  before_action :ensure_admin_user
+  before_action :ensure_spo_user
 
   breadcrumb 'See allocations',
              -> { prison_summary_allocated_path(active_prison_id) },

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module OffenderManagementAllocationClient
     config.active_model.i18n_customize_full_message = true
     # Before filter for Flipflop dashboard. Replace with a lambda or method name
     # defined in ApplicationController to implement access control.
-    config.flipflop.dashboard_access_filter = :ensure_global_admin_user
+    config.flipflop.dashboard_access_filter = :ensure_admin_user
 
     config.load_defaults 6.0
     config.exceptions_app = routes

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -3,7 +3,7 @@
 # be an SPO or you're not authorised to do anything.
 class MoicOAuth2Adapter < ActiveAdmin::AuthorizationAdapter
   def authorized?(_action, _subject = nil)
-    user.is_global_admin?
+    user.current_user_is_admin?
   end
 end
 

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -2,15 +2,15 @@
 
 module FeaturesHelper
   def signin_spo_user(name = 'MOIC_POM')
-    mock_sso_response(name, ['ROLE_ALLOC_MGR'])
+    mock_sso_response(name, [SsoIdentity::SPO_ROLE])
   end
 
   def signin_global_admin_user
-    mock_sso_response('MOIC_POM', ['ROLE_ALLOC_MGR'], PrisonService.prison_codes)
+    mock_sso_response('MOIC_POM', [SsoIdentity::SPO_ROLE, SsoIdentity::ADMIN_ROLE], PrisonService.prison_codes)
   end
 
   def signin_pom_user
-    mock_sso_response('MOIC_POM', ['ROLE_ALLOC_CASE_MGR'])
+    mock_sso_response('MOIC_POM', [SsoIdentity::POM_ROLE])
   end
 
   def mock_sso_response(username, roles, caseloads = %w[LEI RSI])


### PR DESCRIPTION
The 'Elephants' team need a role to allow them to perform admin functions on the service that no ordinary user is permitted to have. This role MOIC_ADMIN wasa created some time ago, but not assigned to anyone. This PR uses that role so that we can be considered to be admins in staging where we only have access to 3 prisons. 