### PR TITLE
POM-788: Push offender handover dates into nDelius

### DIFF
--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RecalculateHandoverDateJob < ApplicationJob
+  queue_as :default
+
+  def perform(nomis_offender_id)
+    offender = OffenderService.get_offender(nomis_offender_id)
+    return if offender.nil? || offender.sentenced? == false
+
+    CalculatedHandoverDate.recalculate_for(offender)
+  end
+end

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -13,12 +13,27 @@ class CalculatedHandoverDate < ApplicationRecord
   validates :nomis_offender_id, uniqueness: true, presence: true
   validates :reason, presence: true
 
+  after_save :push_to_delius
+
   def self.recalculate_for(offender)
     record = self.find_or_initialize_by(nomis_offender_id: offender.offender_no)
     record.update!(
       start_date: offender.handover_start_date,
       handover_date: offender.responsibility_handover_date,
       reason: offender.handover_reason
+    )
+  end
+
+private
+
+  def push_to_delius
+    # Only push if the dates have changed
+    return unless saved_change_to_start_date? || saved_change_to_handover_date?
+
+    HmppsApi::CommunityApi.set_handover_dates(
+      offender_no: nomis_offender_id,
+      handover_start_date: start_date,
+      responsibility_handover_date: handover_date
     )
   end
 end

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CalculatedHandoverDate < ApplicationRecord
+  # This is quite a loose relationship. It exists so that CaseInformation
+  # deletes cascade and tidy up associated CalculatedHandoverDate records.
+  # Ideally CalculatedHandoverDate would belong to a higher-level
+  # Offender model rather than nDelius Case Information
+  belongs_to :case_information,
+             primary_key: :nomis_offender_id,
+             foreign_key: :nomis_offender_id,
+             inverse_of: :responsibility
+
+  validates :nomis_offender_id, uniqueness: true, presence: true
+  validates :reason, presence: true
+end

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -12,4 +12,13 @@ class CalculatedHandoverDate < ApplicationRecord
 
   validates :nomis_offender_id, uniqueness: true, presence: true
   validates :reason, presence: true
+
+  def self.recalculate_for(offender)
+    record = self.find_or_initialize_by(nomis_offender_id: offender.offender_no)
+    record.update!(
+      start_date: offender.handover_start_date,
+      handover_date: offender.responsibility_handover_date,
+      reason: offender.handover_reason
+    )
+  end
 end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -24,6 +24,16 @@ class CaseInformation < ApplicationRecord
           inverse_of: :case_information,
           dependent: :destroy
 
+  # This is quite a loose relationship. It exists so that CaseInformation
+  # deletes cascade and tidy up associated CalculatedHandoverDate records.
+  # Ideally CalculatedHandoverDate would belong to a higher-level
+  # Offender model rather than nDelius Case Information
+  has_one :calculated_handover_date,
+          foreign_key: :nomis_offender_id,
+          primary_key: :nomis_offender_id,
+          inverse_of: :case_information,
+          dependent: :destroy
+
   before_validation :set_probation_service
 
   def local_divisional_unit

--- a/db/migrate/20201023133523_create_calculated_handover_dates.rb
+++ b/db/migrate/20201023133523_create_calculated_handover_dates.rb
@@ -1,0 +1,21 @@
+class CreateCalculatedHandoverDates < ActiveRecord::Migration[6.0]
+  def change
+    create_table :calculated_handover_dates do |t|
+      t.date :start_date
+      t.date :handover_date
+      t.string :reason, null: false
+
+      t.timestamps
+
+      t.references :nomis_offender,
+                   type: :string, null: false,
+                   index: { unique: true },
+                   foreign_key: {
+                     to_table: :case_information,
+                     primary_key: :nomis_offender_id,
+                     on_delete: :cascade,
+                     on_update: :cascade
+                   }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,6 +41,16 @@ ActiveRecord::Schema.define(version: 2020_11_26_123414) do
     t.index ["secondary_pom_nomis_id"], name: "index_allocation_versions_secondary_pom_nomis_id"
   end
 
+  create_table "calculated_handover_dates", force: :cascade do |t|
+    t.date "start_date"
+    t.date "handover_date"
+    t.string "reason", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "nomis_offender_id", null: false
+    t.index ["nomis_offender_id"], name: "index_calculated_handover_dates_on_nomis_offender_id", unique: true
+  end
+
   create_table "case_information", force: :cascade do |t|
     t.string "tier"
     t.string "case_allocation"
@@ -218,4 +228,5 @@ ActiveRecord::Schema.define(version: 2020_11_26_123414) do
     t.index ["case_information_id"], name: "index_victim_liaison_officers_on_case_information_id"
   end
 
+  add_foreign_key "calculated_handover_dates", "case_information", column: "nomis_offender_id", primary_key: "nomis_offender_id", on_update: :cascade, on_delete: :cascade
 end

--- a/deploy/production/cron-recalculate-handover-dates.yaml
+++ b/deploy/production/cron-recalculate-handover-dates.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: recalculate-handover-dates
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          containers:
+            - name: recalculate-handover-dates
+              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
+              imagePullPolicy: Always
+              command: ['sh', '-c', "bundle exec rake recalculate_handover_dates"]
+              envFrom:
+                - configMapRef:
+                    name: shared-environment
+                - secretRef:
+                    name: allocation-manager-secrets
+              env:
+                - name: PROMETHEUS_METRICS
+                  value: "off"
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: rds_instance_address
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_password
+                - name: POSTGRES_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_name
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_user
+                - name: REDIS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: elasticache-offender-management-allocation-manager-token-cache-production
+                      key: url
+          restartPolicy: OnFailure

--- a/lib/tasks/recalculate_handover_dates.rake
+++ b/lib/tasks/recalculate_handover_dates.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+desc 'Recalculate handover dates for all known offenders, and push changes into nDelius'
+task recalculate_handover_dates: :environment do |_task|
+  Rails.logger = Logger.new(STDOUT)
+
+  count = CaseInformation.count
+
+  Rails.logger.info("Queueing jobs for #{count} offenders")
+
+  CaseInformation.find_each.with_index do |case_info, index|
+    RecalculateHandoverDateJob.perform_later(case_info.nomis_offender_id)
+    Rails.logger.info("[#{index + 1}/#{count}] Queued #{case_info.nomis_offender_id}")
+  end
+
+  Rails.logger.info('Done')
+end

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe AllocationsController, type: :controller do
         end
       end
 
-      context 'when DeliusDataJob has updated the COM name' do
+      context 'when DeliusDataJob has updated the COM name', :disable_push_to_delius do
         # set DOB to 8 stars so that Delius matching ignores DoB
         let!(:d1) { create(:delius_data, date_of_birth: '*' * 8, offender_manager: 'Mr Todd', noms_no: offender_no) }
         let(:create_time) { 3.days.ago }

--- a/spec/factories/calculated_handover_date.rb
+++ b/spec/factories/calculated_handover_date.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :calculated_handover_date do
+    association :case_information
+
+    start_date { Faker::Date.forward }
+
+    handover_date { Faker::Date.forward }
+
+    reason {
+      # Randomly select a valid reason
+      ['NPS Inderminate',
+       'NPS - MAPPA level unknown',
+       'CRC Case'].sample
+    }
+  end
+end

--- a/spec/features/delius_import_job_feature_spec.rb
+++ b/spec/features/delius_import_job_feature_spec.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples "imports the Delius spreadsheet and creates case informati
   end
 end
 
-feature "Delius import feature" do
+feature "Delius import feature", :disable_push_to_delius do
   let(:stub_auth_host) { Rails.configuration.nomis_oauth_host }
   let(:stub_api_host) { "#{Rails.configuration.prison_api_host}/api" }
   let(:offender_no) { "GCA2H2A" }

--- a/spec/features/delius_process_data_feature_spec.rb
+++ b/spec/features/delius_process_data_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 # All these tests can use the same VCR cassette as they all visit the same path
-feature 'delius import scenarios', vcr: { cassette_name: :delius_import_scenarios } do
+feature 'delius import scenarios', :disable_push_to_delius, vcr: { cassette_name: :delius_import_scenarios } do
   let(:ldu) {  create(:local_divisional_unit) }
   let(:team) { create(:team, local_divisional_unit: ldu) }
   let(:test_strategy) { Flipflop::FeatureSet.current.test! }

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe RecalculateHandoverDateJob, type: :job do
+  let(:nomis_offender) { build(:nomis_offender) }
+  let(:offender_no) { nomis_offender.fetch(:offenderNo) }
+
+  before do
+    stub_auth_token
+  end
+
+  context "when the offender exists in both NOMIS and nDelius (happy path)" do
+    before do
+      stub_offender(nomis_offender)
+      create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+    end
+
+    it "recalculates the offender's handover dates" do
+      expect(CalculatedHandoverDate).to receive(:recalculate_for) do |received_offender|
+        expect(received_offender.offender_no).to eq(offender_no)
+      end
+      described_class.perform_now(offender_no)
+    end
+
+    it "pushes them to the Community API" do
+      offender = OffenderService.get_offender(offender_no)
+
+      expect(HmppsApi::CommunityApi).to receive(:set_handover_dates).
+        with(offender_no: offender_no,
+             handover_start_date: offender.handover_start_date,
+             responsibility_handover_date: offender.responsibility_handover_date
+        )
+
+      described_class.perform_now(offender_no)
+    end
+  end
+
+  context "when the offender doesn't exist in NOMIS" do
+    before do
+      stub_non_existent_offender(offender_no)
+    end
+
+    it 'does nothing' do
+      expect(CalculatedHandoverDate).not_to receive(:recalculate_for)
+      expect(HmppsApi::CommunityApi).not_to receive(:set_handover_dates)
+      described_class.perform_now(offender_no)
+    end
+  end
+
+  context "when the offender doesn't have a sentence in NOMIS" do
+    let(:nomis_offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, :unsentenced)) }
+
+    before do
+      stub_offender(nomis_offender)
+      create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+    end
+
+    it 'does nothing' do
+      expect(CalculatedHandoverDate).not_to receive(:recalculate_for)
+      expect(HmppsApi::CommunityApi).not_to receive(:set_handover_dates)
+      described_class.perform_now(offender_no)
+    end
+  end
+end

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -41,4 +41,73 @@ RSpec.describe CalculatedHandoverDate, type: :model do
       expect(subject.save).to be(false)
     end
   end
+
+  describe '#recalculate_for(offender)' do
+    let(:offender) { build(:offender) }
+    let!(:case_info) { create(:case_information, :nps, nomis_offender_id: offender.offender_no) }
+
+    before { offender.load_case_information(case_info) }
+
+    describe "when calculated handover dates don't exist yet for the offender" do
+      it 'creates a new record' do
+        expect {
+          described_class.recalculate_for(offender)
+        }.to change(described_class, :count).from(0).to(1)
+
+        record = described_class.find_by(nomis_offender_id: offender.offender_no)
+        expect(record.start_date).to eq(offender.handover_start_date)
+        expect(record.handover_date).to eq(offender.responsibility_handover_date)
+        expect(record.reason).to eq(offender.handover_reason)
+      end
+    end
+
+    describe 'when calculated handover dates already exist for the offender' do
+      let!(:existing_record) {
+        create(:calculated_handover_date,
+               case_information: case_info,
+               start_date: existing_start_date,
+               handover_date: existing_handover_date,
+               reason: existing_reason
+        )
+      }
+
+      before do
+        expect(existing_record.start_date).to eq(existing_start_date)
+        expect(existing_record.handover_date).to eq(existing_handover_date)
+        expect(existing_record.reason).to eq(existing_reason)
+      end
+
+      describe 'when the dates have changed' do
+        let(:existing_start_date) { Time.zone.today + 1.week }
+        let(:existing_handover_date) { existing_start_date + 7.months }
+        let(:existing_reason) { 'CRC Case' }
+
+        it 'updates the existing record' do
+          described_class.recalculate_for(offender)
+
+          existing_record.reload
+          expect(existing_record.start_date).to eq(offender.handover_start_date)
+          expect(existing_record.handover_date).to eq(offender.responsibility_handover_date)
+          expect(existing_record.reason).to eq(offender.handover_reason)
+        end
+      end
+
+      describe "when the dates haven't changed" do
+        let(:existing_start_date) { offender.handover_start_date }
+        let(:existing_handover_date) { offender.responsibility_handover_date }
+        let(:existing_reason) { offender.handover_reason }
+
+        it "does nothing" do
+          old_updated_at = existing_record.updated_at
+
+          travel_to(Time.zone.now + 15.minutes) do
+            described_class.recalculate_for(offender)
+          end
+
+          new_updated_at = existing_record.reload.updated_at
+          expect(new_updated_at).to eq(old_updated_at)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe CalculatedHandoverDate, type: :model do
+  subject { build(:calculated_handover_date) }
+
+  describe 'validation' do
+    it { is_expected.to validate_presence_of(:nomis_offender_id) }
+    it { is_expected.to validate_uniqueness_of(:nomis_offender_id) }
+    it { is_expected.to validate_presence_of(:reason) }
+  end
+
+  it { is_expected.to belong_to(:case_information) }
+
+  it 'allows nil handover dates' do
+    case_info = create(:case_information)
+    com_responsibility = HandoverDateService::NO_HANDOVER_DATE
+
+    record = described_class.create!(
+      nomis_offender_id: case_info.nomis_offender_id,
+      start_date: com_responsibility.start_date,
+      handover_date: com_responsibility.handover_date,
+      reason: com_responsibility.reason
+    )
+
+    record.reload
+    expect(record.start_date).to be_nil
+    expect(record.handover_date).to be_nil
+    expect(record.reason).to eq('COM Responsibility')
+  end
+
+  describe "when nomis_offender_id is set but an associated case information record doesn't exist" do
+    subject {
+      build(:calculated_handover_date,
+            case_information: nil,
+            nomis_offender_id: "A1234BC"
+      )
+    }
+
+    it 'is not valid' do
+      expect(subject.valid?).to be(false)
+      expect(subject.save).to be(false)
+    end
+  end
+end

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe CaseInformation, type: :model do
     expect(case_info.updated_at).not_to eq(case_info.created_at)
   end
 
+  describe 'associations' do
+    subject { build(:case_information) }
+
+    it { is_expected.to have_one(:responsibility).dependent(:destroy) }
+    it { is_expected.to have_one(:calculated_handover_date).dependent(:destroy) }
+  end
+
   describe '#early_allocations' do
     context 'when not setup' do
       it 'is empty' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,12 @@ RSpec.configure do |config|
     page.driver.browser.manage.window.resize_to(1280,3072)
   end
 
+  config.before(:each, :disable_push_to_delius) do
+    # Stub the pushing of handover dates to the Community API
+    # Useful when running ProcessDeliusDataJob, which attempts to push to the Community API
+    allow(HmppsApi::CommunityApi).to receive(:set_handover_dates)
+  end
+
   config.before(:each) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -139,6 +139,15 @@ module ApiHelper
       to_return(body: bookings.to_json)
   end
 
+  # Stub an 'empty' response from the Prison API, indicating that the offender does not exist in NOMIS
+  # Note: you might have expected a 404 Not Found response when the offender doesn't exist, but
+  #       the actual response is 200 OK with an empty JSON array.
+  #       This stub is faithful to the Prison API docs and real-world behaviour.
+  def stub_non_existent_offender(offender_no)
+    stub_request(:get, "#{T3}/prisoners/#{offender_no}").
+      to_return(body: [].to_json)
+  end
+
   def stub_keyworker(prison_code, offender_id, keyworker)
     stub_request(:get, "#{KEYWORKER_API_HOST}/key-worker/#{prison_code}/offender/#{offender_id}").
       to_return(body: keyworker.to_json)


### PR DESCRIPTION
Jira ticket: POM-788

---

This pull request adds functionality to push offender handover dates into nDelius using the Community API.

It also adds a new concept of 'calculated handover dates' – these are effectively cached calculations of offender handover dates. We use these to detect when handover dates have changed, and therefore whether we should push them to the Community API. It means we won't push handover dates into the Community API if they haven't changed since their last push.

Summary of changes:
- Added `RecalculateHandoverDateJob`: this job can be queued and will recalculate handover dates for a given offender, and push them into the Community API if they've changed
- Added rake task `rake recalculate_handover_dates`: this will run through all known offenders (all `CaseInformation` records) and queue up `RecalculateHandoverDateJob` jobs for each one
- The nightly nDelius import will recalculate and push handover dates when offender data changes
- Added new model `CalculatedHandoverDate` with database table `calculated_handover_dates`

## How to use

To push handover dates into nDelius, run the following rake task:

```
rake recalculate_handover_dates
```

This is a potentially expensive / long-running command: it will perform lots of calls to both the Prison API and Community API.

To avoid being 'noisy' to the APIs, we probably shouldn't run it too frequently.

## Error handling

Pushing dates into nDelius could fail for either of the following reasons:

### 1. The offender doesn't exist in NOMIS

**Scenario:** The nightly nDelius import has run and imported a new first-time offender, who has been sentenced but hasn't arrived in prison yet. Therefore, there is no record for them in NOMIS yet. A `RecalculateHandoverDateJob` job has been queued because a new Case Information record was created.

**Behaviour:** The `RecalculateHandoverDateJob` job cannot find a record of the offender in NOMIS. It returns a nil value and the job ends successfully. It is not re-queued.

### 2. The offender doesn't exist in nDelius

**Scenario:** The rake task has been run to recalculate handover dates for all known offenders. For some offenders, nDelius cannot find their record because the "DSS" button has not been used, meaning their NOMIS ID is not associated with their nDelius record. Alternatively, they might be Scottish or Northern Irish offenders, in which case no nDelius record will exist for them.

**Behaviour:** The `RecalculateHandoverDateJob` attempts to push to the Community API. The Community API responds with a '404 Not Found' HTTP error, which is thrown as an exception in our application. The exception is caught and logged to Sentry, and the job is marked as 'failed'. Failed jobs are [automatically retried by Sidekiq](https://github.com/mperham/sidekiq/wiki/Error-Handling).