### PR TITLE
remove attr_reader from OffenderBase#convicted_status

### DIFF
--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -13,7 +13,7 @@ module HmppsApi
     attr_accessor :category_code, :date_of_birth
 
     attr_reader :first_name, :last_name, :booking_id,
-                :offender_no, :convicted_status
+                :offender_no
 
     attr_accessor :sentence, :allocated_pom_name, :allocated_com_name, :case_allocation, :mappa_level, :tier
 
@@ -24,7 +24,7 @@ module HmppsApi
     attr_reader :sentence_type
 
     def convicted?
-      convicted_status == 'Convicted'
+      @convicted_status == 'Convicted'
     end
 
     def sentenced?

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -11,7 +11,7 @@ class OffenderPresenter
            :welsh_offender, :case_allocation, :earliest_release_date,
            :category_code, :conditional_release_date, :automatic_release_date,
            :awaiting_allocation_for, :allocated_pom_name, :allocation_date, :allocated_com_name,
-           :tier, :parole_review_date, :crn, :convicted_status, :convicted?, :ldu,
+           :tier, :parole_review_date, :crn, :convicted?, :ldu,
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
            :licence_expiry_date, :post_recall_release_date,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level, to: :@offender

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -41,7 +41,7 @@
     <tr class="govuk-table__row" id="convicted">
       <td class="govuk-table__cell">Convicted?</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= humanized_bool(@offender.convicted?) %> (<%= @offender.convicted_status %>)
+        <%= humanized_bool(@offender.convicted?) %>
     </tr>
     <tr class="govuk-table__row" id="sentenced">
       <td class="govuk-table__cell">Sentenced?</td>


### PR DESCRIPTION
Found this (IMHO useful) code change behind the back of the sofa this morning. It removed the public attr_reader for the 'Convicted' status - which we actually filter on anyway (at the API level), so is extremely unlikely to make it into our data set - in fact I'm not sure we should have this filter at all...? (as we try and ask the API to filter by Convicted offenders)