### PR TITLE
POM-880 add welsh flag to LDU for mapping welsh offenders

### DIFF
--- a/app/admin/local_divisional_units.rb
+++ b/app/admin/local_divisional_units.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 ActiveAdmin.register LocalDivisionalUnit, as: 'LDU' do
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
   # Uncomment all parameters which should be permitted for assignment
   #
-  permit_params :code, :name, :email_address
+  permit_params :code, :name, :email_address, :in_wales
   #
   # or
   #
@@ -20,7 +22,8 @@ ActiveAdmin.register LocalDivisionalUnit, as: 'LDU' do
     id_column
     column :name
     column :code
-    column :email_address
+    column 'In Wales', :in_wales
+    column 'Email Address', :email_address
     column 'Teams' do |ldu|
       ldu.teams.size
     end

--- a/app/admin/teams.rb
+++ b/app/admin/teams.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Team do
   #
   # Uncomment all parameters which should be permitted for assignment
   #
-  permit_params :code, :name, :shadow_code, :local_divisional_unit_id
+  permit_params :code, :name, :shadow_code, :local_divisional_unit_id, :in_wales
   #
   # or
   #

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ProcessDeliusDataJob < ApplicationJob
   queue_as :default
 
@@ -86,7 +88,7 @@ private
         tier: map_tier(delius_record.tier),
         team: team,
         case_allocation: delius_record.service_provider,
-        welsh_offender: map_welsh_offender(delius_record.welsh_offender?),
+        welsh_offender: map_welsh_offender(delius_record.ldu_code),
         mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
       )
     end
@@ -114,8 +116,8 @@ private
     end
   end
 
-  def map_welsh_offender(welsh_offender)
-    welsh_offender ? 'Yes' : 'No'
+  def map_welsh_offender(ldu_code)
+    LocalDivisionalUnit.find_by(code: ldu_code)&.in_wales? ? 'Yes' : 'No'
   end
 
   def map_tier(tier)

--- a/app/models/delius_data.rb
+++ b/app/models/delius_data.rb
@@ -10,11 +10,6 @@ class DeliusData < ApplicationRecord
     end
   end
 
-  def welsh_offender?
-    # WPT is the first 3 chars of the ldu_code for all Welsh LDU (Local Divisional Unit).
-    ldu_code.present? && ldu_code.start_with?('WPT')
-  end
-
   def service_provider
     if provider_code.present?
       return 'CRC' if provider_code.starts_with? 'C'

--- a/db/migrate/20201014082050_add_welsh_flag_to_ldu.rb
+++ b/db/migrate/20201014082050_add_welsh_flag_to_ldu.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddWelshFlagToLdu < ActiveRecord::Migration[6.0]
+  def change
+    change_table :local_divisional_units do |t|
+      t.boolean :in_wales, default: false
+    end
+
+    LocalDivisionalUnit.where('code like ?', 'WPT%').update_all(in_wales: true)
+    LocalDivisionalUnit.where('code like ?', 'N03%').update_all(in_wales: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_135050) do
+ActiveRecord::Schema.define(version: 2020_10_14_082050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2020_08_03_135050) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email_address"
+    t.boolean "in_wales", default: false
     t.index ["code"], name: "index_local_divisional_units_on_code", unique: true
   end
 

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }, type: :job do
@@ -159,6 +161,29 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
         expect {
           described_class.perform_now d1.noms_no
         }.not_to change(CaseInformation, :count)
+      end
+    end
+
+    describe '#welsh_offender' do
+      let(:case_info) { CaseInformation.last }
+      let(:delius_record) { create(:delius_data, ldu_code: ldu.code, team_code: team.code) }
+
+      context 'with an English LDU' do
+        let(:ldu) { create(:local_divisional_unit, in_wales: false) }
+
+        it 'maps to false' do
+          described_class.perform_now(delius_record.noms_no)
+          expect(case_info.welsh_offender).to eq('No')
+        end
+      end
+
+      context 'with an Welsh LDU' do
+        let(:ldu) { create(:local_divisional_unit, in_wales: true) }
+
+        it 'maps to true' do
+          described_class.perform_now(delius_record.noms_no)
+          expect(case_info.welsh_offender).to eq('Yes')
+        end
       end
     end
 

--- a/spec/models/delius_data_spec.rb
+++ b/spec/models/delius_data_spec.rb
@@ -22,32 +22,6 @@ RSpec.describe DeliusData, type: :model do
     end
   end
 
-  describe '#welsh_offender?' do
-    context 'when a record is Welsh' do
-      subject {
-        described_class.new(
-          crn: '1',
-          noms_no: 'A1234Z',
-          ldu_code: 'WPT123'
-        )
-      }
-
-      it { is_expected.to be_welsh_offender }
-    end
-
-    context 'when a record is not Welsh' do
-      subject {
-        described_class.new(
-          crn: '1',
-          noms_no: 'A1234Z',
-          ldu_code: 'XPT123'
-        )
-      }
-
-      it { is_expected.not_to be_welsh_offender }
-    end
-  end
-
   describe '#service_provider' do
     context 'when provider code starts with C' do
       subject {


### PR DESCRIPTION
Context: We currently map welsh offenders from NOMIS by deciding if they have a Wel;sh LDU. This was originally done by checking that the LDU code started with the letters 'WPT' however this is no longer the case as a new LDU 'Cwn Taf Morganwg' has been created that doesn't match the pattern. Hence the change has been made to make this relationship more explicit.