### PR TITLE
POM-849 add handover dates to fields shown at start of allocation

### DIFF
--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -21,6 +21,20 @@
       <%= pom_responsibility_label(@prisoner) %>
     </td>
   </tr>
+  <tr class="govuk-table__row" id="handover-start-date-row">
+    <td class="govuk-table__cell govuk-!-width-one-half">Handover start date</td>
+    <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+      <%= format_date(@prisoner.handover_start_date) %>
+      <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
+    </td>
+  </tr>
+  <tr class="govuk-table__row" id="responsibility-handover-date-row">
+    <td class="govuk-table__cell govuk-!-width-one-half">Responsibility handover</td>
+    <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+      <%= format_date(@prisoner.responsibility_handover_date, replacement: 'Unknown - missing MAPPA info') %>
+      <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
+    </td>
+  </tr>
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">Last known address in Wales</td>
     <td class="govuk-table__cell table_cell__left_align">

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -44,7 +44,7 @@
           <%= link_to 'Change', new_prison_responsibility_path(@prison.code, nomis_offender_id: @prisoner.offender_no), class: 'govuk-link pull-right' %>
         <% end %>
       </td>
-<!--    </tr>-->
+    </tr>
 <!--    <tr class="govuk-table__row">-->
 <!--      <td class="govuk-table__cell govuk-!-width-one-half">Early assessment eligibility</td>-->
 <!--      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">-->
@@ -88,6 +88,20 @@
       <td class="govuk-table__cell">POM role</td>
       <td class="govuk-table__cell table_cell__left_align">
         <%= pom_responsibility_label(@prisoner) %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="handover-start-date-row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Handover start date</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+        <%= format_date(@prisoner.handover_start_date) %>
+        <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
+      </td>
+    </tr>
+    <tr class="govuk-table__row" id="responsibility-handover-date-row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Responsibility handover</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+        <%= format_date(@prisoner.responsibility_handover_date, replacement: 'Unknown - missing MAPPA info') %>
+        <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
       </td>
     </tr>
     <tr class="govuk-table__row">

--- a/spec/factories/keyworker.rb
+++ b/spec/factories/keyworker.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
-  factory :keyworker, class: Hash do
-    initialize_with { attributes }
+  factory :keyworker, class: HmppsApi::KeyworkerDetails do
+    initialize_with { HmppsApi::KeyworkerDetails.from_json(attributes) }
 
     sequence(:staffId) { |x| x + 1000  }
     firstName { Faker::Name.first_name }

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -20,6 +20,14 @@ FactoryBot.define do
 
   class Elite2POM
     attr_accessor :position, :staffId, :emails, :firstName, :lastName, :positionDescription, :status
+
+    def full_name
+      "#{lastName}, #{firstName}"
+    end
+
+    def staff_id
+      staffId
+    end
   end
 
   factory :pom, class: 'Elite2POM' do

--- a/spec/views/allocations/new.html.erb_spec.rb
+++ b/spec/views/allocations/new.html.erb_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "allocations/new", type: :view do
+  before do
+    assign(:prison, build(:prison))
+    assign(:prisoner, OffenderPresenter.new(build(:offender)))
+    assign(:previously_allocated_pom_ids, [])
+    assign(:recommended_poms, [])
+    assign(:not_recommended_poms, [])
+    assign(:unavailable_pom_count, 0)
+    render
+  end
+
+  let(:page) { Nokogiri::HTML(rendered) }
+
+  it 'shows handover dates' do
+    expect(page.css('#handover-start-date-row')).to have_text('Handover start date')
+    expect(page.css('#handover-start-date-row')).to have_text('05/11/2021')
+
+    expect(page.css('#responsibility-handover-date-row')).to have_text('Responsibility handover')
+    expect(page.css('#responsibility-handover-date-row')).to have_text('05/11/2021')
+  end
+end

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "allocations/show", type: :view do
+  before do
+    assign(:prison, build(:prison))
+    assign(:pom, build(:pom))
+    assign(:prisoner, build(:offender))
+    assign(:allocation, build(:allocation))
+    assign(:keyworker, build(:keyworker))
+    render
+  end
+
+  let(:page) { Nokogiri::HTML(rendered) }
+
+  it 'shows handover dates' do
+    expect(page.css('#handover-start-date-row')).to have_text('Handover start date')
+    expect(page.css('#handover-start-date-row')).to have_text('05/11/2021')
+
+    expect(page.css('#responsibility-handover-date-row')).to have_text('Responsibility handover')
+    expect(page.css('#responsibility-handover-date-row')).to have_text('05/11/2021')
+  end
+end


### PR DESCRIPTION
When an SPO is performing an allocation, they want to see the handover dates before they make the allocation, as it affects how long the POM will have the case for.