### PR TITLE
Enable the Sidekiq admin interface

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,4 +111,12 @@ Rails.application.routes.draw do
   mount Rswag::Api::Engine => '/api-docs'
 
   mount Flipflop::Engine => "/flip-flop-admin"
+
+  # Sidekiq admin interface
+  constraints lambda {|request| SsoIdentity.new(request.session).current_user_is_admin?} do
+    require 'sidekiq/web'
+    mount Sidekiq::Web => '/sidekiq'
+  end
+  # Redirect to 'unauthorized' page if user isn't an admin
+  get '/sidekiq', :to => redirect('/401')
 end

--- a/spec/features/admin_feature_spec.rb
+++ b/spec/features/admin_feature_spec.rb
@@ -20,7 +20,7 @@ feature 'admin urls' do
 
   let(:ldu) { create(:local_divisional_unit) }
   let!(:new_team) { create(:team, local_divisional_unit: ldu) }
-  let(:admin_urls) { ['/admin', '/flip-flop-admin'] }
+  let(:admin_urls) { ['/admin', '/flip-flop-admin', '/sidekiq'] }
 
   context 'when pom' do
     before do


### PR DESCRIPTION
This commit enables the Sidekiq web admin interface. It is now accessible at URL path `/sidekiq`.

Access is limited to admin users only. Other users will be redirected to the generic '401 Unauthorized' error page.

Unlike the other admin interfaces that we use (Active Admin, FlipFlop), Sidekiq doesn't come with a configurable filter for access control. Therefore I've used a [Rails route constraint][1] to control access.

[1]: https://guides.rubyonrails.org/routing.html#advanced-constraints