### PR TITLE
Fix a broken test after something changed on T3

### DIFF
--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 feature "view an offender's allocation information", :versioning do
   let!(:probation_officer_nomis_staff_id) { 485_636 }
-  let!(:nomis_offender_id_with_keyworker) { 'G4273GI' }
-  let!(:nomis_offender_id_without_keyworker) { 'G9403UP' }
+  let!(:nomis_offender_id_with_keyworker) { 'G3462VT' }
+  let!(:nomis_offender_id_without_keyworker) { 'G8859UP' }
   let!(:allocated_at_tier) { 'A' }
   let!(:prison) { 'LEI' }
   let!(:recommended_pom_type) { 'probation' }
@@ -40,7 +40,7 @@ feature "view an offender's allocation information", :versioning do
       expect(page).to have_css('h1', text: 'Allocation information')
 
       # Prisoner
-      expect(page).to have_css('.govuk-table__cell', text: 'Albina, Obinins')
+      expect(page).to have_css('.govuk-table__cell', text: "Alfew, Ef'Liaico")
       # Pom
       expect(page).to have_css('.govuk-table__cell', text: 'Duckett, Jenny')
       # Keyworker
@@ -130,7 +130,7 @@ feature "view an offender's allocation information", :versioning do
       expect(page).to have_css('h1', text: 'Allocation information')
 
       # Prisoner
-      expect(page).to have_css('.govuk-table__cell', text: 'Abbella, Ozullirn')
+      expect(page).to have_css('.govuk-table__cell', text: 'Abelia, Boppreophe')
       # Pom
       expect(page).to have_css('.govuk-table__cell', text: 'Duckett, Jenny')
       # Keyworker
@@ -140,7 +140,7 @@ feature "view an offender's allocation information", :versioning do
     it "displays a link to the prisoner's New Nomis profile", vcr: { cassette_name: :show_allocation_information_new_nomis_profile } do
       expect(page).to have_css('.govuk-table__cell', text: 'View NOMIS profile')
       expect(find_link('View NOMIS profile')[:target]).to eq('_blank')
-      expect(find_link('View NOMIS profile')[:href]).to include('offenders/G4273GI/quick-look')
+      expect(find_link('View NOMIS profile')[:href]).to include("offenders/#{nomis_offender_id_with_keyworker}/quick-look")
     end
 
     it 'displays a link to allocate a co-worker', vcr: { cassette_name: :show_allocation_information_display_coworker_link } do

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Search for offenders' do
+  let(:prison) { 'LEI' }
+
   context 'with stubs' do
     before do
       stub_auth_token
@@ -14,7 +16,6 @@ feature 'Search for offenders' do
     let(:username) { 'MOIC_POM' }
     let(:nomis_staff_id) { 143_876 }
     let(:nomis_offender) { build(:nomis_offender) }
-    let(:prison) { 'LEI' }
     let(:nomis_offender_id) { nomis_offender.fetch(:offenderNo) }
 
     context 'with delius import on' do

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -1,49 +1,66 @@
 require 'rails_helper'
 
 feature 'Search for offenders' do
-  context 'with delius import on' do
-    let(:test_strategy) { Flipflop::FeatureSet.current.test! }
-
+  context 'with stubs' do
     before do
-      test_strategy.switch!(:auto_delius_import, true)
+      stub_auth_token
+      stub_request(:get, "#{ApiHelper::T3}/users/#{username}").
+        to_return(body: { 'staffId': nomis_staff_id }.to_json)
+      stub_pom_emails(nomis_staff_id, [])
+      stub_offenders_for_prison(prison, [nomis_offender])
+      stub_poms(prison, [build(:pom)])
     end
 
-    after do
-      test_strategy.switch!(:auto_delius_import, false)
+    let(:username) { 'MOIC_POM' }
+    let(:nomis_staff_id) { 143_876 }
+    let(:nomis_offender) { build(:nomis_offender) }
+    let(:prison) { 'LEI' }
+    let(:nomis_offender_id) { nomis_offender.fetch(:offenderNo) }
+
+    context 'with delius import on' do
+      let(:test_strategy) { Flipflop::FeatureSet.current.test! }
+
+      before do
+        test_strategy.switch!(:auto_delius_import, true)
+      end
+
+      after do
+        test_strategy.switch!(:auto_delius_import, false)
+      end
+
+      it 'shows update not edit' do
+        signin_spo_user
+        visit prison_summary_allocated_path(prison)
+
+        expect(page).to have_text('See allocations')
+        fill_in 'q', with: nomis_offender_id
+        click_on('search-button')
+
+        update_link = find('td a')
+        expect(update_link.text).to eq('Update')
+        expect(page).to have_current_path(prison_search_path(prison), ignore_query: true)
+      end
     end
 
-    it 'shows update not edit', vcr: { cassette_name: :search_update_edit } do
-      signin_spo_user
-      visit prison_summary_allocated_path('LEI')
+    context 'with delius import off' do
+      let(:test_strategy) { Flipflop::FeatureSet.current.test! }
 
-      expect(page).to have_text('See allocations')
-      fill_in 'q', with: 'G4273GI'
-      click_on('search-button')
+      before do
+        test_strategy.switch!(:auto_delius_import, false)
+      end
 
-      update_link = find('td a')
-      expect(update_link.text).to eq('Update')
-      expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
-    end
-  end
+      it 'shows update not edit' do
+        signin_spo_user
+        visit prison_summary_allocated_path(prison)
 
-  context 'with delius import off' do
-    let(:test_strategy) { Flipflop::FeatureSet.current.test! }
+        expect(page).to have_text('See allocations')
+        fill_in 'q', with: nomis_offender_id
+        click_on('search-button')
 
-    before do
-      test_strategy.switch!(:auto_delius_import, false)
-    end
-
-    it 'shows update not edit', vcr: { cassette_name: :search_update_edit_no_delius } do
-      signin_spo_user
-      visit prison_summary_allocated_path('LEI')
-
-      expect(page).to have_text('See allocations')
-      fill_in 'q', with: 'G4273GI'
-      click_on('search-button')
-
-      update_link = find('td a')
-      expect(update_link.text).to eq('Edit')
-      expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+        update_link = find('td a')
+        expect(update_link.text).to eq('Edit')
+        expect(page).to have_current_path(prison_search_path(prison), ignore_query: true)
+      end
     end
   end
 
@@ -55,43 +72,43 @@ feature 'Search for offenders' do
     fill_in 'q', with: 'Cal'
     click_on('search-button')
 
-    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_current_path(prison_search_path(prison), ignore_query: true)
     expect(page).to have_css('tbody tr', count: 6)
   end
 
   it 'Can search from the Allocations summary page', vcr: { cassette_name: :allocated_search_feature } do
     signin_spo_user
-    visit prison_summary_allocated_path('LEI')
+    visit prison_summary_allocated_path(prison)
 
     expect(page).to have_text('See allocations')
     fill_in 'q', with: 'Fra'
     click_on('search-button')
 
-    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_current_path(prison_search_path(prison), ignore_query: true)
     expect(page).to have_css('tbody tr', count: 9)
   end
 
   it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: :waiting_allocation_search_feature } do
     signin_spo_user
-    visit prison_summary_unallocated_path('LEI')
+    visit prison_summary_unallocated_path(prison)
 
     expect(page).to have_text('Make allocations')
     fill_in 'q', with: 'Tre'
     click_on('search-button')
 
-    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_current_path(prison_search_path(prison), ignore_query: true)
     expect(page).to have_css('tbody tr', count: 1)
   end
 
   it 'Can search from the Missing Information summary page', vcr: { cassette_name: :missing_info_search_feature } do
     signin_spo_user
-    visit  prison_summary_pending_path('LEI')
+    visit  prison_summary_pending_path(prison)
 
     expect(page).to have_text('Make allocations')
     fill_in 'q', with: 'Ste'
     click_on('search-button')
 
-    expect(page).to have_current_path(prison_search_path('LEI'), ignore_query: true)
+    expect(page).to have_current_path(prison_search_path(prison), ignore_query: true)
     expect(page).to have_css('tbody tr', count: 4)
   end
 end


### PR DESCRIPTION
The allocation feature test broke because it was dependent on some data existing in T3 which had changed.

Our test suite's dependence on T3 (NOMIS dev environment) is an ongoing issue which we know needs to be solved. As it stands, this dependency results in brittle tests which break when T3 changes or goes down. Unfortunately there are a large number of tests dependent on it, so there isn't an easy or quick solution to it.

In the meantime, this quick-fix should keep things moving.