### PR TITLE
POM-486 pre-cursor - fixup LocalDivisionalUnit#with_email_address

### DIFF
--- a/app/models/local_divisional_unit.rb
+++ b/app/models/local_divisional_unit.rb
@@ -6,6 +6,6 @@ class LocalDivisionalUnit < ApplicationRecord
   validates :name, presence: true
   validates :code, presence: true, uniqueness: true, format: { with: Team::TEAM_LDU_CODE_REGEX }
 
-  scope :without_email_address, -> { where(email_address: nil) }
-  scope :with_email_address, -> { where.not(email_address: nil) }
+  scope :without_email_address, -> { where(email_address: nil).or(where(email_address: '')) }
+  scope :with_email_address, -> { where.not(email_address: nil).where.not(email_address: '') }
 end

--- a/spec/factories/local_divisional_units.rb
+++ b/spec/factories/local_divisional_units.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :local_divisional_unit do
     sequence(:code) { |seq| "LDU#{seq}" }
-    name do 'An Uninteresting LDU' end
+    sequence(:name) { |seq| "LDU Number #{seq}" }
     email_address { Faker::Internet.email }
   end
 end

--- a/spec/models/local_divisional_unit_spec.rb
+++ b/spec/models/local_divisional_unit_spec.rb
@@ -9,6 +9,30 @@ RSpec.describe LocalDivisionalUnit, type: :model do
     expect(subject).not_to validate_presence_of :email_address
   }
 
+  context 'with and without emails' do
+    before do
+      create(:local_divisional_unit, email_address: nil)
+      create(:local_divisional_unit, email_address: '')
+      create(:local_divisional_unit, email_address: 'test@example.com')
+    end
+
+    describe '#with_email_address' do
+      let(:expected) { described_class.last }
+
+      it 'returns just the filled-in version' do
+        expect(described_class.with_email_address.to_a).to eq([expected])
+      end
+    end
+
+    describe '#without_email_address' do
+      let(:expected) { described_class.first(2) }
+
+      it 'returns just the filled-in version' do
+        expect(described_class.without_email_address.to_a).to match_array(expected)
+      end
+    end
+  end
+
   describe '#code' do
     let(:ldu) { build(:local_divisional_unit, code: code) }
 


### PR DESCRIPTION
LocalDivisionalUnit#with_email_address only checks for nils. When editing LDUs with active admin, it's quite possible to create LDUs with a <blank> email address, which would be caught by the with_email_address method. This PR fixes this problem.