### PR TITLE
Tidy up sentence detail factory

### DIFF
--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -11,11 +11,7 @@ FactoryBot.define do
     # 1 day after policy start in Wales
     sentenceStartDate { '2019-02-05' }
     releaseDate { "2021-01-28" }
-    automaticReleaseDate { "2022-01-28" }
-    postRecallReleaseDate { "2021-01-28" }
     conditionalReleaseDate { "2022-01-28" }
-    actualParoleDate { "2021-01-28" }
-    licenceExpiryDate { "2021-01-28" }
 
     trait :welsh_policy_sentence do
       sentenceStartDate { '2019-02-05' }

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -7,7 +7,7 @@ module ApiHelper
   KEYWORKER_API_HOST = ENV.fetch('KEYWORKER_API_HOST')
 
   def stub_offender(offender)
-    booking_number = 1
+    booking_number = offender.fetch(:bookingId)
     offender_no = offender.fetch(:offenderNo)
     stub_request(:get, "#{T3}/prisoners/#{offender_no}").
       to_return(body: [offender.except(:sentence, :recall).merge('latestBookingId' => booking_number)].to_json)


### PR DESCRIPTION
The SentenceDetail factory is very over-burdensome - it declares many items by default which are not needed.
This PR also fixes up a minor annoyance, as all tests assumed that get_offender() would only be called once for one offender - as a result the stub tended to return the same data as the bookingId field was hard-coded in the stub method