### PR TITLE
MO-60 move com name to case info

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -62,35 +62,28 @@ private
                                   error_type: error_type(field)
       end
     end
-
-    update_com_name(delius_record)
-  end
-
-  def update_com_name(delius_record)
-    allocation = Allocation.find_by(nomis_offender_id: delius_record.noms_no)
-    return if allocation.blank?
-
-    com_name = if ['Unallocated', 'Inactive'].any? { |pattern| delius_record.offender_manager.include?(pattern) }
-                 nil
-               else
-                 delius_record.offender_manager
-               end
-
-    allocation.assign_attributes(com_name: com_name)
-    allocation.save! if allocation.changed?
   end
 
   def map_delius_to_case_info(delius_record)
     find_case_info(delius_record).tap do |case_info|
       team = map_team(delius_record.team_code)
       case_info.assign_attributes(
+        com_name: map_com_name(delius_record.offender_manager),
         crn: delius_record.crn,
         tier: map_tier(delius_record.tier),
-        team: team,
-        case_allocation: delius_record.service_provider,
-        welsh_offender: map_welsh_offender(delius_record.ldu_code),
-        mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
+      team: team,
+      case_allocation: delius_record.service_provider,
+      welsh_offender: map_welsh_offender(delius_record.ldu_code),
+      mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
       )
+    end
+  end
+
+  def map_com_name(offender_manager)
+    if ['Unallocated', 'Inactive'].any? { |pattern| offender_manager.include?(pattern) }
+      nil
+    else
+      offender_manager
     end
   end
 

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -13,9 +13,9 @@ module HmppsApi
     attr_accessor :category_code, :date_of_birth, :prison_arrival_date
 
     attr_reader :first_name, :last_name, :booking_id,
-                :offender_no
+                :offender_no, :allocated_com_name
 
-    attr_accessor :sentence, :allocated_pom_name, :allocated_com_name, :case_allocation, :mappa_level, :tier
+    attr_accessor :sentence, :allocated_pom_name, :case_allocation, :mappa_level, :tier
 
     attr_reader :crn,
                 :welsh_offender, :parole_review_date,
@@ -161,6 +161,7 @@ module HmppsApi
       @early_allocation = record.latest_early_allocation.present? &&
         (record.latest_early_allocation.eligible? || record.latest_early_allocation.community_decision?)
       @responsibility = record.responsibility
+      @allocated_com_name = record.com_name
     end
 
   private

--- a/app/presenters/allocation_presenter.rb
+++ b/app/presenters/allocation_presenter.rb
@@ -3,7 +3,7 @@
 class AllocationPresenter
   delegate :primary_pom_nomis_id, :event, :event_trigger, :secondary_pom_nomis_id, :prison,
            :allocated_at_tier, :nomis_offender_id, :primary_pom_name, :override_reasons, :suitability_detail,
-           :override_detail, :com_name,
+           :override_detail,
            :created_by_name, :nomis_booking_id, :recommended_pom_type, :secondary_pom_name, to: :@allocation
 
   def initialize(allocation, version)

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -45,8 +45,7 @@ class AllocationService
     params_copy = params.merge(
       primary_pom_name: "#{pom_secondname}, #{pom_firstname}",
       created_by_name: "#{user_firstname} #{user_secondname}",
-      primary_pom_allocated_at: DateTime.now.utc,
-      com_name: delius_com_name(params[:nomis_offender_id])
+      primary_pom_allocated_at: DateTime.now.utc
     )
 
     # When we look up the current allocation, we only do this for the current
@@ -120,10 +119,6 @@ class AllocationService
   end
 
 private
-
-  def self.delius_com_name(offender_id)
-    DeliusData.find_by(noms_no: offender_id).try(:offender_manager)
-  end
 
   # Gets the versions in *forward* order - so often we want to reverse
   # this list as we're interested in recent rather than ancient history

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -134,9 +134,6 @@ private
       # Add POM details
       offender.allocated_pom_name = restructure_pom_name(alloc.primary_pom_name)
       offender.allocation_date = (alloc.primary_pom_allocated_at || alloc.updated_at)&.to_date
-
-      # Add COM details
-      offender.allocated_com_name = alloc.com_name
     end
   end
 

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -280,7 +280,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= @allocation&.com_name.presence || "Unknown" %>
+        <%= @offender.allocated_com_name.presence || "Unknown" %>
       </td>
     </tr>
     </tbody>

--- a/app/views/prisoners/_community_information.html.erb
+++ b/app/views/prisoners/_community_information.html.erb
@@ -29,7 +29,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= @allocation&.com_name.presence || "Unknown" %>
+        <%= @prisoner.allocated_com_name.presence || "Unknown" %>
       </td>
     </tr>
   </tbody>

--- a/db/migrate/20201028105256_move_com_name_to_case_info.rb
+++ b/db/migrate/20201028105256_move_com_name_to_case_info.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MoveComNameToCaseInfo < ActiveRecord::Migration[6.0]
+  def change
+    change_table :case_information do |t|
+      t.string :com_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_14_082050) do
+ActiveRecord::Schema.define(version: 2020_10_28_105256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2020_10_14_082050) do
     t.datetime "updated_at"
     t.date "parole_review_date"
     t.string "probation_service"
+    t.string "com_name"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id", unique: true
     t.index ["team_id"], name: "index_case_information_on_team_id"
   end

--- a/lib/tasks/move_com_name.rake
+++ b/lib/tasks/move_com_name.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+BATCH_SIZE = 1000
+
+namespace :move do
+  desc 'Move COM Name field from Allocation to CaseInformation'
+  task com_name: :environment do
+    scope = Allocation.where.not(com_name: nil)
+    count = 1 + scope.count / BATCH_SIZE
+    scope.find_in_batches(batch_size: BATCH_SIZE).each_with_index do |batch, index|
+      puts "Allocation batch #{index + 1}/#{count}"
+      allocs = batch.index_by(&:nomis_offender_id)
+      CaseInformation.where(com_name: nil, nomis_offender_id: allocs.keys).each do |info|
+        info.update(com_name: allocs[info.nomis_offender_id]&.com_name)
+      end
+    end
+  end
+end

--- a/spec/factories/delius_datums.rb
+++ b/spec/factories/delius_datums.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     crn do
       Faker::Number.number(digits: 8)
     end
+    offender_manager { 'Smith, Bob' }
     # This has to match the T3 record for G4281GV above
     date_of_birth do '11/11/1964' end
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -68,10 +68,9 @@ feature 'View a prisoner profile page' do
       team = create(:team, name: 'A team', local_divisional_unit: ldu)
       create(:case_information,
              nomis_offender_id: alloc.nomis_offender_id,
-             team: team
+             team: team,
+             com_name: 'Bob Smith'
       )
-
-      alloc.update(com_name: 'Bob Smith')
 
       visit prison_prisoner_path('LEI', 'G7998GJ')
 

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -64,62 +64,36 @@ RSpec.describe ProcessDeliusDataJob, vcr: { cassette_name: :process_delius_job }
       context 'with a normal COM name' do
         let(:com_name) { 'Bob Smith' }
 
-        it 'does not update if no allocation' do
-          alloc = Allocation.find_by(nomis_offender_id: offender_id)
-          expect(alloc).to be_nil
-
+        it 'shows com name' do
           expect {
             described_class.perform_now d1.noms_no
           }.to change(CaseInformation, :count).by(1)
 
-          alloc = Allocation.find_by(nomis_offender_id: offender_id)
-          expect(alloc).to be_nil
-        end
-
-        context 'with allocation' do
-          before do
-            create(:allocation, nomis_offender_id: d1.noms_no, com_name: 'Fred Bloigs')
-          end
-
-          let!(:allocation) { Allocation.find_by!(nomis_offender_id: d1.noms_no) }
-
-          it 'updates existing allocation without new version' do
-            expect(allocation.version).to be_nil
-
-            expect {
-              described_class.perform_now d1.noms_no
-            }.to change(CaseInformation, :count).by(1)
-
-            allocation.reload
-            expect(allocation.version).to be_nil
-            expect(allocation.com_name).to eq(com_name)
-          end
+          expect(CaseInformation.last.com_name).to eq(com_name)
         end
       end
 
       context 'with an unallocated com name' do
         let(:com_name) { 'Staff, Unallocated' }
 
-        before do
-          create(:allocation, nomis_offender_id: d1.noms_no, com_name: 'Fred Bloigs')
-        end
-
         it 'maps com_name to nil' do
-          described_class.perform_now d1.noms_no
-          expect(Allocation.find_by(nomis_offender_id: d1.noms_no).com_name).to be_nil
+          expect {
+            described_class.perform_now d1.noms_no
+          }.to change(CaseInformation, :count).by(1)
+
+          expect(CaseInformation.last.com_name).to be_nil
         end
       end
 
       context 'with an inactive com name' do
         let(:com_name) { 'Staff, Inactive Staff(N07)' }
 
-        before do
-          create(:allocation, nomis_offender_id: d1.noms_no, com_name: 'Fred Bloigs')
-        end
-
         it 'maps com_name to nil' do
-          described_class.perform_now d1.noms_no
-          expect(Allocation.find_by(nomis_offender_id: d1.noms_no).com_name).to be_nil
+          expect {
+            described_class.perform_now d1.noms_no
+          }.to change(CaseInformation, :count).by(1)
+
+          expect(CaseInformation.last.com_name).to be_nil
         end
       end
     end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -190,29 +190,6 @@ describe AllocationService do
     expect(current_pom.grade).to eq("Prison POM")
   end
 
-  it 'can set the correct com_name', versioning: true, vcr: { cassette_name: 'allocation_service_com_name' }  do
-    create(:delius_data, noms_no: nomis_offender_id, offender_manager: 'Bob')
-    create(:case_information, nomis_offender_id: nomis_offender_id)
-
-    params = {
-      nomis_offender_id: nomis_offender_id,
-      prison: 'LEI',
-      allocated_at_tier: 'A',
-      primary_pom_nomis_id: 485_833,
-      primary_pom_allocated_at: DateTime.now.utc,
-      nomis_booking_id: 1,
-      recommended_pom_type: 'probation',
-      event: Allocation::ALLOCATE_PRIMARY_POM,
-      event_trigger: Allocation::USER,
-      created_by_username: 'MOIC_POM'
-    }
-
-    described_class.create_or_update(params)
-
-    alloc = Allocation.find_by(nomis_offender_id: nomis_offender_id)
-    expect(alloc.com_name).to eq('Bob')
-  end
-
   describe '#allocation_history_pom_emails' do
     it 'can retrieve all the POMs email addresses for ', versioning: true, vcr: { cassette_name: :allocation_service_history_spec } do
       previous_primary_pom_nomis_id = 485_637


### PR DESCRIPTION
During the Community API work, it was discovered that the Allocation was filling in the com_name field from the DeliusData table - which is an 'under the hood' DeliusData import. The com_name field always belonged in case_information (it is an external field) and putting it in Allocation caused some subtle bugs around the updated_at field.
This PR moves the com_name field from Allocation to CaseInformation, and provides a rake task to back-fill the com_name field. There is a separate PR to tidy up and remove the field from Allocation completely, as the rake task needs both fields to exist. The data migration could have been slow without complex SQL, so this has been chosen as the simple option 