### PR TITLE
MO-98 send deallocation email when offender is released or transferred

### DIFF
--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -151,4 +151,20 @@ class PomMailer < GovukNotifyRails::Mailer
 
     mail(to: params[:previous_pom_email])
   end
+
+  def offender_deallocated(email:,
+                           pom_name:,
+                           offender_name:,
+                           nomis_offender_id:,
+                           prison_name:,
+                           url:)
+    set_template('1df51f52-512d-434b-9088-50eacaa47c59')
+    set_personalisation(pom_name: pom_name,
+                        offender_name: offender_name,
+                        nomis_offender_id: nomis_offender_id,
+                        prison_name: prison_name,
+                        url: url)
+
+    mail(to: email)
+  end
 end

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -100,7 +100,7 @@ private
     # When an offender is released, we can no longer rely on their
     # case information (in case they come back one day), and we
     # should de-activate any current allocations.
-    alloc&.deallocate_offender(Allocation::OFFENDER_TRANSFERRED)
+    alloc.offender_transferred if alloc
     true
   end
 
@@ -127,7 +127,6 @@ private
 
     CaseInformation.where(nomis_offender_id: offender_no).destroy_all
     alloc = Allocation.find_by(nomis_offender_id: offender_no)
-    # frozen_string_literal: true
     # We need to check whether the from_agency is from within the prison estate
     # to know whether it is a transfer.  If it isn't then we want to bail and
     # not process the new admission.
@@ -140,6 +139,6 @@ private
     # When an offender is released, we can no longer rely on their
     # case information (in case they come back one day), and we
     # should de-activate any current allocations.
-    alloc&.deallocate_offender(Allocation::OFFENDER_RELEASED)
+    alloc.offender_released if alloc
   end
 end

--- a/spec/controllers/overrides_controller_spec.rb
+++ b/spec/controllers/overrides_controller_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe OverridesController, type: :controller do
 
   context 'with an inactive allocation' do
     before do
-      allocation = create(:allocation, nomis_offender_id: nomis_offender_id)
-      allocation.deallocate_offender(Allocation::OFFENDER_RELEASED)
+      create(:allocation, :release, nomis_offender_id: nomis_offender_id)
     end
 
     it 'redirects to confirm#allocation' do

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -156,16 +156,18 @@ feature 'Allocation History' do
     let(:nomis_offender) { build(:nomis_offender) }
     let(:nomis_offender_id) { nomis_offender.fetch(:offenderNo) }
     let(:prison) { build(:prison).code }
-    let(:staff_id) { 123456 }
+    let(:pom) { build(:pom) }
 
     before do
       stub_auth_token
-      stub_user(username: 'MOIC_POM', staff_id: staff_id)
+      stub_user(username: 'MOIC_POM', staff_id: pom.staff_id)
       stub_offender(nomis_offender)
+      stub_offenders_for_prison(prison, [nomis_offender])
       signin_spo_user([prison])
+      stub_poms(prison, [pom])
       create(:case_information, nomis_offender_id: nomis_offender_id)
-      allocation = create(:allocation, :primary, nomis_offender_id: nomis_offender_id, prison: prison)
-      allocation.deallocate_offender(Allocation::OFFENDER_RELEASED)
+      allocation = create(:allocation, :primary, nomis_offender_id: nomis_offender_id, prison: prison, primary_pom_nomis_id: pom.staff_id)
+      allocation.offender_released
     end
 
     scenario 'visit allocation history page' do

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe MovementsOnDateJob, type: :job do
           directionCode: "IN"
         }].to_json)
 
+    stub_poms('MDI', [build(:pom, staffId: 485926)])
+    stub_offenders_for_prison('MDI', [])
+
     expect(alloc.primary_pom_nomis_id).not_to be_nil
     expect(alloc.secondary_pom_nomis_id).not_to be_nil
 

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
   end
 
   it 'can use previous allocation details where they exist' do
+    offender = build(:nomis_offender, first_name: 'First', last_name: 'Last')
+    stub_offenders_for_prison(closed_prison_code, [offender])
     allow(OffenderService).to receive(:get_offender).
       and_return(HmppsApi::Offender.new(offender_no: nomis_offender_id,
                                      prison_id: open_prison_code,
@@ -110,10 +112,10 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
 
     # Create an allocation where the offender is allocated, and then deallocate so we can
     # test finding the last pom that was allocated to this offender ....
-    alloc = create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: other_staff_id, prison: 'LEI',
+    alloc = create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: other_staff_id, prison: closed_prison_code,
                                 primary_pom_name: 'Primary POMName')
     alloc.update(primary_pom_nomis_id: nomis_staff_id)
-    alloc.deallocate_offender(Allocation::OFFENDER_TRANSFERRED)
+    alloc.offender_transferred
 
     fakejob = double
     allow(fakejob).to receive(:deliver_later)

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -127,20 +127,20 @@ RSpec.describe EmailService do
   context 'when offender has been released' do
     let(:staff_id) { '485833' }
     let!(:released_allocation) do
-      x = create(:allocation,
-                 nomis_offender_id: original_allocation.nomis_offender_id,
-                 primary_pom_nomis_id: original_allocation.primary_pom_nomis_id)
-      x.deallocate_offender(Allocation::OFFENDER_RELEASED)
-      x.reload
-      x.update!(primary_pom_nomis_id: reallocation.primary_pom_nomis_id,
-                event: Allocation::REALLOCATE_PRIMARY_POM,
-                event_trigger: Allocation::USER)
-      x.deallocate_offender(Allocation::OFFENDER_RELEASED)
-      x.reload
-      x.update!(primary_pom_nomis_id: original_allocation.primary_pom_nomis_id,
-                event: Allocation::REALLOCATE_PRIMARY_POM,
-                event_trigger: Allocation::USER)
-      x
+      create(:allocation,
+             nomis_offender_id: original_allocation.nomis_offender_id,
+             primary_pom_nomis_id: original_allocation.primary_pom_nomis_id).tap do |x|
+        x.offender_released
+        x.reload
+        x.update!(primary_pom_nomis_id: reallocation.primary_pom_nomis_id,
+                  event: Allocation::REALLOCATE_PRIMARY_POM,
+                  event_trigger: Allocation::USER)
+        x.offender_released
+        x.reload
+        x.update!(primary_pom_nomis_id: original_allocation.primary_pom_nomis_id,
+                  event: Allocation::REALLOCATE_PRIMARY_POM,
+                  event_trigger: Allocation::USER)
+      end
     end
 
     it "Can send a reallocation email", vcr: { cassette_name: :email_service_reallocation_crash } do


### PR DESCRIPTION
When an offender is released on transferred, the POM is no longer involved but they do not get any notification.

This PR adds an email notification to the primary POM when a release event occurs.