### PR TITLE
Make the check for nDelius case info more truthful

### DIFF
--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
     trait :crc do
       case_allocation { CaseInformation::CRC }
     end
+
+    trait :with_com do
+      com_name { "#{Faker::Name.last_name}, #{Faker::Name.first_name}" }
+    end
   end
 end

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -74,4 +74,110 @@ describe HmppsApi::Offender do
       end
     end
   end
+
+  describe 'fields that come from CaseInformation' do
+    context 'when no CaseInformation has been loaded' do
+      subject { offender.public_send(field) }
+
+      let(:offender) { build(:offender) }
+
+      shared_examples 'expect fields to be' do |value, fields|
+        fields.each do |field|
+          describe "##{field}" do
+            let(:field) { field }
+
+            it { is_expected.to be(value) }
+          end
+        end
+      end
+
+      include_examples 'expect fields to be', nil, [
+        :tier, :case_allocation, :mappa_level, :parole_review_date,
+        :welsh_offender, :ldu, :team, :allocated_com_name
+      ]
+
+      include_examples 'expect fields to be', false, [
+        :has_case_information?, :early_allocation?
+      ]
+    end
+
+    context 'when a CaseInformation record has been loaded' do
+      subject { offender.public_send(field) }
+
+      let(:case_info) { create(:case_information) }
+      let(:offender) { build(:offender).tap { |o| o.load_case_information(case_info) } }
+
+      describe '#has_case_information?' do
+        let(:field) { :has_case_information? }
+
+        it { is_expected.to be(true) }
+      end
+
+      delegated_fields = [:tier, :case_allocation, :mappa_level, :parole_review_date]
+      delegated_fields.each do |delegated_field|
+        describe "##{delegated_field}" do
+          let(:field) { delegated_field }
+
+          it { is_expected.to be(case_info.public_send(delegated_field)) }
+        end
+      end
+
+      describe '#welsh_offender' do
+        let(:field) { :welsh_offender }
+
+        context 'when the welsh_offender field is "Yes"' do
+          let(:case_info) { create(:case_information, welsh_offender: 'Yes') }
+
+          it { is_expected.to be(true) }
+        end
+
+        context 'when the welsh_offender field is "No"' do
+          let(:case_info) { create(:case_information, welsh_offender: 'No') }
+
+          it { is_expected.to be(false) }
+        end
+      end
+
+      describe '#early_allocation?' do
+        let(:field) { :early_allocation? }
+
+        context 'when eligible for early allocation' do
+          let!(:early_allocation) { create(:early_allocation, case_information: case_info) }
+
+          it { is_expected.to be(true) }
+        end
+
+        context 'when ineligible for early allocation' do
+          let!(:early_allocation) { create(:early_allocation, :ineligible, :skip_validate, case_information: case_info) }
+
+          it { is_expected.to be(false) }
+        end
+
+        context 'when discretionary but the community have accepted' do
+          let!(:early_allocation) { create(:early_allocation, :discretionary, community_decision: true, case_information: case_info) }
+
+          it { is_expected.to be(true) }
+        end
+      end
+
+      describe '#ldu' do
+        let(:field) { :ldu }
+
+        it { is_expected.to be(case_info.team.local_divisional_unit) }
+      end
+
+      describe '#team' do
+        let(:field) { :team }
+
+        it { is_expected.to be(case_info.team.name) }
+      end
+
+      describe '#allocated_com_name' do
+        let(:case_info) { create(:case_information, :with_com) }
+        let(:field) { :allocated_com_name }
+
+        it { is_expected.to be(case_info.com_name) }
+      end
+    end
+  end
 end

--- a/spec/presenters/offender_presenter_spec.rb
+++ b/spec/presenters/offender_presenter_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe OffenderPresenter do
     context 'when a probation POM' do
       it "can get for a probation owned offender" do
         offender = build(:offender,  :indeterminate)
-        offender.tier = 'A'
+        case_info = build(:case_information, tier: 'A')
+        offender.load_case_information(case_info)
         subject = described_class.new(offender)
         expect(subject.complex_reason_label).to eq('Prisoner assessed as suitable for a prison officer POM despite tiering calculation')
       end


### PR DESCRIPTION
The `Offender` object comes with a method `.has_case_information?` which will return true is a case information record has been loaded for that offender.

This was reliant upon the tier field being set, which was slightly hacky and would fail if tier was legitimately empty.

This commit changes the method to check whether a CaseInformation record has been loaded at all, rather than depending on the value of that specific field.