### PR TITLE
Fix Automatic Handover email job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,6 @@ workflows:
               only:
                 - main
                 - preproduction
-                - handover-cronjob-failing
       - deploy_staging:
           requires:
             - build_and_push_docker_image
@@ -384,7 +383,6 @@ workflows:
             branches:
               only:
                 - main
-                - handover-cronjob-failing
       - test_staging:
           requires:
             - build_and_push_docker_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,12 @@ references:
         if [ "${CIRCLE_BRANCH}" == "main" ]; then
           docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
+        else
+          docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:testing"
+          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:testing"
         fi
+        docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:testing"
+        docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:testing"
       environment:
         <<: *github_team_name_slug
         REPONAME: offender-management-allocation-manager
@@ -371,13 +376,15 @@ workflows:
               only:
                 - main
                 - preproduction
+                - handover-cronjob-failing
       - deploy_staging:
           requires:
             - build_and_push_docker_image
           filters:
             branches:
               only:
-                main
+                - main
+                - handover-cronjob-failing
       - test_staging:
           requires:
             - build_and_push_docker_image

--- a/deploy/production/handover-email-job.yaml
+++ b/deploy/production/handover-email-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: handover-email-job
 spec:
-  schedule: "4 4 1 * *"
+  schedule: "4 9 3 * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -15,7 +15,7 @@ spec:
           - name: handover-email-job
             image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
             imagePullPolicy: Always
-            command: ['sh', '-c', "bundle exec rails r LocalDivisionalUnit.with_email_address.each { |ldu| AutomaticHandoverEmailJob.perform_later(ldu) }"]
+            command: ['sh', '-c', "bundle exec rake cronjob:handover_email"]
             envFrom:
               - configMapRef:
                   name: shared-environment

--- a/deploy/staging/handover-email-job.yaml
+++ b/deploy/staging/handover-email-job.yaml
@@ -15,7 +15,7 @@ spec:
           - name: handover-email-job
             image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:testing
             imagePullPolicy: Always
-            command: ['sh', '-c', "bundle exec rake -T && bundle exec rake cronjob:handover_email"]
+            command: ['sh', '-c', "bundle exec rake cronjob:handover_email"]
             envFrom:
               - configMapRef:
                   name: shared-environment

--- a/deploy/staging/handover-email-job.yaml
+++ b/deploy/staging/handover-email-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: handover-email-job
 spec:
-  schedule: "4 11 28 * *"
+  schedule: "35 12 2 11 *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -13,9 +13,9 @@ spec:
         spec:
           containers:
           - name: handover-email-job
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:testing
             imagePullPolicy: Always
-            command: ['sh', '-c', "bundle exec rails r LocalDivisionalUnit.with_email_address.each { |ldu| AutomaticHandoverEmailJob.perform_later(ldu) }"]
+            command: ['sh', '-c', "bundle exec rake -T && bundle exec rake cronjob:handover_email"]
             envFrom:
               - configMapRef:
                   name: shared-environment

--- a/lib/tasks/handover_email.rake
+++ b/lib/tasks/handover_email.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :cronjob do
+  desc 'send monthly handover emails'
+  task handover_email: :environment do |_task|
+    LocalDivisionalUnit.with_email_address.each do |ldu|
+      AutomaticHandoverEmailJob.perform_later(ldu)
+    end
+  end
+end


### PR DESCRIPTION
This PR appears to fix the automatic handover email job. When this was first tested, it was forgotten that the 'no emails' scenario send a 'blank' ish email, so that was a requirement that should have been checked and wasn't. 
This changes the job from a long-ish line of ruby to a rake task, which seems to make it work on staging, so should be good for production. I have changed the execution time for production to 9:04am on 3rd so that the job can be observed - failed cronjobs seem to be difficult to diagnose.