### PR TITLE
Support rubocop-rspec 1.41

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'parallel_tests'
   gem 'rubocop'
-  gem 'rubocop-rspec'
+  gem 'rubocop-rspec', '>= 1.41'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-govuk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ GEM
       activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.37.1)
+    rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
     ruby-prof (1.4.1)
     ruby-progressbar (1.10.1)
@@ -508,7 +508,7 @@ DEPENDENCIES
   rubocop-govuk
   rubocop-performance
   rubocop-rails
-  rubocop-rspec
+  rubocop-rspec (>= 1.41)
   ruby-prof (>= 0.16.0)
   rubyzip
   sassc-rails

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -2,13 +2,13 @@
 
 require 'swagger_helper'
 
+# The DescribeClass cop has been disabled as it is insists that the describe
+# block contain the name of the tested class.  However rswag is using this
+# text as part of the API documentation generated from these tests.
 # rubocop:disable RSpec/DescribeClass
 # rubocop:disable RSpec/EmptyExampleGroup
 # Authorization 'method' needs to be defined for rswag
 # rubocop:disable RSpec/VariableName
-# The DescribeClass cop has been disabled as it is insists that the describe
-# block contain the name of the tested class.  However rswag is using this
-# text as part of the API documentation generated from these tests.
 describe 'Allocation API', vcr: { cassette_name: :allocation_api } do
   let!(:private_key) { OpenSSL::PKey::RSA.generate 2048 }
   let!(:public_key) { Base64.strict_encode64(private_key.public_key.to_s) }

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -4,6 +4,8 @@ require 'swagger_helper'
 
 # rubocop:disable RSpec/DescribeClass
 # rubocop:disable RSpec/EmptyExampleGroup
+# Authorization 'method' needs to be defined for rswag
+# rubocop:disable RSpec/VariableName
 # The DescribeClass cop has been disabled as it is insists that the describe
 # block contain the name of the tested class.  However rswag is using this
 # text as part of the API documentation generated from these tests.
@@ -100,5 +102,6 @@ describe 'Allocation API', vcr: { cassette_name: :allocation_api } do
     end
   end
 end
+# rubocop:enable RSpec/VariableName
 # rubocop:enable RSpec/EmptyExampleGroup
 # rubocop:enable RSpec/DescribeClass

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe RecommendationService do
-  let(:tierA) {
+  let(:tier_a) {
     build(:offender,
           sentence: HmppsApi::SentenceDetail.new(
             sentence_start_date: Time.zone.today,
@@ -9,7 +9,7 @@ describe RecommendationService do
       o.load_case_information(build(:case_information, tier: 'A'))
     }
   }
-  let(:tierD) {
+  let(:tier_d) {
     build(:offender,
           sentence: HmppsApi::SentenceDetail.new(
             sentence_start_date: Time.zone.today,
@@ -18,7 +18,7 @@ describe RecommendationService do
     }
   }
 
-  let(:tierA_and_immigration_case) {
+  let(:tier_a_and_immigration_case) {
     build(:offender,
           imprisonmentStatus: 'DET', sentence: HmppsApi::SentenceDetail.new).tap { |o|
       o.load_case_information(build(:case_information, tier: 'A'))
@@ -26,14 +26,14 @@ describe RecommendationService do
   }
 
   it "can determine the best type of POM for Tier A" do
-    expect(described_class.recommended_pom_type(tierA)).to eq(described_class::PROBATION_POM)
+    expect(described_class.recommended_pom_type(tier_a)).to eq(described_class::PROBATION_POM)
   end
 
   it "can determine the best type of POM for Tier D" do
-    expect(described_class.recommended_pom_type(tierD)).to eq(described_class::PRISON_POM)
+    expect(described_class.recommended_pom_type(tier_d)).to eq(described_class::PRISON_POM)
   end
 
   it "can determine the best type of POM for an immigration case" do
-    expect(described_class.recommended_pom_type(tierA_and_immigration_case)).to eq(described_class::PRISON_POM)
+    expect(described_class.recommended_pom_type(tier_a_and_immigration_case)).to eq(described_class::PRISON_POM)
   end
 end

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -14,48 +14,35 @@ RSpec.describe "debugging/debugging", type: :view do
 
   let(:prison) { build(:prison) }
 
-  describe "debugging/debugging.html.erb" do
-    it "displays offender full_name" do
-      assign(:offender, OffenderPresenter.new(offender))
-      assign(:prison, prison)
+  before do
+    assign(:offender, OffenderPresenter.new(offender))
+    assign(:prison, prison)
 
-      render
-      page = Nokogiri::HTML(rendered)
-      full_name = page.css('#prisoner-information').css('#name').first
-      expect(full_name.text).to match(/Dory, John/)
-    end
+    render
   end
 
-  describe "debugging/debugging.html.erb" do
-    it "displays tariff date" do
-      assign(:offender, OffenderPresenter.new(offender))
-      assign(:prison, prison)
+  it "displays offender full_name" do
+    page = Nokogiri::HTML(rendered)
+    full_name = page.css('#prisoner-information').css('#name').first
+    expect(full_name.text).to match(/Dory, John/)
+  end
 
-      render
-      page = Nokogiri::HTML(rendered)
-      tariff_date = page.css('#sentence-information').css('#tariff-date').first
-      expect(tariff_date.text).to match '01/08/2033'
-    end
+  it "displays tariff date" do
+    page = Nokogiri::HTML(rendered)
+    tariff_date = page.css('#sentence-information').css('#tariff-date').first
+    expect(tariff_date.text).to match '01/08/2033'
+  end
 
-    it "displays post recall release date" do
-      assign(:offender, OffenderPresenter.new(offender))
-      assign(:prison, prison)
+  it "displays post recall release date" do
+    page = Nokogiri::HTML(rendered)
+    post_recall_release_date = page.css('#sentence-information').css('#post-recall-release-date').first
+    expect(post_recall_release_date.text).to match '08/11/2028'
+  end
 
-      render
-      page = Nokogiri::HTML(rendered)
-      post_recall_release_date = page.css('#sentence-information').css('#post-recall-release-date').first
-      expect(post_recall_release_date.text).to match '08/11/2028'
-    end
+  it "displays licence end date" do
+    page = Nokogiri::HTML(rendered)
+    licence_expiry_date = page.css('#sentence-information').css('#licence-expiry-date').first
 
-    it "displays licence end date" do
-      assign(:offender, OffenderPresenter.new(offender))
-      assign(:prison, prison)
-
-      render
-      page = Nokogiri::HTML(rendered)
-      licence_expiry_date = page.css('#sentence-information').css('#licence-expiry-date').first
-
-      expect(licence_expiry_date.text).to match '07/10/2025'
-    end
+    expect(licence_expiry_date.text).to match '07/10/2025'
   end
 end


### PR DESCRIPTION
The latest rubocop-rspec upgrade brought a few failures to the table. This PR fixes those failures and brings the new version in at the same time.