### PR TITLE
Automatic Handover Emails - ignore unsentenced offenders

### DIFF
--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -9,7 +9,8 @@ class AutomaticHandoverEmailJob < ApplicationJob
     today = Time.zone.today
     offenders = ldu.teams.map { |team| team.case_information.map(&:nomis_offender_id) }.flatten
                     .map { |offender_id| OffenderService.get_offender(offender_id) }
-                    .select { |o| o.handover_start_date.present? && o.handover_start_date.between?(today, today + SEND_THRESHOLD) }
+                    .compact
+                    .select { |o| o.sentenced? && o.handover_start_date.present? && o.handover_start_date.between?(today, today + SEND_THRESHOLD) }
                     .sort_by(&:handover_start_date)
     if offenders.any?
       allocations = Allocation.where(nomis_offender_id: offenders.map(&:offender_no)).index_by(&:nomis_offender_id)
@@ -27,7 +28,7 @@ class AutomaticHandoverEmailJob < ApplicationJob
                 [offender.conditional_release_date, offender.parole_eligibility_date, offender.tariff_date].compact.min,
                 PrisonService.name_for(offender.prison_id),
                 allocation&.primary_pom_name,
-                allocation&.active? && PrisonOffenderManagerService.get_pom_emails(allocation.primary_pom_nomis_id).first
+                allocation&.active? ? PrisonOffenderManagerService.get_pom_emails(allocation.primary_pom_nomis_id).first : nil
             ]
         end
       end

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       automaticReleaseDate { "2022-01-28" }
     end
 
+    trait :handover_in_3_days do
+      conditionalReleaseDate { Time.zone.today + 3.days + 7.months + 15.days }
+    end
+
     trait :handover_in_4_days do
       conditionalReleaseDate { Time.zone.today + 4.days + 7.months + 15.days }
     end
@@ -35,6 +39,10 @@ FactoryBot.define do
 
     trait :handover_in_6_days do
       conditionalReleaseDate { Time.zone.today + 6.days + 7.months + 15.days }
+    end
+
+    trait :unsentenced do
+      sentenceStartDate { nil }
     end
   end
 end

--- a/spec/jobs/automatic_handover_email_job_spec.rb
+++ b/spec/jobs/automatic_handover_email_job_spec.rb
@@ -12,14 +12,18 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
       build(:team, case_information: case_info_records)])
 
     stub_auth_token
-    offenders.each { |o| stub_offender(o) }
+    offenders.each do |o|
+      stub_offender(o)
+
+      expect(OffenderService).to receive(:get_offender).with(o.fetch(:offenderNo)).and_call_original
+    end
 
     stub_pom_emails staff_id, [email_address]
   end
 
   context 'with some offenders' do
-    let(:case_info_records) { [case_info1, case_info2, case_info3] }
-    let(:offenders) { [offender1, offender2, offender3] }
+    let(:case_info_records) { [case_info1, case_info2, case_info3, case_info4, case_info5, case_info6] }
+    let(:offenders) { [offender1, offender2, offender3, offender4, offender6] }
 
     # adding an early allocation is enough to put the offender within the desired handover window
     let!(:allocation1) { create(:allocation, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
@@ -47,9 +51,36 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
             sentence: attributes_for(:sentence_detail, :handover_in_6_days))
     }
 
+    # This offender is unsentenced and so should be excluded
+    let(:case_info4) { build(:case_information) }
+    let(:offender4) {
+      build(:nomis_offender, latestLocationId: prison3.code, offenderNo: case_info4.nomis_offender_id, firstName: 'Four',
+            sentence: attributes_for(:sentence_detail, :unsentenced, :handover_in_6_days))
+    }
+
+    # This offender isn't in NOMIS and so should be excluded
+    let(:case_info5) { build(:case_information) }
+
+    # This offender has an inactive allocation - but still needs to be included
+    let(:prison6) { build(:prison) }
+    let(:case_info6) { build(:case_information) }
+    let!(:allocation6) { create(:allocation, :release, nomis_offender_id: case_info6.nomis_offender_id) }
+    let(:offender6) {
+      build(:nomis_offender, latestLocationId: prison6.code, offenderNo: case_info6.nomis_offender_id, firstName: 'Six',
+            sentence: attributes_for(:sentence_detail, :handover_in_3_days))
+    }
+
+    before do
+      expect(OffenderService).to receive(:get_offender).with(case_info5.nomis_offender_id).and_return(nil)
+    end
+
     it 'sends an email for offenders handing over in the next 45 days' do
       expected_csv = [
         AutomaticHandoverEmailJob::HEADERS.join(','),
+        (offender_csv_fields(offender6) +
+        [case_info6.crn,
+         case_info6.nomis_offender_id] +
+            handover_fields(3.days) + [prison6.name, '', '']).join(','),
         (offender_csv_fields(offender2) +
         [case_info2.crn,
          case_info2.nomis_offender_id] +

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -28,7 +28,7 @@ module ApiHelper
         {
           offenderNo: offender_no,
           bookingId: booking_number,
-          sentenceDetail: offender.fetch(:sentence)
+          sentenceDetail: offender.fetch(:sentence).reject { |_k, v| v.nil? }
         }].to_json)
 
     stub_request(:post, "#{T3}/offender-assessments/CATEGORY").


### PR DESCRIPTION
Running the automatic emails job uncovered a flaw - we don't ignore unsentenced offenders. This adds that filter, so that hopefully many more emails can be sent.