### PR TITLE
POM-486 Part III - inactive prison and empty LDU

### DIFF
--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -7,35 +7,43 @@ class AutomaticHandoverEmailJob < ApplicationJob
 
   def perform ldu
     today = Time.zone.today
-    offenders = ldu.teams.map { |team| team.case_information.map(&:nomis_offender_id) }.flatten
+    active_prison_codes = Allocation.distinct.pluck(:prison)
+    ldu_offenders = ldu.teams.map { |team| team.case_information.map(&:nomis_offender_id) }.flatten
                     .map { |offender_id| OffenderService.get_offender(offender_id) }
                     .compact
-                    .select { |o| o.sentenced? && o.handover_start_date.present? && o.handover_start_date.between?(today, today + SEND_THRESHOLD) }
-                    .sort_by(&:handover_start_date)
-    if offenders.any?
-      allocations = Allocation.where(nomis_offender_id: offenders.map(&:offender_no)).index_by(&:nomis_offender_id)
-      csv_data = CSV.generate do |csv|
-        csv << HEADERS
-        offenders.each do |offender|
-          allocation = allocations[offender.offender_no]
-          csv <<
-            [
-                offender.full_name,
-                offender.crn,
-                offender.offender_no,
-                offender.handover_start_date,
-                offender.responsibility_handover_date,
-                [offender.conditional_release_date, offender.parole_eligibility_date, offender.tariff_date].compact.min,
-                PrisonService.name_for(offender.prison_id),
-                allocation&.primary_pom_name,
-                allocation&.active? ? PrisonOffenderManagerService.get_pom_emails(allocation.primary_pom_nomis_id).first : nil
-            ]
+    # don't send any emails to empty LDUs with no offenders
+    if ldu_offenders.any?
+      offenders = ldu_offenders.select { |o|
+        active_prison_codes.include?(o.prison_id) &&
+            o.sentenced? &&
+            o.handover_start_date.present? && o.handover_start_date.between?(today, today + SEND_THRESHOLD)
+      }
+                      .sort_by(&:handover_start_date)
+      if offenders.any?
+        allocations = Allocation.where(nomis_offender_id: offenders.map(&:offender_no)).index_by(&:nomis_offender_id)
+        csv_data = CSV.generate do |csv|
+          csv << HEADERS
+          offenders.each do |offender|
+            allocation = allocations[offender.offender_no]
+            csv <<
+                [
+                    offender.full_name,
+                    offender.crn,
+                    offender.offender_no,
+                    offender.handover_start_date,
+                    offender.responsibility_handover_date,
+                    [offender.conditional_release_date, offender.parole_eligibility_date, offender.tariff_date].compact.min,
+                    PrisonService.name_for(offender.prison_id),
+                    allocation&.primary_pom_name,
+                    allocation&.active? ? PrisonOffenderManagerService.get_pom_emails(allocation.primary_pom_nomis_id).first : nil
+                ]
+          end
         end
+        # deliver_now - this is all we are doing, so we want the whole job to repeat if it fails
+        CommunityMailer.pipeline_to_community(ldu: ldu, csv_data: csv_data).deliver_now
+      else
+        CommunityMailer.pipeline_to_community_no_handovers(ldu).deliver_now
       end
-      # deliver_now - this is all we are doing, so we want the whole job to repeat if it fails
-      CommunityMailer.pipeline_to_community(ldu: ldu, csv_data: csv_data).deliver_now
-    else
-      CommunityMailer.pipeline_to_community_no_handovers(ldu).deliver_now
     end
   end
 end

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
       conditionalReleaseDate { Time.zone.today + 6.days + 7.months + 15.days }
     end
 
+    trait :handover_in_46_days do
+      conditionalReleaseDate { Time.zone.today + 46.days + 7.months + 15.days }
+    end
+
     trait :unsentenced do
       sentenceStartDate { nil }
     end

--- a/spec/jobs/automatic_handover_email_job_spec.rb
+++ b/spec/jobs/automatic_handover_email_job_spec.rb
@@ -22,30 +22,28 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
   end
 
   context 'with some offenders' do
-    let(:case_info_records) { [case_info1, case_info2, case_info3, case_info4, case_info5, case_info6] }
-    let(:offenders) { [offender1, offender2, offender3, offender4, offender6] }
+    let(:case_info_records) { [case_info1, case_info2, case_info3, case_info4, case_info5, case_info6, case_info7] }
+    let(:offenders) { [offender1, offender2, offender3, offender4, offender6, offender7] }
 
-    # adding an early allocation is enough to put the offender within the desired handover window
-    let!(:allocation1) { create(:allocation, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
-    let(:case_info1) { build(:case_information) }
     let(:prison1) { build(:prison) }
+    let(:case_info1) { build(:case_information) }
+    let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
     let(:offender1) {
       build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
             sentence: attributes_for(:sentence_detail, :handover_in_8_days))
     }
 
     # This offender doesn't have an allocation (yet) - but still needs to be included
-    let(:prison2) { build(:prison) }
     let(:case_info2) { build(:case_information) }
     let(:offender2) {
-      build(:nomis_offender, latestLocationId: prison2.code, offenderNo: case_info2.nomis_offender_id, firstName: 'Two',
+      build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info2.nomis_offender_id, firstName: 'Two',
             sentence: attributes_for(:sentence_detail, :handover_in_4_days))
     }
 
     # This offender should come first as they have an earlier handover start date
-    let(:case_info3) { build(:case_information) }
-    let!(:allocation3) { create(:allocation,  nomis_offender_id: case_info3.nomis_offender_id, primary_pom_nomis_id: staff_id) }
     let(:prison3) { build(:prison) }
+    let(:case_info3) { build(:case_information) }
+    let!(:allocation3) { create(:allocation, prison: prison3.code, nomis_offender_id: case_info3.nomis_offender_id, primary_pom_nomis_id: staff_id) }
     let(:offender3) {
       build(:nomis_offender, latestLocationId: prison3.code, offenderNo: case_info3.nomis_offender_id, firstName: 'Three',
             sentence: attributes_for(:sentence_detail, :handover_in_6_days))
@@ -64,10 +62,18 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
     # This offender has an inactive allocation - but still needs to be included
     let(:prison6) { build(:prison) }
     let(:case_info6) { build(:case_information) }
-    let!(:allocation6) { create(:allocation, :release, nomis_offender_id: case_info6.nomis_offender_id) }
+    let!(:allocation6) { create(:allocation, :release, prison: prison6.code, nomis_offender_id: case_info6.nomis_offender_id) }
     let(:offender6) {
       build(:nomis_offender, latestLocationId: prison6.code, offenderNo: case_info6.nomis_offender_id, firstName: 'Six',
             sentence: attributes_for(:sentence_detail, :handover_in_3_days))
+    }
+
+    # This offender is in an inactive prison (one with no allocations at all) so should be excluded
+    let(:prison7) { build(:prison) }
+    let(:case_info7) { build(:case_information) }
+    let(:offender7) {
+      build(:nomis_offender, latestLocationId: prison7.code, offenderNo: case_info7.nomis_offender_id, firstName: 'Seven',
+            sentence: attributes_for(:sentence_detail, :handover_in_4_days))
     }
 
     before do
@@ -84,7 +90,7 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
         (offender_csv_fields(offender2) +
         [case_info2.crn,
          case_info2.nomis_offender_id] +
-            handover_fields(4.days) + [prison2.name, '', '']).join(','),
+            handover_fields(4.days) + [prison1.name, '', '']).join(','),
         (offender_csv_fields(offender3) +
             [case_info3.crn,
              case_info3.nomis_offender_id] + handover_fields(6.days) +
@@ -119,6 +125,26 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
   context 'without offenders' do
     let(:case_info_records) { [] }
     let(:offenders) { [] }
+
+    it 'doesnt send an email' do
+      expect_any_instance_of(CommunityMailer)
+        .not_to receive(:pipeline_to_community_no_handovers)
+              .with(active_ldu).and_call_original
+      described_class.perform_now active_ldu
+    end
+  end
+
+  context 'with no-one in the handover window' do
+    let(:case_info_records) { [case_info1] }
+    let(:offenders) { [offender1] }
+
+    let(:prison1) { build(:prison) }
+    let(:case_info1) { build(:case_information) }
+    let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+    let(:offender1) {
+      build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
+            sentence: attributes_for(:sentence_detail, :handover_in_46_days))
+    }
 
     it 'sends the no data email' do
       expect_any_instance_of(CommunityMailer)


### PR DESCRIPTION
During more testing of POM-486 (LDU Allocation Email) 2 more cases were identified - inactive prison (not yet in the service) and LDUs with no offenders (who were being sent the 'no offenders' email)