### PR TITLE
POM-486 post refactor - add Prison#active

### DIFF
--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -7,12 +7,13 @@ class AutomaticHandoverEmailJob < ApplicationJob
 
   def perform ldu
     today = Time.zone.today
-    active_prison_codes = Allocation.distinct.pluck(:prison)
     ldu_offenders = ldu.teams.map { |team| team.case_information.map(&:nomis_offender_id) }.flatten
                     .map { |offender_id| OffenderService.get_offender(offender_id) }
                     .compact
     # don't send any emails to empty LDUs with no offenders
     if ldu_offenders.any?
+      active_prison_codes = Prison.active.map(&:code)
+
       offenders = ldu_offenders.select { |o|
         active_prison_codes.include?(o.prison_id) &&
             o.sentenced? &&

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -3,6 +3,12 @@
 class Prison
   attr_reader :code
 
+  class << self
+    def active
+      PrisonEmumerator.new Allocation.distinct.pluck(:prison)
+    end
+  end
+
   def initialize(prison_code)
     @code = prison_code
   end
@@ -39,6 +45,18 @@ class Prison
   end
 
 private
+
+  class PrisonEmumerator
+    include Enumerable
+
+    def initialize codes
+      @codes = codes
+    end
+
+    def each
+      @codes.each { |code| yield Prison.new(code) }
+    end
+  end
 
   class OffenderEnumerator
     include Enumerable

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -1,6 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Prison, type: :model do
+  describe '#active' do
+    before do
+      create(:allocation, prison: p1.code)
+      create(:allocation, prison: p1.code)
+      create(:allocation, prison: p2.code)
+    end
+
+    let(:p1) { build(:prison) }
+    let(:p2) { build(:prison) }
+
+    it 'only lists prisons with allocations' do
+      expect(described_class.active.map(&:code)).to match_array [p1, p2].map(&:code)
+    end
+  end
+
   describe '#offenders' do
     subject { described_class.new("LEI").offenders }
 


### PR DESCRIPTION
After all the changes dfrom POM-486 (handover emails) it looked like we had an 'active prisons' concept. So here is a refactor to make that much more obvious.