### PR TITLE
MO-101 Sort on POM and COM column in the allocator view

### DIFF
--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -10,7 +10,7 @@ class SummaryService
     sortable_fields = {
         allocated: [:last_name, :earliest_release_date, :tier],
         new_arrivals: [:last_name, :prison_arrival_date, :earliest_release_date],
-        handovers: [:last_name, :handover_start_date, :responsibility_handover_date, :case_allocation],
+        handovers: [:last_name, :handover_start_date, :responsibility_handover_date, :case_allocation, :allocated_pom_name, :allocated_com_name],
         unallocated: [:last_name, :earliest_release_date, :case_owner, :awaiting_allocation_for, :tier],
         pending: [:last_name, :earliest_release_date, :case_owner, :awaiting_allocation_for, :tier]
     }.fetch(summary_type)

--- a/app/views/summary/handovers.html.erb
+++ b/app/views/summary/handovers.html.erb
@@ -40,10 +40,16 @@
         <%= sort_arrow('responsibility_handover_date') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('allocated_pom_name') %>">
         POM
+        </a>
+        <%= sort_arrow('allocated_pom_name') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('allocated_com_name') %>">
         COM
+        </a>
+        <%= sort_arrow('allocated_com_name') %>
       </th>
       <th class="govuk-table__header sorter-false" xscope="col">
         <a href="<%= sort_link('case_allocation') %>">

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
     trait :unsentenced do
       sentenceStartDate { nil }
     end
+
+    trait :inside_handover_window do
+      conditionalReleaseDate { Time.zone.today + 7.days + 7.months + 15.days }
+    end
   end
 end
 


### PR DESCRIPTION
This PR allows the SPO to sort the list of handovers by COM or POM name

### **Before:**

**SPO's are not able to sort by POM or COM**

<img width="1440" alt="Screenshot 2020-03-30 at 08 37 31" src="https://user-images.githubusercontent.com/12900007/98130528-41b00a00-1eb2-11eb-94ac-ba459c8098a6.png">

### **After** 

**SPOs can sort POM alphabetically**

<img width="756" alt="Screenshot 2020-11-04 at 15 21 39" src="https://user-images.githubusercontent.com/12900007/98130666-6c01c780-1eb2-11eb-8bcb-f0f31d74f787.png">

_SPOs can sort COMs alphabetically_
<img width="773" alt="Screenshot 2020-11-04 at 15 21 23" src="https://user-images.githubusercontent.com/12900007/98130794-8b98f000-1eb2-11eb-8ecb-00b393385beb.png">

