### PR TITLE
Default versioning to on by removing paper trail rspec include

### DIFF
--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AllocationsController, :versioning, type: :controller do
+RSpec.describe AllocationsController, type: :controller do
   let(:poms) {
     [
       build(:pom, :prison_officer, emails: []),
@@ -155,7 +155,7 @@ RSpec.describe AllocationsController, :versioning, type: :controller do
             )
           end
 
-          it "Can get the allocation history for an offender", versioning: true do
+          it "Can get the allocation history for an offender" do
             get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
             allocation_list = assigns(:history)
 

--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CaseloadController, type: :controller do
     stub_signed_in_pom(prison, pom.staffId, 'alice')
   end
 
-  context 'with 3 offenders', :versioning do
+  context 'with 3 offenders' do
     let(:today) { Time.zone.today }
     let(:yesterday) { Time.zone.today - 1.day }
 

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -24,7 +24,7 @@ feature 'Allocation' do
     signin_spo_user
   end
 
-  scenario 'accepting a recommended allocation', versioning: true, vcr: { cassette_name: :create_new_allocation_feature } do
+  scenario 'accepting a recommended allocation', vcr: { cassette_name: :create_new_allocation_feature } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
     expect(page).to have_content('Determinate')
@@ -140,7 +140,7 @@ feature 'Allocation' do
     expect(page).to have_content('This reason cannot be more than 175 characters')
   end
 
-  scenario 're-allocating', versioning: true, vcr: { cassette_name: :re_allocate_feature } do
+  scenario 're-allocating', vcr: { cassette_name: :re_allocate_feature } do
     create(
       :allocation,
       nomis_offender_id: nomis_offender_id,

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -34,7 +34,7 @@ feature 'Allocation History' do
 
   let!(:nomis_offender_id) { 'G4273GI' }
 
-  scenario 'view offender allocation history', versioning: true, vcr: { cassette_name: :offender_allocation_history } do
+  scenario 'view offender allocation history', vcr: { cassette_name: :offender_allocation_history } do
     allocation = create(
       :allocation,
       nomis_offender_id: nomis_offender_id,

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "view an offender's allocation information", :versioning do
+feature "view an offender's allocation information" do
   let!(:probation_officer_nomis_staff_id) { 485_636 }
   let!(:nomis_offender_id_with_keyworker) { 'G3462VT' }
   let!(:nomis_offender_id_without_keyworker) { 'G8859UP' }

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "ChangeParoleReviewDates", :versioning, type: :feature do
+RSpec.feature "ChangeParoleReviewDates", type: :feature do
   # This ID has an indeterminate sentence
   let(:nomis_offender_id) { 'G0549UO' }
   let!(:case_info) { create(:case_information, nomis_offender_id: nomis_offender_id) }

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Co-working', :versioning do
+feature 'Co-working' do
   let!(:nomis_offender_id) { 'G4273GI' }
   let!(:prison_pom) do
     {

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Inactive POM' do
-  context 'when viewing an inactive POMs caseload', versioning: true, vcr: { cassette_name: :deallocate_non_pom_caseload } do
+  context 'when viewing an inactive POMs caseload', vcr: { cassette_name: :deallocate_non_pom_caseload } do
     # We need an inactive POM to test this feature, Toby has had his POM role removed and therefore a good candidate!
     let(:inactive_pom)      { 485_595 }
     let(:nomis_offender_id) { "G4273GI" }

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -215,7 +215,7 @@ feature "view POM's caseload" do
     expect(page).to have_current_path(prison_prisoner_path(prison, first_offender.fetch(:offenderNo)), ignore_query: true)
   end
 
-  it 'can sort all cases that have been allocated to a specific POM in the last week', :versioning do
+  it 'can sort all cases that have been allocated to a specific POM in the last week' do
     # Sign in as a POM
     signin_pom_user
     stub_user staff_id: nomis_staff_id

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -56,7 +56,7 @@ feature 'View a prisoner profile page' do
       expect(page.response_headers['Content-Type']).to eq('image/jpg')
     end
 
-    it "has a link to the allocation history", :versioning, vcr: { cassette_name: :link_to_allocation_history } do
+    it "has a link to the allocation history", vcr: { cassette_name: :link_to_allocation_history } do
       visit prison_prisoner_path('LEI', 'G7998GJ')
       click_link "View"
       expect(page).to have_content('Prisoner allocated')

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Responsibility override', :versioning do
+feature 'Responsibility override' do
   include ActiveJob::TestHelper
 
   before do

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
     described_class.perform_now(movement_json)
   end
 
-  it 'can use previous allocation details where they exist', versioning: true do
+  it 'can use previous allocation details where they exist' do
     allow(OffenderService).to receive(:get_offender).
       and_return(HmppsApi::Offender.new(offender_no: nomis_offender_id,
                                      prison_id: open_prison_code,

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Allocation, type: :model do
     }
 
     describe 'Versions' do
-      it 'creates a version when updating a record', versioning: true do
+      it 'creates a version when updating a record' do
         expect(allocation.versions.count).to be(1)
 
         allocation.update(allocated_at_tier: 'B')
@@ -99,7 +99,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe 'when an offender moves prison', versioning: true, vcr: { cassette_name: :allocation_deallocate_offender }  do
+    describe 'when an offender moves prison', vcr: { cassette_name: :allocation_deallocate_offender }  do
       it 'removes the primary pom details in an Offender\'s allocation' do
         nomis_offender_id = 'G2911GD'
         create(:case_information, nomis_offender_id: nomis_offender_id)
@@ -131,7 +131,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe 'when an offender gets released from prison', versioning: true, vcr: { cassette_name: :allocation_deallocate_offender_released }  do
+    describe 'when an offender gets released from prison', vcr: { cassette_name: :allocation_deallocate_offender_released }  do
       it 'removes the primary pom details in an Offender\'s allocation' do
         nomis_offender_id = 'G2911GD'
         create(:case_information, nomis_offender_id: nomis_offender_id)

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe StaffMember, type: :model do
       old_primary_alloc.update!(secondary_pom_nomis_id: other_staff_id)
     end
 
-    it "will get allocations for a POM made within the last 7 days", :versioning do
+    it "will get allocations for a POM made within the last 7 days" do
       allocated_offenders = described_class.new(prison, staff_id).allocations.select(&:new_case?)
       expect(allocated_offenders.count).to eq 2
       expect(allocated_offenders.map(&:pom_responsibility)).to match_array %w[Responsible Co-Working]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,6 @@ require 'support/helpers/auth_helper'
 require 'support/helpers/api_helper'
 require 'capybara/rspec'
 require 'webmock/rspec'
-require 'paper_trail/frameworks/rspec'
 
 Capybara.default_max_wait_time = 4
 Capybara.asset_host = 'http://localhost:3000'

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -73,7 +73,7 @@ describe AllocationService do
         create(:case_information, nomis_offender_id: nomis_offender_id)
       end
 
-      it 'can create a new record', versioning: true, vcr: { cassette_name: :allocation_service_create_allocation__spec } do
+      it 'can create a new record', vcr: { cassette_name: :allocation_service_create_allocation__spec } do
         params = {
           nomis_offender_id: nomis_offender_id,
           prison: 'LEI',
@@ -98,7 +98,7 @@ describe AllocationService do
         create(:allocation, nomis_offender_id: nomis_offender_id)
       end
 
-      it 'can update a record and store a version', versioning: true, vcr: { cassette_name: :allocation_service_update_allocation_spec } do
+      it 'can update a record and store a version', vcr: { cassette_name: :allocation_service_update_allocation_spec } do
         update_params = {
           nomis_offender_id: nomis_offender_id,
           allocated_at_tier: 'B',
@@ -142,13 +142,13 @@ describe AllocationService do
   end
 
   describe '#previously_allocated_poms' do
-    it "Can get previous poms for an offender where there are none", versioning: true, vcr: { cassette_name: :allocation_service_previous_allocations_none } do
+    it "Can get previous poms for an offender where there are none", vcr: { cassette_name: :allocation_service_previous_allocations_none } do
       staff_ids = described_class.previously_allocated_poms('GDF7657')
 
       expect(staff_ids).to eq([])
     end
 
-    it "Can get previous poms for an offender where there are some", versioning: true, vcr: { cassette_name: :allocation_service_previous_allocations } do
+    it "Can get previous poms for an offender where there are some", vcr: { cassette_name: :allocation_service_previous_allocations } do
       nomis_offender_id = 'GHF1234'
       previous_primary_pom_nomis_id = 345_567
       updated_primary_pom_nomis_id = 485_926
@@ -170,7 +170,7 @@ describe AllocationService do
     end
   end
 
-  it 'can get the current allocated primary POM', versioning: true, vcr: { cassette_name: 'current_allocated_primary_pom' }  do
+  it 'can get the current allocated primary POM', vcr: { cassette_name: 'current_allocated_primary_pom' }  do
     previous_primary_pom_nomis_id = 485_637
     updated_primary_pom_nomis_id = 485_926
 
@@ -191,7 +191,7 @@ describe AllocationService do
   end
 
   describe '#allocation_history_pom_emails' do
-    it 'can retrieve all the POMs email addresses for ', versioning: true, vcr: { cassette_name: :allocation_service_history_spec } do
+    it 'can retrieve all the POMs email addresses for ', vcr: { cassette_name: :allocation_service_history_spec } do
       previous_primary_pom_nomis_id = 485_637
       updated_primary_pom_nomis_id = 485_926
       secondary_pom_nomis_id = 485_833

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe EmailService do
   }
 
   context 'when queueing', :queueing do
-    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_allocation_email }, versioning: true  do
+    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_allocation_email }  do
       expect {
         described_class.instance(allocation: allocation, message: "", pom_nomis_id: allocation.primary_pom_nomis_id).send_email
       }.to change(enqueued_jobs, :size).by(1)
     end
 
-    it "Can not crash when a pom has no email", vcr: { cassette_name: :email_service_send_allocation_email }, versioning: true  do
+    it "Can not crash when a pom has no email", vcr: { cassette_name: :email_service_send_allocation_email }  do
       allow(PrisonOffenderManagerService).to receive(:get_pom_emails).and_return([])
 
       expect {
@@ -96,7 +96,7 @@ RSpec.describe EmailService do
       }.to change(enqueued_jobs, :size).by(0)
     end
 
-    it "Can send a reallocation email", vcr: { cassette_name: :email_service_send_deallocation_email }, versioning: true  do
+    it "Can send a reallocation email", vcr: { cassette_name: :email_service_send_deallocation_email }  do
       allow(AllocationService).to receive(:get_versions_for).and_return([original_allocation])
 
       expect {
@@ -105,7 +105,7 @@ RSpec.describe EmailService do
     end
 
     it "Can send a co-working de-allocation email",
-       vcr: { cassette_name: :email_service_send_coworking_deallocation_email }, versioning: true do
+       vcr: { cassette_name: :email_service_send_coworking_deallocation_email } do
       allow(AllocationService).to receive(:get_versions_for).and_return([coworking_allocation])
 
       expect {
@@ -117,7 +117,7 @@ RSpec.describe EmailService do
     end
 
     it "Can not crash when primary pom has no email when deallocating a co-working pom",
-       vcr: { cassette_name: :email_service_send_coworking_deallocation_email_no_pom_email }, versioning: true do
+       vcr: { cassette_name: :email_service_send_coworking_deallocation_email_no_pom_email } do
       allow(PrisonOffenderManagerService).to receive(:get_pom_emails).and_return([])
 
       expect {
@@ -129,7 +129,7 @@ RSpec.describe EmailService do
     end
   end
 
-  context 'when offender has been released', versioning: true do
+  context 'when offender has been released' do
     let(:staff_id) { '485833' }
     let!(:released_allocation) do
       x = create(:allocation,


### PR DESCRIPTION
The 'papertrail' gem which we use to create allocation histiory has an rspec component. However this defaults to enabled: false which results in confusaing behaviour when writing a new test involving allocations, as our usage of papertrail is a little atypical.

Hence this PR turns off the bahviour, as in this project it causes confusion. The only reason for switching it off is performance (I guess) but given that we only use it for allocations, and the vast majoroty of allocation tests will want it enabled anyway, the gains are probably miniscule