### PR TITLE
Mo 36 allocation history doesnt display release events

### DIFF
--- a/app/views/allocations/_deallocate_released_offender.html.erb
+++ b/app/views/allocations/_deallocate_released_offender.html.erb
@@ -1,0 +1,6 @@
+<div class="moj-timeline__item">
+  <div class="moj-timeline__header">
+    <h2 class="moj-timeline__title">Prisoner released</h2>
+  </div>
+  <p class="moj-timeline__date"><%= format_date_long(deallocate_released_offender.updated_at) %></p>
+</div>

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module FeaturesHelper
-  def signin_spo_user(name = 'MOIC_POM')
-    mock_sso_response(name, [SsoIdentity::SPO_ROLE])
+  def signin_spo_user(name = 'MOIC_POM', caseloads = %w[LEI RSI])
+    mock_sso_response(name, [SsoIdentity::SPO_ROLE], caseloads)
   end
 
   def signin_spo_pom_user(name = 'MOIC_POM')

--- a/spec/views/allocations/allocation_history.html.erb_spec.rb
+++ b/spec/views/allocations/allocation_history.html.erb_spec.rb
@@ -50,16 +50,18 @@ RSpec.describe "allocations/history", type: :view do
       assign(:prisoner, build(:offender))
       assign(:pom_emails, {})
       assign(:history, [build(:allocation, :primary),
-                        build(:allocation, :release, updated_at: release_date_and_time)]
-                           .map { |ah| AllocationHistory.new(ah, dummy_version) })
+                        build(:allocation, :release)].
+          map { |ah| AllocationHistory.new(ah, released_version) })
     end
 
+    let(:released_version) { Struct.new(:object_changes).new({ 'updated_at' => [release_date_and_time, release_date_and_time] }.to_yaml) }
     let(:release_date_and_time) { DateTime.new(2019, 8, 19, 11, 28, 0) }
     let(:page) { Nokogiri::HTML(rendered) }
 
-    # Proper test and code fix coming in MO-36
-    it 'doesnt crash' do
+    it 'displays a release label and the release date and time in the allocation history' do
       render
+      expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Prisoner released", "Prisoner allocated"]
+      expect(page.css('.moj-timeline__date')).to have_text('19th August 2019 (11:28)')
     end
   end
 end


### PR DESCRIPTION
This PR allows an SPO to see a prisoner's release information. This includes the label 'Prisoner Released' and the date and time they were released and displays it in the allocation history view.

### BEFORE
**Example of allocation history view with no release information** 
<img width="949" alt="Screenshot 2020-11-11 at 11 45 06" src="https://user-images.githubusercontent.com/12900007/98809301-3eb69b80-2415-11eb-8460-0d1794034df8.png">


### AFTER
**Example of allocation history view with release information**
<img width="657" alt="Screenshot 2020-11-11 at 12 02 18" src="https://user-images.githubusercontent.com/12900007/98809919-4296ed80-2416-11eb-8254-eb781ae7e4a2.png">