### PR TITLE
Refactor the signin_spo_user method in the helper 

### DIFF
--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -162,7 +162,7 @@ feature 'Allocation History' do
       stub_auth_token
       stub_user(username: 'MOIC_POM', staff_id: staff_id)
       stub_offender(nomis_offender)
-      signin_spo_user("MOIC_POM", [prison])
+      signin_spo_user([prison])
       create(:case_information, nomis_offender_id: nomis_offender_id)
       allocation = create(:allocation, :primary, nomis_offender_id: nomis_offender_id, prison: prison)
       allocation.deallocate_offender(Allocation::OFFENDER_RELEASED)

--- a/spec/features/contact_us_feature_spec.rb
+++ b/spec/features/contact_us_feature_spec.rb
@@ -11,7 +11,7 @@ feature 'Getting help' do
   end
 
   it 'shows a pre-filled contact form when a user is signed in', vcr: { cassette_name: :help_logged_in } do
-    signin_spo_user('MOIC_POM')
+    signin_spo_user
     visit '/'
     click_link 'Contact us'
 

--- a/spec/features/delius_import_job_feature_spec.rb
+++ b/spec/features/delius_import_job_feature_spec.rb
@@ -28,14 +28,10 @@ feature "Delius import feature" do
   let(:prison) { "LEI" }
   let(:booking_id) { 754_207 }
   let(:offender) { build(:nomis_offender, offenderNo: offender_no, imprisonmentStatus: 'DET', dateOfBirth: "1985-03-19") }
+  let(:pom) { build(:pom) }
 
   before do
-    signin_spo_user
-
-    stub_auth_token
-    stub_request(:get, "#{ApiHelper::T3}/users/MOIC_POM").
-      to_return(body: { 'staffId': 1 }.to_json)
-    stub_pom_emails(1, [])
+    stub_signin_spo(pom)
 
     stub_offender(offender)
 

--- a/spec/features/feedback_feature_spec.rb
+++ b/spec/features/feedback_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'feedback' do
   it 'provides a link to the feedback form', vcr: { cassette_name: :feedback_link } do
-    signin_spo_user('MOIC_POM')
+    signin_spo_user
 
     visit '/'
 

--- a/spec/features/help_feature_spec.rb
+++ b/spec/features/help_feature_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Help' do
   context 'when accessing help page' do
     it 'provides a link to the help pages', vcr: { cassette_name: :help_link } do
-      signin_spo_user('MOIC_POM')
+      signin_spo_user
 
       visit '/'
       expect(page).to have_link('Help', href: '/help')

--- a/spec/features/prison_switching_feature_spec.rb
+++ b/spec/features/prison_switching_feature_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 feature 'Switching prisons' do
   it 'Shows the switcher if the user has more than one prison',
      vcr: { cassette_name: :prison_switching_feature_many_prisons_spec } do
-    signin_spo_user
+    signin_spo_user(['LEI', 'RSI'])
     visit root_path
 
     expect(page).to have_css('h2', text: 'HMP Leeds')
   end
 
   it 'shows dashboard links if there is no referrer', vcr: { cassette_name: :nav_to_prison_switcher } do
-    signin_spo_user
+    signin_spo_user(['LEI', 'RSI'])
 
     visit root_path
 
@@ -27,7 +27,7 @@ feature 'Switching prisons' do
 
   it 'Shows the list of prisons I can switch to',
      vcr: { cassette_name: :prison_switching_feature_list_spec }do
-    signin_spo_user
+    signin_spo_user(['LEI', 'RSI'])
     visit root_path
 
     click_link('Switch prison')
@@ -38,7 +38,7 @@ feature 'Switching prisons' do
 
   it 'Changes my prison when I choose one',
      vcr: { cassette_name: :prison_switching_feature_change_prisons_spec }do
-    signin_spo_user
+    signin_spo_user(['LEI', 'RSI'])
     visit root_path
 
     click_link('Switch prison')
@@ -50,7 +50,7 @@ feature 'Switching prisons' do
 
   it 'Can remember where I was',
      vcr: { cassette_name: :prison_switching_feature_remember_prison_spec } do
-    signin_spo_user
+    signin_spo_user(['LEI', 'RSI'])
     visit prison_poms_path('LEI')
 
     expect(page).to have_css('h2', text: 'HMP Leeds')

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -4,7 +4,7 @@ context 'when NOMIS is missing information' do
   let(:prison_code) { 'LEI' }
   let(:offender_no) { 'A1' }
   let(:stub_keyworker_host) { Rails.configuration.keyworker_api_host }
-  let(:staff_id) { 111_111 }
+  let(:staff_id) { 123456 }
 
   describe 'when logged in as a POM' do
     before do
@@ -24,7 +24,7 @@ context 'when NOMIS is missing information' do
         to_return(body: stub_poms.to_json)
 
       signin_pom_user
-      stub_user staff_id: staff_id
+      stub_user(username: 'MOIC_POM', staff_id: staff_id)
     end
 
     describe 'the caseload page' do
@@ -100,16 +100,10 @@ context 'when NOMIS is missing information' do
   end
 
   context 'when logged in as an SPO' do
-    before do
-      stub_request(:post, "#{ApiHelper::AUTH_HOST}/auth/oauth/token").
-        with(query: { grant_type: 'client_credentials' }).
-        to_return(body: {}.to_json)
+    let(:pom) { build(:pom) }
 
-      signin_spo_user('example_SPO')
-      stub_request(:get, "#{ApiHelper::T3}/users/example_SPO").
-          to_return(body: { 'staffId': 754_732 }.to_json)
-      stub_request(:get, "#{ApiHelper::T3}/staff/754732/emails").
-          to_return(body: [].to_json)
+    before do
+      stub_signin_spo(pom)
     end
 
     context 'with an NPS offender with an indeterminate sentence, but no release dates' do

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
 module FeaturesHelper
-  def signin_spo_user(name = 'MOIC_POM', caseloads = %w[LEI RSI])
-    mock_sso_response(name, [SsoIdentity::SPO_ROLE], caseloads)
+  def signin_spo_user(prisons = ['LEI'])
+    mock_sso_response('MOIC_POM', [SsoIdentity::SPO_ROLE], prisons)
+  end
+
+  def stub_signin_spo(pom, prisons = ['LEI'])
+    stub_auth_token
+    signin_spo_user(prisons)
+    stub_spo_user(pom)
+  end
+
+  def stub_spo_user(pom)
+    stub_request(:get, "#{ApiHelper::T3}/users/MOIC_POM").
+        to_return(body: { 'staffId': pom.staff_id }.to_json)
+    stub_request(:get, "#{ApiHelper::T3}/staff/#{pom.staff_id}/emails").
+        to_return(body: pom.emails.to_json)
   end
 
   def signin_spo_pom_user(name = 'MOIC_POM')
@@ -17,9 +30,9 @@ module FeaturesHelper
     mock_sso_response('MOIC_POM', [SsoIdentity::POM_ROLE])
   end
 
-  def mock_sso_response(username, roles, caseloads = %w[LEI RSI])
+  def mock_sso_response(username, roles, prisons = %w[LEI RSI])
     hmpps_sso_response = {
-      'info' => double('user_info', username: username, active_caseload: 'LEI', caseloads: caseloads, roles: roles),
+      'info' => double('user_info', username: username, active_caseload: prisons.first, caseloads: prisons, roles: roles),
       'credentials' => double('credentials', expires_at: Time.zone.local(2030, 1, 1).to_i,
                                              'authorities': roles)
     }


### PR DESCRIPTION
The method _signin_spo_user_ is used for test set up when creating tests involving an SPO user. It now includes stub user. This will hopefully make it easier when writing tests as you no longer need to stub the user separately. It also hard codes the users name and staff id, as there doesn't seem to be a case where it needs to be specific. It makes prisons the only parameter that can be assigned as you might want your spo to be signed into a particular prison. 

**Example:** 
_signin_spo_user('LEI')
prison_summary_unallocated_path('LEI')_

It also fixes all the test that failed as a result of the change. 