### PR TITLE
MO56 Allocation History refactor

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -109,12 +109,7 @@ private
   def offender_allocation_history(nomis_offender_id)
     current_allocation = Allocation.find_by(nomis_offender_id: nomis_offender_id)
 
-    unless current_allocation.nil?
-      allocs = AllocationService.get_versions_for(current_allocation).append(current_allocation)
-      allocs.zip(current_allocation.versions).map do |alloc, raw_version|
-        AllocationPresenter.new(alloc, raw_version)
-      end
-    end
+    current_allocation&.history
   end
 
   def unavailable_pom_count

--- a/app/jobs/open_prison_transfer_job.rb
+++ b/app/jobs/open_prison_transfer_job.rb
@@ -43,7 +43,7 @@ private
     alloc = Allocation.find_by(nomis_offender_id: offender.offender_no)
     return nil if alloc.blank?
 
-    AllocationService.get_versions_for(alloc).reverse.detect { |allocation|
+    alloc.get_old_versions.reverse.detect { |allocation|
       allocation.primary_pom_nomis_id.present?
     }
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -77,6 +77,18 @@ class Allocation < ApplicationRecord
     JSON.parse(self[:override_reasons]) if self[:override_reasons].present?
   end
 
+  def get_old_versions
+    versions.map(&:reify).compact
+  end
+
+  # Gets the versions in *forward* order - so often we want to reverse
+  # this list as we're interested in recent rather than ancient history
+  def history
+    get_old_versions.append(self).zip(versions).map do |alloc, raw_version|
+      AllocationPresenter.new(alloc, raw_version)
+    end
+  end
+
   def deallocate_offender(movement_type)
     self.primary_pom_nomis_id = nil
     self.primary_pom_name = nil

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -85,8 +85,7 @@ class AllocationService
 
     return [] if allocation.nil?
 
-    get_versions_for(allocation).
-      map(&:primary_pom_nomis_id)
+    allocation.get_old_versions.map(&:primary_pom_nomis_id)
   end
 
   def self.allocation_history_pom_emails(history)
@@ -119,15 +118,6 @@ class AllocationService
   end
 
 private
-
-  # Gets the versions in *forward* order - so often we want to reverse
-  # this list as we're interested in recent rather than ancient history
-  def self.get_versions_for(allocation)
-    allocation.versions.map { |version|
-      # 'create' events do not have '#reify' method
-      version.reify unless version.event == 'create'
-    }.compact
-  end
 
   def self.delete_overrides(nomis_staff_id, nomis_offender_id)
     Override.where(

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -83,7 +83,7 @@ private
     # and find the last version with a primary_pom id that is not the same as the
     # allocation. That will be the POM that is notified of a reallocation.
     @previous_pom ||= begin
-      versions = AllocationService.get_versions_for(@allocation)
+      versions = @allocation.get_old_versions
 
       previous = versions.reverse.detect { |version|
         version.primary_pom_nomis_id.present? && version.primary_pom_nomis_id != @allocation.primary_pom_nomis_id

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -112,7 +112,7 @@ feature 'Allocation History' do
     signin_spo_user
     visit prison_allocation_history_path('LEI', nomis_offender_id)
 
-    stub_const("TESTS", [
+    [
         ['h1', "Abbella, Ozullirn"],
         ['.govuk-heading-m', "HMP Pentonville"],
         ['.moj-timeline__title', "Prisoner unallocated (transfer)"],
@@ -136,9 +136,7 @@ feature 'Allocation History' do
         ['.moj-timeline__description', "Prisoner allocated to #{history.last.primary_pom_name.titleize} - #{probation_pom[:email]} Tier: #{history.last.allocated_at_tier}"],
         ['.moj-timeline__description', "Probation POM allocated instead of recommended Prison POM", "Reason(s):", "- Prisoner assessed as suitable for a prison POM despite tiering calculation", "Too high risk"],
         ['.moj-timeline__date', "#{formatted_date_for(history.last)} by #{history.last.created_by_name.titleize}"]
-    ])
-
-    TESTS.each do |key, val|
+    ].each do |key, val|
       expect(page).to have_css(key, text: val)
     end
   end
@@ -148,7 +146,7 @@ feature 'Allocation History' do
   end
 
   def offender_allocation_history(current_allocation)
-    AllocationService.get_versions_for(current_allocation).
+    current_allocation.get_old_versions.
       append(current_allocation).
       sort_by!(&:updated_at).
       reverse!

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -211,21 +211,10 @@ describe AllocationService do
         event: Allocation::ALLOCATE_SECONDARY_POM
       )
 
-      history = offender_allocation_history(nomis_offender_id)
+      history = Allocation.find_by!(nomis_offender_id: nomis_offender_id).history
       emails = described_class.allocation_history_pom_emails(history)
 
       expect(emails.count).to eq(3)
-    end
-  end
-
-  def offender_allocation_history(nomis_offender_id)
-    current_allocation = Allocation.find_by(nomis_offender_id: nomis_offender_id)
-
-    unless current_allocation.nil?
-      allocs = AllocationService.get_versions_for(current_allocation).append(current_allocation)
-      allocs.zip(current_allocation.versions).map do |alloc, raw_version|
-        AllocationPresenter.new(alloc, raw_version)
-      end
     end
   end
 end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe EmailService do
     end
 
     it "Can send a reallocation email", vcr: { cassette_name: :email_service_send_deallocation_email }  do
-      allow(AllocationService).to receive(:get_versions_for).and_return([original_allocation])
+      allow(reallocation).to receive(:get_old_versions).and_return([original_allocation])
 
       expect {
         described_class.instance(allocation: reallocation, message: "", pom_nomis_id: allocation.primary_pom_nomis_id).send_email
@@ -106,7 +106,7 @@ RSpec.describe EmailService do
 
     it "Can send a co-working de-allocation email",
        vcr: { cassette_name: :email_service_send_coworking_deallocation_email } do
-      allow(AllocationService).to receive(:get_versions_for).and_return([coworking_allocation])
+      allow(original_allocation).to receive(:get_old_versions).and_return([coworking_allocation])
 
       expect {
         described_class.instance(allocation: coworking_deallocation,


### PR DESCRIPTION
As a pre-cursor to MO-56 altering allocation history, this is a tidy-up to remove some of the quirks from the allocation history code to avoid polluting the feature PR.