### PR TITLE
MO-56 victim liaison officer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,12 @@ gem 'prawn-rails'
 gem 'rswag-api' # api-documentation
 gem 'rswag-ui'  # api-documentation interface
 gem 'sassc-rails'
+# simple validation of email addresses.
+# ministryofjustice/email_address_validation thinks Faker emails don't parse which is annoying,
+# whilst also allowing invalid emails through.
+# https://stackoverflow.com/questions/38611405/email-validation-in-ruby-on-rails
+gem 'valid_email2'
+
 gem 'activeadmin'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,6 +429,9 @@ GEM
       rainbow (>= 2.1, < 4.0)
       rugged (>= 0.27, < 1.1)
     unicode-display_width (1.6.1)
+    valid_email2 (3.5.0)
+      activemodel (>= 3.2)
+      mail (~> 2.5)
     vcr (6.0.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
@@ -523,6 +526,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   undercover
+  valid_email2
   vcr
   webmock
   zendesk_api

--- a/app/controllers/victim_liaison_officers_controller.rb
+++ b/app/controllers/victim_liaison_officers_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+class VictimLiaisonOfficersController < PrisonsApplicationController
+  before_action :load_case_information
+  before_action :find_vlo, only: [:edit, :update, :destroy, :delete]
+  before_action :store_referrer_in_session, only: [:new, :edit, :delete]
+  before_action :set_referrer
+
+  # we need to record users first name and last name for audit purposes
+  # (as we can't rely on their details forever being available on NOMIS)
+  # and we also record the context prison as the case history is organised
+  # in that way.
+  def info_for_paper_trail
+    user = HmppsApi::PrisonApi::UserApi.user_details(current_user)
+    {
+        user_first_name: user.first_name,
+        user_last_name: user.last_name,
+        prison: active_prison_id
+    }
+  end
+
+  def new
+    @vlo = @case_information.victim_liaison_officers.new
+  end
+
+  def create
+    @vlo = @case_information.victim_liaison_officers.new vlo_parameters
+
+    if @vlo.save
+      redirect_to referrer
+    else
+      render 'new'
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @vlo.update vlo_parameters
+      redirect_to referrer
+    else
+      render 'edit'
+    end
+  end
+
+  def delete; end
+
+  def destroy
+    @vlo.destroy
+    redirect_to referrer
+  end
+
+private
+
+  def set_referrer
+    @referrer = referrer
+  end
+
+  def referrer
+    session[:referrer] || request.referer
+  end
+
+  def store_referrer_in_session
+    session[:referrer] = request.referer
+  end
+
+  def find_vlo
+    @vlo = VictimLiaisonOfficer.find params[:id]
+  end
+
+  def vlo_parameters
+    params.require(:victim_liaison_officer).permit(:first_name, :last_name, :email)
+  end
+
+  def load_case_information
+    @case_information = CaseInformation.find_by!(nomis_offender_id: params[:prisoner_id])
+  end
+end

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -16,7 +16,7 @@ module OffenderHelper
 
   def last_event(allocation)
     event = event_type(allocation.event)
-    event + ' - ' + allocation.updated_at.strftime('%d/%m/%Y')
+    event + ' - ' + allocation.created_at.strftime('%d/%m/%Y')
   end
 
   def event_type(event)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -14,6 +14,8 @@ class CaseInformation < ApplicationRecord
            inverse_of: :case_information,
            dependent: :destroy
 
+  has_many :victim_liaison_officers, dependent: :destroy
+
   scope :nps, -> { where(case_allocation: NPS) }
 
   has_one :responsibility,

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -11,7 +11,8 @@ module HmppsApi
     delegate :indeterminate_sentence?, :immigration_case?,
              to: :@sentence_type
 
-    delegate :tier, :case_allocation, :crn, :mappa_level, :parole_review_date,
+    delegate :tier, :case_allocation, :crn, :mappa_level,
+             :parole_review_date, :victim_liaison_officers,
              to: :@case_information, allow_nil: true
 
     attr_accessor :category_code, :date_of_birth, :prison_arrival_date, :sentence, :allocated_pom_name

--- a/app/models/victim_liaison_officer.rb
+++ b/app/models/victim_liaison_officer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class VictimLiaisonOfficer < ApplicationRecord
+  # Other version fields (user_first_name and user_last_name) filled in by controller
+  has_paper_trail meta: { nomis_offender_id: :nomis_id_for_paper_trail }
+
+  belongs_to :case_information
+  validates_presence_of :last_name, :first_name
+
+  validates :email, presence: true, 'valid_email_2/email': true
+
+  def full_name
+    "#{last_name}, #{first_name}"
+  end
+
+private
+
+  def nomis_id_for_paper_trail
+    case_information.nomis_offender_id
+  end
+end

--- a/app/presenters/allocation_history.rb
+++ b/app/presenters/allocation_history.rb
@@ -14,7 +14,9 @@ class AllocationHistory
   # we need to override the 'updated_at' in the history with the 'to' value (index 1)
   # so that if it is changed later w/o history (e.g. by updating the COM name)
   # we don't produce the wrong answer
-  def updated_at
+  # This is now 'created_at' to reflect that this is the 'created time' of the history record
+  # and the 'updated_at' does not exist (because history records cannot be modified)
+  def created_at
     YAML.load(@version.object_changes).fetch('updated_at')[1]
   end
 

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -14,6 +14,7 @@ class OffenderPresenter
            :tier, :parole_review_date, :crn, :convicted?, :ldu,
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
            :licence_expiry_date, :post_recall_release_date,
+           :victim_liaison_officers,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level, to: :@offender
 
   def initialize(offender)

--- a/app/presenters/vlo_history.rb
+++ b/app/presenters/vlo_history.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class VloHistory
+  delegate :created_at, :event, :prison, to: :@version
+
+  def initialize(version)
+    @version = version
+  end
+
+  def to_partial_path
+    "vlo_#{event}"
+  end
+
+  def created_by_name
+    if @version.whodunnit
+      "#{@version.user_last_name}, #{@version.user_first_name}"
+    end
+  end
+end

--- a/app/views/allocations/_allocate_primary_pom.html.erb
+++ b/app/views/allocations/_allocate_primary_pom.html.erb
@@ -18,7 +18,7 @@
     <% end %>
   </div>
 
-  <p class="moj-timeline__date"><%= format_date_long(allocate_primary_pom.updated_at) %>
+  <p class="moj-timeline__date"><%= format_date_long(allocate_primary_pom.created_at) %>
     <% if allocate_primary_pom.created_by_name.present? %>
       by <%= allocate_primary_pom.created_by_name.titleize %>
     <% end %>

--- a/app/views/allocations/_allocate_secondary_pom.html.erb
+++ b/app/views/allocations/_allocate_secondary_pom.html.erb
@@ -8,7 +8,7 @@
     <br/>
   </div>
 
-  <p class="moj-timeline__date"><%= format_date_long(allocate_secondary_pom.updated_at) %>
+  <p class="moj-timeline__date"><%= format_date_long(allocate_secondary_pom.created_at) %>
     <% if allocate_secondary_pom.created_by_name.present? %>
       by <%= allocate_secondary_pom.created_by_name.titleize %>
     <% end %>

--- a/app/views/allocations/_deallocate_primary_pom.html.erb
+++ b/app/views/allocations/_deallocate_primary_pom.html.erb
@@ -15,5 +15,5 @@
   </div>
   <br/>
 &nbsp;
-  <p class="moj-timeline__date"><%= format_date_long(deallocate_primary_pom.updated_at) %></p>
+  <p class="moj-timeline__date"><%= format_date_long(deallocate_primary_pom.created_at) %></p>
 </div>

--- a/app/views/allocations/_deallocate_released_offender.html.erb
+++ b/app/views/allocations/_deallocate_released_offender.html.erb
@@ -2,5 +2,5 @@
   <div class="moj-timeline__header">
     <h2 class="moj-timeline__title">Prisoner released</h2>
   </div>
-  <p class="moj-timeline__date"><%= format_date_long(deallocate_released_offender.updated_at) %></p>
+  <p class="moj-timeline__date"><%= format_date_long(deallocate_released_offender.created_at) %></p>
 </div>

--- a/app/views/allocations/_deallocate_secondary_pom.html.erb
+++ b/app/views/allocations/_deallocate_secondary_pom.html.erb
@@ -15,5 +15,5 @@
   </div>
   <br/>
 &nbsp;
-  <p class="moj-timeline__date"><%= format_date_long(deallocate_secondary_pom.updated_at) %></p>
+  <p class="moj-timeline__date"><%= format_date_long(deallocate_secondary_pom.created_at) %></p>
 </div>

--- a/app/views/allocations/_reallocate_primary_pom.html.erb
+++ b/app/views/allocations/_reallocate_primary_pom.html.erb
@@ -26,7 +26,7 @@
       <% end %>
     </div>
 
-    <p class="moj-timeline__date"><%= format_date_long(reallocate_primary_pom.updated_at) %>
+    <p class="moj-timeline__date"><%= format_date_long(reallocate_primary_pom.created_at) %>
       <% if reallocate_primary_pom.created_by_name.present? %>
         by <%= reallocate_primary_pom.created_by_name.titleize %>
       <% end %>

--- a/app/views/allocations/_vlo_create.html.erb
+++ b/app/views/allocations/_vlo_create.html.erb
@@ -1,0 +1,13 @@
+<div class="moj-timeline__item">
+  <div class="moj-timeline__header">
+    <h2 class="moj-timeline__title">Contact added</h2>
+  </div>
+  <div class="moj-timeline__description">
+    Victim Liaison Officer contact added
+    <p class="moj-timeline__date"><%= format_date_long(vlo_create.created_at) %>
+      <% if vlo_create.created_by_name.present? %>
+        by <%= vlo_create.created_by_name.titleize %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/app/views/allocations/_vlo_destroy.html.erb
+++ b/app/views/allocations/_vlo_destroy.html.erb
@@ -1,0 +1,13 @@
+<div class="moj-timeline__item">
+  <div class="moj-timeline__header">
+    <h2 class="moj-timeline__title">Contact removed</h2>
+  </div>
+  <div class="moj-timeline__description">
+    Victim Liaison Officer contact removed
+  <p class="moj-timeline__date"><%= format_date_long(vlo_destroy.created_at) %>
+    <% if vlo_destroy.created_by_name.present? %>
+      by <%= vlo_destroy.created_by_name.titleize %>
+    <% end %>
+  </p>
+  </div>
+</div>

--- a/app/views/allocations/_vlo_update.html.erb
+++ b/app/views/allocations/_vlo_update.html.erb
@@ -1,0 +1,13 @@
+<div class="moj-timeline__item">
+  <div class="moj-timeline__header">
+    <h2 class="moj-timeline__title">Contact updated</h2>
+  </div>
+  <div class="moj-timeline__description">
+    Victim Liaison Officer contact updated
+  <p class="moj-timeline__date"><%= format_date_long(vlo_update.created_at) %>
+    <% if vlo_update.created_by_name.present? %>
+      by <%= vlo_update.created_by_name.titleize %>
+    <% end %>
+  </p>
+  </div>
+</div>

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -9,6 +9,7 @@
 <%= render 'case_information' %>
 
 <%= render 'prisoners/community_information' %>
+<%= render 'shared/vlo_information' %>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible" />
 

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -140,4 +140,5 @@
   </table>
 
   <%= render 'prisoners/community_information' %>
+  <%= render 'shared/vlo_information' %>
 </div>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -60,3 +60,4 @@
 <%= render partial: 'shared/offence_info', locals: { editable_prd: true}  %>
 <%= render 'prison_allocation' %>
 <%= render 'community_information' %>
+<%= render 'shared/vlo_information' %>

--- a/app/views/shared/_victim_liaison_officer.html.erb
+++ b/app/views/shared/_victim_liaison_officer.html.erb
@@ -1,0 +1,32 @@
+<table class="govuk-table vlo-row-<%= victim_liaison_officer_counter %>">
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-table__header govuk-!-width-one-half" scope="row"><%= t((victim_liaison_officer_counter + 1).ordinalize) %> Contact</td>
+      <td class="govuk-table__cell govuk-table__cell govuk-!-width-one-half">
+        <span class="pull-right">
+          <%= link_to 'Delete Contact', delete_prison_prisoner_victim_liaison_officer_path(@prison.code, @prisoner.offender_no, victim_liaison_officer) %>
+        </span>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half" scope="row">
+        Victim Liaison Officer name
+      </td>
+      <td class="govuk-table__cell govuk-table__cell govuk-!-width-one-half">
+        <%= victim_liaison_officer.full_name %>
+        <span class="pull-right change-name">
+          <%= link_to 'Change', edit_prison_prisoner_victim_liaison_officer_path(@prison.code, @prisoner.offender_no, victim_liaison_officer) %>
+        </span>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half" scope="row">Email address</td>
+      <td class="govuk-table__cell govuk-!-width-one-half">
+        <%= victim_liaison_officer.email %>
+        <span class="pull-right change-email">
+          <%= link_to 'Change', edit_prison_prisoner_victim_liaison_officer_path(@prison.code, @prisoner.offender_no, victim_liaison_officer) %>
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/shared/_vlo_information.html.erb
+++ b/app/views/shared/_vlo_information.html.erb
@@ -1,0 +1,18 @@
+<table class="govuk-table">
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-!-width-one-half" scope="row">Victim Liaison Officer (VLO)</td>
+      <td class="govuk-table__cell govuk-!-width-one-half"></td>
+    </tr>
+    <tr>
+      <td class="govuk-!-width-full">
+        <%= render collection: @prisoner.victim_liaison_officers, partial: 'shared/victim_liaison_officer' %>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= link_to 'Add new VLO contact', new_prison_prisoner_victim_liaison_officer_path(@prison.code, @prisoner.offender_no), class: 'govuk-link govuk-!-margin-top-2' %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/victim_liaison_officers/_form.html.erb
+++ b/app/views/victim_liaison_officers/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for(vlo,
+             url: form_url,
+             method: form_action,
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        Victim Liaison Officer
+      </legend>
+    </fieldset>
+  </div>
+
+  <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
+  <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
+  <!-- govuk_email_field seems to have strange popup behaviour - so use plain text field instead-->
+  <%= f.govuk_text_field :email, label: { text: 'Email address' } %>
+
+  <%= f.submit "Submit", role: "button", draggable: "false", class: "govuk-button" %>
+<% end %>

--- a/app/views/victim_liaison_officers/delete.html.erb
+++ b/app/views/victim_liaison_officers/delete.html.erb
@@ -1,0 +1,20 @@
+<% content_for :switcher do %>
+  <%= render '/layouts/prison_switcher' %>
+<% end %>
+
+<h2 class="govuk-heading-l">Delete the selected Victim Liaison Officer (VLO) contact?</h2>
+
+<p class="govuk-body">
+Contact details for the VLO <%= @vlo.full_name %> will be removed from the prisoner record.
+</p>
+
+<%= form_for(@vlo,
+             url: prison_prisoner_victim_liaison_officer_path(@prison.code, @vlo.case_information.nomis_offender_id, @vlo.id),
+             method: :delete,
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+
+  <%= f.submit "Confirm", role: "button", draggable: "false", class: "govuk-button" %>
+  <%= link_to 'Cancel', @referrer, class: 'govuk-link cancel-button' %>
+
+<% end %>
+

--- a/app/views/victim_liaison_officers/edit.html.erb
+++ b/app/views/victim_liaison_officers/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :switcher do %>
+  <%= render '/layouts/prison_switcher' %>
+<% end %>
+
+<%= render 'shared/backlink', page: @referrer %>
+
+<h2 class="govuk-heading-l">Edit Victim Liaison Officer (VLO) contact details</h2>
+
+<%= render 'form',
+           vlo: @vlo,
+           form_action: :patch,
+           form_url: prison_prisoner_victim_liaison_officer_path(@prison.code, @vlo.case_information.nomis_offender_id, @vlo.id) %>

--- a/app/views/victim_liaison_officers/new.html.erb
+++ b/app/views/victim_liaison_officers/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :switcher do %>
+  <%= render '/layouts/prison_switcher' %>
+<% end %>
+
+<%= render 'shared/backlink', page: @referrer %>
+
+<h2 class="govuk-heading-l">Add Victim Liaison Officer (VLO) contact details</h2>
+
+<%= render 'form',
+           vlo: @vlo,
+           form_action: :post,
+           form_url: prison_prisoner_victim_liaison_officers_path(@prison.code, @vlo.case_information.nomis_offender_id) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,16 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  1st: First
+  2nd: Second
+  3rd: Third
+  4th: Fourth
+  5th: Fifth
+  6th: Sixth
+  7th: Seventh
+  8th: Eighth
+  9th: Ninth
+  10th: Tenth
   activemodel:
     errors:
       models:
@@ -41,6 +51,16 @@ en:
   activerecord:
     errors:
       models:
+        victim_liaison_officer:
+          format: "%{message}"
+          attributes:
+            first_name:
+              blank: Enter a first name
+            last_name:
+              blank: Enter a last name
+            email:
+              blank: Enter an email address in the correct format, like name@example.com
+              invalid: Enter an email address in the correct format, like name@example.com
         case_information:
           attributes:
             parole_review_date:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,12 @@ Rails.application.routes.draw do
 
       # show action produces the most recent assessment - format PDF only
       resource :early_allocation, only: [:show, :edit, :update]
+
+      resources :victim_liaison_officers, only: [:new, :edit, :create, :update, :destroy] do
+        member do
+          get 'delete'
+        end
+      end
     end
 
     resources :allocations, only: %i[ show new create edit update ], param: :nomis_offender_id, path_names: {

--- a/db/migrate/20201111134425_create_victim_liaison_officers.rb
+++ b/db/migrate/20201111134425_create_victim_liaison_officers.rb
@@ -1,0 +1,12 @@
+class CreateVictimLiaisonOfficers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :victim_liaison_officers do |t|
+      t.references :case_information, null: false
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.string :email, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201116101450_add_nomis_offender_id_to_paper_trail_version.rb
+++ b/db/migrate/20201116101450_add_nomis_offender_id_to_paper_trail_version.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddNomisOffenderIdToPaperTrailVersion < ActiveRecord::Migration[6.0]
+  def change
+    change_table :versions do |t|
+      t.string :nomis_offender_id
+      t.index :nomis_offender_id
+    end
+  end
+end

--- a/db/migrate/20201119092144_add_user_and_prison_to_versions.rb
+++ b/db/migrate/20201119092144_add_user_and_prison_to_versions.rb
@@ -1,0 +1,9 @@
+class AddUserAndPrisonToVersions < ActiveRecord::Migration[6.0]
+  def change
+    change_table :versions do |t|
+      t.string :user_first_name
+      t.string :user_last_name
+      t.string :prison
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_175237) do
+ActiveRecord::Schema.define(version: 2020_11_19_092144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -195,7 +195,22 @@ ActiveRecord::Schema.define(version: 2020_11_18_175237) do
     t.text "object"
     t.datetime "created_at"
     t.text "object_changes"
+    t.string "nomis_offender_id"
+    t.string "user_first_name"
+    t.string "user_last_name"
+    t.string "prison"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["nomis_offender_id"], name: "index_versions_on_nomis_offender_id"
+  end
+
+  create_table "victim_liaison_officers", force: :cascade do |t|
+    t.bigint "case_information_id", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "email", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["case_information_id"], name: "index_victim_liaison_officers_on_case_information_id"
   end
 
 end

--- a/spec/factories/victim_liaison_officers.rb
+++ b/spec/factories/victim_liaison_officers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :victim_liaison_officer do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    email { Faker::Internet.email }
+    case_information { build(:case_information) }
+  end
+end

--- a/spec/helpers/history_helper_spec.rb
+++ b/spec/helpers/history_helper_spec.rb
@@ -32,23 +32,26 @@ RSpec.describe HistoryHelper do
     )
   }
 
-  it 'can group the allocations correctly' do
-    list = HistoryHelper::AllocationList.new([current_allocation, middle_allocation1, middle_allocation2, old_allocation])
+  let(:nil_allocation) {
+    build_stubbed(
+      :allocation,
+      prison: nil
+    )
+  }
 
-    expect(list.count).to eq(3)
+  context 'with 1, 2, 1' do
+    it 'can group the allocations correctly' do
+      list = HistoryHelper::AllocationList.new([current_allocation, middle_allocation1, middle_allocation2, old_allocation])
 
-    results = list.to_a
+      expect(list.map { |prison, allocations| [prison, allocations.count] }).to eq [["LEI", 1], ["PVI", 2], ["LEI", 1]]
+    end
+  end
 
-    prison, allocations = results.shift
-    expect(prison).to eq('LEI')
-    expect(allocations.count).to eq(1)
+  context 'with nil prison at the start of the list' do
+    it 'copes' do
+      list = HistoryHelper::AllocationList.new([nil_allocation, current_allocation, middle_allocation1, middle_allocation2])
 
-    prison, allocations = results.shift
-    expect(prison).to eq('PVI')
-    expect(allocations.count).to eq(2)
-
-    prison, allocations = results.shift
-    expect(prison).to eq('LEI')
-    expect(allocations.count).to eq(1)
+      expect(list.map { |prison, allocations| [prison, allocations.count] }).to eq [["LEI", 2], ["PVI", 2]]
+    end
   end
 end

--- a/spec/models/victim_liaison_officer_spec.rb
+++ b/spec/models/victim_liaison_officer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe VictimLiaisonOfficer, type: :model do
+  it 'validates presence of first, last and email' do
+    expect(subject).to validate_presence_of :first_name
+    expect(subject).to validate_presence_of :last_name
+    expect(subject).to validate_presence_of :email
+  end
+
+  context 'with case information record' do
+    before do
+      create(:case_information, victim_liaison_officers: [build(:victim_liaison_officer)])
+    end
+
+    let(:ci) { CaseInformation.last }
+
+    it 'checks the format of emails' do
+      expect(build(:victim_liaison_officer)).to be_valid
+      expect(build(:victim_liaison_officer, email: 'fred@exmaple.com')).to be_valid
+      expect(build(:victim_liaison_officer, email: 'BOGUS !')).not_to be_valid
+    end
+
+    it 'belongs to a case information record and is destroyed with it' do
+      expect {
+        ci.destroy
+      }.to change(described_class, :count).by(-1)
+    end
+  end
+end

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "allocations/show", type: :view do
     assign(:prison, build(:prison))
     assign(:pom, build(:pom))
     assign(:prisoner, build(:offender))
-    assign(:allocation, build(:allocation))
+    assign(:allocation, create(:allocation))
     assign(:keyworker, build(:keyworker))
     render
   end


### PR DESCRIPTION
Add ability to add and remove Victim Liaison Officers and to display those events on the 'allocation history' (case history) page 

![Screen Shot 2020-11-16 at 21 55 11](https://user-images.githubusercontent.com/53059/99312795-78910300-2856-11eb-9886-b852e8e37e97.png)
