### PR TITLE
Remove duplicate API calls for sentence details

### DIFF
--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -8,18 +8,9 @@ class OffenderService
       record = CaseInformation.find_by(nomis_offender_id: offender_no)
       o.load_case_information(record)
 
-      sentence_detail = get_sentence_details([o.booking_id])
-      if sentence_detail.present? && sentence_detail.key?(o.booking_id)
-        o.sentence = sentence_detail[o.booking_id]
-      end
-
       o.category_code = HmppsApi::PrisonApi::OffenderApi.get_category_code(o.offender_no)
       o.main_offence = HmppsApi::PrisonApi::OffenderApi.get_offence(o.booking_id)
     }
-  end
-
-  def self.get_sentence_details(booking_ids)
-    HmppsApi::PrisonApi::OffenderApi.get_bulk_sentence_details(booking_ids)
   end
 
   # Takes a list of OffenderSummary or Offender objects, and returns them with their


### PR DESCRIPTION
The method `OffenderService.get_offender` was retrieving offender data from the Prison API method `OffenderApi.get_offender`, and then manually overwriting the `offender.sentence` attribute with fresh sentence details.

It looks like this was being done unnecessarily, since the `OffenderApi.get_offender` method already retrieves and sets sentence details.

This resulted in duplicate API calls being fired to the Prison API and sentence details being unnecessarily overwritten.

### No test changes

This is a refactor, so no tests needed changing.

The spec for `OffenderService.get_offender` expects the sentence details to be present. This is still true – all I've removed is the duplicate effort of loading sentence details twice.

https://github.com/ministryofjustice/offender-management-allocation-manager/blob/4e2288a0faafd83b7dd87f964566c29d03297084/spec/services/offender_service_spec.rb#L4-L15