### PR TITLE
MO-56 remove unused field from allocations table 

### DIFF
--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -21,7 +21,6 @@ class AllocationService
     alloc_version.update!(
       secondary_pom_name: "#{coworking_pom_secondname}, #{coworking_pom_firstname}",
       created_by_name: "#{user_firstname} #{user_secondname}",
-      created_by_username: created_by_username,
       secondary_pom_nomis_id: secondary_pom_nomis_id,
       event: Allocation::ALLOCATE_SECONDARY_POM,
       event_trigger: Allocation::USER
@@ -42,7 +41,7 @@ class AllocationService
     user_firstname, user_secondname =
       PrisonOffenderManagerService.get_user_name(params[:created_by_username])
 
-    params_copy = params.merge(
+    params_copy = params.except(:created_by_username).merge(
       primary_pom_name: "#{pom_secondname}, #{pom_firstname}",
       created_by_name: "#{user_firstname} #{user_secondname}",
       primary_pom_allocated_at: DateTime.now.utc

--- a/db/migrate/20201118175237_remove_unused_allocation_field.rb
+++ b/db/migrate/20201118175237_remove_unused_allocation_field.rb
@@ -1,0 +1,5 @@
+class RemoveUnusedAllocationField < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :allocations, :created_by_username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_113448) do
+ActiveRecord::Schema.define(version: 2020_11_18_175237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 2020_10_28_113448) do
     t.integer "event_trigger"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "created_by_username"
     t.datetime "primary_pom_allocated_at"
     t.string "recommended_pom_type"
     t.index ["nomis_offender_id"], name: "index_allocations_on_nomis_offender_id"

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -143,16 +143,13 @@ RSpec.describe AllocationsController, type: :controller do
                                 prison: 'PVI',
                                 recommended_pom_type: 'probation',
                                 event: Allocation::ALLOCATE_PRIMARY_POM,
-                                event_trigger: Allocation::USER,
-                                created_by_username: 'MOIC_POM'
+                                event_trigger: Allocation::USER
             )
             allocation.update!(
               primary_pom_nomis_id: poms.second.staffId,
               prison: 'LEI',
               event: Allocation::REALLOCATE_PRIMARY_POM,
-              event_trigger: Allocation::USER,
-              created_by_username: 'MOIC_POM'
-            )
+              event_trigger: Allocation::USER)
           end
 
           it "Can get the allocation history for an offender" do

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -6,10 +6,6 @@ FactoryBot.define do
       'A'
     end
 
-    created_by_username do
-      'MOIC_POM'
-    end
-
     created_by_name do
       "#{Faker::Name.first_name} #{Faker::Name.last_name}"
     end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe EmailService do
     Allocation.new.tap do |a|
       a.primary_pom_nomis_id = 485_833
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
@@ -22,7 +21,6 @@ RSpec.describe EmailService do
     Allocation.new.tap { |a|
       a.primary_pom_nomis_id = 485_766
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
@@ -36,7 +34,6 @@ RSpec.describe EmailService do
     Allocation.new.tap { |a|
       a.primary_pom_nomis_id = 485_833
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.allocated_at_tier = 'A'
       a.prison = 'LEI'
@@ -50,7 +47,6 @@ RSpec.describe EmailService do
       a.primary_pom_nomis_id = 485_833
       a.primary_pom_name = "Ricketts, Andrien"
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.secondary_pom_nomis_id = 485_926
       a.secondary_pom_name = "Pom, Moic"
@@ -66,7 +62,6 @@ RSpec.describe EmailService do
       a.primary_pom_nomis_id = 485_833
       a.primary_pom_name = "Ricketts, Andrien"
       a.nomis_offender_id = 'G2911GD'
-      a.created_by_username = 'MOIC_POM'
       a.nomis_booking_id = 0
       a.secondary_pom_nomis_id = nil
       a.secondary_pom_name = nil

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -57,7 +57,6 @@ describe OffenderService do
       nomis_booking_id: 1_153_753,
       prison: 'LEI',
       allocated_at_tier: 'C',
-      created_by_username: 'MOIC_POM',
       primary_pom_nomis_id: nomis_staff_id,
       primary_pom_allocated_at: allocated_date,
       recommended_pom_type: 'prison',


### PR DESCRIPTION
As part of MO-56, it appears that the allocations table stores (but never uses) a 'username' field (called created_by_username)

1. This is a duplicate of the papertrail 'whodunnit' field
2. It is never looked at (only set)

Thie PR removes this field as it is noise