### PR TITLE
MO-51 Incorrect text in Fix missing information Journey

### DIFF
--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -9,9 +9,6 @@
         <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-2">
           Was this prisoner's last known address in Wales?
         </legend>
-        <p>
-          Only prisoners with a Welsh address will be allocated a responsible<br/> prison or probation POM.
-        </p>
 
         <% if @case_info.errors[:welsh_offender].present? %>
           <span class="govuk-error-message">


### PR DESCRIPTION
The description text when asking the SPO to select whether the POM is in Wales displays incorrect information.
This PR removes this text. 