### PR TITLE
MO-207 VLO Banner

### DIFF
--- a/app/notifications/service_notifications.yaml
+++ b/app/notifications/service_notifications.yaml
@@ -35,3 +35,10 @@ notifications:
       - SPO
     end_date: 16/10/2020
     text: 'You can help us improve this service by participating in research and giving us feedback. Sign up to the HMPPS Digital research panel <a href="https://www.surveymonkey.co.uk/r/79MHSJX">here</a>'
+  - id: vlo-banner-20-11-2020
+    start_date: 20/11/2020
+    role:
+      - POM
+      - SPO
+    end_date: 30/11/2020
+    text: 'NEW FEATURE: Prison offender managers and Head of offender management delivery will now be able to manually input the victim liaison officers name and contact details. Read more.  <a href="/whats-new">read the release notes to find out more</a>'

--- a/app/views/pages/whats_new.html.erb
+++ b/app/views/pages/whats_new.html.erb
@@ -24,6 +24,17 @@
         <p>Notify us of any issues you find by using the 'Contact us'
           form which is linked to at the bottom of every page.</p>
       </div>
+      <div>
+        <h2 class="govuk-heading-l">Release notes: 20 November 2020</h2>
+        <h3 class="govuk-heading-m">New feature</h3>
+        <p>Victim liaison officer details can now be manually added to
+          the profile of the prisoner, you’ll find this under
+          VICTIM LIAISON OFFICER (VLO) section of the page.</p>
+
+        <p>You are able to add, edit and delete these entries plus make multiple
+          contacts if required. Notify us of any issues you find by using the
+          'Contact us' form which is linked to at the bottom of every page. </p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR adds a new banner that informs the POMs and SPOs that a new feature allowing them to manually add VLO information to the profile of a prisoner is now available. 

Its start date and end date have not yet been set as the start date is determined by the release of MO 56 - within 24 hours after. 

The end date is the start date + 10 days. So these need to be added once MO 56 has been released.




