### PR TITLE
improve flakey test by waiting for an element on new page

### DIFF
--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -39,6 +39,7 @@ feature 'case information feature' do
     expect(page).to have_selector('h1', text: 'Case information')
 
     click_link 'Back'
+    find('#awaiting-information')
     expect(page).to have_selector('h1', text: 'Add missing information')
   end
 


### PR DESCRIPTION
One of the case information tests has a js test for the 'Back' button - but it sometimes fails if the page hasn't rendered yet.
This PR fixes the test by doing a find on an element that is on the new page that is being rendered.