### PR TITLE
Mo 87 - Notify SPOs and POMs when no LDU information is available shortly before handover start date 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,3 +50,13 @@ a:visited {
  .govuk-header__navigation-item a {
      color: white !important;
  }
+
+.govuk-table__cell-error {
+  border-left: 5px solid #d4351c;
+  padding-left: 10px;
+}
+
+.govuk-table__cell-error-value {
+  color: #d4351c;
+  font-weight: bold;
+}

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -31,7 +31,7 @@ module OffenderHelper
     end
   end
 
-  def approaching_handover_without_com?(offender)
+  def needs_com_but_ldu_is_uncontactable?(offender)
     return false unless offender.sentenced?
 
     return false if offender.handover_start_date.nil?

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -30,4 +30,16 @@ module OffenderHelper
       type + 'allocated'
     end
   end
+
+  def approaching_handover_without_com?(offender)
+    return false unless offender.sentenced?
+
+    return false if offender.handover_start_date.nil?
+
+    if offender.handover_start_date <= Time.zone.today + 45.days && offender.allocated_com_name.nil?
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -36,10 +36,12 @@ module OffenderHelper
 
     return false if offender.handover_start_date.nil?
 
-    if offender.handover_start_date <= Time.zone.today + 45.days && offender.allocated_com_name.nil?
-      true
-    else
-      false
-    end
+    return false if offender.handover_start_date > Time.zone.today + 45.days
+
+    return false if offender.allocated_com_name.present?
+
+    return true if offender.ldu.try(:email_address).nil?
+
+    false
   end
 end

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -1,5 +1,9 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
+<% if approaching_handover_without_com?(@prisoner)%>
+  <%= render partial: 'shared/no_com_alert' %>
+<% end %>
+
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
 
 <%= render 'shared/basic_prisoner_info' %>

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -1,6 +1,6 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
-<% if approaching_handover_without_com?(@prisoner)%>
+<% if needs_com_but_ldu_is_uncontactable?(@prisoner)%>
   <%= render partial: 'shared/no_com_alert' %>
 <% end %>
 

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -1,4 +1,4 @@
-<% if approaching_handover_without_com?(@prisoner)%>
+<% if needs_com_but_ldu_is_uncontactable?(@prisoner)%>
   <%= render partial: 'shared/no_com_alert' %>
 <% end %>
 

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -1,3 +1,7 @@
+<% if approaching_handover_without_com?(@prisoner)%>
+  <%= render partial: 'shared/no_com_alert' %>
+<% end %>
+
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocation information</h1>
 
 <%= render 'shared/case_type_badge', offender: @prisoner %>

--- a/app/views/prisoners/_community_information.html.erb
+++ b/app/views/prisoners/_community_information.html.erb
@@ -26,9 +26,14 @@
         <%= @prisoner.team.presence || "Unknown"%>
       </td>
     </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
-      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+    <tr class="govuk-table__row ">
+      <% if approaching_handover_without_com?(@prisoner) %>
+        <td class="govuk-table__cell govuk-!-width-one-half govuk-table__cell-error"  id="com-error">
+      <% else %>
+        <td class="govuk-table__cell govuk-!-width-one-half" >
+      <% end %>
+        Community Offender Manager (COM) name</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half <%=' govuk-table__cell-error-value' if approaching_handover_without_com?(@prisoner) %>">
         <%= @prisoner.allocated_com_name.presence || "Unknown" %>
       </td>
     </tr>

--- a/app/views/prisoners/_community_information.html.erb
+++ b/app/views/prisoners/_community_information.html.erb
@@ -27,13 +27,13 @@
       </td>
     </tr>
     <tr class="govuk-table__row ">
-      <% if approaching_handover_without_com?(@prisoner) %>
+      <% if needs_com_but_ldu_is_uncontactable?(@prisoner) %>
         <td class="govuk-table__cell govuk-!-width-one-half govuk-table__cell-error"  id="com-error">
       <% else %>
         <td class="govuk-table__cell govuk-!-width-one-half" >
       <% end %>
         Community Offender Manager (COM) name</td>
-      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half <%=' govuk-table__cell-error-value' if approaching_handover_without_com?(@prisoner) %>">
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half <%=' govuk-table__cell-error-value' if needs_com_but_ldu_is_uncontactable?(@prisoner) %>">
         <%= @prisoner.allocated_com_name.presence || "Unknown" %>
       </td>
     </tr>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -1,4 +1,4 @@
-<% if approaching_handover_without_com?(@prisoner)%>
+<% if needs_com_but_ldu_is_uncontactable?(@prisoner)%>
   <%= render partial: 'shared/no_com_alert' %>
 <% end %>
 

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -1,3 +1,7 @@
+<% if approaching_handover_without_com?(@prisoner)%>
+  <%= render partial: 'shared/no_com_alert' %>
+<% end %>
+
 <% @tasks.each do |task| %>
   <%= render partial: 'shared/info_banner', locals: {
     content: task.long_label.html_safe }

--- a/app/views/shared/_no_com_alert.html.erb
+++ b/app/views/shared/_no_com_alert.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    You must contact the community probation office
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li id="com_warning"><%= link_to I18n.t('views.handover_alert.no_com', date: format_date(@prisoner.handover_start_date)), "#com-error", data: { turbolinks: false } %></li>
+      <li id="ldu_warning">
+        <% if @prisoner.ldu.try(:name).blank? %>
+          <%= link_to I18n.t('views.handover_alert.no_ldu'), "#com-error", data: { turbolinks: false }  %>
+        <% else %>
+          <%= link_to I18n.t('views.handover_alert.no_email', name: @prisoner.ldu.name), "#com-error", data: { turbolinks: false }  %>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,10 @@ en:
       previous: "&lsaquo; Previous"
       next: "Next &rsaquo;"
       truncate: "&hellip;"
+    handover_alert:
+      no_com: "A Community Offender Manager (COM) must be allocated to support this case from %{date}."
+      no_ldu: An automatic email could not be sent to the LDU. You need to find an alternative way of contacting them.
+      no_email: "An automatic email could not be sent to %{name} because the LDU email address is missing. You need need to find an alternative way of contacting them."
   helpers:
     fieldset:
       case_information:

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -46,4 +46,60 @@ RSpec.describe OffenderHelper do
       expect(helper.case_owner_label(offp)).to eq('Community')
     end
   end
+
+  describe 'approaching_handover_without_com?' do
+    it 'returns false if offender is not sentenced' do
+      offender = build(:offender).tap { |o|
+        o.load_case_information(build(:case_information))
+        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
+                                                  automatic_release_date: Time.zone.today + 20.months
+      }
+
+      expect(offender.sentenced?).to eq(false)
+      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+    end
+
+    it 'returns false if offender does not have a handover_start_date' do
+      offender = build(:offender, :indeterminate).tap { |o|
+        o.load_case_information(build(:case_information))
+        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today + 20.months,
+                                                  automatic_release_date: nil
+      }
+
+      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+    end
+
+    it 'returns false if offender has more than 45 days until start_of_handover' do
+      offender = build(:offender).tap { |o|
+        o.load_case_information(build(:case_information))
+        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
+                                                  automatic_release_date: Time.zone.today + 20.months,
+                                                  release_date: Time.zone.today + 20.months
+      }
+
+      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+    end
+
+    it "returns false if offender has a 'COM' assigned with 45 days or less until start_of_handover" do
+      offender = build(:offender).tap { |o|
+        o.load_case_information(build(:case_information, com_name: "Betty White"))
+        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
+                                                  automatic_release_date: Time.zone.today + 8.months,
+                                                  release_date: Time.zone.today + 20.months
+      }
+
+      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+    end
+
+    it "returns true if offender has no 'COM' assigned with 45 days or less until the start_of_handover" do
+      offender = build(:offender).tap { |o|
+        o.load_case_information(build(:case_information))
+        o.sentence = HmppsApi::SentenceDetail.new sentence_start_date: Time.zone.today - 20.months,
+                                                  automatic_release_date: Time.zone.today + 8.months,
+                                                  release_date: Time.zone.today + 20.months
+      }
+
+      expect(helper.approaching_handover_without_com?(offender)).to eq(true)
+    end
+  end
 end

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe OffenderHelper do
       }
 
       expect(offender.sentenced?).to eq(false)
-      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+      expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
     end
 
     it 'returns false if offender does not have a handover start date' do
@@ -66,7 +66,7 @@ RSpec.describe OffenderHelper do
                                                   automatic_release_date: nil
       }
 
-      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+      expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
     end
 
     it 'returns false if offender has more than 45 days until start of handover' do
@@ -77,7 +77,7 @@ RSpec.describe OffenderHelper do
                                                   release_date: Time.zone.today + 20.months
       }
 
-      expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+      expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
     end
 
     context 'when offender has 45 days or less until start of handover' do
@@ -89,7 +89,7 @@ RSpec.describe OffenderHelper do
                                                     release_date: Time.zone.today + 20.months
         }
 
-        expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+        expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
       end
 
       context "when offender has no 'COM'" do
@@ -101,7 +101,7 @@ RSpec.describe OffenderHelper do
                                                       release_date: Time.zone.today + 20.months
           }
 
-          expect(helper.approaching_handover_without_com?(offender)).to eq(false)
+          expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(false)
         end
 
         it "returns true if offender has no LDU" do
@@ -112,7 +112,7 @@ RSpec.describe OffenderHelper do
                                                       release_date: Time.zone.today + 20.months
           }
 
-          expect(helper.approaching_handover_without_com?(offender)).to eq(true)
+          expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(true)
         end
 
         it "returns true if offender has an LDU without an email address" do
@@ -124,7 +124,7 @@ RSpec.describe OffenderHelper do
                                                       release_date: Time.zone.today + 20.months
           }
 
-          expect(helper.approaching_handover_without_com?(offender)).to eq(true)
+          expect(helper.needs_com_but_ldu_is_uncontactable?(offender)).to eq(true)
         end
       end
     end

--- a/spec/views/prisoners/community_information.html.erb_spec.rb
+++ b/spec/views/prisoners/community_information.html.erb_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "prisoners/community_information", type: :view do
+  let(:page) { Nokogiri::HTML(rendered) }
+
+  let(:offender) do
+    build(:offender, :determinate, latestLocationId: 'LEI', offenderNo: 'G8060UF',
+          sentence: build(:sentence_detail,
+                          sentenceStartDate: Time.zone.today - 11.months,
+                          conditionalReleaseDate: Time.zone.today + 8.months,
+                          automaticReleaseDate: Time.zone.today + 8.months,
+                          releaseDate: Time.zone.today + 8.months,
+                          tariffDate: nil))
+  end
+
+  before do
+    allow(OffenderService).to receive(:get_offender).and_return(offender)
+  end
+
+  context 'when there is no COM error' do
+    let(:case_info) do
+      create(:case_information, nomis_offender_id: offender.offender_no,
+             team: build(:team, local_divisional_unit: build(:local_divisional_unit)))
+    end
+
+    before do
+      offender.load_case_information(case_info)
+      assign(:prisoner, OffenderPresenter.new(offender))
+      render partial: 'prisoners/community_information'
+    end
+
+    it 'does not apply css error highlighting on the COM name row' do
+      expect(page).not_to have_css(".govuk-table__cell-error")
+      expect(page).not_to have_css(".govuk-table__cell-error-value")
+    end
+  end
+
+  context 'when there is a COM error' do
+    let(:case_info) do
+      create(:case_information, nomis_offender_id: offender.offender_no,
+             team: build(:team, local_divisional_unit: build(:local_divisional_unit, email_address: nil)))
+    end
+
+    before do
+      offender.load_case_information(case_info)
+      assign(:prisoner, OffenderPresenter.new(offender))
+      render partial: 'prisoners/community_information'
+    end
+
+
+    it 'applies css error highlighting the COM field' do
+      expect(page).to have_css(".govuk-table__cell-error")
+      expect(page).to have_css(".govuk-table__cell-error-value")
+    end
+  end
+end

--- a/spec/views/shared/no_com_alert.html.erb_spec.rb
+++ b/spec/views/shared/no_com_alert.html.erb_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe "shared/no_com_alert", type: :view do
+  let(:page) { Nokogiri::HTML(rendered) }
+
+  let(:offender) do
+    build(:offender, :determinate, latestLocationId: 'LEI', offenderNo: 'G8060UF',
+          sentence: build(:sentence_detail,
+                          sentenceStartDate: Time.zone.today - 11.months,
+                          conditionalReleaseDate: Time.zone.today + 8.months,
+                          automaticReleaseDate: Time.zone.today + 8.months,
+                          releaseDate: Time.zone.today + 8.months,
+                          tariffDate: nil))
+  end
+
+  before do
+    allow(OffenderService).to receive(:get_offender).and_return(offender)
+  end
+
+  context 'when offender has an LDU without an email address' do
+    let(:case_info) do
+      create(:case_information, nomis_offender_id: offender.offender_no,
+             team: build(:team, local_divisional_unit: build(:local_divisional_unit, email_address: nil)))
+    end
+
+    before do
+      offender.load_case_information(case_info)
+      assign(:prisoner, OffenderPresenter.new(offender))
+      render partial: 'shared/no_com_alert'
+    end
+
+    it 'displays message with the LDU name' do
+      expect(page.css('#com_warning'))
+        .to have_link(I18n.t('views.handover_alert.no_com', date: offender.handover_start_date.strftime('%d/%m/%Y')),
+                      href: "#com-error")
+
+      expect(page.css('#ldu_warning'))
+        .to have_link(I18n.t('views.handover_alert.no_email', name: offender.ldu.name), href: "#com-error")
+    end
+  end
+
+  context 'when offender does not have an LDU' do
+    let(:case_info) do
+      create(:case_information, nomis_offender_id: offender.offender_no, team: nil)
+    end
+
+    before do
+      offender.load_case_information(case_info)
+      assign(:prisoner, OffenderPresenter.new(offender))
+      render partial: 'shared/no_com_alert'
+    end
+
+    it 'displays message without an LDU name' do
+      expect(page.css('#com_warning'))
+        .to have_link(I18n.t('views.handover_alert.no_com', date: offender.handover_start_date.strftime('%d/%m/%Y')),
+                      href: "#com-error")
+
+      expect(page.css('#ldu_warning'))
+        .to have_link(I18n.t('views.handover_alert.no_ldu'), href: "#com-error")
+    end
+  end
+end


### PR DESCRIPTION
This means that we have no way of notifying the LDU that they will be responsible for the offender. We alert the SPO and POM in these cases so that they can take necessary action outside of the application to deal with this circumstance.

There are 2 SPO views that will display this alert, allocations/new and allocations/show pages. Both views are quite similar so I am only displaying the allocations/new page in this PR.

### - **Allocate a Prison Offender Manager - top of the page**

![Screen Shot 2020-11-20 at 15 52 44](https://user-images.githubusercontent.com/10685841/99821870-74acfb80-2b4a-11eb-9522-a484a60a2f5a.png)

### - **Allocate a Prison Offender Manager - lower part of the page**

![Screen Shot 2020-11-20 at 15 53 01](https://user-images.githubusercontent.com/10685841/99821894-7d9dcd00-2b4a-11eb-9ebb-13eb66974011.png)


**-------------------------------------------------------------------------------------------**

There is one POM view that will display this alert on the prisoners/show page

### - **Prisoner Information - top of the page**
![Screen Shot 2020-11-20 at 15 54 49](https://user-images.githubusercontent.com/10685841/99821958-8e4e4300-2b4a-11eb-90ed-a833bf18474b.png)

### - **Prisoner Information - bottom of the page**
![Screen Shot 2020-11-20 at 15 55 00](https://user-images.githubusercontent.com/10685841/99821972-927a6080-2b4a-11eb-9791-963decf91a3f.png)
