### PR TITLE
Mo46 add history link to new allocation page

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -12,6 +12,7 @@ class AllocationsController < PrisonsApplicationController
     @recommended_poms, @not_recommended_poms =
       recommended_and_nonrecommended_poms_for(@prisoner)
     @unavailable_pom_count = unavailable_pom_count
+    @allocation = Allocation.find_by nomis_offender_id: nomis_offender_id_from_url
   end
 
   def show
@@ -34,9 +35,9 @@ class AllocationsController < PrisonsApplicationController
   end
 
   def edit
-    allocation = AllocationService.current_allocation_for(nomis_offender_id_from_url)
+    @allocation = AllocationService.current_allocation_for(nomis_offender_id_from_url)
 
-    unless allocation.present? && allocation.active?
+    unless @allocation.present? && @allocation.active?
       redirect_to new_prison_allocation_path(active_prison_id, nomis_offender_id_from_url)
       return
     end

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -56,5 +56,16 @@
       <a class="govuk-link pull-right" href="<%= edit_prison_case_information_path(@prison.code, @prisoner.offender_no) %>">Change</a>
     </td>
   </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">Allocation history</td>
+    <td class="govuk-table__cell table_cell__left_align">
+      <% if @allocation.present? %>
+        <%= last_event(@allocation) %>
+        <%= link_to 'View', prison_allocation_history_path(@prison.code, @prisoner.offender_no), class: "govuk-link pull-right" %>
+      <% else %>
+      No history
+      <% end %>
+    </td>
+  </tr>
   </tbody>
 </table>

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe EarlyAllocationsController, type: :controller do
 
       before do
         create(:case_information, nomis_offender_id: nomis_offender_id, team: team)
-        create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
       end
 
       it 'goes to the dead end' do
@@ -77,7 +76,6 @@ RSpec.describe EarlyAllocationsController, type: :controller do
   describe '#create' do
     before do
       create(:case_information, nomis_offender_id: nomis_offender_id)
-      create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
     end
 
     context 'when stage 1' do

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -86,7 +86,7 @@ feature 'Navigation' do
         let(:index) { 2 }
 
         it 'highlights the section' do
-          click_menu_and_wait(link_css, index)
+          click_menu_and_wait(link_css, index, delay: 2)
           expect(page).to have_content offender_name
           click_link_and_wait offender_name
           new_link = all(link_css)[index]

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -188,7 +188,6 @@ RSpec.describe Allocation, type: :model do
       let!(:allocation_no_overrides) {
         create(
           :allocation,
-          nomis_offender_id: nomis_offender_id,
           primary_pom_nomis_id: nomis_staff_id
         )
       }
@@ -207,7 +206,6 @@ RSpec.describe Allocation, type: :model do
         create(
           :allocation,
           prison: allocation.prison,
-          nomis_offender_id: nomis_offender_id,
           secondary_pom_nomis_id: nomis_staff_id
         )
       }
@@ -215,14 +213,12 @@ RSpec.describe Allocation, type: :model do
         create(
           :allocation,
           prison: allocation.prison,
-          nomis_offender_id: nomis_offender_id,
           primary_pom_nomis_id: 27
         )
       }
       let!(:another_prison) {
         create(
           :allocation,
-          nomis_offender_id: nomis_offender_id,
           primary_pom_nomis_id: nomis_staff_id,
           prison: 'RSI'
         )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,8 @@ SimpleCov.start 'rails' do
   add_group "Services", "app/services"
 
   # Try to set this to current coverage levels so that it never goes down after a PR
-  # 20 lines uncovered at 99.39% coverage
-  minimum_coverage 99.39
+  # 20 lines uncovered at 99.41% coverage
+  minimum_coverage 99.41
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 


### PR DESCRIPTION
Add a link to the 'allocation history' page from the 'new allocation' flow. 
This PR also tightens up the allocations table, as the old code was calling 
Allocation.where(nomis_offender_id: <offender_no>).last which implies that there can be more than 1 allocation per offender. This is not true, so this code has been replaced with a find_by, and the allocations table given a unique key to enforce the constraint. There are no duplicates in production, so this should be extremely safe.