### PR TITLE
change handover email job back to 1st of the month

### DIFF
--- a/deploy/production/handover-email-job.yaml
+++ b/deploy/production/handover-email-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: handover-email-job
 spec:
-  schedule: "4 9 3 * *"
+  schedule: "4 9 1 * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
Put back cronjob for Handover email back to 1st after changing it due teething problems on Nov 1st