### PR TITLE
MO-1 don't send early allocations if they are > 18 months from release

### DIFF
--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -173,6 +173,16 @@ module HmppsApi
       @responsibility_override = record.responsibility
     end
 
+    def within_early_allocation_window?
+      [
+          tariff_date,
+          parole_eligibility_date,
+          parole_review_date,
+          automatic_release_date,
+          conditional_release_date
+      ].compact.min <= Time.zone.today + 18.months
+    end
+
   private
 
     def handover

--- a/app/views/early_allocations/_possible_early_allocation.html.erb
+++ b/app/views/early_allocations/_possible_early_allocation.html.erb
@@ -1,0 +1,9 @@
+<p class="govuk-body">
+  The case record has been updated to show that this might be an early allocation case.
+</p>
+<p class="govuk-body">
+  We will remind the allocated POM to make a new assessment 18 months before release.
+</p>
+<p class="govuk-body">
+  The POM can view saved assessments.
+</p>

--- a/app/views/early_allocations/discretionary.html.erb
+++ b/app/views/early_allocations/discretionary.html.erb
@@ -14,17 +14,30 @@
     </div>
     <h2 class="govuk-heading-m">What happens next</h2>
 
-    <p class="govuk-body">
-      You should receive an email with a decision from the
-      community probation team about this case.
-    </p>
-    <p class="govuk-body">
-      You will need to record this decision on the prisoner profile page.
-    </p>
-    <p class="govuk-body">
-      A new handover date will be calculated
-      if the prisoner is accepted by the community probation team.
-    </p>
+    <% if @offender.within_early_allocation_window? %>
+      <p class="govuk-body">
+        You should receive an email with a decision from the
+        community probation team about this case.
+      </p>
+      <p class="govuk-body">
+        You will need to record this decision on the prisoner profile page.
+      </p>
+      <p class="govuk-body">
+        A new handover date will be calculated
+        if the prisoner is accepted by the community probation team.
+      </p>
+    <% else %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          The assessment has not been sent to the community probation team
+        </strong>
+      </div>
+
+      <%= render(partial: 'possible_early_allocation') %>
+    <% end %>
+
     <%= render(partial: 'landing_page_footer') %>
   </div>
 </div>

--- a/app/views/early_allocations/eligible.html.erb
+++ b/app/views/early_allocations/eligible.html.erb
@@ -14,9 +14,22 @@
     </div>
     <h2 class="govuk-heading-m">What happens next</h2>
 
-    <p class="govuk-body">
-      A new handover date will be calculated automatically.
-    </p>
+    <% if @offender.within_early_allocation_window? %>
+      <p class="govuk-body">
+        A new handover date will be calculated automatically.
+      </p>
+    <% else %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          The assessment has not been sent to the community probation team
+        </strong>
+      </div>
+
+      <%= render(partial: 'possible_early_allocation') %>
+    <% end %>
+
     <%= render(partial: 'landing_page_footer') %>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,6 +91,26 @@ CaseInformation.find_or_create_by!(nomis_offender_id: 'G7517GF') do |info|
     info.team_id = team2.id
 end
 
+# 3 Test offenders which have handovers in Dec 2020
+['G1176UT', 'G0228VG', 'G1289UN'].each do |offender_no|
+  CaseInformation.find_or_create_by!(nomis_offender_id: offender_no) do |info|
+    info.assign_attributes(tier: 'B',
+                           case_allocation:'CRC',
+                           welsh_offender: 'Yes',
+                           manual_entry: true,
+                           team: team2)
+  end
+end
+
+# test offender > 18 months before release (20/12/2023)
+CaseInformation.find_or_create_by!(nomis_offender_id: 'G7281UH') do |info|
+  info.assign_attributes(tier: 'B',
+                         case_allocation:'NPS',
+                         welsh_offender: 'Yes',
+                         manual_entry: true,
+                         team: team2)
+end
+
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G3536UF') do |info|
   info.tier = 'A'
   info.case_allocation = 'NPS'


### PR DESCRIPTION
This changes early allocations in a fundamental way - if there is > 18 months before release, the allocation is saved but not sent to the LDU. It is then up to the POM (at the 18 month mark) to review and agree the assessment