### PR TITLE
MO-257 extra fields on early allocation model to support new features

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -106,7 +106,10 @@ private
   end
 
   def community_decision_params
-    params.fetch(:early_allocation, {}).permit(:community_decision).merge(recording_community_decision: true)
+    params.fetch(:early_allocation, {}).permit(:community_decision).
+        merge(recording_community_decision: true).
+        merge(updated_by_firstname: @current_user.first_name,
+              updated_by_lastname: @current_user.last_name)
   end
 
   def early_allocation_params
@@ -120,7 +123,9 @@ private
                  :stage2_validation,
                  :stage3_validation,
                  :reason,
-                 :approved])
+                 :approved]).merge(prison: active_prison_id,
+                                   created_by_firstname: @current_user.first_name,
+                                   created_by_lastname: @current_user.last_name)
   end
 
   def offender_id_from_url

--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -6,6 +6,8 @@ class EarlyAllocation < ApplicationRecord
              foreign_key: :nomis_offender_id,
              inverse_of: :early_allocations
 
+  validates_presence_of :prison, :created_by_firstname, :created_by_lastname
+
   validates :oasys_risk_assessment_date,
             presence: true,
             date: {

--- a/db/migrate/20201126123414_add_early_allocation_fields.rb
+++ b/db/migrate/20201126123414_add_early_allocation_fields.rb
@@ -1,0 +1,12 @@
+class AddEarlyAllocationFields < ActiveRecord::Migration[6.0]
+  def change
+    change_table :early_allocations do |t|
+      # These first 3 fields should be made non-nullable in the future
+      t.string :prison
+      t.string :created_by_firstname
+      t.string :created_by_lastname
+      t.string :updated_by_firstname
+      t.string :updated_by_lastname
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_092144) do
+ActiveRecord::Schema.define(version: 2020_11_26_123414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,11 @@ ActiveRecord::Schema.define(version: 2020_11_19_092144) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "community_decision"
+    t.string "prison"
+    t.string "created_by_firstname"
+    t.string "created_by_lastname"
+    t.string "updated_by_firstname"
+    t.string "updated_by_lastname"
   end
 
   create_table "flipflop_features", force: :cascade do |t|

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe SearchController, type: :controller do
 
   before do
     stub_poms(prison, poms)
-    stub_signed_in_pom(prison, 1, 'alice')
+    stub_signed_in_pom(prison, 1)
   end
 
   context 'when user is a POM ' do
     before do
-      stub_signed_in_pom(prison, 1, 'alice')
+      stub_signed_in_pom(prison, 1)
     end
 
     it 'user is redirected to caseload' do

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe SummaryController, type: :controller do
 
     before do
       stub_poms(prison, poms)
-      stub_signed_in_pom(prison, 1, 'Alice')
+      stub_signed_in_pom(prison, 1)
       stub_request(:get, "#{ApiHelper::T3}/users/").
         to_return(body: { staffId: 1 }.to_json)
     end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe TasksController, type: :controller do
   let(:prison) { build(:prison).code }
   let(:staff_id) { 123 }
-  let(:username) { 'alice' }
   let(:pom) {
     [
       build(:pom,
@@ -16,7 +15,7 @@ RSpec.describe TasksController, type: :controller do
 
   before do
     stub_poms(prison, pom)
-    stub_signed_in_pom(prison, staff_id, username)
+    stub_signed_in_pom(prison, staff_id)
 
     offenders = [build(:nomis_offender, imprisonmentStatus: 'LIFE', offenderNo: 'G7514GW', firstName: "Alice", lastName: "Aliceson"),
                  build(:nomis_offender, offenderNo: 'G1234VV', firstName: "Bob", lastName: "Bibby"),

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -2,6 +2,10 @@ FactoryBot.define do
   # This object lives in 3 states - eligible, ineligible and discretionary(dont know)
   # The default for this factory is to make the object eligible
   factory :early_allocation do
+    prison { 'LEI' }
+    created_by_firstname { Faker::Name.first_name }
+    created_by_lastname { Faker::Name.last_name }
+
     oasys_risk_assessment_date do Time.zone.today - 2.months end
 
     convicted_under_terrorisom_act_2000 do false end

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -125,11 +125,7 @@ feature "early allocation", type: :feature do
 
         context 'with discretionary path' do
           before do
-            find('#early_allocation_extremism_separation_false').click
-            find('#early-allocation-high-risk-of-serious-harm-field').click
-            find('#early-allocation-mappa-level-2-field').click
-            find('#early-allocation-pathfinder-process-field').click
-            find('#early-allocation-other-reason-true-field').click
+            discretionary_stage2_answers
 
             click_button 'Continue'
             expect(page).not_to have_text 'The community probation team will make a decision'
@@ -141,8 +137,8 @@ feature "early allocation", type: :feature do
             expect(page).to have_css('.govuk-error-message')
 
             expect {
-              fill_in id: 'early_allocation_reason', with: 'Just because'
-              find('#early_allocation_approved').click
+              fill_in id: 'early_allocation_reason', with: Faker::Quote.famous_last_words
+              find('label[for=early_allocation_approved]').click
               click_button 'Continue'
             }.to change(EarlyAllocation, :count).by(1)
 
@@ -154,7 +150,7 @@ feature "early allocation", type: :feature do
             expect(page).to have_current_path("/prisons/#{prison}/prisoners/#{nomis_offender_id}/early_allocation.pdf")
           end
 
-          scenario 'completing the journey' do
+          scenario 'completing the journey', :js do
             click_link 'Return to prisoner page'
             expect(page).to have_content 'Waiting for community decision'
             within '#early_allocation' do
@@ -168,7 +164,7 @@ feature "early allocation", type: :feature do
             end
             expect(page).to have_text 'You must say whether the community has accepted this case or not'
 
-            find('#early_allocation_community_decision_true').click
+            find('label[for=early_allocation_community_decision_true]').click
             click_button('Save')
             expect(page).to have_text('Re-assess')
             expect(page).to have_text 'Eligible'
@@ -230,11 +226,11 @@ feature "early allocation", type: :feature do
     fill_in id: 'early_allocation_oasys_risk_assessment_date_mm', with: valid_date.month
     fill_in id: 'early_allocation_oasys_risk_assessment_date_yyyy', with: valid_date.year
 
-    find('#early-allocation-convicted-under-terrorisom-act-2000-true-field').click
-    find('#early-allocation-high-profile-field').click
-    find('#early-allocation-serious-crime-prevention-order-field').click
-    find('#early-allocation-mappa-level-3-field').click
-    find('#early-allocation-cppc-case-field').click
+    find('label[for=early-allocation-convicted-under-terrorisom-act-2000-true-field]').click
+    find('label[for=early-allocation-high-profile-field]').click
+    find('label[for=early-allocation-serious-crime-prevention-order-field]').click
+    find('label[for=early-allocation-mappa-level-3-field]').click
+    find('label[for=early-allocation-cppc-case-field]').click
   end
 
   def stage1_stage2_answers
@@ -242,10 +238,24 @@ feature "early allocation", type: :feature do
     fill_in id: 'early_allocation_oasys_risk_assessment_date_mm', with: valid_date.month
     fill_in id: 'early_allocation_oasys_risk_assessment_date_yyyy', with: valid_date.year
 
-    find('#early-allocation-convicted-under-terrorisom-act-2000-field').click
-    find('#early-allocation-high-profile-field').click
-    find('#early-allocation-serious-crime-prevention-order-field').click
-    find('#early-allocation-mappa-level-3-field').click
-    find('#early-allocation-cppc-case-field').click
+    find("label[for=early-allocation-convicted-under-terrorisom-act-2000-field]").click
+    find('label[for=early-allocation-high-profile-field]').click
+    find('label[for=early-allocation-serious-crime-prevention-order-field]').click
+    find('label[for=early-allocation-mappa-level-3-field]').click
+    find('label[for=early-allocation-cppc-case-field]').click
+  end
+
+  def discretionary_stage2_answers
+    find('label[for=early_allocation_extremism_separation_false]').click
+    find('label[for=early-allocation-high-risk-of-serious-harm-field]').click
+    find('label[for=early-allocation-mappa-level-2-field]').click
+    find('label[for=early-allocation-pathfinder-process-field]').click
+    find('label[for=early-allocation-other-reason-true-field]').click
+  end
+
+  def complete_form
+    fill_in id: 'early_allocation_reason', with: 'Just because'
+    find('label[for=early_allocation_approved]').click
+    click_button 'Continue'
   end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -71,7 +71,7 @@ module ApiHelper
       to_return(body: pom.to_json)
   end
 
-  def stub_signed_in_pom(prison, staff_id, username)
+  def stub_signed_in_pom(prison, staff_id, username = 'alice')
     stub_auth_token
     stub_sso_data(prison, username: username, role: 'ROLE_ALLOC_CASE_MGR')
     stub_request(:get, "#{T3}/users/#{username}").


### PR DESCRIPTION
This PR adds a number of new fields (particularily around created_by_* and updated_by_* to support several new pieces of functionality