### PR TITLE
Mo 269 early allocation fields

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -125,6 +125,7 @@ private
                  :stage3_validation,
                  :reason,
                  :approved]).merge(prison: active_prison_id,
+                                   created_within_referral_window: @offender.within_early_allocation_window?,
                                    created_by_firstname: @current_user.first_name,
                                    created_by_lastname: @current_user.last_name)
   end

--- a/app/jobs/auto_early_allocation_email_job.rb
+++ b/app/jobs/auto_early_allocation_email_job.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
+# This is needed as a job as the (binary) PDF has to be
+# done with deliver_now
 class AutoEarlyAllocationEmailJob < ApplicationJob
   queue_as :mailer
 
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)
     pdf = Base64.decode64 encoded_pdf
-    PomMailer.auto_early_allocation(email: offender.ldu.email_address,
+    EarlyAllocationMailer.auto_early_allocation(email: offender.ldu.email_address,
                                     prisoner_name: offender.full_name,
                                     prisoner_number: offender.offender_no,
                                     prison_name: PrisonService.name_for(prison),
                                     pdf: pdf).deliver_now
+    EmailHistory.create! nomis_offender_id: offender.offender_no,
+                         name: offender.ldu.name,
+                         email: offender.ldu.email_address,
+                         event: EmailHistory::AUTO_EARLY_ALLOCATION,
+                         prison: prison
   end
 end

--- a/app/jobs/community_early_allocation_email_job.rb
+++ b/app/jobs/community_early_allocation_email_job.rb
@@ -8,12 +8,17 @@ class CommunityEarlyAllocationEmailJob < ApplicationJob
     allocation = Allocation.find_by!(nomis_offender_id: offender_no)
     pom = PrisonOffenderManagerService.get_pom_at(prison, allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
-    PomMailer.community_early_allocation(email: offender.ldu.email_address,
+    EarlyAllocationMailer.community_early_allocation(email: offender.ldu.email_address,
                                          prisoner_name: offender.full_name,
                                          prisoner_number: offender.offender_no,
                                          pom_name: allocation.primary_pom_name,
                                          pom_email: pom.email_address,
                                          prison_name: PrisonService.name_for(prison),
                                          pdf: pdf).deliver_now
+    EmailHistory.create! nomis_offender_id: offender.offender_no,
+                         name: offender.ldu.name,
+                         email: offender.ldu.email_address,
+                         event: EmailHistory::DISCRETIONARY_EARLY_ALLOCATION,
+                         prison: prison
   end
 end

--- a/app/mailers/early_allocation_mailer.rb
+++ b/app/mailers/early_allocation_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class EarlyAllocationMailer < GovukNotifyRails::Mailer
+  def auto_early_allocation(email:, prisoner_name:, prisoner_number:, prison_name:, pdf:)
+    set_template('dfaeb1b1-26c3-4646-8ef4-1f0ebd18e2e7')
+    set_personalisation(prisoner_name: prisoner_name,
+                        prisoner_number: prisoner_number,
+                        prison_name: prison_name,
+                        link_to_document: Notifications.prepare_upload(StringIO.new(pdf)))
+
+    mail(to: email)
+  end
+
+  def community_early_allocation(email:, prisoner_name:, prisoner_number:, pom_name:, pom_email:, prison_name:, pdf:)
+    set_template('5e546d65-57ff-49e1-8fae-c955a7b1da80')
+    set_personalisation(prisoner_name: prisoner_name,
+                        prisoner_number: prisoner_number,
+                        pom_name: pom_name,
+                        pom_email_address: pom_email,
+                        prison_name: prison_name,
+                        link_to_document: Notifications.prepare_upload(StringIO.new(pdf)))
+
+    mail(to: email)
+  end
+end

--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -17,28 +17,6 @@ class PomMailer < GovukNotifyRails::Mailer
     mail(to: params[:pom_email])
   end
 
-  def auto_early_allocation(email:, prisoner_name:, prisoner_number:, prison_name:, pdf:)
-    set_template('dfaeb1b1-26c3-4646-8ef4-1f0ebd18e2e7')
-    set_personalisation(prisoner_name: prisoner_name,
-                        prisoner_number: prisoner_number,
-                        prison_name: prison_name,
-                        link_to_document: Notifications.prepare_upload(StringIO.new(pdf)))
-
-    mail(to: email)
-  end
-
-  def community_early_allocation(email:, prisoner_name:, prisoner_number:, pom_name:, pom_email:, prison_name:, pdf:)
-    set_template('5e546d65-57ff-49e1-8fae-c955a7b1da80')
-    set_personalisation(prisoner_name: prisoner_name,
-                        prisoner_number: prisoner_number,
-                        pom_name: pom_name,
-                        pom_email_address: pom_email,
-                        prison_name: prison_name,
-                        link_to_document: Notifications.prepare_upload(StringIO.new(pdf)))
-
-    mail(to: email)
-  end
-
   def responsibility_override(
     message:,
     prisoner_number:,

--- a/app/models/email_history.rb
+++ b/app/models/email_history.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class EmailHistory < ApplicationRecord
+  AUTO_EARLY_ALLOCATION = 'auto_early_allocation'
+  DISCRETIONARY_EARLY_ALLOCATION = 'discretionary_early_allocation'
+
+  validates_presence_of :name, :nomis_offender_id
+
+  validates :event, inclusion: { in: [AUTO_EARLY_ALLOCATION, DISCRETIONARY_EARLY_ALLOCATION], allow_nil: false }
+  validates :prison, inclusion: { in: PrisonService.prison_codes, allow_nil: false }
+  validates :email, presence: true, 'valid_email_2/email': true
+end

--- a/db/migrate/20201127172113_add_early_allocation_referral_fields.rb
+++ b/db/migrate/20201127172113_add_early_allocation_referral_fields.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddEarlyAllocationReferralFields < ActiveRecord::Migration[6.0]
+  def change
+    change_table :early_allocations do |t|
+      t.boolean :created_within_referral_window, null: false, default: false
+    end
+    create_table :email_histories do |t|
+      t.string :prison, null: false
+      t.string :nomis_offender_id, null: false
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :event, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_26_123414) do
+ActiveRecord::Schema.define(version: 2020_11_27_172113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,6 +134,15 @@ ActiveRecord::Schema.define(version: 2020_11_26_123414) do
     t.string "created_by_lastname"
     t.string "updated_by_firstname"
     t.string "updated_by_lastname"
+    t.boolean "created_within_referral_window", default: false, null: false
+  end
+
+  create_table "email_histories", force: :cascade do |t|
+    t.string "prison", null: false
+    t.string "nomis_offender_id", null: false
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "event", null: false
   end
 
   create_table "flipflop_features", force: :cascade do |t|

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
     ]
   }
 
-  let(:offender) { build(:nomis_offender) }
+  let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, conditionalReleaseDate: release_date)) }
+
   let(:nomis_offender_id) { offender.fetch(:offenderNo) }
 
   before do
@@ -40,6 +41,8 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
     let(:early_allocation) { assigns(:early_assignment) }
 
     describe '#show' do
+      let(:release_date) { Time.zone.today + 17.months }
+
       it 'shows the most recent' do
         get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id }, format: :pdf
         expect(early_allocation).to eq(CaseInformation.last.early_allocations.last)
@@ -47,6 +50,8 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
     end
 
     describe '#update' do
+      let(:release_date) { Time.zone.today + 17.months }
+
       it 'updates the updated_by_ fields' do
         put :update, params: { prison_id: prison, prisoner_id: nomis_offender_id }
         expect(early_allocation.updated_by_firstname).to eq(first_pom.firstName)
@@ -56,7 +61,9 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
   end
 
   describe '#new' do
-    context 'with not ldu email address' do
+    let(:release_date) { Time.zone.today + 17.months }
+
+    context 'with no ldu email address' do
       let(:ldu) { create(:local_divisional_unit, email_address: nil) }
       let(:team) { create(:team, local_divisional_unit: ldu) }
 
@@ -79,41 +86,63 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
     end
 
     context 'when stage 1' do
-      let(:date_params) {
+      let(:stage1_params) {
         { "oasys_risk_assessment_date(3i)" => valid_date.day,
           "oasys_risk_assessment_date(2i)" => valid_date.month,
           "oasys_risk_assessment_date(1i)" => valid_date.year
-        }
+        }.merge(s1_boolean_params)
       }
       let(:early_allocation) { EarlyAllocation.last }
 
-      scenario 'declares assessment complete and eligible when any one boolean true' do
-        s1_boolean_param_names.each do |field|
-          s1_boolean_params[field] = 'true'
+      context 'when > 18 months from release' do
+        let(:release_date) { Time.zone.today + 19.months }
 
+        it 'stores false in created_within_referral_window' do
           post :create, params: { prison_id: prison,
                                   prisoner_id: nomis_offender_id,
-                                  early_allocation: date_params.merge(s1_boolean_params) }
+                                  early_allocation: stage1_params.merge(high_profile: true) }
           assert_template('eligible')
-
-          expect(early_allocation.prison).to eq(prison)
-          expect(early_allocation.created_by_firstname).to eq(first_pom.firstName)
-          expect(early_allocation.created_by_lastname).to eq(first_pom.lastName)
+          expect(early_allocation.created_within_referral_window).to eq(false)
         end
       end
 
-      context 'when no booleans true' do
-        render_views
-        it 'renders the second screen of questions' do
-          post :create, params: { prison_id: prison,
-                                  prisoner_id: nomis_offender_id,
-                                  early_allocation: date_params.merge(s1_boolean_params) }
-          expect(response.body).to include('Extremism separation centres')
+      context 'when < 18 months from release' do
+        let(:release_date) { Time.zone.today + 17.months }
+
+        context 'when any one boolean true' do
+          scenario 'declares assessment complete and eligible' do
+            s1_boolean_param_names.each do |field|
+              expect {
+                post :create, params: { prison_id: prison,
+                                        prisoner_id: nomis_offender_id,
+                                        early_allocation: stage1_params.merge(field => true) }
+              }.to change(EmailHistory, :count).by(1)
+              assert_template('eligible')
+
+              expect(early_allocation.prison).to eq(prison)
+              expect(early_allocation.created_by_firstname).to eq(first_pom.firstName)
+              expect(early_allocation.created_by_lastname).to eq(first_pom.lastName)
+              expect(early_allocation.created_within_referral_window).to eq(true)
+            end
+          end
+        end
+
+        context 'when no booleans true' do
+          render_views
+          it 'renders the second screen of questions' do
+            post :create, params: { prison_id: prison,
+                                    prisoner_id: nomis_offender_id,
+                                    early_allocation: stage1_params }
+            assert_template('stage2')
+            expect(response.body).to include('Extremism separation centres')
+          end
         end
       end
     end
 
     context 'when stage 2' do
+      let(:release_date) { Time.zone.today + 17.months }
+
       let(:s2_boolean_param_names) {
         [:due_for_release_in_less_than_24months,
          :high_risk_of_serious_harm,

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -208,29 +208,33 @@ feature "early allocation", :allocation, type: :feature do
 
         context 'when stage 1 happy path - not sent' do
           before do
-            expect(PomMailer).not_to receive(:auto_early_allocation)
+            expect(EarlyAllocationMailer).not_to receive(:auto_early_allocation)
           end
 
           it 'doesnt send the email' do
-            stage1_eligible_answers
-            click_button 'Continue'
-            expect(page).to have_text('The community probation team will take responsibility for this case early')
-            expect(page).to have_text('The assessment has not been sent to the community probation team')
+            expect {
+              stage1_eligible_answers
+              click_button 'Continue'
+              expect(page).to have_text('The community probation team will take responsibility for this case early')
+              expect(page).to have_text('The assessment has not been sent to the community probation team')
+            }.not_to change(EmailHistory, :count)
           end
         end
 
         context 'with discretionary result' do
           before do
-            expect(PomMailer).not_to receive(:community_early_allocation)
+            expect(EarlyAllocationMailer).not_to receive(:community_early_allocation)
           end
 
           it 'doesnt send the email' do
-            stage1_stage2_answers
-            click_button 'Continue'
-            discretionary_stage2_answers
-            click_button 'Continue'
-            complete_form
-            expect(page).to have_text('The assessment has not been sent to the community probation team')
+            expect {
+              stage1_stage2_answers
+              click_button 'Continue'
+              discretionary_stage2_answers
+              click_button 'Continue'
+              complete_form
+              expect(page).to have_text('The assessment has not been sent to the community probation team')
+            }.not_to change(EmailHistory, :count)
           end
         end
       end

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -20,11 +20,10 @@ feature 'View a prisoner profile page', :allocation do
   context 'with an allocation' do
     before do
       create(:case_information, nomis_offender_id: 'G7998GJ', victim_liaison_officers: [build(:victim_liaison_officer)])
+      create(:allocation, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637', primary_pom_name: 'Pobno, Kath')
     end
 
-    let!(:alloc) {
-      create(:allocation, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637', primary_pom_name: 'Pobno, Kath')
-    }
+    let(:alloc) { Allocation.last }
 
     let(:initial_vlo) { VictimLiaisonOfficer.last }
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -55,6 +55,7 @@ feature 'View a prisoner profile page', :allocation do
             click_link 'Change'
           end
         end
+        find('.govuk-back-link')
         click_link 'Back'
         within '.vlo-row-1' do
           within '.change-email' do


### PR DESCRIPTION
Early allocation needs to know whether an allocation assessment was done < 18 or > 18 months - so store it in the model so it can be queried later (it's quite enough to do 'sent', as 'ineligible' assessments are not sent but can be > 18 months)

This PR added those fields, and also adds a rudimentary EmailHistory model to track emails sent to the LDU as a result