### PR TITLE
MO-203 use SPO filter for POM handovers list

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -5,7 +5,7 @@
 # e.g. PomCaseload.new().allocations
 #
 class AllocatedOffender
-  delegate :last_name, :full_name, :earliest_release_date,
+  delegate :last_name, :full_name, :earliest_release_date, :approaching_handover?,
            :sentence_start_date, :tier, to: :@offender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison,
            to: :@allocation

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -187,6 +187,22 @@ module HmppsApi
       @responsibility_override = record.responsibility
     end
 
+    def approaching_handover?
+      today = Time.zone.today
+      thirty_days_time = today + 30.days
+
+      start_date = handover_start_date
+      handover_date = responsibility_handover_date
+
+      return false if start_date.nil?
+
+      if start_date.future?
+        start_date.between?(today, thirty_days_time)
+      else
+        today.between?(start_date, handover_date)
+      end
+    end
+
     def within_early_allocation_window?
       [
           tariff_date,

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -59,14 +59,7 @@ class StaffMember
   end
 
   def pending_handover_offenders
-    one_month_time = Time.zone.today + 30.days
-
-    upcoming_offenders = allocations.map(&:offender).select { |offender|
-      start_date = offender.handover_start_date
-
-      start_date.present? &&
-          start_date.between?(Time.zone.today, one_month_time)
-    }
+    upcoming_offenders = allocations.map(&:offender).select(&:approaching_handover?)
 
     upcoming_offenders.map { |offender|
       OffenderPresenter.new(offender)

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -38,7 +38,7 @@ class SummaryService
           @buckets.fetch(:unallocated) << offender
         end
 
-        if approaching_handover?(offender)
+        if offender.approaching_handover?
           @buckets.fetch(:handovers) << offender
         end
       elsif new_arrival?(offender)
@@ -105,22 +105,6 @@ private
       offender.awaiting_allocation_for <= 2
     else
       offender.prison_arrival_date.to_date == Time.zone.today
-    end
-  end
-
-  def approaching_handover?(offender)
-    today = Time.zone.today
-    thirty_days_time = today + 30.days
-
-    start_date = offender.handover_start_date
-    handover_date = offender.responsibility_handover_date
-
-    return false if start_date.nil?
-
-    if start_date.future?
-      start_date.between?(today, thirty_days_time)
-    else
-      today.between?(start_date, handover_date)
     end
   end
 


### PR DESCRIPTION
Use the same (SPO) filter for the POM view, so that handover cases dont disappear once the handover period has started