### PR TITLE
MO-95 remove 'change' links for nDelius case info records

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -68,13 +68,14 @@ private
     find_case_info(delius_record).tap do |case_info|
       team = map_team(delius_record.team_code)
       case_info.assign_attributes(
-        com_name: map_com_name(delius_record.offender_manager),
-        crn: delius_record.crn,
-        tier: map_tier(delius_record.tier),
-      team: team,
-      case_allocation: delius_record.service_provider,
-      welsh_offender: map_welsh_offender(delius_record.ldu_code),
-      mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
+        manual_entry: false,
+      com_name: map_com_name(delius_record.offender_manager),
+      crn: delius_record.crn,
+      tier: map_tier(delius_record.tier),
+    team: team,
+    case_allocation: delius_record.service_provider,
+    welsh_offender: map_welsh_offender(delius_record.ldu_code),
+    mappa_level: map_mappa_level(delius_record.mappa, delius_record.mappa_levels)
       )
     end
   end
@@ -96,9 +97,7 @@ private
   def find_case_info(delius_record)
     CaseInformation.find_or_initialize_by(
       nomis_offender_id: delius_record.noms_no
-    ) { |item|
-      item.manual_entry = false
-    }
+    )
   end
 
   def map_mappa_level(delius_mappa, delius_mappa_levels)

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -11,7 +11,7 @@ module HmppsApi
     delegate :indeterminate_sentence?, :immigration_case?,
              to: :@sentence_type
 
-    delegate :tier, :case_allocation, :crn, :mappa_level,
+    delegate :tier, :case_allocation, :crn, :mappa_level, :manual_entry?,
              :parole_review_date, :victim_liaison_officers,
              to: :@case_information, allow_nil: true
 

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -14,7 +14,7 @@ class OffenderPresenter
            :tier, :parole_review_date, :crn, :convicted?, :ldu,
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
            :licence_expiry_date, :post_recall_release_date,
-           :victim_liaison_officers,
+           :victim_liaison_officers, :manual_entry?,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level, to: :@offender
 
   def initialize(offender)

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -35,25 +35,25 @@
       <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
     </td>
   </tr>
-  <tr class="govuk-table__row">
+  <tr class="govuk-table__row" id="welsh-offender-row">
     <td class="govuk-table__cell">Last known address in Wales</td>
     <td class="govuk-table__cell table_cell__left_align">
       <%= humanized_bool(@prisoner.welsh_offender) %>
-      <%= link_to 'Change', edit_prison_case_information_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' %>
+      <%= link_to 'Change', edit_prison_case_information_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' if @prisoner.manual_entry? %>
     </td>
   </tr>
-  <tr class="govuk-table__row">
+  <tr class="govuk-table__row" id="service-provider-row">
     <td class="govuk-table__cell">Service provider</td>
     <td class="govuk-table__cell table_cell__left_align">
       <%= service_provider_label(@prisoner.case_allocation) %>
-      <a class="govuk-link pull-right" href="<%= edit_prison_case_information_path(@prison.code, @prisoner.offender_no) %>">Change</a>
+      <%= link_to 'Change', edit_prison_case_information_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' if @prisoner.manual_entry? %>
     </td>
   </tr>
-  <tr class="govuk-table__row">
+  <tr class="govuk-table__row" id="tier-row">
     <td class="govuk-table__cell">Tiering calculation</td>
     <td class="govuk-table__cell table_cell__left_align">
     Tier <%= @prisoner.tier %>
-      <a class="govuk-link pull-right" href="<%= edit_prison_case_information_path(@prison.code, @prisoner.offender_no) %>">Change</a>
+      <%= link_to 'Change', edit_prison_case_information_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' if @prisoner.manual_entry? %>
     </td>
   </tr>
   <tr class="govuk-table__row">


### PR DESCRIPTION
When case information data has been sourced from nDelius, it makes little sense to allow the user to edit it. It can be overwritten at any time (either from the nDelius API, or from DeliusData from the spreadsheet import) so this is a confusing mis-feature