### PR TITLE
Mo 270 early allocation side bar panel

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,3 +60,9 @@ a:visited {
   color: #d4351c;
   font-weight: bold;
 }
+
+.sidebar-panel {
+  border-top: 10px solid #1d70b8;
+  border-top-width: 10px;
+  padding-top: 10px;
+}

--- a/app/views/early_allocations/_prisoner_info_sidebar.html.erb
+++ b/app/views/early_allocations/_prisoner_info_sidebar.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-column-one-third">
+  <aside class="sidebar-panel" role="complementary">
+    <h2 class="govuk-heading-m">
+      Guidance
+    </h2>
+    <nav role="navigation" aria-labelledby="subsection-title">
+      <ul class="govuk-list govuk-!-font-size-16">
+        <li>
+          <p>
+            <a class="govuk-link">
+              <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">View EQuiP guidance</a>
+            </a>
+          </p>
+        </li>
+      </ul>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <h2 class="govuk-heading-m" id="subsection-title">
+        Prisoner information
+      </h2>
+      <ul class="govuk-list govuk-!-font-size-16">
+        <li>
+          <p class="govuk-body" id="prisoner-name">Name: <%= @offender.full_name %></p>
+          <p class="govuk-body" id="date-of-birth">Date of birth: <%= format_date(@offender.date_of_birth)%></p>
+          <p class="govuk-body" id="nomis-number">NOMIS number: <%= @offender.offender_no %></p>
+        </li></ul>
+    </nav>
+  </aside>
+</div>

--- a/app/views/early_allocations/_stage1.html.erb
+++ b/app/views/early_allocations/_stage1.html.erb
@@ -4,7 +4,7 @@
              builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
 
   <p class="govuk-body">
     Some cases will be referred to the community automatically. Others need the

--- a/app/views/early_allocations/_stage2.html.erb
+++ b/app/views/early_allocations/_stage2.html.erb
@@ -4,7 +4,7 @@
              builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <%= form.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
 
   <% EarlyAllocation::STAGE1_FIELDS.each do |field| %>
     <%= form.hidden_field(field) %>

--- a/app/views/early_allocations/edit.html.erb
+++ b/app/views/early_allocations/edit.html.erb
@@ -1,14 +1,15 @@
 <% content_for :switcher do %>
   <%= render '/layouts/prison_switcher' %>
 <% end %>
-
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 <%= form_for @early_assignment,
              url: prison_prisoner_early_allocation_path(@prison.code, @early_assignment.nomis_offender_id),
              method: :put,
              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <%= form.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl govuk-!-margin-top-4">Record a decision from the community probation team about early allocation</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-4">Record a decision from the community probation team about early allocation</h1>
 
   <%= render partial: "community_decision_field", locals: { form: form,
                                                  heading_text: "What decision did the community probation team make?",
@@ -17,3 +18,6 @@
                                                  fieldname: :community_decision} %>
   <%= form.submit 'Save', role: "button", draggable: "false", class: "govuk-button" %>
 <% end %>
+  </div>
+  <%= render(partial: 'prisoner_info_sidebar') %>
+</div>

--- a/app/views/early_allocations/new.html.erb
+++ b/app/views/early_allocations/new.html.erb
@@ -1,10 +1,14 @@
 <% content_for :switcher do %>
   <%= render '/layouts/prison_switcher' %>
 <% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  <p class="govuk-body">
+    For further guidance on Early Allocation referral please see
+    <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">EQuiP</a>
+  </p>
+    <%= render 'stage1', form_method: :post %>
+  </div>
+    <%= render(partial: 'prisoner_info_sidebar') %>
+</div>
 
-<p class="govuk-body">
-  For further guidance on Early Allocation referral please see
-  <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">EQuiP</a>
-</p>
-
-<%= render 'stage1', form_method: :post %>

--- a/app/views/early_allocations/stage2.html.erb
+++ b/app/views/early_allocations/stage2.html.erb
@@ -1,5 +1,9 @@
 <% content_for :switcher do %>
   <%= render '/layouts/prison_switcher' %>
 <% end %>
-
-<%= render 'stage2', form_method: :post %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  <%= render 'stage2', form_method: :post %>
+  </div>
+  <%= render(partial: 'prisoner_info_sidebar') %>
+</div>

--- a/app/views/early_allocations/stage3.html.erb
+++ b/app/views/early_allocations/stage3.html.erb
@@ -1,14 +1,15 @@
 <% content_for :switcher do %>
   <%= render '/layouts/prison_switcher' %>
 <% end %>
-
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 <%= form_for(@early_assignment,
              url: discretionary_prison_prisoner_early_allocations_path(@prison.code, @early_assignment.nomis_offender_id),
              builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
 
   <%= form.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
 
   <% (EarlyAllocation::STAGE1_FIELDS + EarlyAllocation::ALL_STAGE2_FIELDS).each do |field| %>
     <%= form.hidden_field(field) unless form.object.public_send(field).nil? %>
@@ -17,7 +18,7 @@
 
   <div class="govuk-form-group">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-full">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             <%= form.label(:reason, 'Why are you referring this case for early allocation to the community?', class: 'govuk-label govuk-!-font-weight-bold') %>
@@ -38,4 +39,7 @@
 
   <%= form.submit "Continue", role: "button", draggable: "false", class: "govuk-button" %>
 <% end %>
+  </div>
+  <%= render(partial: 'prisoner_info_sidebar') %>
+</div>
 


### PR DESCRIPTION
This commit creates a partial for the ‘prisoner info’ sidebar panel which is displayed on pages throughout the Early Allocation journey.

It then implements this partial on existing pages:
- page 1 of the EA form
- page 2 of the EA form
-  ‘stage 3’ of the early allocation creation journey
-  ‘edit’ journey for recording community decisions on ‘discretionary’ outcomes

It still needs to be added to pages in development:
- EA start page
- when viewing a saved assessment (HTML view)

The partial can be seen in the [MOIC prototype page](https://hmpps-moic-staging.herokuapp.com/view-past-ea-forml)

It also reduced the font size on the titles on a few pages as the new partial was causing them to become a bit squashed.
 