### PR TITLE
Titleize surnames to avoid flaky test failures

### DIFF
--- a/spec/factories/keyworker.rb
+++ b/spec/factories/keyworker.rb
@@ -5,7 +5,9 @@ FactoryBot.define do
     initialize_with { HmppsApi::KeyworkerDetails.from_json(attributes) }
 
     sequence(:staffId) { |x| x + 1000  }
-    firstName { Faker::Name.first_name }
-    lastName { Faker::Name.last_name }
+    # Keyworker 'full name' is titleized as it's passed through KeyworkerDetails, e.g. "McDonald, Ronald" becomes "Mcdonald, Ronald"
+    # So we also .titleize the first and last name here to avoid breaking tests
+    firstName { Faker::Name.first_name.titleize }
+    lastName { Faker::Name.last_name.titleize }
   end
 end

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -41,7 +41,9 @@ FactoryBot.define do
     status { 'ACTIVE' }
 
     firstName { Faker::Name.first_name }
-    lastName { Faker::Name.last_name }
+    # The POM's last name is titleized as it's passed through StaffMember, e.g. "McDonald" becomes "Mcdonald"
+    # So we also .titleize the last name here to avoid breaking tests
+    lastName { Faker::Name.last_name.titleize }
     positionDescription { Faker::Company.type }
 
     trait :probation_officer do


### PR DESCRIPTION
I've adjusted the test factories for POM details and Keyworker details to 'titleize' their names correctly.

This is needed because POM and Keyworker details are passed through model classes (`StaffMember` and `KeyworkerDetails`, respectively) which transform names into 'title case' – e.g. surname 'McDonald' becomes 'Mcdonald', where the first character is uppercase and all others become lowercase.

Names are transformed into title case because they're received from NOMIS as ALL UPPERCASE. They're transformed to improve legibility within the service.

To avoid breaking test expectations – for example, where we assert that the 'created by' field contains the same name as a dummy POM created using the POM factory – we need to make sure the name doesn't change. Therefore we 'titleize' the name in the factory, so that it doesn't change once 'titleized' within the service.