### PR TITLE
Fix broken Kubernetes cron job configuration

### DIFF
--- a/deploy/preprod/cron-delius-import.yaml
+++ b/deploy/preprod/cron-delius-import.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600

--- a/deploy/preprod/cron-process-movements.yaml
+++ b/deploy/preprod/cron-process-movements.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600

--- a/deploy/production/cron-delius-import.yaml
+++ b/deploy/production/cron-delius-import.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600

--- a/deploy/production/cron-handover-chase-email-job.yaml
+++ b/deploy/production/cron-handover-chase-email-job.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600

--- a/deploy/production/cron-handover-email-job.yaml
+++ b/deploy/production/cron-handover-email-job.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600

--- a/deploy/production/cron-process-movements.yaml
+++ b/deploy/production/cron-process-movements.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600

--- a/deploy/staging/cron-integration-test-cleanup.yaml
+++ b/deploy/staging/cron-integration-test-cleanup.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -50,4 +51,3 @@ spec:
                       name: elasticache-offender-management-allocation-manager-token-cache-staging
                       key: url
           restartPolicy: OnFailure
-          ttlSecondsAfterFinished: 3600


### PR DESCRIPTION
This commit fixes 24f778a03937c42858615d3e24c45ae298c35b9f, which introduced the new config key `ttlSecondsAfterFinished` to allow Kubernetes to clean up old finished cron jobs.

I'd put the key in the wrong place, resulting in invalid Kube config. This commit moves the key to the correct place.