### PR TITLE
MO-20 remove skip_validation trait in factory

### DIFF
--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe TasksController, :allocation, type: :controller do
         create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id, prison: prison)
       end
 
-      create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: test_offender_no)
-      create(:early_allocation, :stage2, :skip_validate, nomis_offender_id: test_offender_no)
+      create(:early_allocation, :discretionary, nomis_offender_id: test_offender_no)
+      create(:early_allocation, :stage2, nomis_offender_id: test_offender_no)
 
       get :index, params: { prison_id: prison }
 
@@ -155,8 +155,8 @@ RSpec.describe TasksController, :allocation, type: :controller do
 
     it 'can show multiple types at once' do
       # One offender should have a pending early allocation
-      create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: test_offender_no)
-      create(:early_allocation, :stage2, :skip_validate, nomis_offender_id: test_offender_no)
+      create(:early_allocation, :discretionary, nomis_offender_id: test_offender_no)
+      create(:early_allocation, :stage2, nomis_offender_id: test_offender_no)
 
       get :index, params: { prison_id: prison }
 
@@ -168,11 +168,11 @@ RSpec.describe TasksController, :allocation, type: :controller do
 
     it 'can sort the results' do
       # Two offenders should have a pending early allocation
-      create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: 'G1234AB')
-      create(:early_allocation, :stage2, :skip_validate, nomis_offender_id: 'G1234AB')
+      create(:early_allocation, :discretionary, nomis_offender_id: 'G1234AB')
+      create(:early_allocation, :stage2, nomis_offender_id: 'G1234AB')
 
-      create(:early_allocation, :discretionary, :skip_validate, nomis_offender_id: 'G1234GG')
-      create(:early_allocation, :stage2, :skip_validate, nomis_offender_id: 'G1234GG')
+      create(:early_allocation, :discretionary, nomis_offender_id: 'G1234GG')
+      create(:early_allocation, :stage2, nomis_offender_id: 'G1234GG')
 
       get :index, params: { prison_id: prison, sort: 'offender_name asc' }
       expect(response).to be_successful

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -18,11 +18,9 @@ FactoryBot.define do
     association :case_information
 
     trait :discretionary do
-      cppc_case do false end
-      extremism_separation do
-        false
-      end
-      high_risk_of_serious_harm do false end
+      cppc_case { false }
+      extremism_separation { false }
+      high_risk_of_serious_harm { false }
       mappa_level_2 do false end
       pathfinder_process do false end
       other_reason do true end
@@ -32,14 +30,13 @@ FactoryBot.define do
     end
 
     trait :ineligible do
-      cppc_case do false end
-      extremism_separation do
-        false
-      end
-      high_risk_of_serious_harm do false end
-      mappa_level_2 do false end
-      pathfinder_process do false end
+      cppc_case { false }
+      extremism_separation { false }
+      high_risk_of_serious_harm { false }
+      mappa_level_2 { false }
+      pathfinder_process { false }
       other_reason { false }
+      stage2_validation { true }
     end
 
     trait :stage2 do
@@ -53,10 +50,6 @@ FactoryBot.define do
       mappa_level_2 do false end
       pathfinder_process do false end
       other_reason { false }
-    end
-
-    trait :skip_validate do
-      to_create { |instance| instance.save(validate: false) }
     end
   end
 end

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -223,7 +223,7 @@ describe HmppsApi::Offender do
         end
 
         context 'when ineligible for early allocation' do
-          let!(:early_allocation) { create(:early_allocation, :ineligible, :skip_validate, case_information: case_info) }
+          let!(:early_allocation) { create(:early_allocation, :ineligible, case_information: case_info) }
 
           it { is_expected.to be(false) }
         end


### PR DESCRIPTION
Whilst implementing MO-20, a 'skip-validate' trait was found in early_allocations factory which is confusing to read.

This PR removes it (and fixes one defect in the factory which probably led to the trait in the first place)