### PR TITLE
MO-267 >18 month early allocation doesn't change handover dates

### DIFF
--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -47,7 +47,7 @@ module HmppsApi
       return false if @case_information.blank?
 
       early_allocation = @case_information.latest_early_allocation
-      early_allocation.present? && (early_allocation.eligible? || early_allocation.community_decision?)
+      early_allocation.present? && early_allocation.created_within_referral_window? && (early_allocation.eligible? || early_allocation.community_decision?)
     end
 
     # Has a CaseInformation record been loaded for this offender?


### PR DESCRIPTION
When an early allocation is created >18 months before release, it should have no effect on the handover dates