### PR TITLE
MO-222 add EA notification to prisoner info screen

### DIFF
--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -22,7 +22,7 @@ class EarlyAllocation < ApplicationRecord
   # nomis_offender_ids of offenders who have assessments completed before 18 months prior to their release date, where
   # the assessment outcomes are 'discretionary' or 'eligible'
   scope :suitable_offenders_pre_referral_window, -> {
-    where(created_within_referral_window: false).where.not(outcome: 'ineligible').pluck(:nomis_offender_id).uniq
+    where(created_within_referral_window: false).where.not(outcome: 'ineligible')
   }
 
   STAGE1_BOOLEAN_FIELDS = [:convicted_under_terrorisom_act_2000,

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -46,8 +46,11 @@ module HmppsApi
     def early_allocation?
       return false if @case_information.blank?
 
-      early_allocation = @case_information.latest_early_allocation
-      early_allocation.present? && early_allocation.created_within_referral_window? && (early_allocation.eligible? || early_allocation.community_decision?)
+      early_allocation.present?
+    end
+
+    def needs_early_allocation_notify?
+      has_case_information? && within_early_allocation_window? && @case_information.early_allocations.suitable_offenders_pre_referral_window.any?
     end
 
     # Has a CaseInformation record been loaded for this offender?
@@ -221,6 +224,11 @@ module HmppsApi
                     else
                       HandoverDateService::NO_HANDOVER_DATE
                     end
+    end
+
+    def early_allocation
+      allocation = @case_information&.latest_early_allocation
+      allocation if allocation.present? && (allocation.created_within_referral_window? && allocation.eligible? || allocation.community_decision?)
     end
   end
 end

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -5,6 +5,7 @@ class OffenderPresenter
            :indeterminate_sentence?, :describe_sentence,
            :full_name_ordered, :full_name, :main_offence,
            :sentence_start_date, :team_name, :prison_id,
+           :needs_early_allocation_notify?,
            :home_detention_curfew_eligibility_date, :home_detention_curfew_actual_date,
            :tariff_date, :responsibility_override?,
            :date_of_birth, :release_date, :parole_eligibility_date,

--- a/app/views/layouts/_info_banner.html.erb
+++ b/app/views/layouts/_info_banner.html.erb
@@ -1,0 +1,8 @@
+<div class="moj-banner">
+  <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
+  </svg>
+  <div class="moj-banner__message">
+    <%= yield :info_banner %>
+  </div>
+</div>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -8,6 +8,14 @@
   %>
 <% end %>
 
+<% if @prisoner.needs_early_allocation_notify? %>
+  <% content_for :info_banner do %>
+    <%= @prisoner.full_name %> might be eligible for early allocation to the community probation team.
+    You must now <%= link_to 'check and carry out a new assessment', new_prison_prisoner_early_allocations_path(@prison.code, @prisoner.offender_no), class: 'govuk-link' %>
+  <% end %>
+  <%= render '/layouts/info_banner' %>
+<% end %>
+
 <div class="govuk-grid-row govuk-!-margin-bottom-5">
   <div class="govuk-grid-column-one-quarter">
     <img src="<%= prison_prisoner_image_path(@prison.code, @prisoner.offender_no, format: :jpg) %>" alt="Prisoner photo will be here" width="95%">

--- a/lib/tasks/early_allocation_suitability_email.rake
+++ b/lib/tasks/early_allocation_suitability_email.rake
@@ -5,7 +5,7 @@ require 'rake'
 namespace :early_allocation_suitability_email do
   desc 'Send emails to allocated POMs whose offenders have Early Allocation assessment forms due to be reviewed now'
   task process: :environment do
-    offenders = EarlyAllocation.suitable_offenders_pre_referral_window
+    offenders = EarlyAllocation.suitable_offenders_pre_referral_window.pluck(:nomis_offender_id).uniq
 
     offenders.each do |offender|
       SuitableForEarlyAllocationEmailJob(offender).perform_later

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe EarlyAllocation, type: :model do
       create(:early_allocation, :discretionary, created_within_referral_window: true)
       create(:early_allocation, created_within_referral_window: true)
 
-      expect(described_class.suitable_offenders_pre_referral_window).to match_array([discretionary_outside_referral.nomis_offender_id,
-                                                                                     eligible_outside_referral.nomis_offender_id])
+      expect(described_class.suitable_offenders_pre_referral_window).to match_array([discretionary_outside_referral,
+                                                                                     eligible_outside_referral])
     end
   end
 end


### PR DESCRIPTION
Add a notification to the prisoner info screen when there is an early allocation that needs to be followed up as we are now within the handover window