### PR TITLE
Don't try to push unmatched offenders into nDelius

### DIFF
--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -27,8 +27,12 @@ class CalculatedHandoverDate < ApplicationRecord
 private
 
   def push_to_delius
-    # Only push if the dates have changed
+    # Don't push if the dates haven't changed
     return unless saved_change_to_start_date? || saved_change_to_handover_date?
+
+    # Don't push if the CaseInformation record is a manual entry (meaning it didn't match against nDelius)
+    # This avoids 404 Not Found errors for offenders who don't exist in nDelius (they could be Scottish, etc.)
+    return if case_information.manual_entry
 
     HmppsApi::CommunityApi.set_handover_dates(
       offender_no: nomis_offender_id,

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
   context "when the offender exists in both NOMIS and nDelius (happy path)" do
     before do
       stub_offender(nomis_offender)
-      create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+      create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS', manual_entry: false)
     end
 
     it "recalculates the offender's handover dates" do


### PR DESCRIPTION
This commit stops the `CalculatedHandoverDate` model from attempting to push handover dates into nDelius for offenders who haven't successfully matched against nDelius.

This should reduce the number of 404 Not Found errors caused when pushing handover dates.

It's perfectly legitimate for offenders not to exist in nDelius. Since nDelius is only for the English and Welsh probation services, offenders under the Scottish or Northern Irish probation services will not be present in nDelius, and so we shouldn't attempt to push their handover dates into nDelius.