### PR TITLE
Mo 220 Early Allocation Suitability email cron job

### DIFF
--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class SuitableForEarlyAllocationEmailJob < ApplicationJob
+  queue_as :mailer
+
+  EQUIP_URL = 'https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777'
+
+  def perform
+    offenders = EarlyAllocation.where(created_within_referral_window: false).where.not(outcome: 'ineligible').pluck(:nomis_offender_id).uniq
+
+    offenders.each do |offender_no|
+      allocation = Allocation.where(nomis_offender_id: offender_no).first
+      next if allocation.nil?
+
+      prisoner = OffenderService.get_offender(offender_no)
+      if !prisoner.nil? && eligible_today?(prisoner)
+        pom = PrisonOffenderManagerService.get_pom_at(prisoner.prison_id, allocation.primary_pom_nomis_id)
+        EarlyAllocationMailer.review_early_allocation(
+          email: pom.email_address,
+          prisoner_name: prisoner.full_name,
+          start_page_link: Rails.application.routes.url_helpers.prison_prisoner_early_allocations_path(
+            prison_id: prisoner.prison_id,
+            prisoner_id: prisoner.offender_no),
+          equip_guidance_link: EQUIP_URL).deliver_now
+      end
+    end
+  end
+
+private
+
+  def eligible_today?(offender)
+    [
+      offender.tariff_date,
+      offender.parole_eligibility_date,
+      offender.parole_review_date,
+      offender.automatic_release_date,
+      offender.conditional_release_date
+    ].compact.min == Time.zone.today + 18.months
+  end
+end

--- a/app/mailers/early_allocation_mailer.rb
+++ b/app/mailers/early_allocation_mailer.rb
@@ -22,4 +22,12 @@ class EarlyAllocationMailer < GovukNotifyRails::Mailer
 
     mail(to: email)
   end
+
+  def review_early_allocation(email:, prisoner_name:, start_page_link:, equip_guidance_link:)
+    set_template('502e057c-a875-4653-9b33-63dcfd33e582')
+    set_personalisation(prisoner_name: prisoner_name,
+                        start_page_link: start_page_link,
+                        equip_guidance_link: equip_guidance_link)
+    mail(to: email)
+  end
 end

--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -19,6 +19,12 @@ class EarlyAllocation < ApplicationRecord
               allow_nil: true
             }
 
+  # nomis_offender_ids of offenders who have assessments completed before 18 months prior to their release date, where
+  # the assessment outcomes are 'discretionary' or 'eligible'
+  scope :suitable_offenders_pre_referral_window, -> {
+    where(created_within_referral_window: false).where.not(outcome: 'ineligible').pluck(:nomis_offender_id).uniq
+  }
+
   STAGE1_BOOLEAN_FIELDS = [:convicted_under_terrorisom_act_2000,
                            :high_profile,
                            :serious_crime_prevention_order,

--- a/app/models/email_history.rb
+++ b/app/models/email_history.rb
@@ -3,10 +3,13 @@
 class EmailHistory < ApplicationRecord
   AUTO_EARLY_ALLOCATION = 'auto_early_allocation'
   DISCRETIONARY_EARLY_ALLOCATION = 'discretionary_early_allocation'
+  SUITABLE_FOR_EARLY_ALLOCATION = 'suitable_for_early_allocation'
 
   validates_presence_of :name, :nomis_offender_id
 
-  validates :event, inclusion: { in: [AUTO_EARLY_ALLOCATION, DISCRETIONARY_EARLY_ALLOCATION], allow_nil: false }
+  validates :event, inclusion: { in: [AUTO_EARLY_ALLOCATION,
+                                      DISCRETIONARY_EARLY_ALLOCATION,
+                                      SUITABLE_FOR_EARLY_ALLOCATION], allow_nil: false }
   validates :prison, inclusion: { in: PrisonService.prison_codes, allow_nil: false }
   validates :email, presence: true, 'valid_email_2/email': true
 end

--- a/deploy/production/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/production/cron-early-allocation-suitability-email-job.yaml
@@ -3,12 +3,13 @@ kind: CronJob
 metadata:
   name: early-allocation-suitability-email-job
 spec:
-  schedule: "55 11 17 12 *"
+  schedule: "30 4 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:
@@ -47,6 +48,6 @@ spec:
                 - name: REDIS_URL
                   valueFrom:
                     secretKeyRef:
-                      name: elasticache-offender-management-allocation-manager-token-cache-staging
+                      name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
           restartPolicy: OnFailure

--- a/deploy/staging/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/staging/cron-early-allocation-suitability-email-job.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: early-allocation-suitability-email-job
+spec:
+  schedule: "55 11 11 12 *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: early-allocation-suitability-email-job
+              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:testing
+              imagePullPolicy: Always
+              command: ['sh', '-c', "bundle exec rake early_allocation_suitability_email:process"]
+              envFrom:
+                - configMapRef:
+                    name: shared-environment
+                - secretRef:
+                    name: allocation-manager-secrets
+              env:
+                - name: PROMETHEUS_METRICS
+                  value: "off"
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: rds_instance_address
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_password
+                - name: POSTGRES_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_name
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: allocation-rds-instance-output
+                      key: postgres_user
+                - name: REDIS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: elasticache-offender-management-allocation-manager-token-cache-staging
+                      key: url
+          restartPolicy: OnFailure

--- a/deploy/staging/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/staging/cron-early-allocation-suitability-email-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: early-allocation-suitability-email-job
 spec:
-  schedule: "55 11 11 12 *"
+  schedule: "55 11 14 12 *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: early-allocation-suitability-email-job
-              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:testing
+              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake early_allocation_suitability_email:process"]
               envFrom:

--- a/deploy/staging/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/staging/cron-early-allocation-suitability-email-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: early-allocation-suitability-email-job
 spec:
-  schedule: "55 11 14 12 *"
+  schedule: "55 11 15 12 *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/lib/tasks/early_allocation_suitability_email.rake
+++ b/lib/tasks/early_allocation_suitability_email.rake
@@ -5,6 +5,10 @@ require 'rake'
 namespace :early_allocation_suitability_email do
   desc 'Send emails to allocated POMs whose offenders have Early Allocation assessment forms due to be reviewed now'
   task process: :environment do
-    SuitableForEarlyAllocationEmailJob.perform_later
+    offenders = EarlyAllocation.suitable_offenders_pre_referral_window
+
+    offenders.each do |offender|
+      SuitableForEarlyAllocationEmailJob(offender).perform_later
+    end
   end
 end

--- a/lib/tasks/early_allocation_suitability_email.rake
+++ b/lib/tasks/early_allocation_suitability_email.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :early_allocation_suitability_email do
+  desc 'Send emails to allocated POMs whose offenders have Early Allocation assessment forms due to be reviewed now'
+  task process: :environment do
+    SuitableForEarlyAllocationEmailJob.perform_later
+  end
+end

--- a/spec/factories/email_history.rb
+++ b/spec/factories/email_history.rb
@@ -1,0 +1,36 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :email_history do
+    prison do
+      'LEI'
+    end
+
+    sequence(:nomis_offender_id) do |seq|
+      number = seq / 26 + 1000
+      letter = ('A'..'Z').to_a[seq % 26]
+      # This and the offender should produce different values to avoid clashes
+      "T#{number}C#{letter}"
+    end
+
+    name do
+      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+    end
+
+    email do
+      Faker::Internet.email
+    end
+
+    trait :auto_early_allocation do
+      event { EmailHistory::AUTO_EARLY_ALLOCATION }
+    end
+
+    trait :discretionary_early_allocation do
+      event { EmailHistory::DISCRETIONARY_EARLY_ALLOCATION }
+    end
+
+    trait :suitable_early_allocation do
+      event { EmailHistory::SUITABLE_FOR_EARLY_ALLOCATION }
+    end
+  end
+end

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
+  let(:offender) do
+    build(:offender, :determinate, latestLocationId: 'LEI',
+          sentence: build(:sentence_detail,
+                          sentenceStartDate: Time.zone.today - 10.months,
+                          conditionalReleaseDate: release_date,
+                          automaticReleaseDate: release_date,
+                          releaseDate: release_date,
+                          tariffDate: nil))
+  end
+
+  before do
+    create(:case_information, nomis_offender_id: offender.offender_no)
+    create(:allocation, nomis_offender_id: offender.offender_no)
+    allow(OffenderService).to receive(:get_offender).and_return(offender)
+  end
+
+  context 'when form created within the referral window (within 18 months to release)' do
+    let(:release_date) { Time.zone.today + 8.months }
+
+    it 'does not send email' do
+      early_alloc_form = create(:early_allocation, :discretionary,
+                                created_within_referral_window: offender.within_early_allocation_window?,
+                                nomis_offender_id:  offender.offender_no)
+
+      expect(early_alloc_form.created_within_referral_window).to eq(true)
+      expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+      described_class.perform_now
+    end
+  end
+
+  context 'when form created outside of the referral window (more than 18 months to release)' do
+    context 'when form outcome is ineligible' do
+      let(:release_date) { Time.zone.today + 28.months }
+
+      it 'does not send email' do
+        create(:early_allocation, :ineligible, created_within_referral_window: false, nomis_offender_id: offender.offender_no)
+
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now
+      end
+    end
+
+    context 'when offender is not allocated to a POM' do
+      let(:release_date) { Time.zone.today + 17.months }
+
+      before do
+        Allocation.first.destroy
+      end
+
+      it 'does not send email' do
+        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+               created_within_referral_window: false, nomis_offender_id: offender.offender_no)
+
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now
+      end
+    end
+
+    context 'when offender not found in NOMIS' do
+      let(:release_date) { Time.zone.today + 17.months }
+
+      before do
+        allow(OffenderService).to receive(:get_offender).and_return(nil)
+      end
+
+      it 'does not send email' do
+        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+               created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now
+      end
+    end
+
+    context 'when offender has more than 18 months of sentence remaining' do
+      let(:release_date) { Time.zone.today + 19.months }
+
+      it 'does not send email' do
+        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+               created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now
+      end
+    end
+
+    context 'when offender has exactly 18 months of sentence remaining' do
+      let(:release_date) { Time.zone.today + 18.months }
+      let(:pom) { build(:pom) }
+
+      before do
+        create(:allocation, nomis_offender_id: offender.offender_no, primary_pom_nomis_id: pom.staff_id, primary_pom_name: pom.full_name)
+        allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+      end
+
+      it 'sends email' do
+        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+               created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+
+        expect_any_instance_of(EarlyAllocationMailer).to receive(:review_early_allocation).with(
+          email: pom.email_address,
+          prisoner_name: offender.full_name,
+          start_page_link: "/prisons/#{offender.prison_id}/prisoners/#{offender.offender_no}/early_allocations",
+          equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
+        ).and_call_original
+
+        described_class.perform_now
+      end
+    end
+  end
+end

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
+  let(:pom) { build(:pom) }
+
   let(:offender) do
     build(:offender, :determinate, latestLocationId: 'LEI',
           sentence: build(:sentence_detail,
@@ -24,27 +26,13 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
              created_within_referral_window: false, nomis_offender_id: offender.offender_no)
 
       expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-      described_class.perform_now
+      described_class.perform_now(offender.offender_no)
     end
   end
 
   context 'when offender is allocated to a POM' do
     before do
-      create(:allocation, nomis_offender_id: offender.offender_no)
-    end
-
-    context 'when form created within the referral window (within 18 months to release)' do
-      let(:release_date) { Time.zone.today + 8.months }
-
-      it 'does not send email' do
-        early_alloc_form = create(:early_allocation, :discretionary,
-                                  created_within_referral_window: offender.within_early_allocation_window?,
-                                  nomis_offender_id:  offender.offender_no)
-
-        expect(early_alloc_form.created_within_referral_window).to eq(true)
-        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-        described_class.perform_now
-      end
+      create(:allocation, nomis_offender_id: offender.offender_no, primary_pom_nomis_id: pom.staff_id, primary_pom_name: pom.full_name)
     end
 
     context 'when form created outside of the referral window (more than 18 months to release)' do
@@ -55,7 +43,7 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
           create(:early_allocation, :ineligible, created_within_referral_window: false, nomis_offender_id: offender.offender_no)
 
           expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-          described_class.perform_now
+          described_class.perform_now(offender.offender_no)
         end
       end
 
@@ -71,7 +59,7 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
                  created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
 
           expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-          described_class.perform_now
+          described_class.perform_now(offender.offender_no)
         end
       end
 
@@ -83,19 +71,17 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
                  created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
 
           expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-          described_class.perform_now
+          described_class.perform_now(offender.offender_no)
         end
       end
 
       context 'when offender has 18 months or less of sentence remaining' do
+        before do
+          allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+        end
+
         context 'when no previous Early Allocation reminder email sent for this offender' do
           let(:release_date) { Time.zone.today + 18.months }
-          let(:pom) { build(:pom) }
-
-          before do
-            create(:allocation, nomis_offender_id: offender.offender_no, primary_pom_nomis_id: pom.staff_id, primary_pom_name: pom.full_name)
-            allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
-          end
 
           it 'sends email' do
             create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
@@ -108,24 +94,44 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
               equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
             ).and_call_original
 
-            expect { described_class.perform_now }.to change(EmailHistory, :count).by(1)
+            expect { described_class.perform_now(offender.offender_no) }.to change(EmailHistory, :count).by(1)
           end
         end
 
-        context 'when previous Early Allocation reminder email sent for this offenders' do
+        context 'when there are previous Early Allocation reminders emails sent for this offenders' do
           let(:release_date) { Time.zone.today + 17.months }
 
-          before do
-            create(:allocation, nomis_offender_id: offender.offender_no)
-            create(:email_history, :suitable_early_allocation, nomis_offender_id: offender.offender_no)
+          context 'when the email relates to the current sentence' do
+            before do
+              create(:email_history, :suitable_early_allocation, nomis_offender_id: offender.offender_no)
+            end
+
+            it 'does not send email if email previously sent' do
+              create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+                     created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+
+              expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+              expect { described_class.perform_now(offender.offender_no) }.to change(EmailHistory, :count).by(0)
+            end
           end
 
-          it 'does not send email if email previously sent' do
-            create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                   created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+          context 'when the email relates to the offenders previous sentence' do
+            before do
+              create(:email_history, :suitable_early_allocation, nomis_offender_id: offender.offender_no, created_at: Time.zone.today - 3.years)
+            end
 
-            expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-            expect { described_class.perform_now }.to change(EmailHistory, :count).by(0)
+            it 'does send email' do
+              create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+                     created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+              expect_any_instance_of(EarlyAllocationMailer).to receive(:review_early_allocation).with(
+                email: pom.email_address,
+                prisoner_name: offender.full_name,
+                start_page_link: "http://localhost:3000/prisons/#{offender.prison_id}/prisoners/#{offender.offender_no}/early_allocations",
+                equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
+                ).and_call_original
+
+              expect { described_class.perform_now(offender.offender_no) }.to change(EmailHistory, :count).by(1)
+            end
           end
         end
       end

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -13,101 +13,102 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
 
   before do
     create(:case_information, nomis_offender_id: offender.offender_no)
-    create(:allocation, nomis_offender_id: offender.offender_no)
     allow(OffenderService).to receive(:get_offender).and_return(offender)
   end
 
-  context 'when form created within the referral window (within 18 months to release)' do
-    let(:release_date) { Time.zone.today + 8.months }
+  context 'when offender is not allocated to a POM' do
+    let(:release_date) { Time.zone.today + 17.months }
 
     it 'does not send email' do
-      early_alloc_form = create(:early_allocation, :discretionary,
-                                created_within_referral_window: offender.within_early_allocation_window?,
-                                nomis_offender_id:  offender.offender_no)
+      create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+             created_within_referral_window: false, nomis_offender_id: offender.offender_no)
 
-      expect(early_alloc_form.created_within_referral_window).to eq(true)
       expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
       described_class.perform_now
     end
   end
 
-  context 'when form created outside of the referral window (more than 18 months to release)' do
-    context 'when form outcome is ineligible' do
-      let(:release_date) { Time.zone.today + 28.months }
+  context 'when offender is allocated to a POM' do
+    before do
+      create(:allocation, nomis_offender_id: offender.offender_no)
+    end
+
+    context 'when form created within the referral window (within 18 months to release)' do
+      let(:release_date) { Time.zone.today + 8.months }
 
       it 'does not send email' do
-        create(:early_allocation, :ineligible, created_within_referral_window: false, nomis_offender_id: offender.offender_no)
+        early_alloc_form = create(:early_allocation, :discretionary,
+                                  created_within_referral_window: offender.within_early_allocation_window?,
+                                  nomis_offender_id:  offender.offender_no)
 
+        expect(early_alloc_form.created_within_referral_window).to eq(true)
         expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
         described_class.perform_now
       end
     end
 
-    context 'when offender is not allocated to a POM' do
-      let(:release_date) { Time.zone.today + 17.months }
+    context 'when form created outside of the referral window (more than 18 months to release)' do
+      context 'when form outcome is ineligible' do
+        let(:release_date) { Time.zone.today + 28.months }
 
-      before do
-        Allocation.first.destroy
+        it 'does not send email' do
+          create(:early_allocation, :ineligible, created_within_referral_window: false, nomis_offender_id: offender.offender_no)
+
+          expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+          described_class.perform_now
+        end
       end
 
-      it 'does not send email' do
-        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-               created_within_referral_window: false, nomis_offender_id: offender.offender_no)
+      context 'when offender not found in NOMIS' do
+        let(:release_date) { Time.zone.today + 17.months }
 
-        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-        described_class.perform_now
-      end
-    end
+        before do
+          allow(OffenderService).to receive(:get_offender).and_return(nil)
+        end
 
-    context 'when offender not found in NOMIS' do
-      let(:release_date) { Time.zone.today + 17.months }
+        it 'does not send email' do
+          create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+                 created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
 
-      before do
-        allow(OffenderService).to receive(:get_offender).and_return(nil)
-      end
-
-      it 'does not send email' do
-        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-               created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
-
-        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-        described_class.perform_now
-      end
-    end
-
-    context 'when offender has more than 18 months of sentence remaining' do
-      let(:release_date) { Time.zone.today + 19.months }
-
-      it 'does not send email' do
-        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-               created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
-
-        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-        described_class.perform_now
-      end
-    end
-
-    context 'when offender has exactly 18 months of sentence remaining' do
-      let(:release_date) { Time.zone.today + 18.months }
-      let(:pom) { build(:pom) }
-
-      before do
-        create(:allocation, nomis_offender_id: offender.offender_no, primary_pom_nomis_id: pom.staff_id, primary_pom_name: pom.full_name)
-        allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+          expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+          described_class.perform_now
+        end
       end
 
-      it 'sends email' do
-        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-               created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+      context 'when offender has more than 18 months of sentence remaining' do
+        let(:release_date) { Time.zone.today + 19.months }
 
-        expect_any_instance_of(EarlyAllocationMailer).to receive(:review_early_allocation).with(
-          email: pom.email_address,
-          prisoner_name: offender.full_name,
-          start_page_link: "/prisons/#{offender.prison_id}/prisoners/#{offender.offender_no}/early_allocations",
-          equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
-        ).and_call_original
+        it 'does not send email' do
+          create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+                 created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
 
-        described_class.perform_now
+          expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+          described_class.perform_now
+        end
+      end
+
+      context 'when offender has exactly 18 months of sentence remaining' do
+        let(:release_date) { Time.zone.today + 18.months }
+        let(:pom) { build(:pom) }
+
+        before do
+          create(:allocation, nomis_offender_id: offender.offender_no, primary_pom_nomis_id: pom.staff_id, primary_pom_name: pom.full_name)
+          allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+        end
+
+        it 'sends email' do
+          create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+                 created_within_referral_window: false, nomis_offender_id:  offender.offender_no)
+
+          expect_any_instance_of(EarlyAllocationMailer).to receive(:review_early_allocation).with(
+            email: pom.email_address,
+            prisoner_name: offender.full_name,
+            start_page_link: "http://localhost:3000/prisons/#{offender.prison_id}/prisoners/#{offender.offender_no}/early_allocations",
+            equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
+          ).and_call_original
+
+          expect { described_class.perform_now }.to change(EmailHistory, :count).by(1)
+        end
       end
     end
   end

--- a/spec/mailers/early_allocation_mailer_spec.rb
+++ b/spec/mailers/early_allocation_mailer_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe EarlyAllocationMailer, type: :mailer do
+  describe 'review_early_allocation' do
+    let(:params) do
+      {
+      prisoner_name: "Brown, James",
+      start_page_link: prison_prisoner_early_allocations_path(prison_id: "LEI", prisoner_id: "T1000AA"),
+      equip_guidance_link: "http://www.equip_guidance_link.html",
+      email: "ursula.richards@thelighthouse.gov.uk"
+      }
+    end
+
+    let(:mail) { described_class.review_early_allocation(params) }
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template).to eq('502e057c-a875-4653-9b33-63dcfd33e582')
+    end
+
+    it 'sets the To address of the email using the provided user' do
+      expect(mail.to).to eq([params[:email]])
+    end
+
+    it 'personalises the email' do
+      expect(mail.govuk_notify_personalisation).
+      to eq(prisoner_name: params[:prisoner_name],
+            start_page_link: "/prisons/LEI/prisoners/T1000AA/early_allocations",
+            equip_guidance_link: params[:equip_guidance_link]
+         )
+    end
+  end
+end

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -128,4 +128,17 @@ RSpec.describe EarlyAllocation, type: :model do
       end
     end
   end
+
+  describe '#suitable_offenders_pre_referral_window' do
+    it 'selects only those assessments that are NOT ineligible and were created before the referral window' do
+      discretionary_outside_referral = create(:early_allocation, :discretionary, outcome: 'discretionary', created_within_referral_window: false)
+      eligible_outside_referral = create(:early_allocation, created_within_referral_window: false)
+      create(:early_allocation, :ineligible)
+      create(:early_allocation, :discretionary, created_within_referral_window: true)
+      create(:early_allocation, created_within_referral_window: true)
+
+      expect(described_class.suitable_offenders_pre_referral_window).to match_array([discretionary_outside_referral.nomis_offender_id,
+                                                                                     eligible_outside_referral.nomis_offender_id])
+    end
+  end
 end


### PR DESCRIPTION
This PR identifies the POM's that have offenders with: 

- Early Allocation assessment forms with the outcome of 'discretionary' or 'eligible'

- that were previously completed before the offenders had 18 months left to serve of their sentence 

- and now have exactly 18 months left until release. 

At this point we email the POM to remind them of their offenders that meets this criteria and ask that they review the Early Allocation assessment form/s.