### PR TITLE
MO-11: Early Allocations start page

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -3,6 +3,10 @@
 class EarlyAllocationsController < PrisonsApplicationController
   before_action :load_prisoner
 
+  def index
+    @early_allocations = EarlyAllocation.where(offender_id_from_url).order(created_at: :desc)
+  end
+
   def new
     case_info = CaseInformation.find_by offender_id_from_url
     @early_assignment = case_info.early_allocations.new
@@ -61,7 +65,7 @@ class EarlyAllocationsController < PrisonsApplicationController
   end
 
   def show
-    @early_assignment = EarlyAllocation.where(offender_id_from_url).last
+    @early_assignment = EarlyAllocation.where(id: params[:id]).where(offender_id_from_url).first!
     @referrer = request.referer
 
     respond_to do |format|

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -22,12 +22,7 @@ class PrisonersController < PrisonsApplicationController
       active_prison_id, @prisoner.offender_no
     )
 
-    case_information = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: id_for_show_action)
-    # Only show an early allocation if it was completed after sentence start
-    if case_information.present? && case_information.latest_early_allocation.present? &&
-      case_information.latest_early_allocation.updated_at > @offender.sentence_start_date
-      @early_allocation = case_information.latest_early_allocation
-    end
+    @case_info = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: id_for_show_action)
   end
 
   def image

--- a/app/helpers/early_allocation_helper.rb
+++ b/app/helpers/early_allocation_helper.rb
@@ -1,11 +1,72 @@
 # frozen_string_literal: true
 
 module EarlyAllocationHelper
-  def early_allocation_status(early_allocation)
-    if early_allocation.present?
-      active_status(early_allocation)
-    else
+  def early_allocation_status(early_allocations, offender)
+    most_recent = early_allocations.last
+    indicative_assessments = early_allocations.select { |ea| %w[eligible discretionary].include?(ea.outcome) }
+
+    if early_allocations.empty?
+      # No assessments done yet
       'Not assessed'
+
+    elsif !offender.within_early_allocation_window?
+      # Offender is not within referral window
+      'Has saved assessments'
+
+    elsif !most_recent.created_within_referral_window && indicative_assessments.any?
+      # A previous assessment was eligible or discretionary, indicating the offender may now be eligible
+      'New assessment required'
+
+    elsif most_recent.community_decision_eligible_or_automatically_eligible?
+      # Assessment was done within the 18 month referral window, and it was eligible
+      'Eligible - case handover date has been updated'
+
+    elsif most_recent.awaiting_community_decision?
+      # Assessment was done within the 18 month referral window, but is awaiting a community decision
+      'Discretionary - the community probation team will make a decision'
+
+    else
+      # The Early Allocation was not eligible, or the community rejected it
+      'Has saved assessments'
+    end
+  end
+
+  def early_allocation_action_link(early_allocations, offender, prison)
+    most_recent = early_allocations.last
+    start_page = prison_prisoner_early_allocations_path(prison.code, offender.offender_no)
+    check_and_reassess = link_to 'Check and reassess', start_page
+
+    if early_allocations.empty?
+      # No assessment done yet
+      link_to 'Start assessment', start_page
+
+    elsif !offender.within_early_allocation_window? || !most_recent.created_within_referral_window
+      # Offender is not within referral window, or the latest assessment wasn't done within the 18 month referral window
+      check_and_reassess
+
+    elsif most_recent.community_decision_eligible_or_automatically_eligible?
+      # Assessment was eligible
+      view_assessment = prison_prisoner_early_allocation_path(prison.code, offender.offender_no, most_recent.id)
+      link_to 'View assessment', view_assessment
+
+    elsif most_recent.awaiting_community_decision?
+      # Waiting for a community decision
+      record_decision = edit_prison_prisoner_latest_early_allocation_path(prison.code, offender.offender_no)
+      link_to 'Record community decision', record_decision
+
+    else
+      # The Early Allocation was not eligible, or the community rejected it
+      check_and_reassess
+    end
+  end
+
+  def early_allocation_outcome(early_allocation)
+    if early_allocation.community_decision_eligible_or_automatically_eligible?
+      'Eligible'
+    elsif early_allocation.discretionary? && early_allocation.community_decision.nil?
+      'Waiting for community decision'
+    else
+      'Not eligible'
     end
   end
 
@@ -25,7 +86,6 @@ module EarlyAllocationHelper
     end
   end
 
-
   DESCRIPTIONS = {
       convicted_under_terrorisom_act_2000: 'Convicted under Terrorism Act 2000',
       high_profile: 'Identified as \'high profile\'',
@@ -41,21 +101,5 @@ module EarlyAllocationHelper
 
   def pom_full_name(early_allocation)
     "#{early_allocation.created_by_lastname}, #{early_allocation.created_by_firstname}"
-  end
-
-private
-
-  def active_status(early_allocation)
-    if early_allocation.eligible?
-      'Eligible'
-    elsif early_allocation.ineligible?
-      'Not eligible'
-    elsif early_allocation.community_decision.nil?
-      'Waiting for community decision'
-    elsif early_allocation.community_decision?
-      'Eligible'
-    else
-      'Not eligible'
-    end
   end
 end

--- a/app/helpers/early_assignment_pdf_helper.rb
+++ b/app/helpers/early_assignment_pdf_helper.rb
@@ -144,7 +144,7 @@ private
     pdf.text "Assessment date #{format_date(early_allocation.updated_at)}", size: 20
 
     pdf.move_down 10
-    pdf.table([['Assessment outcome',  early_allocation_status(early_allocation)]],
+    pdf.table([['Assessment outcome',  early_allocation_outcome(early_allocation)]],
               column_widths: column_widths,
               cell_style: { padding: 15, border_width: 2 }) do
       column(0).style(borders: [:left, :top, :bottom], font_style: :bold)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -13,6 +13,7 @@ class CaseInformation < ApplicationRecord
   belongs_to :local_delivery_unit, optional: true
 
   has_many :early_allocations,
+           -> { order(created_at: :asc) },
            foreign_key: :nomis_offender_id,
            primary_key: :nomis_offender_id,
            inverse_of: :case_information,

--- a/app/presenters/offender_presenter.rb
+++ b/app/presenters/offender_presenter.rb
@@ -16,6 +16,7 @@ class OffenderPresenter
            :handover_start_date, :responsibility_handover_date, :handover_reason, :prison_arrival_date,
            :licence_expiry_date, :post_recall_release_date,
            :victim_liaison_officers, :manual_entry?,
+           :within_early_allocation_window?,
            :over_18?, :recalled?, :sentenced?, :immigration_case?, :mappa_level, to: :@offender
 
   def initialize(offender)

--- a/app/views/early_allocations/_early_allocations_list.html.erb
+++ b/app/views/early_allocations/_early_allocations_list.html.erb
@@ -1,0 +1,26 @@
+<% if early_allocations.present? %>
+  <table class="govuk-table" id="saved_assessments">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Assessment date</th>
+      <th scope="col" class="govuk-table__header">Outcome</th>
+      <th scope="col" class="govuk-table__header">POM name</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% early_allocations.each do |early_allocation| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= format_date(early_allocation.created_at) %></td>
+        <td class="govuk-table__cell"><%= early_allocation_long_outcome(early_allocation) %></td>
+        <td class="govuk-table__cell"><%= pom_full_name(early_allocation) %></td>
+        <td class="govuk-table__cell">
+          <%= link_to "View", prison_prisoner_early_allocation_path(prison_id, prisoner_id, early_allocation.id) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="govuk-body">This case has no saved assessments.</p>
+<% end %>

--- a/app/views/early_allocations/_landing_page_footer.html.erb
+++ b/app/views/early_allocations/_landing_page_footer.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Save this assessment</h2>
 <p class="govuk-body">
   <%= link_to('Save completed assessment (pdf)',
-              prison_prisoner_early_allocation_path(@prison.code, @offender.offender_no, format: :pdf),
+              prison_prisoner_early_allocation_path(@prison.code, @offender.offender_no, @early_assignment.id, format: :pdf),
               class: 'govuk-link') %>
 </p>
 <p class="govuk-body">

--- a/app/views/early_allocations/edit.html.erb
+++ b/app/views/early_allocations/edit.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 <%= form_for @early_assignment,
-             url: prison_prisoner_early_allocation_path(@prison.code, @early_assignment.nomis_offender_id),
+             url: prison_prisoner_latest_early_allocation_path(@prison.code, @early_assignment.nomis_offender_id),
              method: :put,
              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <%= form.govuk_error_summary %>

--- a/app/views/early_allocations/index.html.erb
+++ b/app/views/early_allocations/index.html.erb
@@ -1,0 +1,40 @@
+<%= back_link %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Early allocation assessment process</h1>
+    <p class="govuk-body">Use this form to assess whether the community probation team should take responsibility for this case early.</p>
+    <p class="govuk-body">There are three possible outcomes:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>eligible - the community probation team will take responsibility for this case early</li>
+      <li>discretionary - the community probation team will need to make a decision</li>
+      <li>not eligible</li>
+    </ul>
+
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              View saved assessments
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <%= render 'early_allocations_list', early_allocations: @early_allocations, prison_id: @prison.code, prisoner_id: @offender.offender_no %>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="govuk-heading-m">Before you start</h2>
+    <h3 class="govuk-heading-s">Cases with less than 18 months until release</h3>
+    <p class="govuk-body">Eligible and discretionary assessments will be sent to the community probation team.</p>
+    <h3 class="govuk-heading-s">Cases with over 18 months until release</h3>
+    <p class="govuk-body">Assessments will be saved but not sent to the community probation team.</p>
+    <p class="govuk-body">Cases with any eligible or discretionary saved assessments might be eligible for early allocation.</p>
+    <p class="govuk-body">We will remind the allocated POM to make a new assessment 18 months before release. The POM can view saved assessments.</p>
+
+    <%= link_to 'Start new assessment', new_prison_prisoner_early_allocations_path(@prison.code, @offender.offender_no), class: 'govuk-button' %>
+  </div>
+  <%= render(partial: 'prisoner_info_sidebar') %>
+</div>

--- a/app/views/prisoners/_prisoner_information.html.erb
+++ b/app/views/prisoners/_prisoner_information.html.erb
@@ -24,25 +24,19 @@
         <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
       </td>
     </tr>
-    <% if Flipflop.early_allocation? %>
+    <% if Flipflop.early_allocation? && @case_info.present? %>
     <tr id="early_allocation" class="govuk-table__row">
-      <td class="govuk-table__cell">Early allocation eligibility</td>
+      <td class="govuk-table__cell">Early allocation referral</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= early_allocation_status(@early_allocation) %>
-        <span class="pull-right">
-          <% if @early_allocation.present? %>
-            <% if @early_allocation.discretionary? && @early_allocation.community_decision.nil? %>
-              <%= link_to('Update', edit_prison_prisoner_early_allocation_path(@prison.code, @prisoner.offender_no)) %>
-            <% else %>
-              <%= link_to 'Re-assess', new_prison_prisoner_early_allocations_path(@prison.code, @prisoner.offender_no) %>
-            <% end %>
-          <% else %>
-            <%= link_to 'Assess eligibility', new_prison_prisoner_early_allocations_path(@prison.code, @prisoner.offender_no) %>
-          <% end %>
+        <span id="early_allocation_status">
+          <%= early_allocation_status(@case_info.early_allocations, @prisoner) %>
+        </span>
+        <span id="early_allocation_action" class="pull-right">
+          <%= early_allocation_action_link(@case_info.early_allocations, @prisoner, @prison) %>
         </span>
       </td>
     </tr>
-  <% end %>
+    <% end %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Last known address in Wales</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,8 +25,11 @@ Rails.application.routes.draw do
         post('discretionary')
       end
 
-      # show action produces the most recent assessment - format PDF only
-      resource :early_allocation, only: [:show, :edit, :update]
+      resources :early_allocations, only: [:index, :show]
+
+      # edit action always updates the most recent assessment
+      # uses `as: :latest_early_allocation` to avoid clashes with `resources :early_allocations` above
+      resource :early_allocation, only: [:edit, :update], as: :latest_early_allocation
 
       resources :victim_liaison_officers, only: [:new, :edit, :create, :update, :destroy] do
         member do

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -35,28 +35,14 @@ FactoryBot.define do
     end
 
     trait :discretionary_accepted do
-      cppc_case { false }
-      extremism_separation { false }
-      high_risk_of_serious_harm { false }
-      mappa_level_2 { false }
-      pathfinder_process { false }
-      other_reason { true }
-      reason { 'Just a reason' }
-      approved { true }
+      discretionary
       community_decision { true }
       updated_by_firstname { Faker::Name.first_name }
       updated_by_lastname { Faker::Name.last_name }
     end
 
     trait :discretionary_declined do
-      cppc_case { false }
-      extremism_separation { false }
-      high_risk_of_serious_harm { false }
-      mappa_level_2 { false }
-      pathfinder_process { false }
-      other_reason { true }
-      reason { 'Just a reason' }
-      approved { true }
+      discretionary
       community_decision { false }
       updated_by_firstname { Faker::Name.first_name }
       updated_by_lastname { Faker::Name.last_name }

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :offender_base, class: 'HmppsApi::Offender' do
     imprisonmentStatus { 'SENT03' }
-    prisonId { 'LEI' }
+    latestLocationId { 'LEI' }
 
     # offender numbers are of the form <letter><4 numbers><2 letters>
     sequence(:offenderNo) do |seq|

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -5,7 +5,7 @@ feature 'View a prisoner profile page', :allocation do
     signin_spo_user
   end
 
-  context 'without allocation' do
+  context 'without allocation or case information' do
     it 'doesnt crash', vcr: { cassette_name: :show_unallocated_offender } do
       visit prison_prisoner_path('LEI', 'G7998GJ')
 

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe CaseInformation, type: :model do
 
     it { is_expected.to have_one(:responsibility).dependent(:destroy) }
     it { is_expected.to have_one(:calculated_handover_date).dependent(:destroy) }
+    it { is_expected.to have_many(:early_allocations).dependent(:destroy) }
   end
 
   describe '#early_allocations' do
@@ -24,12 +25,29 @@ RSpec.describe CaseInformation, type: :model do
       end
     end
 
-    context 'with an allocation' do
+    context 'with Early Allocation assessments' do
       let!(:early_allocation) { create(:early_allocation, nomis_offender_id: case_info.nomis_offender_id) }
       let!(:early_allocation2) { create(:early_allocation, nomis_offender_id: case_info.nomis_offender_id) }
 
       it 'has some entries' do
         expect(case_info.early_allocations).to eq([early_allocation, early_allocation2])
+      end
+    end
+
+    describe 'sort order' do
+      let(:creation_dates) { [1.year.ago, 1.day.ago, 1.month.ago].map(&:to_date) }
+
+      before do
+        # Deliberately create records out of order so we can assert that we order them correctly
+        # This is unlikely to happen in real life because we use numeric primary keys – but it helps for this test
+        creation_dates.each do |date|
+          create(:early_allocation, nomis_offender_id: case_info.nomis_offender_id, created_at: date)
+        end
+      end
+
+      it 'sorts by date created (ascending)' do
+        retrieved_dates = case_info.early_allocations.map(&:created_at)
+        expect(retrieved_dates).to eq(creation_dates.sort)
       end
     end
   end

--- a/spec/views/early_allocations/early_allocations_list.html.erb_spec.rb
+++ b/spec/views/early_allocations/early_allocations_list.html.erb_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe "early_allocations/early_allocations_list", type: :view do
+  let(:page) { Nokogiri::HTML(rendered) }
+  let(:offender) { build(:offender) }
+
+  before do
+    render partial: 'early_allocations/early_allocations_list', locals: {
+      early_allocations: early_allocations,
+      prison_id: offender.prison_id,
+      prisoner_id: offender.offender_no
+    }
+  end
+
+  context 'with Early Allocation assessments' do
+    let(:early_allocations) {
+      # Create 5 Early Allocation records with different creation dates
+      [
+        create(:early_allocation, created_at: 1.year.ago),
+        create(:early_allocation, created_at: 6.months.ago),
+        create(:early_allocation, created_at: 1.month.ago),
+        create(:early_allocation, created_at: 1.week.ago),
+        create(:early_allocation, created_at: 1.day.ago)
+      ]
+    }
+
+    it 'renders a table with one row for each assessment' do
+      rows = page.css('table > tbody > tr')
+      expect(rows.length).to eq(5)
+    end
+
+    it 'has column headings: Assessment date, Outcome, POM name, Action' do
+      headings = page.css('thead th').map(&:text)
+      expect(headings).to eq(['Assessment date', 'Outcome', 'POM name', 'Action'])
+    end
+
+    describe 'column values' do
+      let(:rendered_values) {
+        # An array of string cell values, one for each row for the table, for column specified by column_index
+        page.css("tr > td:nth-child(#{column_index})").map(&:text).map(&:strip)
+      }
+
+      describe 'Assessment date' do
+        let(:column_index) { 1 }
+
+        it 'shows the date the record was created' do
+          created_dates = early_allocations.map { |record| record.created_at.strftime('%d/%m/%Y') }
+          expect(rendered_values).to eq(created_dates)
+        end
+      end
+
+      describe 'Outcome' do
+        let(:column_index) { 2 }
+
+        context 'when eligible' do
+          let(:early_allocations) { [create(:early_allocation)] }
+
+          it 'shows "Eligible"' do
+            message = "Eligible - the community probation team will take responsibility for this case early"
+            expect(rendered_values.first).to eq(message)
+          end
+        end
+
+        context 'when discretionary' do
+          let(:early_allocations) { [create(:early_allocation, :discretionary)] }
+
+          it 'shows "Discretionary"' do
+            message = "Discretionary - the community probation team will make a decision"
+            expect(rendered_values.first).to eq(message)
+          end
+        end
+
+        context 'when ineligible' do
+          let(:early_allocations) { [create(:early_allocation, :ineligible)] }
+
+          it 'shows "Not eligible"' do
+            message = "Not eligible"
+            expect(rendered_values.first).to eq(message)
+          end
+        end
+      end
+
+      describe 'POM name' do
+        let(:column_index) { 3 }
+
+        it 'shows the name of the POM who created the record' do
+          pom_names = early_allocations.map { |record|
+            "#{record.created_by_lastname}, #{record.created_by_firstname}"
+          }
+          expect(rendered_values).to eq(pom_names)
+        end
+      end
+
+      describe 'Action' do
+        let(:column_index) { 4 }
+
+        let(:links) { page.css("tr > td:nth-child(#{column_index}) > a") }
+
+        it 'renders a "View" link which goes to the #show action' do
+          early_allocations.each_with_index do |early_allocation, index|
+            link = links[index]
+            view_assessment_path = prison_prisoner_early_allocation_path(
+              offender.prison_id, offender.offender_no, early_allocation.id
+            )
+            expect(link.text).to eq('View')
+            expect(link.attribute('href').value).to eq(view_assessment_path)
+          end
+        end
+      end
+    end
+  end
+
+  context 'when there are no Early Allocation assessments' do
+    let(:early_allocations) { [] }
+
+    it 'does not render a table' do
+      expect(page.css('table').present?).to be(false)
+    end
+
+    it 'renders a "no assessments" message' do
+      expect(page.text.strip).to eq('This case has no saved assessments.')
+    end
+  end
+end

--- a/spec/views/early_allocations/show.html.erb_spec.rb
+++ b/spec/views/early_allocations/show.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "early_allocations/show", type: :view do
 
     describe 'outcome' do
       context 'when the outcome is eligible' do
-        it 'shows the previous outcome' do
+        it 'shows the outcome' do
           expect(page.css('#outcome-label')).to have_text('Outcome')
           expect(page.css('#outcome')).to have_text('Eligible - the community probation team will take responsibility for this case early')
         end
@@ -57,7 +57,7 @@ RSpec.describe "early_allocations/show", type: :view do
   context 'when eligible and unsent' do
     let(:early_allocation) { create(:early_allocation, :eligible, :unsent) }
 
-    it 'shows the previous outcome' do
+    it 'shows the outcome' do
       expect(page).to have_text('Eligible - assessment not sent to the community probation team')
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe "early_allocations/show", type: :view do
   context 'when not eligible' do
     let(:early_allocation) { create(:early_allocation, :ineligible) }
 
-    it 'shows the previous outcome' do
+    it 'shows the outcome' do
       expect(page).to have_text('Not eligible')
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe "early_allocations/show", type: :view do
   context 'when discretionary - not sent' do
     let(:early_allocation) { create(:early_allocation, :discretionary, :unsent) }
 
-    it 'shows the previous outcome' do
+    it 'shows the outcome' do
       expect(page).to have_text('Discretionary - assessment not sent to the community probation team')
     end
   end
@@ -81,7 +81,7 @@ RSpec.describe "early_allocations/show", type: :view do
   context 'when discretionary - accepted' do
     let(:early_allocation) { create(:early_allocation, :discretionary, community_decision: true) }
 
-    it 'shows the previous outcome' do
+    it 'shows the outcome' do
       expect(page).to have_text('Eligible - the community probation team will take responsibility for this case early')
     end
   end
@@ -89,7 +89,7 @@ RSpec.describe "early_allocations/show", type: :view do
   context 'when discretionary - waiting' do
     let(:early_allocation) { create(:early_allocation, :discretionary) }
 
-    it 'shows the previous outcome' do
+    it 'shows the outcome' do
       expect(page).to have_text('Discretionary - the community probation team will make a decision')
     end
   end


### PR DESCRIPTION
Jira ticket: MO-11

This Pull Request adds the Early Allocations start page, and updates the prisoner profile page to reflect the new workflow in the status message and links.

### Change to prisoner profile page

The 'Early allocation referral' column now has a new name (used to be called 'Early allocation status'), and new status messages and links:

<img width="991" alt="Screenshot 2020-12-11 at 17 45 12" src="https://user-images.githubusercontent.com/7735945/101936797-eb349a80-3bd8-11eb-9eb2-13719fd2b495.png">

### Early Allocation start page

<img width="1027" alt="Screenshot 2020-12-11 at 17 48 38" src="https://user-images.githubusercontent.com/7735945/101936944-1cad6600-3bd9-11eb-86dd-ae430def7354.png">
