### PR TITLE
MO-235 secure debugging page to just global admins not to SPOs

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class DebuggingController < PrisonsApplicationController
+  before_action :ensure_admin_user
+
   def debugging
     nomis_offender_id = id
 
-    prisoner = OffenderService.get_offender(nomis_offender_id)
+    prisoner = OffenderService.get_offender(nomis_offender_id) if nomis_offender_id.present?
 
     if prisoner.present?
       @offender = OffenderPresenter.new(prisoner)
@@ -56,10 +58,4 @@ private
   def id
     params[:offender_no].present? ? params[:offender_no].strip : params[:offender_no]
   end
-
-  # def offender(offender_no)
-  #   return nil if offender_no.blank?
-  #
-  #   OffenderService.get_offender(offender_no)
-  # end
 end

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DebuggingController, :allocation, type: :controller do
   let(:prison_id) { prison.code }
 
   before do
-    stub_sso_data(prison_id)
+    stub_sso_data(prison_id, roles: [SsoIdentity::SPO_ROLE, SsoIdentity::ADMIN_ROLE])
   end
 
   context 'when debugging at a prison level' do

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -3,9 +3,12 @@ require 'rails_helper'
 feature 'Provide debugging information for our team to use', :allocation do
   let(:nomis_offender_id) { "G1670VU" }
 
+  before do
+    signin_global_admin_user
+  end
+
   context 'when debugging an individual offender' do
     it 'returns information for an unallocated offender', vcr: { cassette_name: :debugging_feature } do
-      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -27,7 +30,6 @@ feature 'Provide debugging information for our team to use', :allocation do
              nomis_offender_id: nomis_offender_id,
              primary_pom_name: "Rossana Spinka"
              )
-      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -50,7 +52,6 @@ feature 'Provide debugging information for our team to use', :allocation do
     end
 
     it 'can handle an incorrect offender number', vcr: { cassette_name: :debugging_incorrect_offender_feature } do
-      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -61,7 +62,6 @@ feature 'Provide debugging information for our team to use', :allocation do
     end
 
     it 'can handle no offender number being entered', vcr: { cassette_name: :debugging_no_offender_feature } do
-      signin_spo_user
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -74,7 +74,6 @@ feature 'Provide debugging information for our team to use', :allocation do
 
   context 'when debugging at a prison level', vcr: { cassette_name: :debugging_prison_level } do
     it 'displays a dashboard' do
-      signin_spo_user
       visit prison_debugging_prison_path('LEI')
 
       expect(page).to have_text("Prison Debugging")

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -74,7 +74,7 @@ module ApiHelper
 
   def stub_signed_in_pom(prison, staff_id, username = 'alice')
     stub_auth_token
-    stub_sso_data(prison, username: username, role: 'ROLE_ALLOC_CASE_MGR')
+    stub_sso_data(prison, username: username, roles: [SsoIdentity::POM_ROLE])
     stub_request(:get, "#{T3}/users/#{username}").
       to_return(body: { 'staffId': staff_id }.to_json)
   end

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -15,10 +15,10 @@ module AuthHelper
       }.to_json)
   end
 
-  def stub_sso_data(prison, username: 'user', role: 'ROLE_ALLOC_MGR', emails: [])
+  def stub_sso_data(prison, username: 'user', roles: [SsoIdentity::SPO_ROLE], emails: [])
     allow(HmppsApi::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
     session[:sso_data] = { 'expiry' => Time.zone.now + 1.day,
-                           'roles' => [role],
+                           'roles' => roles,
                            'caseloads' => [prison],
                            'username' => username }
     stub_request(:get, "#{ApiHelper::T3}/users/#{username}").


### PR DESCRIPTION
The 2 debugging pages were both only secured to SPO access.

This PR changes this so SPOs cannot access these hidden URLs, and limits them to users with actual admin access