### PR TITLE
MO-297 use new ldu data

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -54,12 +54,19 @@ private
         com_name: delius_record.offender_manager,
         crn: delius_record.crn,
         tier: map_tier(delius_record.tier),
+        local_delivery_unit: map_ldu(delius_record.ldu_code),
         team: team,
+        team_name: team&.name,
         case_allocation: delius_record.service_provider,
         welsh_offender: map_welsh_offender(delius_record.ldu_code),
         mappa_level: map_mappa_level(delius_record.mappa_levels)
       )
     end
+  end
+
+  # map the LDU regardless of enabled switch, but only expose it from offender when enabled
+  def map_ldu(ldu_code)
+    LocalDeliveryUnit.find_by(code: ldu_code)
   end
 
   def map_team(team_code)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -6,7 +6,11 @@ class CaseInformation < ApplicationRecord
   NPS = 'NPS'
   CRC = 'CRC'
 
+  #  Old mapping - will be going away in Feb 2021
   belongs_to :team, optional: true, counter_cache: :case_information_count
+
+  # new mapping - don't need team data any more, only team_name for display purposes
+  belongs_to :local_delivery_unit, optional: true
 
   has_many :early_allocations,
            foreign_key: :nomis_offender_id,

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -69,11 +69,11 @@ module HmppsApi
     end
 
     def ldu_name
-      @case_information&.local_divisional_unit&.name
+      ldu&.name
     end
 
     def ldu_email_address
-      @case_information&.local_divisional_unit&.email_address
+      ldu&.email_address
     end
 
     def team_name
@@ -217,6 +217,17 @@ module HmppsApi
     end
 
   private
+
+    # Take either the new LocalDeliveryUnit (if available and enabled) and
+    # fall back to the old local_divisional_unit if not. This should all go away
+    # in Feb 2021 after the PDU changes have been rolled out in nDelius
+    def ldu
+      if @case_information&.local_delivery_unit&.enabled?
+        @case_information.local_delivery_unit
+      else
+        @case_information&.local_divisional_unit
+      end
+    end
 
     def handover
       @handover ||= if pom_responsibility.custody?

--- a/db/migrate/20201215133824_add_new_ldu_to_case_info.rb
+++ b/db/migrate/20201215133824_add_new_ldu_to_case_info.rb
@@ -1,0 +1,8 @@
+class AddNewLduToCaseInfo < ActiveRecord::Migration[6.0]
+  def change
+    change_table :case_information do |t|
+      t.string :team_name
+      t.references :local_delivery_unit
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_130556) do
+ActiveRecord::Schema.define(version: 2020_12_15_133824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,9 @@ ActiveRecord::Schema.define(version: 2020_12_14_130556) do
     t.date "parole_review_date"
     t.string "probation_service"
     t.string "com_name"
+    t.string "team_name"
+    t.bigint "local_delivery_unit_id"
+    t.index ["local_delivery_unit_id"], name: "index_case_information_on_local_delivery_unit_id"
     t.index ["nomis_offender_id"], name: "index_case_information_on_nomis_offender_id", unique: true
     t.index ["team_id"], name: "index_case_information_on_team_id"
   end

--- a/spec/factories/local_delivery_units.rb
+++ b/spec/factories/local_delivery_units.rb
@@ -5,7 +5,11 @@ FactoryBot.define do
     sequence(:code) { |seq| "LDU#{seq}" }
     name { "MyString" }
     email_address { Faker::Internet.email }
-    enabled { false }
+    enabled { true }
     country { 'England' }
+
+    trait :disabled do
+      enabled { false }
+    end
   end
 end

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -8,17 +8,22 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
   let(:ldu) {  create(:local_divisional_unit) }
   let(:team) { create(:team, local_divisional_unit: ldu) }
 
+  before do
+    stub_auth_token
+  end
+
   context 'with auto_delius_import enabled' do
     let(:test_strategy) { Flipflop::FeatureSet.current.test! }
+    let(:case_info) { CaseInformation.last }
 
     before do
       test_strategy.switch!(:auto_delius_import, true)
-      stub_auth_token
     end
 
     after do
       test_strategy.switch!(:auto_delius_import, false)
     end
+
 
     context 'when on the happy path' do
       before do
@@ -31,13 +36,16 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
           described_class.perform_now nomis_offender_id
         }.to change(CaseInformation, :count).by(1)
 
-        expect(CaseInformation.last.attributes.symbolize_keys.except(:created_at, :id, :updated_at))
-            .to eq(case_allocation: "NPS", crn: "X362207", manual_entry: false, mappa_level: 0, nomis_offender_id: "G4281GV", parole_review_date: nil,
-                    probation_service: "England",
-                    welsh_offender: 'No',
-                    team_id: team.id,
+        expect(case_info.attributes.symbolize_keys.except(:created_at, :id, :updated_at, :parole_review_date))
+            .to eq(case_allocation: "NPS", crn: "X362207", manual_entry: false, mappa_level: 0,
+                   nomis_offender_id: "G4281GV",
+                   probation_service: "England",
+                   welsh_offender: 'No',
+                   local_delivery_unit_id: nil,
+                   team_id: team.id,
+                   team_name: team.name,
                    com_name: "Jones, Ruth Mary",
-                    tier: "A")
+                   tier: "A")
       end
     end
 
@@ -59,7 +67,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
             described_class.perform_now offender_id
           }.to change(CaseInformation, :count).by(1)
 
-          expect(CaseInformation.last.com_name).to eq(com_name)
+          expect(case_info.com_name).to eq(com_name)
         end
       end
 
@@ -72,7 +80,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
             described_class.perform_now offender_id
           }.to change(CaseInformation, :count).by(1)
 
-          expect(CaseInformation.last.com_name).to be_nil
+          expect(case_info.com_name).to be_nil
         end
       end
 
@@ -85,7 +93,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
             described_class.perform_now offender_id
           }.to change(CaseInformation, :count).by(1)
 
-          expect(CaseInformation.last.com_name).to be_nil
+          expect(case_info.com_name).to be_nil
         end
       end
     end
@@ -96,7 +104,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
         stub_community_offender(remand_nomis_offender_id, build(:community_data, offenderManagers: [build(:community_offender_manager, team: { code: team.code, localDeliveryUnit: { code: ldu.code } })]))
       end
 
-      it 'does not case information' do
+      it 'does not store case information' do
         expect {
           described_class.perform_now remand_nomis_offender_id
         }.to change(CaseInformation, :count).by(0)
@@ -113,7 +121,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
         expect {
           described_class.perform_now nomis_offender_id
         }.to change(CaseInformation, :count).by(1)
-        expect(CaseInformation.last.tier).to eq('B')
+        expect(case_info.tier).to eq('B')
       end
     end
 
@@ -123,7 +131,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
         stub_community_offender(nomis_offender_id, build(:community_data, currentTier: 'X', offenderManagers: [build(:community_offender_manager, team: { code: team.code, localDeliveryUnit: { code: ldu.code } })]))
       end
 
-      it 'does not creates case information' do
+      it 'does not create case information' do
         expect {
           described_class.perform_now nomis_offender_id
         }.not_to change(CaseInformation, :count)
@@ -131,8 +139,6 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
     end
 
     describe '#welsh_offender' do
-      let(:case_info) { CaseInformation.last }
-
       before do
         stub_offender(build(:nomis_offender, offenderNo: nomis_offender_id))
         stub_community_offender(nomis_offender_id, build(:community_data, offenderManagers: [build(:community_offender_manager, team: { code: team.code, localDeliveryUnit: { code: ldu.code } })]))
@@ -153,6 +159,26 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
         it 'maps to true' do
           described_class.perform_now(nomis_offender_id)
           expect(case_info.welsh_offender).to eq('Yes')
+        end
+      end
+    end
+
+    describe '#local_delivery_unit' do
+      before do
+        stub_offender(build(:nomis_offender, offenderNo: nomis_offender_id))
+        stub_community_offender(nomis_offender_id, build(:community_data, offenderManagers: [build(:community_offender_manager, team: { code: team.code, localDeliveryUnit: { code: ldu.code } })]))
+      end
+
+      context 'with an existing new shiny LDU' do
+        before do
+          create(:local_delivery_unit, code: ldu.code)
+        end
+
+        let(:local_delivery_unit) { LocalDeliveryUnit.last }
+
+        it 'maps to the new one' do
+          described_class.perform_now(nomis_offender_id)
+          expect(case_info.local_delivery_unit).to eq local_delivery_unit
         end
       end
     end
@@ -178,7 +204,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
           expect {
             described_class.perform_now nomis_offender_id
           }.to change(CaseInformation, :count).by(1)
-          expect(CaseInformation.last.mappa_level).to eq(0)
+          expect(case_info.mappa_level).to eq(0)
         end
       end
 
@@ -196,7 +222,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
             expect {
               described_class.perform_now nomis_offender_id
             }.to change(CaseInformation, :count).by(1)
-            expect(CaseInformation.last.mappa_level).to eq(1)
+            expect(case_info.mappa_level).to eq(1)
           end
         end
 
@@ -207,7 +233,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
             expect {
               described_class.perform_now nomis_offender_id
             }.to change(CaseInformation, :count).by(1)
-            expect(CaseInformation.last.mappa_level).to eq(2)
+            expect(case_info.mappa_level).to eq(2)
           end
         end
 
@@ -218,7 +244,7 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
             expect {
               described_class.perform_now nomis_offender_id
             }.to change(CaseInformation, :count).by(1)
-            expect(CaseInformation.last.mappa_level).to eq(1)
+            expect(case_info.mappa_level).to eq(1)
           end
         end
       end
@@ -239,69 +265,69 @@ RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type:
         expect(c1.reload.tier).to eq('C')
       end
     end
+  end
 
-    describe 'pushing handover dates into nDelius' do
-      let(:offender) { build(:nomis_offender) }
-      let(:offender_no) { offender.fetch(:offenderNo) }
-      let(:crn) { 'X89264GC' }
+  describe 'pushing handover dates into nDelius' do
+    let(:offender) { build(:nomis_offender) }
+    let(:offender_no) { offender.fetch(:offenderNo) }
+    let(:crn) { 'X89264GC' }
 
-      before do
-        stub_community_offender(offender_no, build(:community_data,
-                                                   currentTier: 'C',
-                                                   otherIds: { crn: crn },
-                                                   offenderManagers: [
-                                                       build(:community_offender_manager,
-                                                             team: {
-                                                                 code: team.code,
-                                                                 localDeliveryUnit: { code: ldu.code }
-                                                             })
-                                                   ]))
-        stub_offender(offender)
-      end
+    before do
+      stub_community_offender(offender_no, build(:community_data,
+                                                 currentTier: 'C',
+                                                 otherIds: { crn: crn },
+                                                 offenderManagers: [
+                                                   build(:community_offender_manager,
+                                                         team: {
+                                                           code: team.code,
+                                                           localDeliveryUnit: { code: ldu.code }
+                                                         })
+                                                 ]))
+      stub_offender(offender)
+    end
 
-      shared_examples 'recalculate handover dates' do
-        it "recalculates the offender's handover dates, using the new Case Information data" do
-          expect(CalculatedHandoverDate).to receive(:recalculate_for) do |received_offender|
-            expect(received_offender).to be_an_instance_of(HmppsApi::Offender)
+    shared_examples 'recalculate handover dates' do
+      it "recalculates the offender's handover dates, using the new Case Information data" do
+        expect(CalculatedHandoverDate).to receive(:recalculate_for) do |received_offender|
+          expect(received_offender).to be_an_instance_of(HmppsApi::Offender)
 
-            expected_fields = {
-              crn: crn,
-              tier: 'C',
-              case_allocation: 'NPS',
-              welsh_offender: false,
-              mappa_level: 0
-            }
+          expected_fields = {
+            crn: crn,
+            tier: 'C',
+            case_allocation: 'NPS',
+            welsh_offender: false,
+            mappa_level: 0
+          }
 
-            received_fields = {
-              crn: received_offender.crn,
-              tier: received_offender.tier,
-              case_allocation: received_offender.case_allocation,
-              welsh_offender: received_offender.welsh_offender,
-              mappa_level: received_offender.mappa_level
-            }
+          received_fields = {
+            crn: received_offender.crn,
+            tier: received_offender.tier,
+            case_allocation: received_offender.case_allocation,
+            welsh_offender: received_offender.welsh_offender,
+            mappa_level: received_offender.mappa_level
+          }
 
-            expect(received_fields).to eq(expected_fields)
-          end
-          described_class.perform_now offender_no
+          expect(received_fields).to eq(expected_fields)
         end
+        described_class.perform_now offender_no
       end
+    end
 
-      context 'when creating a new Case Information record' do
-        include_examples 'recalculate handover dates'
-      end
+    context 'when creating a new Case Information record' do
+      include_examples 'recalculate handover dates'
+    end
 
-      context 'when updating an existing Case Information record' do
-        let!(:case_info) {
-          create(:case_information, tier: 'B', nomis_offender_id: offender_no, crn: crn)
-        }
+    context 'when updating an existing Case Information record' do
+      let!(:case_info) {
+        create(:case_information, tier: 'B', nomis_offender_id: offender_no, crn: crn)
+      }
 
-        include_examples 'recalculate handover dates'
+      include_examples 'recalculate handover dates'
 
-        it 'does not re-calculate if CaseInformation is unchanged' do
-          described_class.perform_now offender_no
-          expect(CalculatedHandoverDate).not_to receive(:recalculate_for)
-          described_class.perform_now offender_no
-        end
+      it 'does not re-calculate if CaseInformation is unchanged' do
+        described_class.perform_now offender_no
+        expect(CalculatedHandoverDate).not_to receive(:recalculate_for)
+        described_class.perform_now offender_no
       end
     end
   end

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -240,13 +240,35 @@ describe HmppsApi::Offender do
       describe '#ldu_name' do
         let(:field) { :ldu_name }
 
-        it { is_expected.to be(case_info.team.local_divisional_unit.name) }
+        context 'when there is a new LDU mapping' do
+          let(:ldu) { create(:local_delivery_unit) }
+          let(:case_info) { create(:case_information, local_delivery_unit: ldu) }
+
+          it { is_expected.to be(ldu.name) }
+        end
+
+        context 'without a new LDU mapping' do
+          let(:case_info) { create(:case_information) }
+
+          it { is_expected.to be(case_info.team.local_divisional_unit.name) }
+        end
       end
 
       describe '#ldu_email_address' do
         let(:field) { :ldu_email_address }
 
-        it { is_expected.to be(case_info.team.local_divisional_unit.email_address) }
+        context 'when there is a new LDU mapping' do
+          let(:ldu) { create(:local_delivery_unit) }
+          let(:case_info) { create(:case_information, local_delivery_unit: ldu) }
+
+          it { is_expected.to be(ldu.email_address) }
+        end
+
+        context 'without a new LDU mapping' do
+          let(:case_info) { create(:case_information) }
+
+          it { is_expected.to be(case_info.team.local_divisional_unit.email_address) }
+        end
       end
 
       describe '#team_name' do


### PR DESCRIPTION
As part of the LDU/PDU changes, Teams will be moved under the correct LDUs - so there will be no more need for the 'shadow team' concept with all the pian that brought this project.

There will be a complete 'new' set of LDUs (which are actually LocalDeliveryUnits) so in a clean break, a new table of LocalDeliveryUnits has been created with an 'enabled' flag so that they can be created in advance of the rollout. 
The first 'new' LDU is Kent going live on 9th January, with the rest following on 29th. After that we should be able to clean up the old team mappings, and delete the 'Team' and 'LocalDivisionalUnit' models along with the import job from the NART report (and decommision the email address associated with it also)