### PR TITLE
MO-219/221 cope with nil values for POM and COM during sort

### DIFF
--- a/app/services/bucket.rb
+++ b/app/services/bucket.rb
@@ -16,15 +16,25 @@ class Bucket
     @items << item
   end
 
-  def sort_bucket!(field, direction = :asc)
+  def sort_bucket!(field, direction)
     return unless @valid_sort_fields.include?(field)
 
-    if field == :earliest_release_date
-      @items.sort_by! { |e| e.public_send(field) || Date.new(1) }
-    else
-      @items.sort_by!(&field)
+    @items.sort! do |x, y|
+      if direction == :asc
+        a = x.public_send(field)
+        b = y.public_send(field)
+      else
+        b = x.public_send(field)
+        a = y.public_send(field)
+      end
+      # ensure that nil values sort low, but other values sort by comparison
+      if a.present? && b.present?
+        a <=> b
+      elsif a.nil?
+        -1
+      else
+        1
+      end
     end
-
-    @items.reverse! if direction == :desc
   end
 end

--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -50,6 +50,14 @@ class SummaryService
 
     add_allocated_poms_and_coms(@buckets[summary_type], active_allocations_hash)
 
+    default_sort_params =
+      { allocated: [nil, nil],
+        unallocated: [:sentence_start_date, :asc],
+        pending: [:sentence_start_date, :asc],
+        new_arrivals: [:sentence_start_date, :asc],
+        handovers: [:handover_start_date, :asc]
+      }.fetch(summary_type)
+
     @sort_params = if sort_params
                      parts = sort_params.split.map { |s| s.downcase.to_sym }
 
@@ -91,15 +99,6 @@ class SummaryService
   end
 
 private
-
-  def default_sort_params
-    { allocated: [nil, nil],
-        unallocated: [:sentence_start_date, :asc],
-        pending: [:sentence_start_date, :asc],
-        new_arrivals: [:sentence_start_date, :asc],
-        handovers: [:handover_start_date, :asc]
-    }.fetch(@summary_type)
-  end
 
   def new_arrival?(offender)
     if Time.zone.today.monday?

--- a/spec/controllers/handovers_controller_spec.rb
+++ b/spec/controllers/handovers_controller_spec.rb
@@ -45,6 +45,28 @@ RSpec.describe HandoversController, type: :controller do
         stub_movements
       end
 
+      describe 'sorting', :allocation do
+        before do
+          create(:case_information, :with_com, case_allocation: 'CRC', nomis_offender_id: 'G1234VV')
+          create(:allocation, nomis_offender_id: 'G1234VV', primary_pom_nomis_id: pom.staffId)
+          stub_pom(pom)
+        end
+
+        let(:pom) { build(:pom) }
+
+        it 'sorts by COM' do
+          get :index, params: { prison_id: prison, sort: 'allocated_com_name asc' }
+          expect(response).to be_successful
+          expect(assigns(:offenders).map(&:offender_no)).to eq(["G4234GG", 'G1234VV'])
+        end
+
+        it 'sorts by POM' do
+          get :index, params: { prison_id: prison, sort: 'allocated_pom_name asc' }
+          expect(response).to be_successful
+          expect(assigns(:offenders).map(&:offender_no)).to eq(['G1234VV', "G4234GG"])
+        end
+      end
+
       context 'when NPS case' do
         it 'returns cases that are within the thirty day window, but not those that dont have case information' do
           get :index, params: { prison_id: prison }

--- a/spec/services/bucket_spec.rb
+++ b/spec/services/bucket_spec.rb
@@ -23,7 +23,7 @@ describe Bucket do
     b << OpenStruct.new(last_name: "M")
     expect(b.count).to be(3)
 
-    b.sort_bucket!(:last_name)
+    b.sort_bucket!(:last_name, :asc)
     expect(b.map(&:last_name)).to eq(['A', 'M', 'Z'])
   end
 
@@ -70,7 +70,7 @@ describe Bucket do
       last_name: "A",
       earliest_release_date: Date.new(2000, 1, 1)
     )
-    b.sort_bucket!(:earliest_release_date)
+    b.sort_bucket!(:earliest_release_date, :asc)
     expect(b.map(&:earliest_release_date)).to eq([nil, Date.new(2000, 1, 1)])
 
     b.sort_bucket!(:earliest_release_date, :desc)


### PR DESCRIPTION
MO-219 and MO-221 are about sorting of the handover section not working when either POM or COM is nil.

This PR fixes this defect, and also tidies up a little in the same area - specifically removing the 'special' earliest_release_date sorting - which was a little curious as there are lots of dates (other than earliest release date) which might have had the potential for nil values.