### PR TITLE
MO-112 sort by allocation date

### DIFF
--- a/app/services/summary_service.rb
+++ b/app/services/summary_service.rb
@@ -8,7 +8,7 @@ class SummaryService
     # :pending, or :new_arrivals or :handovers. The other types will return totals, and do not contain
     # any data.
     sortable_fields = {
-        allocated: [:last_name, :earliest_release_date, :tier],
+        allocated: [:last_name, :earliest_release_date, :tier, :allocation_date],
         new_arrivals: [:last_name, :prison_arrival_date, :earliest_release_date],
         handovers: [:last_name, :handover_start_date, :responsibility_handover_date, :case_allocation, :allocated_pom_name, :allocated_com_name],
         unallocated: [:last_name, :earliest_release_date, :case_owner, :awaiting_allocation_for, :tier],

--- a/app/views/summary/allocated.html.erb
+++ b/app/views/summary/allocated.html.erb
@@ -32,7 +32,12 @@
         <%= sort_arrow('earliest_release_date') %>
       </th>
       <th class="govuk-table__header" scope="col">POM</th>
-      <th class="govuk-table__header" scope="col">Allocation date</th>
+      <th class="govuk-table__header sorter-false" scope="col">
+        <a href="<%= sort_link('allocation_date') %>">
+          Allocation date
+        </a>
+        <%= sort_arrow('allocation_date') %>
+      </th>
       <th class="govuk-table__header sorter-false" scope="col">Action</th>
     </tr>
     </thead>


### PR DESCRIPTION
This PR adds sorting to the 'allocated summary' tab for SPOs to sort by allocation data