### PR TITLE
Mo 234 view previous early allocation forms

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -62,12 +62,14 @@ class EarlyAllocationsController < PrisonsApplicationController
 
   def show
     @early_assignment = EarlyAllocation.where(offender_id_from_url).last
+    @referrer = request.referer
 
     respond_to do |format|
       format.pdf {
         # disposition 'attachment' is the default for send_data
         send_data pdf_as_string
       }
+      format.html
     end
   end
 

--- a/app/helpers/early_allocation_helper.rb
+++ b/app/helpers/early_allocation_helper.rb
@@ -9,6 +9,40 @@ module EarlyAllocationHelper
     end
   end
 
+  def early_allocation_long_outcome(early_allocation)
+    if early_allocation.community_decision_eligible_or_automatically_eligible?
+      if early_allocation.created_within_referral_window?
+        'Eligible - the community probation team will take responsibility for this case early'
+      else
+        'Eligible - assessment not sent to the community probation team'
+      end
+    elsif early_allocation.community_decision_ineligible_or_automatically_ineligible?
+      'Not eligible'
+    elsif early_allocation.created_within_referral_window?
+      'Discretionary - the community probation team will make a decision'
+    else
+      'Discretionary - assessment not sent to the community probation team'
+    end
+  end
+
+
+  DESCRIPTIONS = {
+      convicted_under_terrorisom_act_2000: 'Convicted under Terrorism Act 2000',
+      high_profile: 'Identified as \'high profile\'',
+      serious_crime_prevention_order: 'Has Serious Crime Prevention Order',
+      mappa_level_3: 'Requires management as a Multi-Agency Public Protection (MAPPA) level 3',
+      cppc_case: 'Likely to be a Critical Public Protection Case (CPPC)',
+      extremism_separation: 'Has been held in an extremism separation centre',
+      high_risk_of_serious_harm: 'Presents a very high risk of serious harm',
+      mappa_level_2: 'Requires management as a Multi-Agency Public Protection (MAPPA) level 2',
+      pathfinder_process: 'Identified through the \'pathfinder\' process',
+      other_reason: 'Other reason for consideration for early allocation to the probation team',
+  }.freeze
+
+  def pom_full_name(early_allocation)
+    "#{early_allocation.created_by_lastname}, #{early_allocation.created_by_firstname}"
+  end
+
 private
 
   def active_status(early_allocation)

--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -119,6 +119,18 @@ class EarlyAllocation < ApplicationRecord
     created_within_referral_window? && discretionary? && community_decision.nil?
   end
 
+  def community_decision_eligible_or_automatically_eligible?
+    self.eligible? || community_decision == true
+  end
+
+  def community_decision_ineligible_or_automatically_ineligible?
+    self.ineligible? || community_decision == false
+  end
+
+  def assessment_date
+    created_at
+  end
+
 private
 
   def stage1_eligible?

--- a/app/views/early_allocations/show.html.erb
+++ b/app/views/early_allocations/show.html.erb
@@ -1,0 +1,82 @@
+<div class="govuk-width-container">
+
+  <%= render :partial => "/shared/backlink", :locals => { :page => @referrer || root_path } %>
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <dl class="govuk-grid-row">
+
+
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">View previous early allocation assessment</h1>
+
+        <h2 class="govuk-heading-m">Summary</h2>
+
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th id="assessment-date-label" scope="col" class="govuk-table__header app-custom-class">Assessment date</th>
+            <th id="outcome-label" scope="col" class="govuk-table__header app-custom-class">Outcome</th>
+            <th id="pom-name-label" scope="col" class="govuk-table__header app-custom-class">POM name</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td id="assessment-date" class="govuk-table__cell"><%= format_date(@early_assignment.assessment_date) %></td>
+            <td id="outcome" class="govuk-table__cell"><%= early_allocation_long_outcome(@early_assignment) %></td>
+            <td id="pom-name" class="govuk-table__cell"><%= pom_full_name(@early_assignment) %></td>
+          </tr>
+          </tbody>
+        </table>
+
+        <h2 class="govuk-heading-m">Assessment details</h2>
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Date of last OASys risk assessment
+            </dt>
+
+            <dd class="govuk-summary-list__value">
+              <%= format_date(@early_assignment.oasys_risk_assessment_date) %>
+            </dd>
+          </div>
+          <% EarlyAllocationHelper::DESCRIPTIONS.each do |field_name, description| %>
+            <% field = @early_assignment.public_send(field_name) %>
+            <% if field.in? [true, false] %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <%= description %>
+                </dt>
+
+                <dd class="govuk-summary-list__value">
+                  <%= humanized_bool(field) %>
+                </dd>
+              </div>
+            <% end %>
+          <% end %>
+          <% if @early_assignment.discretionary? %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Approval from the Head of Offender Management Delivery
+              </dt>
+
+              <dd class="govuk-summary-list__value">
+                <%= humanized_bool(@early_assignment.approved) %>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Detail about why this case needs to be referred early
+              </dt>
+
+              <dd class="govuk-summary-list__value">
+                <%= @early_assignment.reason %>
+              </dd>
+            </div>
+          <% end %>
+        </dl>
+      </div>
+      <%= render(partial: 'prisoner_info_sidebar') %>
+    </dl>
+  </main>
+</div>
+

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
         get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id }, format: :pdf
         expect(early_allocation).to eq(CaseInformation.last.early_allocations.last)
       end
+
+      it 'shows most recent html' do
+        get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id }, format: :html
+        expect(early_allocation).to eq(CaseInformation.last.early_allocations.last)
+      end
     end
 
     describe '#update' do

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -18,6 +18,10 @@ FactoryBot.define do
 
     association :case_information
 
+    trait :eligible do
+      # Does nothing - eligible is the default outcome of early-allocation
+    end
+
     trait :discretionary do
       cppc_case { false }
       extremism_separation { false }
@@ -83,6 +87,10 @@ FactoryBot.define do
       mappa_level_2 do false end
       pathfinder_process do false end
       other_reason { false }
+    end
+
+    trait :unsent do
+      created_within_referral_window { false }
     end
   end
 end

--- a/spec/helpers/early_allocation_helper_spec.rb
+++ b/spec/helpers/early_allocation_helper_spec.rb
@@ -46,4 +46,62 @@ RSpec.describe EarlyAllocationHelper, type: :helper do
       expect(helper.early_allocation_status(subject)).to eq('Not eligible')
     end
   end
+
+  describe '#early_allocation_long_outcome' do
+    context 'when eligible and unsent' do
+      let(:early_allocation) { build(:early_allocation, :eligible, :unsent) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Eligible - assessment not sent to the community probation team')
+      end
+    end
+
+    context 'when eligible and sent' do
+      let(:early_allocation) { build(:early_allocation, :eligible) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Eligible - the community probation team will take responsibility for this case early')
+      end
+    end
+
+    context 'when not eligible' do
+      let(:early_allocation) { build(:early_allocation, :ineligible) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Not eligible')
+      end
+    end
+
+    context 'when discretionary - not sent' do
+      let(:early_allocation) { build(:early_allocation, :discretionary, :unsent) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Discretionary - assessment not sent to the community probation team')
+      end
+    end
+
+    context 'when discretionary - sent' do
+      let(:early_allocation) { build(:early_allocation, :discretionary) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Discretionary - the community probation team will make a decision')
+      end
+    end
+
+    context 'when discretionary - accepted' do
+      let(:early_allocation) { build(:early_allocation, :discretionary, community_decision: true) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Eligible - the community probation team will take responsibility for this case early')
+      end
+    end
+
+    context 'when discretionary - rejected' do
+      let(:early_allocation) { build(:early_allocation, :discretionary, community_decision: false) }
+
+      it 'works' do
+        expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Not eligible')
+      end
+    end
+  end
 end

--- a/spec/views/early_allocations/show.html.erb_spec.rb
+++ b/spec/views/early_allocations/show.html.erb_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "early_allocations/show", type: :view do
+  before do
+    assign(:case_information, build(:case_information))
+    assign(:offender, build(:offender, sentence: attributes_for(:sentence_detail)))
+
+    assign(:early_assignment, early_allocation)
+    assign(:referrer, referrer)
+    render
+  end
+
+  let(:page) { Nokogiri::HTML(rendered) }
+  let(:referrer) { nil }
+
+  context 'when reviewing an elibigle early assessment' do
+    let(:early_allocation) {  create(:early_allocation, :eligible, created_at: '05/11/2021', created_by_firstname: 'Olivia', created_by_lastname: 'Mann') }
+
+    it 'shows the previous assessment date' do
+      expect(page.css('#assessment-date-label')).to have_text('Assessment date')
+      expect(page.css('#assessment-date')).to have_text('05/11/2021')
+    end
+
+    it 'shows the previous POM who made the assessment' do
+      expect(page.css('#pom-name-label')).to have_text('POM name')
+      expect(page.css('#pom-name')).to have_text('Mann, Olivia')
+    end
+
+    describe 'outcome' do
+      context 'when the outcome is eligible' do
+        it 'shows the previous outcome' do
+          expect(page.css('#outcome-label')).to have_text('Outcome')
+          expect(page.css('#outcome')).to have_text('Eligible - the community probation team will take responsibility for this case early')
+        end
+      end
+    end
+
+    describe 'backlink' do
+      context 'when the referer is nil' do
+        it 'links to home' do
+          expect(page).to have_link('Back', href: '/')
+        end
+      end
+
+      context 'when the referer is a page' do
+        let(:referrer) { '/fred' }
+
+        it 'links to that page' do
+          expect(page).to have_link('Back', href: '/fred')
+        end
+      end
+    end
+  end
+
+  context 'when eligible and unsent' do
+    let(:early_allocation) { create(:early_allocation, :eligible, :unsent) }
+
+    it 'shows the previous outcome' do
+      expect(page).to have_text('Eligible - assessment not sent to the community probation team')
+    end
+  end
+
+  context 'when not eligible' do
+    let(:early_allocation) { create(:early_allocation, :ineligible) }
+
+    it 'shows the previous outcome' do
+      expect(page).to have_text('Not eligible')
+    end
+  end
+
+  context 'when discretionary - not sent' do
+    let(:early_allocation) { create(:early_allocation, :discretionary, :unsent) }
+
+    it 'shows the previous outcome' do
+      expect(page).to have_text('Discretionary - assessment not sent to the community probation team')
+    end
+  end
+
+  context 'when discretionary - accepted' do
+    let(:early_allocation) { create(:early_allocation, :discretionary, community_decision: true) }
+
+    it 'shows the previous outcome' do
+      expect(page).to have_text('Eligible - the community probation team will take responsibility for this case early')
+    end
+  end
+
+  context 'when discretionary - waiting' do
+    let(:early_allocation) { create(:early_allocation, :discretionary) }
+
+    it 'shows the previous outcome' do
+      expect(page).to have_text('Discretionary - the community probation team will make a decision')
+    end
+  end
+end


### PR DESCRIPTION
This PR creates an uneditable, html version of the form that was entered by a previous POM.

It is a stand alone page that will be used by [MO-11 View Early Assessment start page](https://dsdmoj.atlassian.net/browse/MO-11) and is displayed when a user(POM) clicks on a link. 
It allows the current pom to view all the previous answers that had been entered.

[View early allocations form design here ](https://hmpps-moic-staging.herokuapp.com/view-past-ea-form)