### PR TITLE
Stop re-queueing dates that fail to push to Delius

### DIFF
--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -7,6 +7,14 @@ class RecalculateHandoverDateJob < ApplicationJob
     offender = OffenderService.get_offender(nomis_offender_id)
     return if offender.nil? || offender.sentenced? == false
 
-    CalculatedHandoverDate.recalculate_for(offender)
+    begin
+      # Recalculate handover dates, which will trigger a push to the Community API after_save
+      CalculatedHandoverDate.recalculate_for(offender)
+    rescue Faraday::ClientError # rubocop:disable Lint/SuppressedException
+      # Swallow Community API errors to allow this job to complete successfully.
+      # The calculated handover date will not be saved, and we'll retry again in tomorrow night's cron.
+      # Without this, bad data in nDelius will cause our retry queue to continually grow as fresh jobs
+      # are queued every night alongside old failed jobs continually retrying.
+    end
   end
 end


### PR DESCRIPTION
The RecalculateHandoverDateJob triggers a calculation of offender handover dates, and subsequent push to nDelius via the Community API in an `after_save` callback.

We fail to push handover dates into nDelius for a number of offenders due to bad data existing. Usually this is because the offender has multiple active custodial events, or has multiple offender records in nDelius. In these cases, the Community API returns an error code to signify that it failed to save the handover dates.

The default behaviour of our API client is to raise an error, which then causes our job runner to mark the job as failed and re-queue it to try again later.

However, the CalculatedHandoverDate model attempts the nDelius push in an `after_save` callback, which happens as part of the database transaction to create the record. Since that push raises an error, the write transaction is rolled back and the record never gets written. Right now, this seems like desirable behaviour since the CalculatedHandoverDate model isn't used for anything else – so it represents only dates which have successfully been pushed into nDelius.

The transaction rollback behaviour paired with our job runner's retry behaviour meant that failed jobs would be requeued and retried up to 25 times. Additionally, the next night, the cron job would see that a CalculatedHandoverDate doesn't yet exist for the offender, so it'd queue up a fresh job to try pushing the handover date again.

This combination of behaviours meant that our job runner's retry queue was growing every night, and duplicate RecalculateHandoverDate jobs were being queued for offenders.

The changes in this commit will resolve the continual growth of retry jobs by allowing them to complete even if the Community API push failed. This shouldn't be a problem because we'll queue up fresh jobs for those offenders the next day as part of our cron job – and since the CalculatedHandoverDate wasn't written, it'll attempt to write and push again.