### PR TITLE
Fixup offender spec

### DIFF
--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -66,12 +66,10 @@ module HmppsApi
     end
 
     def self.from_json(payload)
-      SentenceDetail.new.tap { |obj|
-        obj.load_from_json(payload)
-      }
+      SentenceDetail.new(payload)
     end
 
-    def load_from_json(payload)
+    def initialize(payload)
       @parole_eligibility_date = deserialise_date(payload, 'paroleEligibilityDate')
       @release_date = deserialise_date(payload, 'releaseDate')
       @sentence_start_date = deserialise_date(payload, 'sentenceStartDate')

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe HmppsApi::Offender do
@@ -6,8 +8,8 @@ describe HmppsApi::Offender do
       let(:offender) {
         build(:offender, sentence: build(:sentence_detail,
                                          conditionalReleaseDate: Time.zone.today + 24.months,
-                                               automaticReleaseDate: Time.zone.today + 19.months
-      ))
+                                         automaticReleaseDate: Time.zone.today + 19.months
+        ))
       }
 
       it 'is not within window' do
@@ -19,7 +21,7 @@ describe HmppsApi::Offender do
       let(:offender) {
         build(:offender, sentence: build(:sentence_detail,
                                          conditionalReleaseDate: Time.zone.today + 24.months,
-                                               automaticReleaseDate: Time.zone.today + 17.months))
+                                         automaticReleaseDate: Time.zone.today + 17.months))
       }
 
       it 'is within window' do
@@ -81,7 +83,7 @@ describe HmppsApi::Offender do
       let(:offender) {
         build(:offender).tap { |o|
           o.sentence = HmppsApi::SentenceDetail.from_json('automaticReleaseDate' => (Time.zone.today + 1.year).to_s,
-                                                           'sentenceStartDate' => Time.zone.today.to_s)
+                                                          'sentenceStartDate' => Time.zone.today.to_s)
           o.load_case_information(build(:case_information, case_allocation: 'NPS', mappa_level: 0))
         }
       }
@@ -94,7 +96,7 @@ describe HmppsApi::Offender do
     context 'when COM responsible already' do
       let(:offender) {
         build(:offender).tap { |o|
-          o.sentence = HmppsApi::SentenceDetail.new
+          o.sentence = build(:sentence_detail, conditionalReleaseDate: Time.zone.today + 1.week)
           o.load_case_information(build(:case_information))
         }
       }
@@ -167,12 +169,12 @@ describe HmppsApi::Offender do
       end
 
       include_examples 'expect fields to be', nil, [
-        :tier, :case_allocation, :mappa_level, :parole_review_date,
-        :welsh_offender, :ldu_name, :team_name, :allocated_com_name, :ldu_email_address
+          :tier, :case_allocation, :mappa_level, :parole_review_date,
+          :welsh_offender, :ldu_name, :team_name, :allocated_com_name, :ldu_email_address
       ]
 
       include_examples 'expect fields to be', false, [
-        :has_case_information?, :early_allocation?
+          :has_case_information?, :early_allocation?
       ]
     end
 

--- a/spec/models/hmpps_api/offender_summary_spec.rb
+++ b/spec/models/hmpps_api/offender_summary_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe HmppsApi::OffenderSummary do
   describe '#earliest_release_date' do
     context 'with blank sentence detail' do
-      before { subject.sentence = HmppsApi::SentenceDetail.new }
+      before { subject.sentence = HmppsApi::SentenceDetail.from_json({}) }
 
       it 'responds with no earliest release date' do
         expect(subject.earliest_release_date).to be_nil
@@ -15,7 +17,7 @@ describe HmppsApi::OffenderSummary do
 
       context 'with just the sentence expiry date' do
         before do
-          subject.sentence = HmppsApi::SentenceDetail.new.tap { |s| s.sentence_expiry_date = today_plus1 }
+          subject.sentence = HmppsApi::SentenceDetail.from_json({}).tap { |s| s.sentence_expiry_date = today_plus1 }
         end
 
         it 'uses the SED' do
@@ -123,7 +125,7 @@ describe HmppsApi::OffenderSummary do
     end
 
     context 'with blank sentence detail' do
-      before { subject.sentence = HmppsApi::SentenceDetail.new }
+      before { subject.sentence = HmppsApi::SentenceDetail.from_json({}) }
 
       it 'marks the offender as not sentenced' do
         expect(subject.sentenced?).to be false

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -1,39 +1,46 @@
 require 'rails_helper'
 
 describe RecommendationService do
-  let(:tier_a) {
-    build(:offender,
-          sentence: HmppsApi::SentenceDetail.from_json(
-            'sentenceStartDate' => Time.zone.today.to_s,
-            'automaticReleaseRate' => (Time.zone.today + 15.months).to_s)).tap { |o|
-      o.load_case_information(build(:case_information, tier: 'A'))
+  context 'when tier A' do
+    let(:tier_a) {
+      build(:offender,
+            sentence: HmppsApi::SentenceDetail.from_json(
+              'sentenceStartDate' => Time.zone.today.to_s,
+              'automaticReleaseRate' => (Time.zone.today + 15.months).to_s)).tap { |o|
+        o.load_case_information(build(:case_information, tier: 'A'))
+      }
     }
-  }
-  let(:tier_d) {
-    build(:offender,
-          sentence: HmppsApi::SentenceDetail.from_json(
-            'sentenceStartDate' => Time.zone.today.to_s,
-            'automaticReleaseDate' => (Time.zone.today + 10.months).to_s)).tap { |o|
-      o.load_case_information(build(:case_information, tier: 'D'))
-    }
-  }
 
-  let(:tier_a_and_immigration_case) {
-    build(:offender,
-          imprisonmentStatus: 'DET', sentence: HmppsApi::SentenceDetail.new).tap { |o|
-      o.load_case_information(build(:case_information, tier: 'A'))
-    }
-  }
-
-  it "can determine the best type of POM for Tier A" do
-    expect(described_class.recommended_pom_type(tier_a)).to eq(described_class::PROBATION_POM)
+    it "can determine the best type of POM for Tier A" do
+      expect(described_class.recommended_pom_type(tier_a)).to eq(described_class::PROBATION_POM)
+    end
   end
 
-  it "can determine the best type of POM for Tier D" do
-    expect(described_class.recommended_pom_type(tier_d)).to eq(described_class::PRISON_POM)
+  context 'when tier D' do
+    let(:tier_d) {
+      build(:offender,
+            sentence: HmppsApi::SentenceDetail.from_json(
+              'sentenceStartDate' => Time.zone.today.to_s,
+              'automaticReleaseDate' => (Time.zone.today + 10.months).to_s)).tap { |o|
+        o.load_case_information(build(:case_information, tier: 'D'))
+      }
+    }
+
+    it "can determine the best type of POM for Tier D" do
+      expect(described_class.recommended_pom_type(tier_d)).to eq(described_class::PRISON_POM)
+    end
   end
 
-  it "can determine the best type of POM for an immigration case" do
-    expect(described_class.recommended_pom_type(tier_a_and_immigration_case)).to eq(described_class::PRISON_POM)
+  context 'when tier A immigration case' do
+    let(:tier_a_and_immigration_case) {
+      build(:offender,
+            imprisonmentStatus: 'DET', sentence: HmppsApi::SentenceDetail.from_json('sentenceStartDate' => Time.zone.today.to_s)).tap { |o|
+        o.load_case_information(build(:case_information, tier: 'A'))
+      }
+    }
+
+    it "can determine the best type of POM for an immigration case" do
+      expect(described_class.recommended_pom_type(tier_a_and_immigration_case)).to eq(described_class::PRISON_POM)
+    end
   end
 end


### PR DESCRIPTION
A couple of specs were still using SentenceDetail.new - this really shouldn't be done (although maybe there's another refactor required to move from_json into initialize)  

This PR fixed up those 2 tests, as they crash after a later PR makes SentenceDetail.new totally illegal