### PR TITLE
fix new year coverage failures

### DIFF
--- a/spec/models/hmpps_api/offender_summary_spec.rb
+++ b/spec/models/hmpps_api/offender_summary_spec.rb
@@ -149,10 +149,10 @@ describe HmppsApi::OffenderSummary do
     end
 
     context 'with an 18th birthday in a past month' do
-      Timecop.travel('19 Feb 2020') do
-        before { subject.date_of_birth = '5 Jan 2002'.to_date }
+      before { subject.date_of_birth = '5 Jan 2001'.to_date }
 
-        it 'returns 18' do
+      it 'returns 18' do
+        Timecop.travel('19 Feb 2019') do
           expect(subject.age).to eq(18)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,8 @@ SimpleCov.start 'rails' do
   add_group "Services", "app/services"
 
   # Try to set this to current coverage levels so that it never goes down after a PR
-  # 20 lines uncovered at 99.40% coverage
-  minimum_coverage 99.40
+  # 20 lines uncovered at 99.41% coverage
+  minimum_coverage 99.41
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 


### PR DESCRIPTION
When 2021 rolled around, it showed up that we had missed a test when writing the age code in OffenderBase in Feb 2020. This PR adds an extra test for the missing case.