### PR TITLE
MO-281 upgrade faraday to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.6'
 gem 'auto_strip_attributes'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'coffee-rails', '~> 5.0'
-gem 'faraday'
+gem 'faraday', '~> 1.0'
 gem 'govuk_notify_rails'
 # we need the extra is_csv parameter available in 5.2 and above
 gem 'notifications-ruby-client', '>= 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,10 +130,13 @@ GEM
       railties (>= 5.0.0)
     faker (2.14.0)
       i18n (>= 1.6, < 2)
-    faraday (0.17.3)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.0)
     fast_underscore (0.3.1)
-    ffi (1.13.1)
+    ffi (1.14.2)
     flamegraph (0.9.5)
     flipflop (2.6.0)
       activesupport (>= 4.0)
@@ -409,8 +412,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (2.13.0)
-      faraday (>= 0.7.6, < 1.0)
+    sentry-raven (3.1.1)
+      faraday (>= 1.0)
     shellany (0.0.1)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
@@ -450,7 +453,7 @@ GEM
       rack (>= 1.3, < 3)
       rack-accept (~> 0.4)
       tilt (>= 1.4, < 3)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
@@ -500,7 +503,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  faraday
+  faraday (~> 1.0)
   fast_underscore
   flamegraph
   flipflop

--- a/app/services/hmpps_api/client.rb
+++ b/app/services/hmpps_api/client.rb
@@ -13,7 +13,7 @@ module HmppsApi
                         # Note - this might break if we ever use an API that uses a real POST
                         # rather than the fake GETs used by the Prison API
                         methods: Faraday::Request::Retry::IDEMPOTENT_METHODS + [:post],
-                        exceptions: [Faraday::ClientError, 'Timeout::Error']
+                        exceptions: [Faraday::ServerError, 'Timeout::Error']
 
         faraday.options.params_encoder = Faraday::FlatParamsEncoder
         faraday.request :instrumentation

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
     it 'raises an exception so the job will go into the retry queue' do
       expect {
         described_class.perform_now(offender_no)
-      }.to raise_error(Faraday::ClientError)
+      }.to raise_error(Faraday::Error)
     end
   end
 

--- a/spec/services/hmpps_api/client_spec.rb
+++ b/spec/services/hmpps_api/client_spec.rb
@@ -62,9 +62,9 @@ describe HmppsApi::Client do
     describe 'a 5xx error' do
       let(:status) { 500 }
 
-      it 'raises a Faraday::ClientError error' do
+      it 'raises the correct error' do
         expect { client.get(route) }.
-          to raise_error(Faraday::ClientError, "the server responded with status #{status}")
+          to raise_error(Faraday::ServerError, "the server responded with status #{status}")
       end
     end
   end


### PR DESCRIPTION
Our copy of the faraday need updating, but it is a major version change so it is not backwards-compatible.

This will enable the neew sentry-ruby gem (amongst others)