### PR TITLE
Fix label_tags to produce correct label for= attributes

### DIFF
--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -19,11 +19,11 @@
         <div class="govuk-radios">
           <div class="govuk-radios__item">
             <%= radio_button_tag("case_information[welsh_offender]", 'Yes', @case_info.welsh_offender == 'Yes', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[welsh_offender]", 'Yes', class: "govuk-label govuk-radios__label" %>
+            <%= label_tag "case_information_welsh_offender_Yes", 'Yes', class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
             <%= radio_button_tag("case_information[welsh_offender]", 'No', @case_info.welsh_offender == 'No', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[welsh_offender]", "No", class: "govuk-label govuk-radios__label" %>
+            <%= label_tag "case_information_welsh_offender_No", "No", class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>
@@ -43,11 +43,11 @@
         <div class="govuk-radios">
           <div class="govuk-radios__item">
             <%= radio_button_tag("case_information[case_allocation]", "NPS", @case_info.case_allocation == 'NPS', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[case_allocation]", "National Probation Service (NPS)", class: "govuk-label govuk-radios__label" %>
+            <%= label_tag "case_information_case_allocation_NPS", "National Probation Service (NPS)", class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
             <%= radio_button_tag("case_information[case_allocation]", "CRC", @case_info.case_allocation == 'CRC', class: "govuk-radios__input") %>
-            <%= label_tag "case_information[case_allocation]", "Community Rehabilitation Company (CRC)", class: "govuk-label govuk-radios__label" %>
+            <%= label_tag "case_information_case_allocation_CRC", "Community Rehabilitation Company (CRC)", class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
       </fieldset>
@@ -68,19 +68,19 @@
       <div class="govuk-radios">
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "A", @case_info[:tier] == 'A', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "A", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information_tier_A", "A", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "B", @case_info[:tier] == 'B', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "B", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information_tier_B", "B", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "C", @case_info[:tier] == 'C', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "C", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information_tier_C", "C", class: "govuk-label govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
           <%= radio_button_tag("case_information[tier]", "D", @case_info[:tier] == 'D', class: "govuk-radios__input") %>
-          <%= label_tag "case_information[tier]", "D", class: "govuk-label govuk-radios__label" %>
+          <%= label_tag "case_information_tier_D", "D", class: "govuk-label govuk-radios__label" %>
         </div>
       </div>
     </fieldset>

--- a/app/views/overrides/new.html.erb
+++ b/app/views/overrides/new.html.erb
@@ -37,7 +37,7 @@
                 <div class="govuk-form-group <% if @override.errors[:suitability_detail].present? %>govuk-form-group--error<% end %>">
                   <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="175">
                     <div class="govuk-form-group">
-                      <label class="govuk-label" for="provide-detail">Enter your reason for this decision</label>
+                      <label class="govuk-label" for="suitability-detail">Enter your reason for this decision</label>
                       <textarea class="govuk-textarea js-character-count " id="suitability-detail" name="override[suitability_detail]" rows="3" aria-describedby="suitability-detail-hint suitability-detail-error"></textarea>
                     </div>
                   </div>
@@ -45,11 +45,11 @@
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "no_staff", override_reason_contains(@override, 'no_staff'), id: "override-2", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "No available #{@prisoner.recommended_pom_type_label.downcase} POMs", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= label_tag "override-2", "No available #{@prisoner.recommended_pom_type_label.downcase} POMs", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
                 <%= check_box_tag("override[override_reasons][]", "continuity", override_reason_contains(@override, 'continuity'), id: "override-3", class: "govuk-checkboxes__input") %>
-                <%= label_tag "override[override_reasons][]", "This POM has worked with the prisoner before", class: 'govuk-label govuk-checkboxes__label' %>
+                <%= label_tag "override-3", "This POM has worked with the prisoner before", class: 'govuk-label govuk-checkboxes__label' %>
               </div>
               <div class="govuk-checkboxes__item">
                 <input class="govuk-checkboxes__input" id="override-conditional-4" name="override[override_reasons][]" type="checkbox" value="other" data-aria-controls="override-4"
@@ -66,7 +66,7 @@
                 <% end %>
                 <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="175">
                   <div class="govuk-form-group">
-                    <label class="govuk-label" for="provide-detail">Please provide detail here</label>
+                    <label class="govuk-label" for="more-detail">Please provide detail here</label>
                     <textarea class="govuk-textarea js-character-count govuk-textarea--error" id="more-detail" name="override[more_detail]" rows="3" aria-describedby="more-detail-hint more-detail-error"></textarea>
                   </div>
                 </div>

--- a/app/views/pages/contact_us.html.erb
+++ b/app/views/pages/contact_us.html.erb
@@ -34,7 +34,7 @@
 
       <%= form_tag(contact_us_path, method: :post, id: "help_form") do %>
         <div class="<%= field_error(@contact.errors, :name) %>">
-          <%= label_tag "Full name", "Full name", class: 'govuk-label' %>
+          <%= label_tag "name", "Full name", class: 'govuk-label' %>
           <% if @contact.errors[:name].present? %>
                   <span class="govuk-error-message">
                     <%= @contact.errors[:name].first %>
@@ -52,7 +52,7 @@
           <%= email_field_tag("email_address", @contact.email_address, id: "email_address", class: "govuk-input") %>
         </div>
         <div class="<%= field_error(@contact.errors, :job_type) %>">
-          <%= label_tag "Your job role", "Your job role", class: 'govuk-label' %>
+          <%= label_tag "job_type", "Your job role", class: 'govuk-label' %>
           <% if @contact.errors[:job_type].present? %>
                   <span class="govuk-error-message">
                     <%= @contact.errors[:job_type].first %>
@@ -70,7 +70,7 @@
           <%= text_field_tag("prison", @contact.prison, id: "prison", class: "govuk-input") %>
         </div>
         <div class="<%= field_error(@contact.errors, :message) %>">
-          <%= label_tag "Describe what you need help with", "Describe what you need help with", class: 'govuk-label' %>
+          <%= label_tag "message", "Describe what you need help with", class: 'govuk-label' %>
           <% if @contact.errors[:message].present? %>
                   <span class="govuk-error-message">
                     <%= @contact.errors[:message].first %>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -21,7 +21,7 @@
             <div class="govuk-form-group">
               <div class="govuk-radios__item">
                 <%= radio_button_tag("edit_pom[description]", "FT", @pom.working_pattern.to_s == '1.0', id: "working_pattern-ft", class: "govuk-radios__input") %>
-                <%= label_tag "edit_pom[description]", "Full time", class: "govuk-label govuk-radios__label" %>
+                <%= label_tag "working_pattern-ft", "Full time", class: "govuk-label govuk-radios__label" %>
               </div>
               <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
                 <div class="govuk-radios__item">
@@ -34,7 +34,7 @@
                   <% 9.downto(1).each do |value| %>
                     <div class="govuk-radios__item">
                       <%= radio_button_tag("edit_pom[working_pattern]", "0.#{value}", @pom.working_pattern.to_s == "0.#{value}", id: "working_pattern-#{value}", class: "govuk-radios__input") %>
-                      <%= label_tag "edit_pom[working_pattern]", "Part time 0.#{value} - #{working_pattern_to_days(value)}", class: "govuk-label govuk-radios__label" %>
+                      <%= label_tag "working_pattern-#{value}", "Part time 0.#{value} - #{working_pattern_to_days(value)}", class: "govuk-label govuk-radios__label" %>
                     </div>
                   <% end %>
                 </div>
@@ -54,7 +54,7 @@
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
               <%= radio_button_tag("edit_pom[status]", "active", @pom.status == 'active', id: "status-1", class: "govuk-radios__input") %>
-              <%= label_tag "edit_pom[status]", "Active", class: "govuk-label govuk-radios__label" %>
+              <%= label_tag "status-1", "Active", class: "govuk-label govuk-radios__label" %>
             </div>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="status-conditional-2" name="edit_pom[status]" type="radio" value="unavailable" data-aria-controls="status-2" <%= 'checked' if @pom.status == 'unavailable'%>>


### PR DESCRIPTION
During another story, it appeared that we have a number of label_tag calls that don't map the label onto the input field. This seems like it should be important for accessibility (and technical HTML standards compliance) 