### PR TITLE
MO-342 - don't crash checking early_allocation_window 

### DIFF
--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -207,13 +207,14 @@ module HmppsApi
     end
 
     def within_early_allocation_window?
-      [
+      earliest_date = [
           tariff_date,
           parole_eligibility_date,
           parole_review_date,
           automatic_release_date,
           conditional_release_date
-      ].compact.min <= Time.zone.today + 18.months
+      ].compact.min
+      earliest_date.present? && earliest_date <= Time.zone.today + 18.months
     end
 
   private

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -4,6 +4,19 @@ require 'rails_helper'
 
 describe HmppsApi::Offender do
   describe '#within_early_allocation_window?' do
+    context 'with no dates' do
+      let(:offender) {
+        build(:offender, sentence: build(:sentence_detail,
+                                         conditionalReleaseDate: nil,
+                                         automaticReleaseDate: nil
+        ))
+      }
+
+      it 'is not within window' do
+        expect(offender.within_early_allocation_window?).to eq(false)
+      end
+    end
+
     context 'when ARD > 18 months' do
       let(:offender) {
         build(:offender, sentence: build(:sentence_detail,


### PR DESCRIPTION
This is a fix for a production bug - if no early allocation dates are present, we should say 'not within window' rather than crashing