### PR TITLE
MO-323 run 45 day email on 28th Jan 2021

### DIFF
--- a/deploy/production/cron-handover-email-job.yaml
+++ b/deploy/production/cron-handover-email-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: handover-email-job
 spec:
-  schedule: "4 9 1 * *"
+  schedule: "4 9 28 * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
Run the 45-dsy handover email on 28th Jan 2021, to avoid the transition of LDU/PDU on 29th.

Remember to revert this PR before 1sr March 2021