### PR TITLE
raise HTTP errors in OAuth client

### DIFF
--- a/app/services/hmpps_api/oauth/client.rb
+++ b/app/services/hmpps_api/oauth/client.rb
@@ -7,7 +7,9 @@ module HmppsApi
 
       def initialize(host)
         @host = host
-        @connection = Faraday.new
+        @connection = Faraday.new do |faraday|
+          faraday.response :raise_error
+        end
       end
 
       def post(route)

--- a/spec/services/hmpps_api/oauth/client_spec.rb
+++ b/spec/services/hmpps_api/oauth/client_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 require 'base64'
 
 describe HmppsApi::Oauth::Client do
-  describe 'with a valid request' do
+  let(:api_host) { Rails.configuration.nomis_oauth_host }
+  let(:client) { described_class.new(api_host) }
+  let(:route) { '/auth/oauth/token?grant_type=client_credentials' }
+
+  context 'with a valid request' do
     it 'sets the Authorization header' do
       WebMock.stub_request(:post, /\w/).to_return(body: '{}')
-
-      api_host = Rails.configuration.nomis_oauth_host
-      route = '/auth/oauth/token?grant_type=client_credentials'
-      client = described_class.new(api_host)
 
       client.post(route)
 
@@ -20,6 +20,22 @@ describe HmppsApi::Oauth::Client do
             )
           }
       )
+    end
+
+    context 'when a HTTP error response is received' do
+      before do
+        WebMock.stub_request(:post, /\w/).
+            to_return(status: status)
+      end
+
+      describe 'a 5xx error' do
+        let(:status) { 504 }
+
+        it 'raises the correct error' do
+          expect { client.post(route) }.
+              to raise_error(Faraday::ServerError, "the server responded with status #{status}")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://sentry.io/organizations/ministryofjustice/issues/2148575505/?project=5584139&query=is%3Aunresolved

OAuth client doesn't raise when HTTP errors happen, so it fails by accident
