### PR TITLE
MO-266: Remove whitespace on VLO emails

### DIFF
--- a/app/models/victim_liaison_officer.rb
+++ b/app/models/victim_liaison_officer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class VictimLiaisonOfficer < ApplicationRecord
+  auto_strip_attributes :email
   # Other version fields (user_first_name and user_last_name) filled in by controller
   has_paper_trail meta: { nomis_offender_id: :nomis_id_for_paper_trail }
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -68,7 +68,8 @@ feature 'View a prisoner profile page', :allocation do
 
         # fill in missing fields and submit
         fill_in 'Last name', with: 'Smith'
-        fill_in 'Email address', with: 'jim.smith@hotmail.com'
+        # email has leading and trailing whitespaces, that are removed before validation
+        fill_in 'Email address', with: ' jim.smith@hotmail.com '
         click_button 'Submit'
         find '.vlo-row-1' # wait for page to load
         expect(page).to have_content('Smith, Jim')


### PR DESCRIPTION
If there are leading or trailing spaces around an email address entered on to the VLO form, the form will generate an error message. This commit removes the whitespaces before validation so errors won't occur for this issue.