### PR TITLE
Add ruby-gemset to git-ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 *.swp
 *.swo
 /Brewfile.lock.json
+
+# Ignore ruby-gemset (local isolated environments for dependencies)
+.ruby-gemset


### PR DESCRIPTION
This PR adds a ruby-gemset to git ignore.

This came about as I had issues with another project I was working in my 10% time that used a different version of bundler and made a muddle of things for me in offender-management-allocation-manager! 

__**What’s a Gemset?**_
RVM Gemset allows you to create a new isolated environment for dependencies. This means that you ensure to avoid cross-dependency issues as you are isolated from other gemsets for a given Ruby version._

I tried to just create a local git ignore but unfortunately it didn't work, so I have put it in the main git-ignore. 