### PR TITLE
Mo217 pom handover like spo

### DIFF
--- a/app/views/caseload_handovers/index.html.erb
+++ b/app/views/caseload_handovers/index.html.erb
@@ -2,7 +2,9 @@
   <%= render '/layouts/prison_switcher' %>
 <% end %>
 
-<%= render(:partial => 'handovers/subnav', :locals => {:active => :caseload_handovers}) %>
+<%= render(:partial => 'handovers/subnav', :locals => {:active => :caseload_handovers,
+                                                       prison_total_handovers: @prison_total_handovers,
+                                                       pending_handover_count: @pending_handover_count}) %>
 
 <% if @pom.blank? %>
   <h2 class="govuk-heading-l">No pending cases </h2>
@@ -14,24 +16,72 @@
   <table class="govuk-table responsive tablesorter">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Prisoner name</th>
-      <th class="govuk-table__header" scope="col">Prisoner number</th>
-      <th class="govuk-table__header" scope="col">Handover<br/>start date</th>
-      <th class="govuk-table__header" scope="col">Responsibility<br/>handover</th>
-      <th class="govuk-table__header" scope="col">Earliest release<br/>date</th>
-      <th class="govuk-table__header" scope="col">Role</th>
-      <th class="govuk-table__header" scope="col">Action</th>
+      <th class="govuk-table__header" scope="col">
+        <a href="<%= sort_link('last_name') %>">
+          Prisoner
+        </a>
+        <%= sort_arrow('last_name') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('handover_start_date') %>">
+          Handover start date
+        </a>
+        <%= sort_arrow('handover_start_date') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('responsibility_handover_date') %>">
+          Responsibility changes
+        </a>
+        <%= sort_arrow('responsibility_handover_date') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('pom_responsibility') %>">
+          POM Role
+        </a>
+        <%= sort_arrow('pom_responsibility') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('allocated_com_name') %>">
+          COM
+        </a>
+        <%= sort_arrow('allocated_com_name') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        <a href="<%= sort_link('case_allocation') %>">
+          Service provider
+        </a>
+        <%= sort_arrow('case_allocation') %>
+      </th>
+      <th class="govuk-table__header sorter-false" xscope="col">
+        Action
+      </th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
-    <% @upcoming_handovers.each_with_index do |offender, i| %>
+    <% @offenders.each_with_index do |offender, i| %>
       <tr class="govuk-table__row offender_row_<%= i %>">
-        <td aria-label="Prisoner name" class="govuk-table__cell "><%= offender.full_name %></td>
-        <td aria-label="Prisoner number" class="govuk-table__cell "><%= offender.offender_no %></td>
-        <td aria-label="Handover start date" class="govuk-table__cell "><%= format_date(offender.handover_start_date) %></td>
-        <td aria-label="Responsibility handover" class="govuk-table__cell "><%= format_date(offender.responsibility_handover_date) %></td>
-        <td aria-label="Earliest release date" class="govuk-table__cell "><%= format_date(offender.earliest_release_date, replacement: "Unknown") %></td>
-        <td aria-label="Role" class="govuk-table__cell "><%= offender.pom_responsibility %></td>
+        <td aria-label="Prisoner name" class="govuk-table__cell ">
+          <%= offender.full_name %>
+          <br/>
+          <span class='govuk-hint govuk-!-margin-bottom-0'>
+            <%= offender.offender_no %>
+          </span>
+        </td>
+        <td aria-label="Handover start date" class="govuk-table__cell">
+          <%= format_date(offender.handover_start_date, replacement: "Unknown") %>
+        </td>
+        <td aria-label="Responsibility changes" class="govuk-table__cell">
+          <%= format_date(offender.responsibility_handover_date, replacement: "Unknown") %>
+        </td>
+        <td aria-label="POM Role" class="govuk-table__cell">
+          <%= offender.pom_responsibility %>
+        </td>
+        <td aria-label="COM" class="govuk-table__cell">
+          <%= offender.allocated_com_name || "Not allocated" %>
+        </td>
+        <td aria-label="Service provider" class="govuk-table__cell">
+          <%= offender.case_allocation %>
+        </td>
         <td aria-label="Action" class="govuk-table__cell ">
           <%= link_to('View', prison_prisoner_path(@prison.code, offender.offender_no), class: "govuk-link" ) %>
         </td>

--- a/app/views/handovers/_subnav.html.erb
+++ b/app/views/handovers/_subnav.html.erb
@@ -4,7 +4,7 @@
       <li class="moj-sub-navigation__item">
         <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :all_handovers %>
            href="<%= prison_handovers_path(@prison.code) %>">
-          See all handover cases in <%= @prison.name %> (<%= @summary.handovers_total %>)
+          See all handover cases in <%= @prison.name %> (<%= prison_total_handovers %>)
         </a>
       </li>
     <% end %>
@@ -12,7 +12,7 @@
       <li class="moj-sub-navigation__item">
         <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :caseload_handovers %>
            href="<%= prison_staff_caseload_handovers_path(@prison.code, @staff_id) %>">
-          See handover cases that you are allocated (<%= @pending_handover_count %>)
+          See handover cases that you are allocated (<%= pending_handover_count %>)
         </a>
       </li>
     <% end %>

--- a/app/views/handovers/index.html.erb
+++ b/app/views/handovers/index.html.erb
@@ -2,7 +2,9 @@
   <%= render '/layouts/prison_switcher' %>
 <% end %>
 
-<%= render(:partial => 'subnav', :locals => {:active => :all_handovers}) %>
+<%= render(:partial => 'subnav', :locals => {:active => :all_handovers,
+                                             prison_total_handovers: @summary.handovers_total,
+                                             pending_handover_count: @pending_handover_count}) %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Case handover status</h1>
 <p>Cases where responsibility is being handed over (or is within 30 days of handover) to the community probation team.</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -129,6 +129,17 @@ end
   end
 end
 
+# Test offenders which have handovers in Feb 2021
+['G2407UH', 'G5884GU'].each do |offender_no|
+  CaseInformation.find_or_create_by!(nomis_offender_id: offender_no) do |info|
+    info.assign_attributes(tier: 'B',
+                           case_allocation:'NPS',
+                           welsh_offender: 'Yes',
+                           manual_entry: true,
+                           team: team2)
+  end
+end
+
 # test offender > 18 months before release (20/12/2023)
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G7281UH') do |info|
   info.assign_attributes(tier: 'B',

--- a/spec/controllers/caseload_handovers_controller_spec.rb
+++ b/spec/controllers/caseload_handovers_controller_spec.rb
@@ -20,11 +20,12 @@ RSpec.describe CaseloadHandoversController, :allocation, type: :controller do
 
   before do
     stub_poms(prison, poms)
-    stub_signed_in_pom(prison, pom.staffId, 'alice')
   end
 
   describe '#index' do
     let(:handover_offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, automaticReleaseDate: Time.zone.today + 31.weeks)) }
+    let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, automaticReleaseDate: Time.zone.today + 13.weeks)) }
+    let(:case_allocation) { 'CRC' }
 
     before do
       stub_offenders_for_prison(prison, [offender, handover_offender])
@@ -36,29 +37,30 @@ RSpec.describe CaseloadHandoversController, :allocation, type: :controller do
       create(:allocation, nomis_offender_id: handover_offender.fetch(:offenderNo), primary_pom_nomis_id: pom.staffId, prison: prison)
     end
 
-    context 'when NPS' do
+    context 'with POM role' do
       before do
-        stub_sso_data(prison)
+        stub_signed_in_pom(prison, pom.staffId, 'alice')
       end
 
-      let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, paroleEligibilityDate: Time.zone.today + 36.weeks)) }
-      let(:case_allocation) { 'NPS' }
-
-      it 'can pull back a NPS offender due for handover' do
+      it 'retrieves just offenders due for handover' do
         get :index, params: { prison_id: prison, staff_id: staff_id }
         expect(response).to be_successful
-        expect(assigns(:upcoming_handovers).map(&:offender_no)).to match_array([offender, handover_offender].map { |o| o.fetch(:offenderNo) })
+        expect(assigns(:offenders).map(&:offender_no)).to match_array([offender.fetch(:offenderNo)])
       end
     end
 
-    context 'when CRC' do
-      let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, automaticReleaseDate: Time.zone.today + 13.weeks)) }
-      let(:case_allocation) { 'CRC' }
+    context 'with POM and SPO roles' do
+      before do
+        stub_signed_in_spo_pom(prison, pom.staffId, 'alice')
+      end
 
-      it 'can pull back a CRC offender due for handover' do
+      render_views
+
+      it 'retrieves just offenders due for handover' do
         get :index, params: { prison_id: prison, staff_id: staff_id }
+        expect(response).to have_http_status(200)
         expect(response).to be_successful
-        expect(assigns(:upcoming_handovers).map(&:offender_no)).to match_array([offender.fetch(:offenderNo)])
+        expect(assigns(:offenders).map(&:offender_no)).to match_array([offender.fetch(:offenderNo)])
       end
     end
   end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -79,6 +79,13 @@ module ApiHelper
       to_return(body: { 'staffId': staff_id }.to_json)
   end
 
+  def stub_signed_in_spo_pom(prison, staff_id, username = 'alice')
+    stub_auth_token
+    stub_sso_data(prison, username: username, roles: [SsoIdentity::POM_ROLE, SsoIdentity::SPO_ROLE])
+    stub_request(:get, "#{T3}/users/#{username}").
+        to_return(body: { 'staffId': staff_id }.to_json)
+  end
+
   def stub_offenders_for_prison(prison, offenders, movements = [])
     # Stub the call to get_offenders_for_prison. Takes a list of offender hashes (in nomis camelCase format) and
     # a list of bookings (same key format). It it your responsibility to make sure they contain the data you want

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -18,19 +18,19 @@ module FeaturesHelper
         to_return(body: pom.emails.to_json)
   end
 
-  def signin_spo_pom_user(name = 'MOIC_POM')
-    mock_sso_response(name, ['ROLE_ALLOC_MGR', 'ROLE_ALLOC_CASE_MGR'])
+  def signin_spo_pom_user(prisons = %w[LEI RSI], name = 'MOIC_POM')
+    mock_sso_response(name, [SsoIdentity::SPO_ROLE, SsoIdentity::POM_ROLE], prisons)
   end
 
   def signin_global_admin_user
     mock_sso_response('MOIC_POM', [SsoIdentity::SPO_ROLE, SsoIdentity::ADMIN_ROLE], PrisonService.prison_codes)
   end
 
-  def signin_pom_user
-    mock_sso_response('MOIC_POM', [SsoIdentity::POM_ROLE])
+  def signin_pom_user prisons = %w[LEI RSI]
+    mock_sso_response('MOIC_POM', [SsoIdentity::POM_ROLE], prisons)
   end
 
-  def mock_sso_response(username, roles, prisons = %w[LEI RSI])
+  def mock_sso_response(username, roles, prisons)
     hmpps_sso_response = {
       'info' => double('user_info', username: username, active_caseload: prisons.first, caseloads: prisons, roles: roles),
       'credentials' => double('credentials', expires_at: Time.zone.local(2030, 1, 1).to_i,


### PR DESCRIPTION
This change makes the POM handover view almost identical to the SPO one - apart from the POM Name which is replaced by the rensponsibility field