### PR TITLE
Fix spec which failed on 18th Jan 2021

### DIFF
--- a/spec/services/handover_date_service_responsibility_spec.rb
+++ b/spec/services/handover_date_service_responsibility_spec.rb
@@ -321,6 +321,14 @@ describe HandoverDateService do
           end
 
           context 'when the prison is private' do
+            before do
+              Timecop.travel Date.new(2021, 1, 1)
+            end
+
+            after do
+              Timecop.return
+            end
+
             let(:offender) {
               OpenStruct.new  prison_id: 'TSI',
                               nps_case?: true,


### PR DESCRIPTION
Add a Timecop before/after to freeze date on a time-sensitive spec