### PR TITLE
Fix 'last name' title case discrepancy in test factories

### DIFF
--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -7,7 +7,9 @@ FactoryBot.define do
     end
 
     created_by_name do
-      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      "#{Faker::Name.first_name} #{Faker::Name.last_name.titleize}"
     end
 
     event do
@@ -33,7 +35,9 @@ FactoryBot.define do
     end
 
     primary_pom_name do
-      "#{Faker::Name.last_name}, #{Faker::Name.first_name}"
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      "#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"
     end
 
     primary_pom_allocated_at do
@@ -52,7 +56,9 @@ FactoryBot.define do
       event {Allocation::ALLOCATE_PRIMARY_POM}
       event_trigger { Allocation::USER }
       primary_pom_nomis_id { 123_456}
-      primary_pom_name {"#{Faker::Name.last_name}, #{Faker::Name.first_name}"}
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      primary_pom_name {"#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"}
       secondary_pom_nomis_id { nil }
       secondary_pom_name { nil }
     end
@@ -79,7 +85,9 @@ FactoryBot.define do
       event {Allocation::REALLOCATE_PRIMARY_POM}
       event_trigger { Allocation::USER }
       primary_pom_nomis_id { 123_456}
-      primary_pom_name {"#{Faker::Name.last_name}, #{Faker::Name.first_name}"}
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      primary_pom_name {"#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"}
       secondary_pom_nomis_id { nil }
       secondary_pom_name { nil }
     end

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -4,7 +4,9 @@ FactoryBot.define do
   factory :early_allocation do
     prison { 'LEI' }
     created_by_firstname { Faker::Name.first_name }
-    created_by_lastname { Faker::Name.last_name }
+    # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+    # So we also .titleize the last name here to avoid breaking tests
+    created_by_lastname { Faker::Name.last_name.titleize }
 
     oasys_risk_assessment_date { Time.zone.today - 2.months }
 
@@ -36,14 +38,18 @@ FactoryBot.define do
       discretionary
       community_decision { true }
       updated_by_firstname { Faker::Name.first_name }
-      updated_by_lastname { Faker::Name.last_name }
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      updated_by_lastname { Faker::Name.last_name.titleize }
     end
 
     trait :discretionary_declined do
       discretionary
       community_decision { false }
       updated_by_firstname { Faker::Name.first_name }
-      updated_by_lastname { Faker::Name.last_name }
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      updated_by_lastname { Faker::Name.last_name.titleize }
     end
 
     trait :ineligible do

--- a/spec/factories/email_history.rb
+++ b/spec/factories/email_history.rb
@@ -14,7 +14,9 @@ FactoryBot.define do
     end
 
     name do
-      "#{Faker::Name.first_name} #{Faker::Name.last_name}"
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      "#{Faker::Name.first_name} #{Faker::Name.last_name.titleize}"
     end
 
     email do


### PR DESCRIPTION
We had some test factories which were causing flaky test failures, due to a discrepancy between lower/uppercase letters in 'last name' fields.

This is an annoying side-effect of the fact that POM names in NOMIS are always UPPERCASE. Whilst reading them into the application, we convert them to Title Case using Rails' `.titleize` method.

However for surnames such as 'McDonald', the Title Case conversion transforms this to 'Mcdonald' (note the lowercase 'd').

To counteract this, our test factories need to fake names in the same format – i.e. they _also_ need to titleize names.

Without this, some tests sometimes fail due to 'McDonald' not matching 'Mcdonald'. In reality this was just a bug in the factories.