### PR TITLE
MO-49: Bug Fix - Responsibility handover should not take place before the start of handover

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -39,7 +39,9 @@ class HandoverDateService
       responsibility = responsibility_override(offender)
       if responsibility.nil?
         handover_date, reason = nps_handover_date(offender)
-        HandoverData.new nps_responsibility(offender, handover_date), nps_start_date(offender), handover_date, reason
+        start_date = nps_start_date(offender)
+        handover_date = start_date if start_date > handover_date
+        HandoverData.new nps_responsibility(offender, handover_date), start_date, handover_date, reason
       elsif responsibility == UNKNOWN
         HandoverData.new UNKNOWN, nil, nil, 'NPS Case - missing dates'
       else


### PR DESCRIPTION
This applies to the scenario that the home detention curfew eligibility date is entered incorrectly too early.

This resulted in the responsibility handover is taking place before start of handover.

This commit fixes this by setting the responsibility handover to the same date as the start of handover in this scenario