### PR TITLE
MO-193: Prevents pom name from displaying in DPS quick look screen after an offenders sentence has ended

### DIFF
--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -4,7 +4,9 @@ module Api
   class AllocationApiController < Api::ApiController
     def show
       render_404('Not ready for allocation') && return if allocation.nil?
-      render_404('Not allocated') && return if allocation.primary_pom_nomis_id.nil?
+
+      offender = OffenderService.get_offender(offender_number)
+      render_404('Not allocated') && return unless allocation.active? && offender.inside_omic_policy?
 
       render json: allocation_as_json
     end

--- a/spec/controllers/api/allocation_api_controller_spec.rb
+++ b/spec/controllers/api/allocation_api_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe Api::AllocationApiController, :allocation, type: :controller do
+  describe '#show' do
+    let(:rsa_private) { OpenSSL::PKey::RSA.generate 2048 }
+    let(:stub_url) { "#{api_host}/secure/offenders/nomsNumber/#{offender.fetch(:offenderNo)}/prisonOffenderManager" }
+    let(:api_host) { Rails.configuration.community_api_host }
+
+    let(:prison) { build(:prison) }
+    let!(:co_working_allocation) {
+      create(:allocation, :co_working, primary_pom_nomis_id: primary_pom.staff_id,
+                                          secondary_pom_nomis_id: secondary_pom.staff_id, nomis_offender_id: offender.fetch(:offenderNo))
+    }
+    let(:primary_pom) { build(:pom) }
+    let(:secondary_pom) { build(:pom) }
+
+    let(:rsa_public) { Base64.strict_encode64(rsa_private.public_key.to_s) }
+
+    before do
+      allow(Rails.configuration).to receive(:nomis_oauth_public_key).and_return(rsa_public)
+      accepts_bearer_tokens
+      stub_pom(primary_pom)
+      stub_pom(secondary_pom)
+      stub_offender(offender)
+      stub_auth_token
+    end
+
+
+    describe 'when a pom has been allocated an offender' do
+      context 'when an offender is currently serving a sentence' do
+        let(:offender) { build(:nomis_offender, agencyId: prison.code,  sentence: attributes_for(:sentence_detail)) }
+
+        it 'returns pom allocation details' do
+          get :show, params: { prison_id: prison.code, offender_no: offender.fetch(:offenderNo) }
+
+          expect(response).to have_http_status(200)
+          expect(JSON.parse(response.body)).to eq("primary_pom" => { "name" => primary_pom.full_name.to_s, "staff_id" => primary_pom.staff_id },
+                                                  "secondary_pom" => {  "name" => secondary_pom.full_name.to_s, "staff_id" => secondary_pom.staff_id })
+        end
+      end
+
+      context 'when an offender has finished their sentence' do
+        # currently an offender is not able to be unallocated from a pom. As a result the the pom remains on the DPS
+        # quick look screen once an offenders sentence has finished. This is a quick fix to stop this happening.
+        let(:offender) { build(:nomis_offender, agencyId: prison.code,  sentence: attributes_for(:sentence_detail, :unsentenced)) }
+
+        it 'does not return a poms allocation details' do
+          create(:allocation, nomis_offender_id: offender.fetch(:offenderNo), primary_pom_nomis_id: primary_pom.staffId, secondary_pom_nomis_id: secondary_pom.staffId)
+          get :show, params: { prison_id: prison.code, offender_no: offender.fetch(:offenderNo) }
+
+          expect(response).to have_http_status(404)
+          expect(JSON.parse(response.body)).to eq("message" => "Not allocated", "status" => "error")
+        end
+      end
+    end
+  end
+
+  def accepts_bearer_tokens
+    payload = {
+      user_name: 'Sally600',
+      scope: ['read'],
+      exp: 4.hours.from_now.to_i
+    }
+    request_header(payload)
+  end
+
+  def encode_payload(payload)
+    JWT.encode(payload, OpenSSL::PKey::RSA.new(rsa_private), 'RS256')
+  end
+
+  def request_header(payload)
+    token = encode_payload(payload)
+    request.headers['AUTHORIZATION'] = "Bearer #{token}"
+  end
+end

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -63,6 +63,17 @@ FactoryBot.define do
       secondary_pom_name { nil }
     end
 
+    trait :co_working do
+      event {Allocation:: ALLOCATE_SECONDARY_POM}
+      event_trigger { Allocation::USER }
+      primary_pom_nomis_id {345_456}
+      # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
+      # So we also .titleize the last name here to avoid breaking tests
+      primary_pom_name {"#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"}
+      secondary_pom_nomis_id {234_567}
+      secondary_pom_name {"#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"}
+    end
+
     trait :release do
       event { Allocation::DEALLOCATE_RELEASED_OFFENDER }
       event_trigger {Allocation::OFFENDER_RELEASED}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ SimpleCov.start 'rails' do
 
   # Try to set this to current coverage levels so that it never goes down after a PR
   # 20 lines uncovered at 99.41% coverage
-  minimum_coverage 99.41
+  minimum_coverage 99.46
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 


### PR DESCRIPTION
POM names have remained on DPS quick look screen after an offender sentence has ended which has caused some confusion. This is because currently an offender can not be unallocated from a POM. This is PR is just a quick fix. 