### PR TITLE
MO-293 give the early allocation OaSys date question its own page

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -8,11 +8,23 @@ class EarlyAllocationsController < PrisonsApplicationController
   end
 
   def new
-    @early_allocation = EarlyAllocationEligibleForm.new offender_id_from_url
+    @early_allocation = EarlyAllocationDateForm.new offender_id_from_url
     if @offender.ldu_email_address.present?
       render
     else
       render 'dead_end'
+    end
+  end
+
+  def oasys_date
+    form_params = oasys_date_params.merge(offender_id_from_url)
+    form = EarlyAllocationDateForm.new form_params
+    if form.valid?
+      @early_allocation = EarlyAllocation.new form_params.merge(default_params)
+      render 'eligible'
+    else
+      @early_allocation = form
+      render 'new'
     end
   end
 
@@ -33,7 +45,7 @@ class EarlyAllocationsController < PrisonsApplicationController
       end
     else
       @early_allocation = form
-      render 'new'
+      render 'eligible'
     end
   end
 
@@ -123,6 +135,10 @@ private
     params.require(:early_allocation).
       permit(EarlyAllocation::ELIGIBLE_BOOLEAN_FIELDS +
                 [:oasys_risk_assessment_date])
+  end
+
+  def oasys_date_params
+    params.fetch(:early_allocation, {}).permit(:oasys_risk_assessment_date)
   end
 
   def discretionary_params

--- a/app/forms/early_allocation_date_form.rb
+++ b/app/forms/early_allocation_date_form.rb
@@ -1,0 +1,21 @@
+class EarlyAllocationDateForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  # ActiveRecord version needed to consume the multi-parameter date field
+  include ActiveRecord::AttributeAssignment
+
+  attribute :nomis_offender_id, :string
+
+  validates_presence_of :nomis_offender_id, strict: true
+
+  attribute :oasys_risk_assessment_date, :date
+
+  validates :oasys_risk_assessment_date,
+            presence: true,
+            date: {
+                before: proc { Time.zone.today },
+                after: proc { Time.zone.today - 3.months },
+                # validating presence, so stop date validator double-checking
+                allow_nil: true
+            }
+end

--- a/app/forms/early_allocation_discretionary_form.rb
+++ b/app/forms/early_allocation_discretionary_form.rb
@@ -1,8 +1,6 @@
 class EarlyAllocationDiscretionaryForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-  # ActiveRecord version needed to consume the multi-parameter date field
-  include ActiveRecord::AttributeAssignment
 
   attribute :nomis_offender_id, :string
 

--- a/app/forms/early_allocation_eligible_form.rb
+++ b/app/forms/early_allocation_eligible_form.rb
@@ -1,23 +1,13 @@
 class EarlyAllocationEligibleForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-  # ActiveRecord version needed to consume the multi-parameter date field
-  include ActiveRecord::AttributeAssignment
 
   attribute :nomis_offender_id, :string
 
   validates_presence_of :nomis_offender_id, strict: true
 
+  # Stage 1 fields - delivered as hidden fields on the form
   attribute :oasys_risk_assessment_date, :date
-
-  validates :oasys_risk_assessment_date,
-            presence: true,
-            date: {
-                before: proc { Time.zone.today },
-                after: proc { Time.zone.today - 3.months },
-                # validating presence, so stop date validator double-checking
-                allow_nil: true
-            }
 
   EarlyAllocation::ELIGIBLE_BOOLEAN_FIELDS.each do |field|
     attribute field, :boolean

--- a/app/views/early_allocations/_eligible.html.erb
+++ b/app/views/early_allocations/_eligible.html.erb
@@ -7,18 +7,7 @@
 
   <h1 class="govuk-heading-l govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
 
-  <p class="govuk-body">
-    Some cases will be referred to the community automatically. Others need the
-    agreement of both the Head of Offender Management Delivery and the
-    community probation team. This assessment will help you determine what
-    kind of community referral you need to make.
-  </p>
-
-  <%= f.govuk_date_field(:oasys_risk_assessment_date,
-                         legend: {
-                             size: 's',
-                             text: 'When was the last OASys risk assessment?'
-                         }) %>
+  <%= f.hidden_field :oasys_risk_assessment_date %>
 
   <%= render partial: 'yes_no_boolean_field', locals: {form: f,
                                                 heading_text: 'Was this prisoner convicted under the Terrorism Act 2000?',

--- a/app/views/early_allocations/_oasys_date.html.erb
+++ b/app/views/early_allocations/_oasys_date.html.erb
@@ -1,0 +1,24 @@
+<%= form_for(@early_allocation,
+             as: :early_allocation,
+             url: oasys_date_prison_prisoner_early_allocations_path(@prison.code, @early_allocation.nomis_offender_id),
+             method: form_method,
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l govuk-!-margin-top-4">Assessment for early allocation to the community probation team</h1>
+
+  <p class="govuk-body">
+    Some cases will be referred to the community automatically. Others need the
+    agreement of both the Head of Offender Management Delivery and the
+    community probation team. This assessment will help you determine what
+    kind of community referral you need to make.
+  </p>
+
+  <%= f.govuk_date_field(:oasys_risk_assessment_date,
+                         legend: {
+                             size: 's',
+                             text: 'When was the last OASys risk assessment?'
+                         }) %>
+
+  <%= f.submit "Continue", role: "button", draggable: "false", class: "govuk-button" %>
+<% end %>

--- a/app/views/early_allocations/eligible.html.erb
+++ b/app/views/early_allocations/eligible.html.erb
@@ -7,7 +7,7 @@
     For further guidance on Early Allocation referral please see
     <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">EQuiP</a>
   </p>
-    <%= render 'oasys_date', form_method: :post %>
+    <%= render 'eligible', form_method: :post %>
   </div>
     <%= render(partial: 'prisoner_info_sidebar') %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,13 +49,16 @@ en:
           attributes:
             reason_text:
               blank: You must say why you are changing responsibility for this case
-        early_allocation_eligible_form:
+        early_allocation_date_form:
           format: "%{message}"
           attributes:
             oasys_risk_assessment_date:
               blank: Enter the date of the last OASys risk assessment
               after: This date must be in the last 3 months
               before: This must not be a date in the future
+        early_allocation_eligible_form:
+          format: "%{message}"
+          attributes:
             # These attributes are all 'inclusion' because booleans are validated in: [true false] otherwise No isn't accepted
             convicted_under_terrorisom_act_2000:
               inclusion: You must say if they were convicted under the Terrorism Act 2000

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
 
       resources :early_allocations, only: [:new, :index, :show] do
         collection do
+          post 'oasys_date'
           post 'eligible'
           post 'discretionary'
           post 'confirm_with_reason'

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -138,11 +138,9 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
       create(:case_information, nomis_offender_id: nomis_offender_id)
     end
 
-    context 'when stage 1' do
+    context 'when on eligible screen' do
       let(:eligible_params) {
-        { "oasys_risk_assessment_date(3i)" => valid_date.day,
-          "oasys_risk_assessment_date(2i)" => valid_date.month,
-          "oasys_risk_assessment_date(1i)" => valid_date.year
+        { "oasys_risk_assessment_date" => valid_date,
         }.merge(s1_boolean_params)
       }
       let(:early_allocation) { EarlyAllocation.last }

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -86,6 +86,10 @@ FactoryBot.define do
     nomis_offender_id { 'T9999FC' }
   end
 
+  factory :early_allocation_date_form do
+    nomis_offender_id { 'T9999FC' }
+  end
+
   factory :early_allocation_discretionary_form do
     nomis_offender_id { 'T9999FC' }
 

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -7,8 +7,16 @@ RSpec.describe EarlyAllocation, type: :model do
     expect(build(:early_allocation)).to be_valid
   end
 
-  context 'when oasys date more than 2 years adrift' do
-    let(:ea) { build(:early_allocation_eligible_form, oasys_risk_assessment_date: Time.zone.today - 3.years) }
+  context 'when oasys date 3 months in the past' do
+    let(:ea) { build(:early_allocation_date_form, oasys_risk_assessment_date: Time.zone.today - 3.months + 1.day) }
+
+    it 'is valid' do
+      expect(ea).to be_valid
+    end
+  end
+
+  context 'when oasys date more than 3 months in the past' do
+    let(:ea) { build(:early_allocation_date_form, oasys_risk_assessment_date: Time.zone.today - 3.months) }
 
     it 'validates' do
       expect(ea).not_to be_valid
@@ -16,8 +24,8 @@ RSpec.describe EarlyAllocation, type: :model do
     end
   end
 
-  context 'when in the future' do
-    let(:ea) { build(:early_allocation_eligible_form, oasys_risk_assessment_date: Time.zone.today + 3.years) }
+  context 'when oasys date is in the future' do
+    let(:ea) { build(:early_allocation_date_form, oasys_risk_assessment_date: Time.zone.today + 1.day) }
 
     it 'validates' do
       expect(ea).not_to be_valid


### PR DESCRIPTION
This changes the Early Allocation journey so that there is a seperate page for the OASys date question - this helps the user bale from the from if the OaSys hasn't been completed rather than asking them 6 pointless questions