### PR TITLE
MO-359: Use new LocalDeliveryUnit model

### DIFF
--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -8,9 +8,8 @@ class EarlyAllocationsController < PrisonsApplicationController
   end
 
   def new
-    case_info = CaseInformation.find_by offender_id_from_url
     @early_allocation = EarlyAllocationEligibleForm.new offender_id_from_url
-    if case_info.local_divisional_unit.try(:email_address)
+    if @offender.ldu_email_address.present?
       render
     else
       render 'dead_end'

--- a/app/jobs/handover_follow_up_job.rb
+++ b/app/jobs/handover_follow_up_job.rb
@@ -1,43 +1,41 @@
 class HandoverFollowUpJob < ApplicationJob
   queue_as :default
 
-  def perform(date)
-    ldus = LocalDivisionalUnit.with_email_address
+  def perform(ldu)
+    today = Time.zone.today
     active_prisons = Prison.active
     active_prison_codes = active_prisons.map(&:code)
 
-    ldus.each do |ldu|
-      offenders = ldu.teams.map { |team| team.case_information.where(com_name: nil).map(&:nomis_offender_id) }.flatten
-                  .map { |off_id| OffenderService.get_offender(off_id) }
-                    .select { |o|
-                      !o.nil? && o.sentenced? && o.handover_start_date.present? &&
-                        active_prison_codes.include?(o.prison_id) && o.handover_start_date == date - 1.week
-                    }
+    offenders = ldu.teams.map { |team| team.case_information.where(com_name: nil).map(&:nomis_offender_id) }.flatten
+                .map { |off_id| OffenderService.get_offender(off_id) }
+                  .select { |o|
+                    !o.nil? && o.sentenced? && o.handover_start_date.present? &&
+                      active_prison_codes.include?(o.prison_id) && o.handover_start_date == today - 1.week
+                  }
 
-      offenders.each do |offender|
-        allocation = Allocation.where(nomis_offender_id: offender.offender_no).first
+    offenders.each do |offender|
+      allocation = Allocation.where(nomis_offender_id: offender.offender_no).first
 
-        pom = if allocation.nil?
-                nil
-              else
-                PrisonOffenderManagerService.get_pom_at(offender.prison_id, allocation.primary_pom_nomis_id)
-              end
+      pom = if allocation.nil?
+              nil
+            else
+              PrisonOffenderManagerService.get_pom_at(offender.prison_id, allocation.primary_pom_nomis_id)
+            end
 
-        offender_type = offender.indeterminate_sentence? ? 'Indeterminate' : 'Determinate'
+      offender_type = offender.indeterminate_sentence? ? 'Indeterminate' : 'Determinate'
 
-        CommunityMailer.urgent_pipeline_to_community(
-          nomis_offender_id: offender.offender_no,
-          offender_name: offender.full_name,
-          offender_crn: offender.crn,
-          sentence_type: offender_type,
-          ldu_email: offender.ldu_email_address,
-          prison: PrisonService.name_for(offender.prison_id),
-          start_date: offender.handover_start_date,
-          responsibility_handover_date: offender.responsibility_handover_date,
-          pom_name: pom.nil? ? 'This offender does not have an allocated POM' : pom.full_name,
-          pom_email: pom.nil? ? '' : pom.email_address
-        ).deliver_now
-      end
+      CommunityMailer.urgent_pipeline_to_community(
+        nomis_offender_id: offender.offender_no,
+        offender_name: offender.full_name,
+        offender_crn: offender.crn,
+        sentence_type: offender_type,
+        ldu_email: offender.ldu_email_address,
+        prison: PrisonService.name_for(offender.prison_id),
+        start_date: offender.handover_start_date,
+        responsibility_handover_date: offender.responsibility_handover_date,
+        pom_name: pom.nil? ? 'This offender does not have an allocated POM' : pom.full_name,
+        pom_email: pom.nil? ? '' : pom.email_address
+      ).deliver_now
     end
   end
 end

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 class CommunityMailer < GovukNotifyRails::Mailer
-  def pipeline_to_community(ldu:, csv_data:)
+  def pipeline_to_community(ldu_name:, ldu_email:, csv_data:)
     set_template('6e2f7565-a0e3-4fd7-b814-ee9dd5148924')
-    set_personalisation(ldu_name: ldu.name,
+    set_personalisation(ldu_name: ldu_name,
                         link_to_document: Notifications.prepare_upload(StringIO.new(csv_data), true))
 
-    mail(to: ldu.email_address)
+    mail(to: ldu_email)
   end
 
-  def pipeline_to_community_no_handovers(ldu)
+  def pipeline_to_community_no_handovers(ldu_name:, ldu_email:)
     set_template('bac3628c-aabe-4043-af11-147467720e04')
-    set_personalisation(ldu_name: ldu.name)
+    set_personalisation(ldu_name: ldu_name)
 
-    mail(to: ldu.email_address)
+    mail(to: ldu_email)
   end
 
   def urgent_pipeline_to_community(nomis_offender_id:, offender_name:, offender_crn:, ldu_email:, prison:,

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -65,8 +65,9 @@ class Allocation < ApplicationRecord
 
   # find all allocations which cannot be handed over as there is no LDU email address
   def self.without_ldu_emails
+    # TODO: Remove use of 'old' LDUs and Teams after Feb 2021
     teams = Team.joins(:local_divisional_unit).nps.merge(LocalDivisionalUnit.without_email_address)
-    blank_team_cases = CaseInformation.where(team: teams).or(CaseInformation.where(team: nil))
+    blank_team_cases = CaseInformation.where(team: teams).or(CaseInformation.where(team: nil, local_delivery_unit: nil))
     offenders = blank_team_cases.nps.map(&:nomis_offender_id)
     Allocation.where(nomis_offender_id: offenders)
   end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -53,7 +53,7 @@ class CaseInformation < ApplicationRecord
   validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }
   validates :nomis_offender_id, presence: true, uniqueness: true
 
-  validates :team, presence: true, unless: -> { manual_entry }
+  validates :team, presence: true, unless: -> { manual_entry || local_delivery_unit.present? }
 
   validates :welsh_offender, inclusion: {
     in: %w[Yes No],

--- a/app/models/local_delivery_unit.rb
+++ b/app/models/local_delivery_unit.rb
@@ -12,4 +12,8 @@ class LocalDeliveryUnit < ApplicationRecord
   validates :code, presence: true, uniqueness: true, format: { with: CODE_REGEX }
   validates :name, presence: true
   validates :email_address,  presence: true, 'valid_email_2/email': true
+
+  scope :enabled, -> { where(enabled: true) }
+
+  has_many :case_information, dependent: :restrict_with_exception
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,32 @@ PomDetail.find_or_create_by!(
   working_pattern: 1
 )
 
+LocalDeliveryUnit.find_or_create_by!(
+  code: 'WELDU',
+  name: 'Welsh LDU',
+  email_address: 'WalesNPS@example.com',
+  country: 'Wales',
+  enabled: true
+)
+
+LocalDeliveryUnit.find_or_create_by!(
+  code: 'ENLDU',
+  name: 'English LDU',
+  email_address: 'EnglishNPS@example.com',
+  country: 'England',
+  enabled: true
+)
+
+LocalDeliveryUnit.find_or_create_by!(
+  code: "OTHERLDU",
+  name: "English LDU 2",
+  email_address: 'AnotherEnglishNPS@example.com',
+  country: 'England',
+  enabled: true
+)
+
+# Create 'old' LDUs
+# TODO: Remove after PDU/LDU switchover in Feb 2021
 ldu1 = LocalDivisionalUnit.find_or_create_by!(
     code: "WELDU",
     name: "Welsh LDU",
@@ -72,6 +98,7 @@ team3 = Team.find_or_create_by!(
     local_divisional_unit: ldu3
 )
 
+# TODO: Change these CaseInformation records to use 'new' LDUs once the 'old' are removed
 # The offenders below are those with release dates a few years in the future and can therefore use the
 # responsibility override workflow
 

--- a/lib/tasks/handover_chase_email.rake
+++ b/lib/tasks/handover_chase_email.rake
@@ -5,6 +5,8 @@ require 'rake'
 namespace :handover_chase_emails do
   desc 'Send follow-up emails LDUs two weeks before handover if COM still not assigned'
   task process: :environment do
-    HandoverFollowUpJob.perform_later(Time.zone.today)
+    LocalDivisionalUnit.with_email_address.each do |ldu|
+      HandoverFollowUpJob.perform_later(ldu)
+    end
   end
 end

--- a/lib/tasks/handover_chase_email.rake
+++ b/lib/tasks/handover_chase_email.rake
@@ -5,7 +5,14 @@ require 'rake'
 namespace :handover_chase_emails do
   desc 'Send follow-up emails LDUs two weeks before handover if COM still not assigned'
   task process: :environment do
+    # Send to 'old' LDUs
+    # These will be removed in February 2021 after the PDU/LDU go live
     LocalDivisionalUnit.with_email_address.each do |ldu|
+      HandoverFollowUpJob.perform_later(ldu)
+    end
+
+    # Send to 'new' (2021) LDUs
+    LocalDeliveryUnit.enabled.each do |ldu|
       HandoverFollowUpJob.perform_later(ldu)
     end
   end

--- a/lib/tasks/handover_email.rake
+++ b/lib/tasks/handover_email.rake
@@ -3,7 +3,14 @@
 namespace :cronjob do
   desc 'send monthly handover emails'
   task handover_email: :environment do |_task|
+    # Send to 'old' LDUs
+    # These will be removed in February 2021 after the PDU/LDU go live
     LocalDivisionalUnit.with_email_address.each do |ldu|
+      AutomaticHandoverEmailJob.perform_later(ldu)
+    end
+
+    # Send to 'new' (2021) LDUs
+    LocalDeliveryUnit.enabled.each do |ldu|
       AutomaticHandoverEmailJob.perform_later(ldu)
     end
   end

--- a/spec/factories/local_delivery_units.rb
+++ b/spec/factories/local_delivery_units.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :local_delivery_unit do
     sequence(:code) { |seq| "LDU#{seq}" }
-    name { "MyString" }
+    name { Faker::Address.county } # LDUs tend to be named after a county (e.g. Kent)
     email_address { Faker::Internet.email }
     enabled { true }
     country { 'England' }

--- a/spec/jobs/automatic_handover_email_job_spec.rb
+++ b/spec/jobs/automatic_handover_email_job_spec.rb
@@ -3,162 +3,177 @@
 require 'rails_helper'
 
 RSpec.describe AutomaticHandoverEmailJob, :allocation, type: :job do
-  let(:active_ldu) { LocalDivisionalUnit.first }
   let(:staff_id) { 123456 }
   let(:email_address) { Faker::Internet.email }
 
-  before do
-    # Need to freeze the date so that CRDs don't end up 29th of June - substracting 4 months is then
-    # tricky (as 29th Feb doesn't exist) resulting in inconsistent test results(+- 1 day) as the date changes
-    Timecop.travel Date.new(2020, 11, 5)
-
-    create(:local_divisional_unit, teams: [
-      build(:team, case_information: case_info_records)])
-
-    stub_auth_token
-    offenders.each do |o|
-      stub_offender(o)
-
-      expect(OffenderService).to receive(:get_offender).with(o.fetch(:offenderNo)).and_call_original
-    end
-
-    stub_pom_emails staff_id, [email_address]
-  end
-
-  after do
-    Timecop.return
-  end
-
-  context 'with some offenders' do
-    let(:case_info_records) { [case_info1, case_info2, case_info3, case_info4, case_info5, case_info6, case_info7] }
-    let(:offenders) { [offender1, offender2, offender3, offender4, offender6, offender7] }
-
-    let(:prison1) { build(:prison) }
-    let(:case_info1) { build(:case_information) }
-    let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
-    let(:offender1) {
-      build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
-            sentence: attributes_for(:sentence_detail, :handover_in_8_days))
-    }
-
-    # This offender doesn't have an allocation (yet) - but still needs to be included
-    let(:case_info2) { build(:case_information) }
-    let(:offender2) {
-      build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info2.nomis_offender_id, firstName: 'Two',
-            sentence: attributes_for(:sentence_detail, :handover_in_4_days))
-    }
-
-    # This offender should come first as they have an earlier handover start date
-    let(:prison3) { build(:prison) }
-    let(:case_info3) { build(:case_information) }
-    let!(:allocation3) { create(:allocation, prison: prison3.code, nomis_offender_id: case_info3.nomis_offender_id, primary_pom_nomis_id: staff_id) }
-    let(:offender3) {
-      build(:nomis_offender, latestLocationId: prison3.code, offenderNo: case_info3.nomis_offender_id, firstName: 'Three',
-            sentence: attributes_for(:sentence_detail, :handover_in_6_days))
-    }
-
-    # This offender is unsentenced and so should be excluded
-    let(:case_info4) { build(:case_information) }
-    let(:offender4) {
-      build(:nomis_offender, latestLocationId: prison3.code, offenderNo: case_info4.nomis_offender_id, firstName: 'Four',
-            sentence: attributes_for(:sentence_detail, :unsentenced, :handover_in_6_days))
-    }
-
-    # This offender isn't in NOMIS and so should be excluded
-    let(:case_info5) { build(:case_information) }
-
-    # This offender has an inactive allocation - but still needs to be included
-    let(:prison6) { build(:prison) }
-    let(:case_info6) { build(:case_information) }
-    let!(:allocation6) { create(:allocation, :release, prison: prison6.code, nomis_offender_id: case_info6.nomis_offender_id) }
-    let(:offender6) {
-      build(:nomis_offender, latestLocationId: prison6.code, offenderNo: case_info6.nomis_offender_id, firstName: 'Six',
-            sentence: attributes_for(:sentence_detail, :handover_in_3_days))
-    }
-
-    # This offender is in an inactive prison (one with no allocations at all) so should be excluded
-    let(:prison7) { build(:prison) }
-    let(:case_info7) { build(:case_information) }
-    let(:offender7) {
-      build(:nomis_offender, latestLocationId: prison7.code, offenderNo: case_info7.nomis_offender_id, firstName: 'Seven',
-            sentence: attributes_for(:sentence_detail, :handover_in_4_days))
-    }
-
+  shared_context 'with expected behaviour' do
     before do
-      expect(OffenderService).to receive(:get_offender).with(case_info5.nomis_offender_id).and_return(nil)
+      # Need to freeze the date so that CRDs don't end up 29th of June - subtracting 4 months is then
+      # tricky (as 29th Feb doesn't exist) resulting in inconsistent test results(+- 1 day) as the date changes
+      Timecop.travel Date.new(2020, 11, 5)
+
+      stub_auth_token
+      offenders.each do |o|
+        stub_offender(o)
+
+        expect(OffenderService).to receive(:get_offender).with(o.fetch(:offenderNo)).and_call_original
+      end
+
+      stub_pom_emails staff_id, [email_address]
     end
 
-    it 'sends an email for offenders handing over in the next 45 days' do
-      expected_csv = [
-        AutomaticHandoverEmailJob::HEADERS.join(','),
-        (offender_csv_fields(offender6) +
-        [case_info6.crn,
-         case_info6.nomis_offender_id] +
+    after do
+      Timecop.return
+    end
+
+    context 'with some offenders' do
+      let(:case_info_records) { [case_info1, case_info2, case_info3, case_info4, case_info5, case_info6, case_info7] }
+      let(:offenders) { [offender1, offender2, offender3, offender4, offender6, offender7] }
+
+      let(:prison1) { build(:prison) }
+      let(:case_info1) { build(:case_information) }
+      let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+      let(:offender1) {
+        build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
+              sentence: attributes_for(:sentence_detail, :handover_in_8_days))
+      }
+
+      # This offender doesn't have an allocation (yet) - but still needs to be included
+      let(:case_info2) { build(:case_information) }
+      let(:offender2) {
+        build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info2.nomis_offender_id, firstName: 'Two',
+              sentence: attributes_for(:sentence_detail, :handover_in_4_days))
+      }
+
+      # This offender should come first as they have an earlier handover start date
+      let(:prison3) { build(:prison) }
+      let(:case_info3) { build(:case_information) }
+      let!(:allocation3) { create(:allocation, prison: prison3.code, nomis_offender_id: case_info3.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+      let(:offender3) {
+        build(:nomis_offender, latestLocationId: prison3.code, offenderNo: case_info3.nomis_offender_id, firstName: 'Three',
+              sentence: attributes_for(:sentence_detail, :handover_in_6_days))
+      }
+
+      # This offender is unsentenced and so should be excluded
+      let(:case_info4) { build(:case_information) }
+      let(:offender4) {
+        build(:nomis_offender, latestLocationId: prison3.code, offenderNo: case_info4.nomis_offender_id, firstName: 'Four',
+              sentence: attributes_for(:sentence_detail, :unsentenced, :handover_in_6_days))
+      }
+
+      # This offender isn't in NOMIS and so should be excluded
+      let(:case_info5) { build(:case_information) }
+
+      # This offender has an inactive allocation - but still needs to be included
+      let(:prison6) { build(:prison) }
+      let(:case_info6) { build(:case_information) }
+      let!(:allocation6) { create(:allocation, :release, prison: prison6.code, nomis_offender_id: case_info6.nomis_offender_id) }
+      let(:offender6) {
+        build(:nomis_offender, latestLocationId: prison6.code, offenderNo: case_info6.nomis_offender_id, firstName: 'Six',
+              sentence: attributes_for(:sentence_detail, :handover_in_3_days))
+      }
+
+      # This offender is in an inactive prison (one with no allocations at all) so should be excluded
+      let(:prison7) { build(:prison) }
+      let(:case_info7) { build(:case_information) }
+      let(:offender7) {
+        build(:nomis_offender, latestLocationId: prison7.code, offenderNo: case_info7.nomis_offender_id, firstName: 'Seven',
+              sentence: attributes_for(:sentence_detail, :handover_in_4_days))
+      }
+
+      before do
+        expect(OffenderService).to receive(:get_offender).with(case_info5.nomis_offender_id).and_return(nil)
+      end
+
+      it 'sends an email for offenders handing over in the next 45 days' do
+        expected_csv = [
+          AutomaticHandoverEmailJob::HEADERS.join(','),
+          (offender_csv_fields(offender6) +
+            [case_info6.crn,
+             case_info6.nomis_offender_id] +
             handover_fields(3.days) + [prison6.name, '', '']).join(','),
-        (offender_csv_fields(offender2) +
-        [case_info2.crn,
-         case_info2.nomis_offender_id] +
+          (offender_csv_fields(offender2) +
+            [case_info2.crn,
+             case_info2.nomis_offender_id] +
             handover_fields(4.days) + [prison1.name, '', '']).join(','),
-        (offender_csv_fields(offender3) +
+          (offender_csv_fields(offender3) +
             [case_info3.crn,
              case_info3.nomis_offender_id] + handover_fields(6.days) +
             [prison3.name, "\"#{allocation3.primary_pom_name}\"", email_address
-        ]).join(','),
-        (offender_csv_fields(offender1) +
+            ]).join(','),
+          (offender_csv_fields(offender1) +
             [case_info1.crn,
              case_info1.nomis_offender_id] + handover_fields(8.days) +
             [prison1.name, "\"#{allocation1.primary_pom_name}\"", email_address
-        ]).join(','),
-      ].map { |row| "#{row}\n" }.join
+            ]).join(','),
+        ].map { |row| "#{row}\n" }.join
 
-      expect_any_instance_of(CommunityMailer)
-        .to receive(:pipeline_to_community)
-              .with(ldu: active_ldu, csv_data: expected_csv).and_call_original
-      described_class.perform_now active_ldu
+        expect_any_instance_of(CommunityMailer)
+          .to receive(:pipeline_to_community)
+                .with(
+                  ldu_name: active_ldu.name,
+                  ldu_email: active_ldu.email_address,
+                  csv_data: expected_csv
+                ).and_call_original
+        described_class.perform_now active_ldu
+      end
+    end
+
+    def handover_fields(offset)
+      [today_plus(offset), today_plus(3.months + offset), today_plus(7.months + 15.days + offset)]
+    end
+
+    def offender_csv_fields(offender)
+      ["\"#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}\""]
+    end
+
+    def today_plus(offset)
+      (Time.zone.today + offset).to_s
+    end
+
+    context 'without offenders' do
+      let(:case_info_records) { [] }
+      let(:offenders) { [] }
+
+      it 'doesnt send an email' do
+        expect_any_instance_of(CommunityMailer)
+          .not_to receive(:pipeline_to_community_no_handovers)
+                    .with(active_ldu).and_call_original
+        described_class.perform_now active_ldu
+      end
+    end
+
+    context 'with no-one in the handover window' do
+      let(:case_info_records) { [case_info1] }
+      let(:offenders) { [offender1] }
+
+      let(:prison1) { build(:prison) }
+      let(:case_info1) { build(:case_information) }
+      let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+      let(:offender1) {
+        build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
+              sentence: attributes_for(:sentence_detail, :handover_in_46_days))
+      }
+
+      it 'sends the no data email' do
+        expect_any_instance_of(CommunityMailer)
+          .to receive(:pipeline_to_community_no_handovers)
+                .with(ldu_name: active_ldu.name, ldu_email: active_ldu.email_address).and_call_original
+        described_class.perform_now active_ldu
+      end
     end
   end
 
-  def handover_fields(offset)
-    [today_plus(offset), today_plus(3.months + offset), today_plus(7.months + 15.days + offset)]
+  # TODO: remove old LDUs after LDU/PDU switchover has happened (Feb 2021)
+  context 'when given a LocalDivisionalUnit (old LDU model)' do
+    let(:active_ldu) { create(:local_divisional_unit, teams: [build(:team, case_information: case_info_records)]) }
+
+    include_context 'with expected behaviour'
   end
 
-  def offender_csv_fields(offender)
-    ["\"#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}\""]
-  end
+  context 'when given a LocalDeliveryUnit' do
+    let(:active_ldu) { create(:local_delivery_unit, case_information: case_info_records) }
 
-  def today_plus(offset)
-    (Time.zone.today + offset).to_s
-  end
-
-  context 'without offenders' do
-    let(:case_info_records) { [] }
-    let(:offenders) { [] }
-
-    it 'doesnt send an email' do
-      expect_any_instance_of(CommunityMailer)
-        .not_to receive(:pipeline_to_community_no_handovers)
-              .with(active_ldu).and_call_original
-      described_class.perform_now active_ldu
-    end
-  end
-
-  context 'with no-one in the handover window' do
-    let(:case_info_records) { [case_info1] }
-    let(:offenders) { [offender1] }
-
-    let(:prison1) { build(:prison) }
-    let(:case_info1) { build(:case_information) }
-    let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
-    let(:offender1) {
-      build(:nomis_offender, latestLocationId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
-            sentence: attributes_for(:sentence_detail, :handover_in_46_days))
-    }
-
-    it 'sends the no data email' do
-      expect_any_instance_of(CommunityMailer)
-        .to receive(:pipeline_to_community_no_handovers)
-              .with(active_ldu).and_call_original
-      described_class.perform_now active_ldu
-    end
+    include_context 'with expected behaviour'
   end
 end

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -1,195 +1,211 @@
 require 'rails_helper'
 
 RSpec.describe HandoverFollowUpJob, :allocation, type: :job do
-  let!(:ldu) { create(:local_divisional_unit, teams: [build(:team, case_information: [case_info])]) }
+  shared_context 'with expected behaviour' do
+    let(:offender) do
+      build_offender(Time.zone.today + 8.months,
+                     sentence_type: :determinate,
+                     ard_crd_release: Time.zone.today + 8.months,
+                     ted: nil)
+    end
 
-  let(:offender) do
-    build_offender(Time.zone.today + 8.months,
-                   sentence_type: :determinate,
-                   ard_crd_release: Time.zone.today + 8.months,
-                   ted: nil)
-  end
+    let(:offender_no) { offender.offender_no }
 
-  let(:offender_no) { offender.offender_no }
+    let(:pom) { build(:pom) }
 
-  let(:pom) { build(:pom) }
+    # This prison is active because we give it an allocation in the `before` test setup block
+    let(:active_prison) { build(:prison) }
 
-  # This prison is active because we give it an allocation in the `before` test setup block
-  let(:active_prison) { build(:prison) }
+    # This prison is inactive because we don't give it any allocations
+    let(:inactive_prison) { build(:prison) }
 
-  # This prison is inactive because we don't give it any allocations
-  let(:inactive_prison) { build(:prison) }
+    let(:case_info) { build(:case_information, nomis_offender_id: offender_no) }
 
-  let!(:case_info) { create(:case_information, nomis_offender_id: offender_no) }
-  let!(:allocation) {
-    create(:allocation,
-           prison: active_prison.code,
-           nomis_offender_id: offender_no,
-           primary_pom_nomis_id: pom.staff_id,
-           primary_pom_name: pom.full_name)
-  }
-
-  let(:today) { Time.zone.today }
-
-  before do
-    Timecop.travel today
-
-    allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
-
-    allow(OffenderService).to receive(:get_offender).and_return(offender)
-    offender.load_case_information(case_info) unless offender.nil?
-
-    # Create an unrelated allocation so that active_prison counts as active
-    create(:allocation, prison: active_prison.code)
-  end
-
-  after do
-    Timecop.return
-  end
-
-  context 'when the offender does not exist in NOMIS' do
-    let(:offender) { nil }
-    let(:offender_no) {
-      # Use offender factory to give a 'realistic' offender number
-      build(:offender).offender_no
+    let!(:allocation) {
+      create(:allocation,
+             prison: active_prison.code,
+             nomis_offender_id: offender_no,
+             primary_pom_nomis_id: pom.staff_id,
+             primary_pom_name: pom.full_name)
     }
 
-    it 'does not send email' do
-      expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-      expect { described_class.perform_now(ldu) }.not_to raise_error
+    let(:today) { Time.zone.today }
+
+    before do
+      Timecop.travel today
+
+      allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+
+      allow(OffenderService).to receive(:get_offender).and_return(offender)
+      offender.load_case_information(case_info) unless offender.nil?
+
+      # Create an unrelated allocation so that active_prison counts as active
+      create(:allocation, prison: active_prison.code)
     end
-  end
 
-  context 'when the offender exists in NOMIS' do
-    let(:today) { offender.handover_start_date + 1.week }
+    after do
+      Timecop.return
+    end
 
-    context 'when the offender is not in an active prison' do
-      let(:release_date) { Time.zone.today + 8.months }
-      let(:offender) {
-        build_offender(release_date,
-                       prison: inactive_prison,
-                       sentence_type: :determinate,
-                       ard_crd_release: release_date,
-                       ted: nil)
+    context 'when the offender does not exist in NOMIS' do
+      let(:offender) { nil }
+      let(:offender_no) {
+        # Use offender factory to give a 'realistic' offender number
+        build(:offender).offender_no
       }
 
       it 'does not send email' do
         expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
+        expect { described_class.perform_now(ldu) }.not_to raise_error
       end
     end
 
-    context 'when the offender is un-sentenced' do
-      let(:offender) {
-        build_offender(sentence_type: :determinate, ard_crd_release: nil, ted: nil)
-      }
-      let(:today) { Time.zone.today }
-
-      it 'does not send email' do
-        expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
-      end
-    end
-
-    context 'when the offender already has a COM allocated' do
-      let(:case_info) { create(:case_information, :with_com, nomis_offender_id: offender_no) }
-
-      it 'does not send email' do
-        expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
-      end
-    end
-
-    context 'when the offender does not have a handover_start_date' do
-      let(:offender) {
-        build_offender(Time.zone.today + 10.months,
-                       sentence_type: :indeterminate,
-                       ard_crd_release: nil,
-                       ted: nil)
-      }
-      let(:today) { Time.zone.today }
-
-      it 'does not send email' do
-        expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
-      end
-    end
-
-    context 'when start of handover is in the future' do
-      let(:today) { offender.handover_start_date - 1.day }
-
-      it 'does not send email' do
-        expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
-      end
-    end
-
-    context 'when handover started less than 1 week ago' do
-      let(:today) { offender.handover_start_date + 6.days }
-
-      it 'does not send email' do
-        expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
-      end
-    end
-
-    context 'when handover started more than 1 week ago' do
-      let(:today) { offender.handover_start_date + 8.days }
-
-      it 'does not send email' do
-        expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
-        described_class.perform_now(ldu)
-      end
-    end
-
-    context 'when handover started exactly 1 week ago' do
+    context 'when the offender exists in NOMIS' do
       let(:today) { offender.handover_start_date + 1.week }
 
-      context 'when the offender does not have a POM allocated' do
-        let!(:allocation) { create(:allocation, :release, nomis_offender_id: offender_no) }
+      context 'when the offender is not in an active prison' do
+        let(:release_date) { Time.zone.today + 8.months }
+        let(:offender) {
+          build_offender(release_date,
+                         prison: inactive_prison,
+                         sentence_type: :determinate,
+                         ard_crd_release: release_date,
+                         ted: nil)
+        }
 
-        it 'emails the LDU' do
-          expect_any_instance_of(CommunityMailer)
-            .to receive(:urgent_pipeline_to_community)
-                  .with(
-                    nomis_offender_id: offender_no,
-                    offender_name: offender.full_name,
-                    offender_crn: offender.crn,
-                    ldu_email: offender.ldu_email_address,
-                    sentence_type: "Determinate",
-                    prison: active_prison.name,
-                    start_date: offender.handover_start_date,
-                    responsibility_handover_date: offender.responsibility_handover_date,
-                    pom_name: "This offender does not have an allocated POM",
-                    pom_email: ""
-                  ).and_call_original
-
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
           described_class.perform_now(ldu)
         end
       end
 
-      context 'when the offender has a POM allocated' do
-        it 'emails the LDU' do
-          expect_any_instance_of(CommunityMailer)
-            .to receive(:urgent_pipeline_to_community)
-                  .with(
-                    nomis_offender_id: offender_no,
-                    offender_name: offender.full_name,
-                    offender_crn: offender.crn,
-                    ldu_email: offender.ldu_email_address,
-                    sentence_type: "Determinate",
-                    prison: active_prison.name,
-                    start_date: offender.handover_start_date,
-                    responsibility_handover_date: offender.responsibility_handover_date,
-                    pom_name: pom.full_name,
-                    pom_email: pom.email_address
-                  ).and_call_original
+      context 'when the offender is un-sentenced' do
+        let(:offender) {
+          build_offender(sentence_type: :determinate, ard_crd_release: nil, ted: nil)
+        }
+        let(:today) { Time.zone.today }
 
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
           described_class.perform_now(ldu)
+        end
+      end
+
+      context 'when the offender already has a COM allocated' do
+        let(:case_info) { create(:case_information, :with_com, nomis_offender_id: offender_no) }
+
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
+          described_class.perform_now(ldu)
+        end
+      end
+
+      context 'when the offender does not have a handover_start_date' do
+        let(:offender) {
+          build_offender(Time.zone.today + 10.months,
+                         sentence_type: :indeterminate,
+                         ard_crd_release: nil,
+                         ted: nil)
+        }
+        let(:today) { Time.zone.today }
+
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
+          described_class.perform_now(ldu)
+        end
+      end
+
+      context 'when start of handover is in the future' do
+        let(:today) { offender.handover_start_date - 1.day }
+
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
+          described_class.perform_now(ldu)
+        end
+      end
+
+      context 'when handover started less than 1 week ago' do
+        let(:today) { offender.handover_start_date + 6.days }
+
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
+          described_class.perform_now(ldu)
+        end
+      end
+
+      context 'when handover started more than 1 week ago' do
+        let(:today) { offender.handover_start_date + 8.days }
+
+        it 'does not send email' do
+          expect_any_instance_of(CommunityMailer).not_to receive(:urgent_pipeline_to_community)
+          described_class.perform_now(ldu)
+        end
+      end
+
+      context 'when handover started exactly 1 week ago' do
+        let(:today) { offender.handover_start_date + 1.week }
+
+        context 'when the offender does not have a POM allocated' do
+          let!(:allocation) { create(:allocation, :release, nomis_offender_id: offender_no) }
+
+          it 'emails the LDU' do
+            expect_any_instance_of(CommunityMailer)
+              .to receive(:urgent_pipeline_to_community)
+                    .with(
+                      nomis_offender_id: offender_no,
+                      offender_name: offender.full_name,
+                      offender_crn: offender.crn,
+                      ldu_email: offender.ldu_email_address,
+                      sentence_type: "Determinate",
+                      prison: active_prison.name,
+                      start_date: offender.handover_start_date,
+                      responsibility_handover_date: offender.responsibility_handover_date,
+                      pom_name: "This offender does not have an allocated POM",
+                      pom_email: ""
+                    ).and_call_original
+
+            described_class.perform_now(ldu)
+          end
+        end
+
+        context 'when the offender has a POM allocated' do
+          it 'emails the LDU' do
+            expect_any_instance_of(CommunityMailer)
+              .to receive(:urgent_pipeline_to_community)
+                    .with(
+                      nomis_offender_id: offender_no,
+                      offender_name: offender.full_name,
+                      offender_crn: offender.crn,
+                      ldu_email: offender.ldu_email_address,
+                      sentence_type: "Determinate",
+                      prison: active_prison.name,
+                      start_date: offender.handover_start_date,
+                      responsibility_handover_date: offender.responsibility_handover_date,
+                      pom_name: pom.full_name,
+                      pom_email: pom.email_address
+                    ).and_call_original
+
+            described_class.perform_now(ldu)
+          end
         end
       end
     end
   end
+
+  # TODO: remove old LDUs after LDU/PDU switchover has happened (Feb 2021)
+  context 'when given a LocalDivisionalUnit (old LDU model)' do
+    let!(:ldu) { create(:local_divisional_unit, teams: [build(:team, case_information: [case_info])]) }
+
+    include_context 'with expected behaviour'
+  end
+
+  context 'when given a LocalDeliveryUnit' do
+    let!(:ldu) { create(:local_delivery_unit, case_information: [case_info]) }
+
+    include_context 'with expected behaviour'
+  end
+
+private
 
   def build_offender(release_date = nil, prison: nil, sentence_type:, ard_crd_release:, ted:)
     prison = prison || active_prison

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CommunityMailer, type: :mailer do
-  describe 'handover_chase_email' do
+  describe '#urgent_pipeline_to_community' do
     let(:offender) { build(:offender, latestLocationId: 'LEI') }
 
     let(:case_info) do
@@ -51,6 +51,42 @@ RSpec.describe CommunityMailer, type: :mailer do
             pom_name: params[:pom_name],
             pom_email: params[:pom_email]
          )
+    end
+  end
+
+  describe '#pipeline_to_community' do
+    subject { described_class.pipeline_to_community(params) }
+
+    let(:ldu) { build(:local_delivery_unit) }
+
+    let(:params) {
+      {
+        ldu_name: ldu.name,
+        ldu_email: ldu.email_address,
+        csv_data: "Comma, Separated, Values"
+      }
+    }
+
+    it 'sends to the LDU email address' do
+      expect(subject.to).to eq([ldu.email_address])
+    end
+
+    it 'sets the LDU name' do
+      expect(subject.govuk_notify_personalisation).to include(ldu_name: ldu.name)
+    end
+  end
+
+  describe '#pipeline_to_community_no_handovers' do
+    subject { described_class.pipeline_to_community_no_handovers(ldu_name: ldu.name, ldu_email: ldu.email_address) }
+
+    let(:ldu) { build(:local_delivery_unit) }
+
+    it 'sends to the LDU email address' do
+      expect(subject.to).to eq([ldu.email_address])
+    end
+
+    it 'sets the LDU name' do
+      expect(subject.govuk_notify_personalisation).to include(ldu_name: ldu.name)
     end
   end
 end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -6,34 +6,43 @@ RSpec.describe Allocation, type: :model do
   let(:another_nomis_offender_id) { 654_321 }
 
   describe '#without_ldu_emails', :allocation do
-    before do
-      crcci1 = create(:case_information, case_allocation: 'CRC', team: nil)
-      create(:allocation, nomis_offender_id: crcci1.nomis_offender_id)
-
-      blank_team = create(:team, local_divisional_unit: build(:local_divisional_unit, email_address: nil))
-      crc_ci2 = create(:case_information, case_allocation: 'CRC', team: blank_team)
-      create(:allocation, nomis_offender_id: crc_ci2.nomis_offender_id)
-    end
-
-    let!(:c1) {
-      ci1 = create(:case_information, team: nil)
-      create(:allocation, nomis_offender_id: ci1.nomis_offender_id)
+    # CRC offender with no team
+    let!(:crc_without_team) {
+      case_info = create(:case_information, case_allocation: 'CRC', team: nil)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
     }
-    let!(:c2) {
+
+    # CRC offender with a team/LDU with no email address
+    let!(:crc_without_email) {
+      blank_team = create(:team, local_divisional_unit: build(:local_divisional_unit, email_address: nil))
+      case_info = create(:case_information, case_allocation: 'CRC', team: blank_team)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
+    }
+
+    # NPS offender with no team
+    let!(:nps_without_team) {
+      case_info = create(:case_information, team: nil)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
+    }
+
+    # NPS offender with a team/LDU with no email address
+    let!(:nps_without_email) {
       ldu = create(:local_divisional_unit, email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
-      ci2 = create(:case_information, team: team)
-      create(:allocation, nomis_offender_id: ci2.nomis_offender_id)
+      case_info = create(:case_information, team: team)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
     }
-    let!(:c3) {
+
+    # NPS offender with a team/LDU that has an email address
+    let!(:nps_with_email) {
       ldu = create(:local_divisional_unit, email_address: 'someone@example.com')
       team = create(:team, local_divisional_unit: ldu)
-      ci3 = create(:case_information, team: team)
-      create(:allocation, nomis_offender_id: ci3.nomis_offender_id)
+      case_info = create(:case_information, team: team)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
     }
 
     it 'picks up NPS allocations without emails' do
-      expect(described_class.without_ldu_emails).to match_array([c1, c2])
+      expect(described_class.without_ldu_emails).to match_array([nps_without_team, nps_without_email])
     end
   end
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Allocation, type: :model do
       create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
     }
 
+    # NPS offender with a new LocalDeliveryUnit, but no Team
+    let!(:nps_with_new_ldu) {
+      ldu = create(:local_delivery_unit)
+      case_info = create(:case_information, team: nil, local_delivery_unit: ldu)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
+    }
+
     it 'picks up NPS allocations without emails' do
       expect(described_class.without_ldu_emails).to match_array([nps_without_team, nps_without_email])
     end

--- a/spec/models/local_delivery_unit_spec.rb
+++ b/spec/models/local_delivery_unit_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe LocalDeliveryUnit, type: :model do
       expect(subject).to validate_inclusion_of(:country).in_array(['England', "Wales"])
     end
   end
+
+  describe '"enabled" scope' do
+    let!(:enabled_ldus) { create_list(:local_delivery_unit, 5) }
+    let!(:disabled_ldus) { create_list(:local_delivery_unit, 5, :disabled) }
+
+    it 'only retrieves enabled LDUs' do
+      expect(described_class.enabled).to eq(enabled_ldus)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,3 +108,8 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+# Set the locale for Faker gem to en-GB
+# The en-GB locale gives us UK counties (used by the LocalDeliveryUnit factory)
+# See all the things we gain here: https://github.com/faker-ruby/faker/blob/master/lib/locales/en-GB.yml
+Faker::Config.locale = 'en-GB'


### PR DESCRIPTION
Jira ticket: MO-359

---

This PR brings MPC one step closer to fully utilising the new Local Delivery Unit model.

It adapts the two handover email jobs sent to LDUs (the 45 day upcoming email, and the chaser email) to work with both 'old' LDUs (Team/LocalDivisionalUnit, deprecated after 31/01/2021) and 'new' LDUs (LocalDeliveryUnit).

For the month of January 2021, 'old' and 'new' LDUs have been running in parallel, which is why this work is needed to allow the handover email jobs to work with either model.

From 31/01/2021, the 'old' LDUs will be deprecated and the Team/LocalDivisionalUnit functionality will need to be removed from the codebase. So the switching functionality implemented in this PR will only be needed until that code cleanup is done.

Also included in this PR:
- Allow `CaseInformation` to be valid if there's a (new) `LocalDeliveryUnit` but no (old) `Team`
- Update the ActiveAdmin 'offenders without an LDU email address' dashboard to exclude offenders who have a `LocalDeliveryUnit` but no `Team`
- Make the `LocalDeliveryUnit` test factory generate realistic LDU names (using UK counties from the `Faker` library)
- Create `LocalDeliveryUnit` records in the database seed script (`db/seeds.rb`)

### Commit history

I've tried to keep the commit history clear to show the steps taken – so feel free to read through them.

Before merging this PR, I will squash the 'refactor' commits into their respective 'main' commit. I've left them in for now as they show my working, so might be helpful for code review.