### PR TITLE
MO-366-Use PRD to calculate handover

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -87,7 +87,7 @@ private
     if offender.early_allocation?
       early_allocation_handover_start_date(offender)
     elsif offender.indeterminate_sentence?
-      indeterminate_sentence_handover_start_date(offender)
+      indeterminate_responsibility_date(offender)
     else
       determinate_sentence_handover_start_date(offender)
     end
@@ -97,12 +97,6 @@ private
     return nil if offender.conditional_release_date.nil?
 
     offender.conditional_release_date - 18.months
-  end
-
-  def self.indeterminate_sentence_handover_start_date(offender)
-    return nil if offender.tariff_date.nil?
-
-    offender.tariff_date - 8.months
   end
 
   def self.determinate_sentence_handover_start_date(offender)
@@ -150,6 +144,7 @@ private
   # the parole board decision which currently is not available to us.
   def self.indeterminate_responsibility_date(offender)
     [
+      offender.parole_review_date,
       offender.parole_eligibility_date,
       offender.tariff_date
     ].compact.map { |date| date - 8.months }.min

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -49,5 +49,9 @@ FactoryBot.define do
     trait :with_com do
       com_name { "#{Faker::Name.last_name}, #{Faker::Name.first_name}" }
     end
+
+    trait :with_prd do
+      parole_review_date {Time.zone.today + 8.months}
+    end
   end
 end

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -31,10 +31,12 @@ FactoryBot.define do
     end
     trait :indeterminate do
       imprisonmentStatus {'LIFE'}
+      sentence {build :sentence_detail, :indeterminate}
     end
     trait :indeterminate_recall do
       imprisonmentStatus {'LR_LIFE'}
       recall { true }
+      sentence {build :sentence_detail, :indeterminate}
     end
     trait :determinate_recall do
       imprisonmentStatus {'LR_EPP'}

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -52,6 +52,10 @@ FactoryBot.define do
     trait :inside_handover_window do
       conditionalReleaseDate { Time.zone.today + 7.days + 7.months + 15.days }
     end
+
+    trait :indeterminate do
+      tariffDate { Time.zone.today + 1.year}
+    end
   end
 end
 

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -436,6 +436,7 @@ describe HandoverDateService do
           "early_allocation?" => early_allocation,
           "indeterminate_sentence?" => indeterminate_sentence,
           parole_eligibility_date: parole_eligibility_date,
+          parole_review_date: nil,
           tariff_date: tariff_date
         )
       )
@@ -527,6 +528,19 @@ describe HandoverDateService do
           end
         end
       end
+    end
+  end
+
+  context 'with an NPS and indeterminate case with a PRD' do
+    let(:case_info) { build(:case_information, :with_prd, :nps) }
+    let(:offender) {
+      build(:offender, :indeterminate, sentence: build(:sentence_detail, :indeterminate, tariffDate: case_info.parole_review_date + 1.month)).tap {  |offender|
+        offender.load_case_information(case_info)
+      }
+    }
+
+    it 'displays the handover date (which is 8 months prior to PRD) ' do
+      expect(described_class.handover(offender).handover_date).to eq(case_info.parole_review_date - 8.months)
     end
   end
 end

--- a/spec/views/shared/case_type_badge.html.erb_spec.rb
+++ b/spec/views/shared/case_type_badge.html.erb_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe "allocations/new", type: :view do
     let(:offender_no) { 'G7514GW' }
     let(:case_information) { build(:case_information,  nomis_offender_id: offender_no) }
     let(:offender) {
-      offender = build(:offender, :indeterminate, offenderNo: offender_no)
+      offender = build(:offender, :indeterminate, offenderNo: offender_no,
+       sentence: build(:sentence_detail, tariffDate: nil))
       offender.load_case_information(case_information)
       offender
     }


### PR DESCRIPTION
This PR uses PRD to calculate handover.

It also removes the method `indeterminate_sentence_handover_start_date` that calculates handover start date separately to the responsibility date. In this scenario these 2 dates should be exactly the same so this method isn't needed and was causing issues.