### PR TITLE
Checks which offenders are inside omic policy

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -45,7 +45,7 @@ private
 
   def filtered_offenders
     @unfiltered_offenders.group_by { |offender|
-      if offender.age < 18
+      if !offender.over_18?
         :under18
       elsif offender.civil_sentence?
         :civil

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -18,13 +18,7 @@ class Prison
   end
 
   def offenders
-    OffenderEnumerator.new(@code).select do |offender|
-      next if offender.age.blank?
-
-      offender.age >= 18 &&
-        (offender.sentenced? || offender.immigration_case?) &&
-        offender.criminal_sentence?
-    end
+    OffenderEnumerator.new(@code).select(&:inside_omic_policy?)
   end
 
   def unfiltered_offenders

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -42,7 +42,9 @@ FactoryBot.define do
       imprisonmentStatus {'LR_EPP'}
       recall { true }
     end
-
+    trait :civil_sentence do
+      imprisonmentStatus {'CIVIL'}
+    end
   end
 
   factory :offender, parent: :offender_base, class: 'HmppsApi::Offender' do


### PR DESCRIPTION
This PR is a refactor. It takes a set of methods that together calculate if an offender is inside the omic policy - and therefore available in the service. These methods are: `over_18?`,  `sentenced?`, `immigration_case?`, `criminal_sentence?` and `convicted?`  Methods such as `sentenced?` have potentially been used incorrectly through out the code base thinking that it was checking if an offender was inside the omic service. 
This PR also tries to make some of these methods private but `sentenced?` has been used in too many places so would require a bigger refactor - I think a ticket has been made for this.