### PR TITLE
Fixes to Active Admin

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -5,9 +5,10 @@ ActiveAdmin.register_page 'Dashboard' do
 
   content title: proc { I18n.t('active_admin.dashboard') } do
     panel 'Offenders w/o LDU EMail Addresses' do
+      allocations = Allocation.without_ldu_emails
+      case_infos_hash = CaseInformationService.get_case_information(allocations.map(&:nomis_offender_id))
+      para "Total: #{allocations.count}"
       ul do
-        allocations = Allocation.without_ldu_emails
-        case_infos_hash = CaseInformationService.get_case_information(allocations.map(&:nomis_offender_id))
         allocations.each do |allocation|
           ldu_code = case_infos_hash.fetch(allocation.nomis_offender_id).team.try(:local_divisional_unit).try(:code)
           li "Prison #{allocation.prison} Offender #{allocation.nomis_offender_id} LDU Code #{ldu_code}"

--- a/app/admin/local_delivery_units.rb
+++ b/app/admin/local_delivery_units.rb
@@ -15,4 +15,8 @@ ActiveAdmin.register LocalDeliveryUnit do
     end
     actions
   end
+
+  # Filter fields
+  preserve_default_filters!
+  remove_filter :case_information
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -67,8 +67,8 @@ class Allocation < ApplicationRecord
   def self.without_ldu_emails
     # TODO: Remove use of 'old' LDUs and Teams after Feb 2021
     teams = Team.joins(:local_divisional_unit).nps.merge(LocalDivisionalUnit.without_email_address)
-    blank_team_cases = CaseInformation.where(team: teams).or(CaseInformation.where(team: nil, local_delivery_unit: nil))
-    offenders = blank_team_cases.nps.map(&:nomis_offender_id)
+    blank_team_cases = CaseInformation.where(team: teams + [nil], local_delivery_unit: nil)
+    offenders = blank_team_cases.nps.pluck(:nomis_offender_id)
     Allocation.where(nomis_offender_id: offenders)
   end
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe Allocation, type: :model do
       create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
     }
 
+    # NPS offender with a new LocalDeliveryUnit and a Team/LDU with no email address
+    let!(:nps_with_new_ldu_and_bad_team) {
+      ldu = create(:local_delivery_unit)
+      team = create(:team, local_divisional_unit: build(:local_divisional_unit, email_address: nil))
+      case_info = create(:case_information, team: team, local_delivery_unit: ldu)
+      create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
+    }
+
     it 'picks up NPS allocations without emails' do
       expect(described_class.without_ldu_emails).to match_array([nps_without_team, nps_without_email])
     end


### PR DESCRIPTION
This Pull Request fixes a couple of defects in Active Admin, and adds a new feature.

- Fix a bad query which caused offenders to wrongly appear in the list of offenders missing an LDU email address (dashboard page)
- Add a count to the dashboard page to show the total number of offenders missing an LDU email address
- Fix a performance issue which caused the Local Delivery Unit page to time out (or take a very long time to load)