### PR TITLE
MO-316 search refactor bug fix

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -26,7 +26,7 @@ private
     # We will only show PAGE_SIZE at a time, so there is no need
     # to get the allocated POM name for offenders, we will just get them
     # for the much smaller slice.
-    OffenderService.set_allocated_pom_name(slice, active_prison_id)
+    set_allocated_pom_names(slice, active_prison_id)
   end
 
   def page
@@ -36,5 +36,31 @@ private
   def search_term
     # defaults to an empty string if the key 'q' can't be found
     params.fetch('q', '').strip
+  end
+
+  # Takes a list of OffenderSummary or Offender objects, and returns them with their
+  # allocated POM name set in :allocated_pom_name.
+  def set_allocated_pom_names(offenders, prison_id)
+    pom_names = PrisonOffenderManagerService.get_pom_names(prison_id)
+    nomis_offender_ids = offenders.map(&:offender_no)
+    offender_to_staff_hash = Allocation.
+      where(nomis_offender_id: nomis_offender_ids).
+      map { |a|
+        [
+          a.nomis_offender_id,
+          {
+            pom_name: pom_names[a.primary_pom_nomis_id],
+            allocation_date: (a.primary_pom_allocated_at || a.updated_at)&.to_date
+          }
+        ]
+      }.to_h
+
+    offenders.each do |offender|
+      if offender_to_staff_hash.key?(offender.offender_no)
+        offender.allocated_pom_name = offender_to_staff_hash[offender.offender_no][:pom_name]
+        offender.allocation_date = offender_to_staff_hash[offender.offender_no][:allocation_date]
+      end
+    end
+    offenders
   end
 end

--- a/app/models/hmpps_api/movement_direction.rb
+++ b/app/models/hmpps_api/movement_direction.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module HmppsApi
   class MovementDirection
-    IN = 'IN'.freeze
-    OUT = 'OUT'.freeze
+    IN = 'IN'
+    OUT = 'OUT'
   end
 end

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -112,7 +112,7 @@ class AllocationService
 
   def self.current_pom_for(nomis_offender_id, prison_id)
     current_allocation = active_allocations(nomis_offender_id, prison_id)
-    nomis_staff_id = current_allocation[nomis_offender_id]['primary_pom_nomis_id']
+    nomis_staff_id = current_allocation[nomis_offender_id].primary_pom_nomis_id
 
     PrisonOffenderManagerService.get_pom_at(prison_id, nomis_staff_id)
   end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -32,31 +32,4 @@ class OffenderService
         mappa_levels: mappa_registrations.map { |r| r.dig(:registerLevel, :code).last.to_i }
     }
   end
-
-  # Takes a list of OffenderSummary or Offender objects, and returns them with their
-  # allocated POM name set in :allocated_pom_name.
-  # This is now only used by the SearchController.
-  def self.set_allocated_pom_name(offenders, prison_id)
-    pom_names = PrisonOffenderManagerService.get_pom_names(prison_id)
-    nomis_offender_ids = offenders.map(&:offender_no)
-    offender_to_staff_hash = Allocation.
-      where(nomis_offender_id: nomis_offender_ids).
-      map { |a|
-        [
-          a.nomis_offender_id,
-          {
-            pom_name: pom_names[a.primary_pom_nomis_id],
-            allocation_date: (a.primary_pom_allocated_at || a.updated_at)&.to_date
-          }
-        ]
-      }.to_h
-
-    offenders.each do |offender|
-      if offender_to_staff_hash.key?(offender.offender_no)
-        offender.allocated_pom_name = offender_to_staff_hash[offender.offender_no][:pom_name]
-        offender.allocation_date = offender_to_staff_hash[offender.offender_no][:allocation_date]
-      end
-    end
-    offenders
-  end
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -9,8 +9,8 @@ class SearchService
     search_term = text.upcase
 
     prison.offenders.select do |offender|
-      offender.last_name.start_with?(search_term) ||
-        offender.first_name.start_with?(search_term) ||
+      offender.last_name.upcase.start_with?(search_term) ||
+        offender.first_name.upcase.start_with?(search_term) ||
         offender.offender_no.include?(search_term)
     end
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -2,30 +2,32 @@ require 'rails_helper'
 
 RSpec.describe SearchController, type: :controller do
   let(:prison) { build(:prison).code }
+  let(:nomis_staff_id) { 485_926 }
 
   let(:poms) {
     [
       build(:pom,
             firstName: 'Alice',
+            lastName: 'Ward',
             position: RecommendationService::PRISON_POM,
-            staffId: 1
+            staffId: nomis_staff_id
       )
     ]
   }
 
   before do
     stub_poms(prison, poms)
-    stub_signed_in_pom(prison, 1)
+    stub_signed_in_pom(prison, nomis_staff_id)
   end
 
   context 'when user is a POM ' do
     before do
-      stub_signed_in_pom(prison, 1)
+      stub_signed_in_pom(prison, nomis_staff_id)
     end
 
     it 'user is redirected to caseload' do
       get :search, params: { prison_id: prison, q: 'Cal' }
-      expect(response).to redirect_to(prison_staff_caseload_index_path(prison, 1, q: 'Cal'))
+      expect(response).to redirect_to(prison_staff_caseload_index_path(prison, nomis_staff_id, q: 'Cal'))
     end
   end
 
@@ -44,6 +46,53 @@ RSpec.describe SearchController, type: :controller do
 
       expect(assigns(:q)).to eq('Cal')
       expect(assigns(:offenders).size).to eq(0)
+    end
+
+    context "with 3 offenders", :allocation do
+      let(:offenders) { build_list(:nomis_offender, 3, lastName: 'Bloggs', firstName: 'Alice') }
+      let(:updated_offenders) { assigns(:offenders) }
+      let(:alloc_offender) { updated_offenders.detect { |o| o.offender_no == offenders.first.fetch(:offenderNo) } }
+
+      before do
+        stub_offenders_for_prison(prison, offenders)
+        PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
+
+        create(:allocation,
+               nomis_offender_id: offenders.first.fetch(:offenderNo),
+               primary_pom_allocated_at: allocated_date,
+               primary_pom_nomis_id: nomis_staff_id)
+      end
+
+      context "with a date" do
+        let(:allocated_date) { DateTime.now.utc }
+
+        it 'gets the POM names for allocated offenders' do
+          get :search, params: { prison_id: prison, q: 'Blog' }
+
+          expect(updated_offenders).to be_kind_of(Array)
+          expect(updated_offenders.count).to eq(offenders.count)
+          expect(alloc_offender).to be_kind_of(HmppsApi::OffenderSummary)
+          expect(alloc_offender.allocated_pom_name).to eq('Ward, Alice')
+          expect(alloc_offender.allocation_date).to be_kind_of(Date)
+        end
+
+        it 'can find all the Alices' do
+          get :search, params: { prison_id: prison, q: 'Alice' }
+
+          expect(updated_offenders.count).to eq(offenders.count)
+        end
+      end
+
+      context "when 'primary_pom_allocated_at' date is nil" do
+        let(:allocated_date) { DateTime.now.utc }
+
+        it "uses 'updated_at' date when 'primary_pom_allocated_at' date is nil" do
+          get :search, params: { prison_id: prison, q: 'Blog' }
+
+          expect(alloc_offender.allocated_pom_name).to eq('Ward, Alice')
+          expect(alloc_offender.allocation_date).to be_kind_of(Date)
+        end
+      end
     end
   end
 end

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -54,7 +54,7 @@ feature 'View a prisoner profile page' do
         visit prison_prisoner_path('LEI', 'G7998GJ')
       end
 
-      scenario 'adding a VLO', :js do
+      scenario 'adding a VLO' do
         expect(page).to have_content('First Contact')
         click_link 'Add new VLO contact'
         find('.govuk-back-link')

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -150,47 +150,4 @@ describe OffenderService, type: :feature do
       end
     end
   end
-
-  describe "#set_allocated_pom_name" do
-    let(:offenders) { Prison.new('LEI').offenders.first(3) }
-    let(:nomis_staff_id) { 485_926 }
-
-    before do
-      PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
-    end
-
-    it "gets the POM names for allocated offenders", vcr: { cassette_name: :offender_service_pom_names_spec } do
-      allocate_offender(DateTime.now.utc)
-
-      updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
-      expect(updated_offenders).to be_kind_of(Array)
-      expect(updated_offenders.first).to be_kind_of(HmppsApi::OffenderSummary)
-      expect(updated_offenders.count).to eq(offenders.count)
-      expect(updated_offenders.first.allocated_pom_name).to eq('Pom, Moic')
-      expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
-    end
-
-    it "uses 'updated_at' date when 'primary_pom_allocated_at' date is nil",
-       vcr: { cassette_name: :offender_service_set_allocated_pom_when_primary_pom_date_nil } do
-      allocate_offender(nil)
-
-      updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
-      expect(updated_offenders.first.allocated_pom_name).to eq('Pom, Moic')
-      expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
-    end
-  end
-
-  def allocate_offender(allocated_date)
-    Allocation.create!(
-      nomis_offender_id: offenders.first.offender_no,
-      nomis_booking_id: 1_153_753,
-      prison: 'LEI',
-      allocated_at_tier: 'C',
-      primary_pom_nomis_id: nomis_staff_id,
-      primary_pom_allocated_at: allocated_date,
-      recommended_pom_type: 'prison',
-      event: Allocation::ALLOCATE_PRIMARY_POM,
-      event_trigger: Allocation::USER
-    )
-  end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -58,6 +58,7 @@ module ApiHelper
         }).
       to_return(body: poms.to_json)
     poms.each do |pom|
+      stub_pom(pom)
       stub_pom_emails(pom.staffId, pom.emails)
     end
   end


### PR DESCRIPTION
While working on MO-316, I discovered a subtle defect in the search controller - it assumes (incorrectly, but possibly practically nearly always) that prisoner names are all upper-casesd. This minor part of the refactor moves a test from service to controller, uncovers the defect and fixes it. 