### PR TITLE
Convert :allocation tag into !:push_pom_to_delius

### DIFF
--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -9,7 +9,7 @@ require 'swagger_helper'
 # rubocop:disable RSpec/EmptyExampleGroup
 # Authorization 'method' needs to be defined for rswag
 # rubocop:disable RSpec/VariableName
-describe 'Allocation API', :allocation, vcr: { cassette_name: :allocation_api } do
+describe 'Allocation API', vcr: { cassette_name: :allocation_api } do
   let!(:private_key) { OpenSSL::PKey::RSA.generate 2048 }
   let!(:public_key) { Base64.strict_encode64(private_key.public_key.to_s) }
   let!(:payload) {

--- a/spec/controllers/api/allocation_api_controller_spec.rb
+++ b/spec/controllers/api/allocation_api_controller_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 RSpec.describe Api::AllocationApiController, :allocation, type: :controller do
   describe '#show' do
     let(:rsa_private) { OpenSSL::PKey::RSA.generate 2048 }
-    let(:stub_url) { "#{api_host}/secure/offenders/nomsNumber/#{offender.fetch(:offenderNo)}/prisonOffenderManager" }
-    let(:api_host) { Rails.configuration.community_api_host }
-
     let(:prison) { build(:prison) }
     let!(:co_working_allocation) {
       create(:allocation, :co_working, primary_pom_nomis_id: primary_pom.staff_id,

--- a/spec/features/admin_feature_spec.rb
+++ b/spec/features/admin_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'admin urls', :allocation do
+feature 'admin urls' do
   # This works as expected (i.e. it sends the user to login)
   # but doesn't work in test-land for some unknown reason
   # context 'without login' do

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Allocation', :allocation do
+feature 'Allocation' do
   let!(:probation_officer_nomis_staff_id) { 485_636 }
   let!(:prison_officer_nomis_staff_id) { 485_926 }
   let!(:nomis_offender_id) { 'G7266VD' }

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Allocation History', :allocation do
+feature 'Allocation History' do
   let!(:probation_pom) do
     {
       primary_pom_nomis_id: 485_926,

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "view an offender's allocation information", :allocation do
+feature "view an offender's allocation information" do
   let!(:probation_officer_nomis_staff_id) { 485_636 }
   let!(:nomis_offender_id_with_keyworker) { 'G3462VT' }
   let!(:nomis_offender_id_without_keyworker) { 'G8859UP' }

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -28,7 +28,7 @@ feature 'summary summary feature' do
       expect(page).to have_content('Add missing information')
     end
 
-    context 'with allocations', :allocation do
+    context 'with allocations' do
       let(:first) { 'G7806VO' }
       let(:last) { 'G3462VT' }
 

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "ChangeParoleReviewDates", :allocation, type: :feature do
+RSpec.feature "ChangeParoleReviewDates", type: :feature do
   # This ID has an indeterminate sentence
   let(:nomis_offender_id) { 'G0549UO' }
   let!(:case_info) { create(:case_information, nomis_offender_id: nomis_offender_id) }

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Co-working', :allocation do
+feature 'Co-working' do
   let!(:nomis_offender_id) { 'G4273GI' }
   let!(:prison_pom) do
     {

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Provide debugging information for our team to use', :allocation do
+feature 'Provide debugging information for our team to use' do
   let(:nomis_offender_id) { "G1670VU" }
 
   before do

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature "early allocation", :allocation, type: :feature do
+feature "early allocation", type: :feature do
   let(:nomis_staff_id) { 485_926 }
   # any date less than 3 months
   let(:valid_date) { Time.zone.today - 2.months }

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -61,7 +61,7 @@ feature "edit a POM's details" do
     expect(page).to have_content('Active')
   end
 
-  context 'when a POM is made inactive', :allocation do
+  context 'when a POM is made inactive' do
     before do
       # create an allocation with the POM as the primary POM
       create(

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Inactive POM' do
-  context 'when viewing an inactive POMs caseload', :allocation, vcr: { cassette_name: :deallocate_non_pom_caseload } do
+  context 'when viewing an inactive POMs caseload', vcr: { cassette_name: :deallocate_non_pom_caseload } do
     # We need an inactive POM to test this feature, Toby has had his POM role removed and therefore a good candidate!
     let(:inactive_pom)      { 485_595 }
     let(:nomis_offender_id) { "G4273GI" }

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -76,7 +76,7 @@ feature 'Navigation' do
       end
     end
 
-    context 'with a browser', :js, :allocation do
+    context 'with a browser', :js do
       before do
         create(:case_information, nomis_offender_id: offender_no)
         create(:allocation, prison: prison.code, primary_pom_nomis_id: moic_pom_staff_id, nomis_offender_id: offender_no)

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "view POM's caseload", :allocation do
+feature "view POM's caseload" do
   let(:nomis_staff_id) { 485_926 }
   let(:nomis_offender_id) { 'G4273GI' }
   let(:tomorrow) { Date.tomorrow }

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'View a prisoner profile page', :allocation do
+feature 'View a prisoner profile page' do
   before do
     signin_spo_user
   end

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Responsibility override', :allocation do
+feature 'Responsibility override' do
   include ActiveJob::TestHelper
 
   before do

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -16,7 +16,7 @@ feature "get poms list" do
     expect(page).to have_content("Probation POM")
   end
 
-  it "handles missing sentence data", :allocation, vcr: { cassette_name: :show_poms_feature_missing_sentence } do
+  it "handles missing sentence data", vcr: { cassette_name: :show_poms_feature_missing_sentence } do
     visit prison_confirm_allocation_path('LEI', offender_missing_sentence_case_info.nomis_offender_id, 485_926)
     click_button 'Complete allocation'
 
@@ -35,7 +35,7 @@ feature "get poms list" do
     expect(page).to have_content("Caseload")
   end
 
-  it "can sort offenders allocated to a POM", :allocation,  vcr: { cassette_name: :show_poms_feature_view_sorting } do
+  it "can sort offenders allocated to a POM", vcr: { cassette_name: :show_poms_feature_view_sorting } do
     [['G7806VO', 754_207], ['G2911GD', 1_175_317]].each do |offender_id, booking|
       create(:case_information, nomis_offender_id: offender_id)
       AllocationService.create_or_update(

--- a/spec/features/spo_handover_cases_feature_spec.rb
+++ b/spec/features/spo_handover_cases_feature_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "SPO viewing upcoming handover cases", :allocation do
+feature "SPO viewing upcoming handover cases" do
   let(:prison) { 'LEI' }
 
   context 'when signed in as an SPO' do

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-context 'when NOMIS is missing information', :allocation do
+context 'when NOMIS is missing information' do
   let(:prison_code) { 'LEI' }
   let(:offender_no) { 'A1' }
   let(:stub_keyworker_host) { Rails.configuration.keyworker_api_host }

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OffenderHelper do
     end
   end
 
-  describe '#event_type', :allocation do
+  describe '#event_type' do
     let(:nomis_staff_id) { 456_789 }
     let(:nomis_offender_id) { 123_456 }
 

--- a/spec/jobs/automatic_handover_email_job_spec.rb
+++ b/spec/jobs/automatic_handover_email_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AutomaticHandoverEmailJob, :allocation, type: :job do
+RSpec.describe AutomaticHandoverEmailJob, type: :job do
   let(:staff_id) { 123456 }
   let(:email_address) { Faker::Internet.email }
 

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe HandoverFollowUpJob, :allocation, type: :job do
+RSpec.describe HandoverFollowUpJob, type: :job do
   shared_context 'with expected behaviour' do
     let(:offender) do
       build_offender(Time.zone.today + 8.months,

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe MovementsOnDateJob, :allocation, type: :job do
+RSpec.describe MovementsOnDateJob, type: :job do
   let(:nomis_offender_id) { 'G3462VT' }
   let!(:alloc) { create(:allocation, nomis_offender_id: nomis_offender_id, secondary_pom_nomis_id: 123_435, prison: 'MDI') }
 

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe OpenPrisonTransferJob, :allocation, type: :job do
+RSpec.describe OpenPrisonTransferJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:nomis_offender_id) { 'G3462VT' }

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ProcessDeliusDataJob, :allocation, :disable_push_to_delius, type: :job do
+RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
   let(:nomis_offender_id) { 'G4281GV' }
   let(:remand_nomis_offender_id) { 'G3716UD' }
   let(:ldu) {  create(:local_divisional_unit) }

--- a/spec/jobs/push_pom_to_delius_job_spec.rb
+++ b/spec/jobs/push_pom_to_delius_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe PushPomToDeliusJob, :allocation, type: :job, versioning: true do
+RSpec.describe PushPomToDeliusJob, type: :job, versioning: true do
   let(:offender) { build(:nomis_offender) }
   let(:offender_no) { offender.fetch(:offenderNo) }
   let(:pom) { build(:pom) }

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SuitableForEarlyAllocationEmailJob, :allocation, type: :job do
+RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
   let(:pom) { build(:pom) }
 
   let(:offender) do

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Allocation, type: :model do
   let(:nomis_offender_id) { 'A3434LK' }
   let(:another_nomis_offender_id) { 654_321 }
 
-  describe '#without_ldu_emails', :allocation do
+  describe '#without_ldu_emails' do
     # CRC offender with no team
     let!(:crc_without_team) {
       case_info = create(:case_information, case_allocation: 'CRC', team: nil)
@@ -70,7 +70,7 @@ RSpec.describe Allocation, type: :model do
     it { is_expected.to validate_presence_of(:event_trigger) }
   end
 
-  context 'with allocations', :allocation do
+  context 'with allocations' do
     let(:prison) { build(:prison) }
     let(:pom) { build(:pom, staffId: nomis_staff_id) }
 
@@ -194,7 +194,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe '#active?', :allocation do
+    describe '#active?' do
       it 'return true if an Allocation has been assigned a Primary POM' do
         alloc = AllocationService.current_allocation_for(nomis_offender_id)
         expect(alloc.active?).to be(true)
@@ -208,7 +208,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe '#override_reasons', :allocation do
+    describe '#override_reasons' do
       let!(:allocation_no_overrides) {
         create(
           :allocation,
@@ -225,7 +225,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe '#active_pom_allocations', :allocation do
+    describe '#active_pom_allocations' do
       let!(:secondary_allocation) {
         create(
           :allocation,
@@ -254,7 +254,7 @@ RSpec.describe Allocation, type: :model do
     end
   end
 
-  describe 'automate pushing the primary pom to ndelius' do
+  describe 'automate pushing the primary pom to ndelius', :push_pom_to_delius do
     let(:prison) { build(:prison).code }
 
     context 'when a new allocation is created and a POM is set' do
@@ -262,7 +262,6 @@ RSpec.describe Allocation, type: :model do
         expect(PrisonOffenderManagerService).to receive(:get_pom_name).with(nomis_staff_id).and_return ['Bill', 'Jones']
         expect(HmppsApi::CommunityApi).to receive(:set_pom).with offender_no: nomis_offender_id, prison: prison, forename: 'Bill', surname: 'Jones'
       end
-
 
       it 'pushes the POM name to Ndelius'do
         create(:allocation, :primary, nomis_offender_id: nomis_offender_id, prison: prison, primary_pom_nomis_id: nomis_staff_id)

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Prison, type: :model do
-  describe '#active', :allocation do
+  describe '#active' do
     before do
       create(:allocation, prison: p1.code)
       create(:allocation, prison: p1.code)

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe StaffMember, :allocation, type: :model do
+RSpec.describe StaffMember, type: :model do
   let(:prison) { Prison.new('LEI') }
   let(:staff_id) { 123 }
   let(:user) { described_class.new(prison, staff_id) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,9 +95,10 @@ RSpec.configure do |config|
     WebMock.disable_net_connect!(allow_localhost: true)
   end
 
-  # This is to prevent test from having to mock this callback due
-  # to an after_save call back in Allocation.
-  config.before(:each, :allocation) do
+  # This is to prevent most tests from having to mock this callback due
+  # to an after_save call back in Allocation. Enable by setting
+  # the push_pom_to_delius tag in your tests
+  config.before(:each, type: lambda { |_v, m| m[:push_pom_to_delius] != true } ) do
     allow(PushPomToDeliusJob).to receive(:perform_later)
   end
 end

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe AllocationService, :allocation do
+describe AllocationService do
   include ActiveJob::TestHelper
 
   let(:nomis_offender_id) { 'G4273GI' }

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe EmailService, :allocation do
+RSpec.describe EmailService do
   include ActiveJob::TestHelper
 
   before do

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe MovementService, :allocation do
+describe MovementService, type: :feature do
   let(:new_offender_court) { build(:movement, offenderNo: 'G4273GI', fromAgency: 'COURT')   }
   let(:new_offender_nil) { build(:movement, offenderNo: 'G4273GI', fromAgency: nil)   }
   let(:transfer_out) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'TRN')   }

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OffenderService do
+describe OffenderService, type: :feature do
   describe '#get_offender' do
     it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
       nomis_offender_id = 'G4273GI'
@@ -159,7 +159,7 @@ describe OffenderService do
       PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
     end
 
-    it "gets the POM names for allocated offenders", :allocation, vcr: { cassette_name: :offender_service_pom_names_spec } do
+    it "gets the POM names for allocated offenders", vcr: { cassette_name: :offender_service_pom_names_spec } do
       allocate_offender(DateTime.now.utc)
 
       updated_offenders = described_class.set_allocated_pom_name(offenders, 'LEI')
@@ -170,7 +170,7 @@ describe OffenderService do
       expect(updated_offenders.first.allocation_date).to be_kind_of(Date)
     end
 
-    it "uses 'updated_at' date when 'primary_pom_allocated_at' date is nil", :allocation,
+    it "uses 'updated_at' date when 'primary_pom_allocated_at' date is nil",
        vcr: { cassette_name: :offender_service_set_allocated_pom_when_primary_pom_date_nil } do
       allocate_offender(nil)
 

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "allocations/show", :allocation, type: :view do
+RSpec.describe "allocations/show", type: :view do
   before do
     assign(:prison, build(:prison))
     assign(:pom, build(:pom))


### PR DESCRIPTION
Currently if a new test is written that creates an allocation, the :allocation rspec tag has to be added to it to prevent an accidental PushPomToDeliusJob being kicked off - due to its implementation in after_save. 

This PR turns that setting on its head, so that now tests have to enable the 'PushPomToDeliusJob' via the :push_pom_to_delius tag - this is much safer and should result in less confusion and noise in the tests