### PR TITLE
Mo357 disable cache when set

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,7 @@ module OffenderManagementAllocationClient
     config.zendesk_enabled =
       [config.zendesk_username, config.zendesk_url, config.zendesk_password].all?
 
-    config.cache_expiry = 60.minutes
+    config.cache_expiry = (ENV['CACHE_TIMEOUT']&.strip || 60.minutes).to_i
 
     # overriding the normal wrapping in a div with class 'field-with-errors' seems to be
     # neccesary in this project, otherwise Gov Design system check-boxes and radio buttons


### PR DESCRIPTION
Allow our redis cache timeout to be overridden, and hence effectively disabled by setting it to 1 second