### PR TITLE
Allow POMs to see the case history page

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AllocationsController < PrisonsApplicationController
-  before_action :ensure_spo_user
+  before_action :ensure_spo_user, except: :history
 
   delegate :update, to: :create
 

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -35,97 +35,96 @@ feature 'Allocation History' do
   let(:ci) { create(:case_information, nomis_offender_id: 'G4273GI') }
   let(:nomis_offender_id) { ci.nomis_offender_id }
 
-  context 'when offender allocation history', vcr: { cassette_name: :offender_allocation_history } do
-    before do
-      signin_spo_user
-
-      allocation = create(
-        :allocation,
-        nomis_offender_id: nomis_offender_id,
-        primary_pom_nomis_id: probation_pom[:primary_pom_nomis_id],
-        primary_pom_name: probation_pom[:primary_pom_name],
-        recommended_pom_type: 'prison',
-        override_reasons: ["suitability"],
-        suitability_detail: "Too high risk",
-        created_at: Time.zone.now - 10.days,
-        updated_at: Time.zone.now - 10.days,
-        primary_pom_allocated_at: Time.zone.now - 12.days
-      )
-      allocation.update!(event: Allocation::REALLOCATE_PRIMARY_POM,
-                         primary_pom_nomis_id: probation_pom_2[:primary_pom_nomis_id],
-                         primary_pom_name: probation_pom_2[:primary_pom_name],
-                         recommended_pom_type: 'probation',
-                         updated_at: Time.zone.now - 10.days
-      )
-      allocation.update!(event: Allocation::ALLOCATE_SECONDARY_POM,
-                         secondary_pom_nomis_id: probation_pom[:primary_pom_nomis_id],
-                         secondary_pom_name: probation_pom[:primary_pom_name],
-                         updated_at: Time.zone.now - 8.days
-      )
-      allocation.update!(event: Allocation::DEALLOCATE_SECONDARY_POM,
-                         secondary_pom_nomis_id: nil,
-                         secondary_pom_name: nil,
-                         recommended_pom_type: nil,
-                         updated_at: Time.zone.now - 7.days
-      )
-      Timecop.travel(deallocate_date) do
-        allocation.offender_transferred
-      end
-      Timecop.travel(Time.zone.now - 5.days) do
-        allocation.update!(event: Allocation::ALLOCATE_PRIMARY_POM,
-                           prison: 'PVI',
-                           primary_pom_nomis_id: prison_pom[:primary_pom_nomis_id],
-                           primary_pom_name: prison_pom[:primary_pom_name],
-                           recommended_pom_type: 'prison',
-                           created_by_name: nil)
-      end
-
-      Timecop.travel(Time.zone.now - 4.days) do
-        create(:early_allocation, case_information: ci, prison: 'PVI', nomis_offender_id: nomis_offender_id)
-        create :email_history, nomis_offender_id: nomis_offender_id,
-               name: ci.team.local_divisional_unit.name,
-               email: ci.team.local_divisional_unit.email_address,
-                             event: EmailHistory::AUTO_EARLY_ALLOCATION,
-                             prison: 'PVI'
-      end
-
-      Timecop.travel(Time.zone.now - 3.days) do
-        create(:early_allocation, :discretionary, case_information: ci, prison: 'PVI', nomis_offender_id: nomis_offender_id)
-        create :email_history, nomis_offender_id: nomis_offender_id,
-               name: ci.team.local_divisional_unit.name,
-               email: ci.team.local_divisional_unit.email_address,
-                             event: EmailHistory::DISCRETIONARY_EARLY_ALLOCATION,
-                             prison: 'PVI'
-      end
-
-      Timecop.travel(Time.zone.now - 2.days) do
+  describe 'offender allocation history', vcr: { cassette_name: :offender_allocation_history } do
+    shared_context 'when on the allocation history page' do
+      before do
+        allocation = create(
+          :allocation,
+          nomis_offender_id: nomis_offender_id,
+          primary_pom_nomis_id: probation_pom[:primary_pom_nomis_id],
+          primary_pom_name: probation_pom[:primary_pom_name],
+          recommended_pom_type: 'prison',
+          override_reasons: ["suitability"],
+          suitability_detail: "Too high risk",
+          created_at: Time.zone.now - 10.days,
+          updated_at: Time.zone.now - 10.days,
+          primary_pom_allocated_at: Time.zone.now - 12.days
+        )
         allocation.update!(event: Allocation::REALLOCATE_PRIMARY_POM,
-                           primary_pom_nomis_id: pom_without_email[:primary_pom_nomis_id],
-                           primary_pom_name: pom_without_email[:primary_pom_name],
-                           recommended_pom_type: 'probation')
+                           primary_pom_nomis_id: probation_pom_2[:primary_pom_nomis_id],
+                           primary_pom_name: probation_pom_2[:primary_pom_name],
+                           recommended_pom_type: 'probation',
+                           updated_at: Time.zone.now - 10.days
+        )
+        allocation.update!(event: Allocation::ALLOCATE_SECONDARY_POM,
+                           secondary_pom_nomis_id: probation_pom[:primary_pom_nomis_id],
+                           secondary_pom_name: probation_pom[:primary_pom_name],
+                           updated_at: Time.zone.now - 8.days
+        )
+        allocation.update!(event: Allocation::DEALLOCATE_SECONDARY_POM,
+                           secondary_pom_nomis_id: nil,
+                           secondary_pom_name: nil,
+                           recommended_pom_type: nil,
+                           updated_at: Time.zone.now - 7.days
+        )
+        Timecop.travel(deallocate_date) do
+          allocation.offender_transferred
+        end
+        Timecop.travel(Time.zone.now - 5.days) do
+          allocation.update!(event: Allocation::ALLOCATE_PRIMARY_POM,
+                             prison: 'PVI',
+                             primary_pom_nomis_id: prison_pom[:primary_pom_nomis_id],
+                             primary_pom_name: prison_pom[:primary_pom_name],
+                             recommended_pom_type: 'prison',
+                             created_by_name: nil)
+        end
+
+        Timecop.travel(Time.zone.now - 4.days) do
+          create(:early_allocation, case_information: ci, prison: 'PVI', nomis_offender_id: nomis_offender_id)
+          create :email_history, nomis_offender_id: nomis_offender_id,
+                 name: ci.team.local_divisional_unit.name,
+                 email: ci.team.local_divisional_unit.email_address,
+                 event: EmailHistory::AUTO_EARLY_ALLOCATION,
+                 prison: 'PVI'
+        end
+
+        Timecop.travel(Time.zone.now - 3.days) do
+          create(:early_allocation, :discretionary, case_information: ci, prison: 'PVI', nomis_offender_id: nomis_offender_id)
+          create :email_history, nomis_offender_id: nomis_offender_id,
+                 name: ci.team.local_divisional_unit.name,
+                 email: ci.team.local_divisional_unit.email_address,
+                 event: EmailHistory::DISCRETIONARY_EARLY_ALLOCATION,
+                 prison: 'PVI'
+        end
+
+        Timecop.travel(Time.zone.now - 2.days) do
+          allocation.update!(event: Allocation::REALLOCATE_PRIMARY_POM,
+                             primary_pom_nomis_id: pom_without_email[:primary_pom_nomis_id],
+                             primary_pom_name: pom_without_email[:primary_pom_name],
+                             recommended_pom_type: 'probation')
+        end
+
+        Timecop.travel(transfer_date) do
+          allocation.offender_transferred
+        end
+
+        visit prison_allocation_history_path('LEI', nomis_offender_id)
       end
 
-      Timecop.travel(transfer_date) do
-        allocation.offender_transferred
-      end
+      let(:deallocate_date) { Time.zone.now - 6.days }
+      let(:formatted_deallocate_date) { deallocate_date.strftime("#{deallocate_date.day.ordinalize} %B %Y") }
+      let(:transfer_date) { Time.zone.now - 1.day }
+      let(:formatted_transfer_date) { transfer_date.strftime("#{transfer_date.day.ordinalize} %B %Y") + " (" + transfer_date.strftime("%R") + ")" }
+      let(:allocation) { Allocation.last }
+      let(:history) { allocation.get_old_versions.append(allocation).sort_by!(&:updated_at).reverse! }
 
-      visit prison_allocation_history_path('LEI', nomis_offender_id)
-    end
+      it 'shows the case history' do
+        history1 = history[1]
+        history2 = history[2]
+        hist_allocate_secondary = history[5]
+        history6 = history[6]
 
-    let(:deallocate_date) { Time.zone.now - 6.days }
-    let(:formatted_deallocate_date) { deallocate_date.strftime("#{deallocate_date.day.ordinalize} %B %Y") }
-    let(:transfer_date) { Time.zone.now - 1.day }
-    let(:formatted_transfer_date) { transfer_date.strftime("#{transfer_date.day.ordinalize} %B %Y") + " (" + transfer_date.strftime("%R") + ")" }
-    let(:allocation) { Allocation.last }
-    let(:history) { allocation.get_old_versions.append(allocation).sort_by!(&:updated_at).reverse! }
-
-    it 'shows the case history' do
-      history1 = history[1]
-      history2 = history[2]
-      hist_allocate_secondary = history[5]
-      history6 = history[6]
-
-      [
+        [
           ['h1', "Abbella, Ozullirn"],
           ['.govuk-heading-m', "HMP Pentonville"],
           ['.moj-timeline__title', "Prisoner unallocated (transfer)"],
@@ -149,31 +148,44 @@ feature 'Allocation History' do
           ['.moj-timeline__description', "Prisoner allocated to #{history.last.primary_pom_name.titleize} - #{probation_pom[:email]} Tier: #{history.last.allocated_at_tier}"],
           ['.moj-timeline__description', "Probation POM allocated instead of recommended Prison POM", "Reason(s):", "- Prisoner assessed as suitable for a prison POM despite tiering calculation", "Too high risk"],
           ['.moj-timeline__date', "#{formatted_date_for(history.last)} by #{history.last.created_by_name.titleize}"]
-      ].each do |key, val|
-        expect(page).to have_css(key, text: val)
+        ].each do |key, val|
+          expect(page).to have_css(key, text: val)
+        end
+      end
+
+      it 'links to previous Early Allocation assessments' do
+        # The 6th history item is an 'eligible' early allocation assessment
+        eligible_assessment = page.find('.moj-timeline > .moj-timeline__item:nth-child(6)')
+
+        within eligible_assessment do
+          expect(page).to have_css('.moj-timeline__title', text: 'Early allocation assessment form completed')
+          expect(page).to have_link('View saved assessment')
+          click_link 'View saved assessment'
+        end
+
+        # Assert that we're on the correct 'view' page
+        target_early_allocation = EarlyAllocation.where(nomis_offender_id: nomis_offender_id).find(&:eligible?)
+        view_assessment_page = prison_prisoner_early_allocation_path('LEI', nomis_offender_id, target_early_allocation.id)
+        expect(page).to have_current_path(view_assessment_page)
+        expect(page).to have_content('Eligible')
+
+        # Back link takes us back
+        click_link 'Back'
+        case_history_page = prison_allocation_history_path('LEI', nomis_offender_id)
+        expect(page).to have_current_path(case_history_page)
       end
     end
 
-    it 'links to previous Early Allocation assessments' do
-      # The 6th history item is an 'eligible' early allocation assessment
-      eligible_assessment = page.find('.moj-timeline > .moj-timeline__item:nth-child(6)')
+    context 'when logged in as an SPO' do
+      before { signin_spo_user }
 
-      within eligible_assessment do
-        expect(page).to have_css('.moj-timeline__title', text: 'Early allocation assessment form completed')
-        expect(page).to have_link('View saved assessment')
-        click_link 'View saved assessment'
-      end
+      include_context 'when on the allocation history page'
+    end
 
-      # Assert that we're on the correct 'view' page
-      target_early_allocation = EarlyAllocation.where(nomis_offender_id: nomis_offender_id).find(&:eligible?)
-      view_assessment_page = prison_prisoner_early_allocation_path('LEI', nomis_offender_id, target_early_allocation.id)
-      expect(page).to have_current_path(view_assessment_page)
-      expect(page).to have_content('Eligible')
+    context 'when logged in as a POM' do
+      before { signin_pom_user }
 
-      # Back link takes us back
-      click_link 'Back'
-      case_history_page = prison_allocation_history_path('LEI', nomis_offender_id)
-      expect(page).to have_current_path(case_history_page)
+      include_context 'when on the allocation history page'
     end
   end
 


### PR DESCRIPTION
This fixes a bug where only SPOs were permitted to see the case history page for an offender, despite links to the page being on POM-accessible views.

This PR opens the page up to both POMs and SPOs.

### Changes made

The diff looks like I've changed more than I really have.

### Feature spec

I moved the test for the case history page into a `shared_context` block, which meant indenting it. This is why it looks like loads has changed in this file.

This was so I can run the exact same test in two contexts:
- when logged in as an SPO
- when logged in as a POM

The page should behave the same in both contexts.

### Controller spec

I had to shuffle some bits around to allow the `#history` page to load. I've only implemented enough to render a HTTP 200 response.

I also replaced a manual stub of the Keyworker API with the API helper function `stub_keyworker`.