### PR TITLE
Mo 231 display early allocation badge

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -13,6 +13,7 @@ class AllocationsController < PrisonsApplicationController
       recommended_and_nonrecommended_poms_for(@prisoner)
     @unavailable_pom_count = unavailable_pom_count
     @allocation = Allocation.find_by nomis_offender_id: nomis_offender_id_from_url
+    @case_info = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: nomis_offender_id_from_url)
   end
 
   def show
@@ -32,6 +33,7 @@ class AllocationsController < PrisonsApplicationController
       end
     end
     @keyworker = HmppsApi::KeyworkerApi.get_keyworker(active_prison_id, @prisoner.offender_no)
+    @case_info = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: nomis_offender_id_from_url)
   end
 
   def edit
@@ -50,6 +52,7 @@ class AllocationsController < PrisonsApplicationController
     @unavailable_pom_count = unavailable_pom_count
 
     @current_pom = current_pom_for(nomis_offender_id_from_url)
+    @case_info = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: nomis_offender_id_from_url)
   end
 
   def confirm

--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -19,6 +19,7 @@ class CoworkingController < PrisonsApplicationController
 
     @prison_poms = @active_poms.select(&:prison_officer?)
     @probation_poms = @active_poms.select(&:probation_officer?)
+    @case_info = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: nomis_offender_id_from_url)
   end
 
   def confirm

--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -22,4 +22,18 @@ module BadgeHelper
   def parole_review_date?(offender)
     offender.indeterminate_sentence? && offender.parole_review_date.present?
   end
+
+  def early_allocation_notes?(offender, early_allocations)
+    if early_allocations.any?
+      !offender.within_early_allocation_window? || early_allocations.last.community_decision == false
+    end
+  end
+
+  def early_allocation_active?(early_allocations)
+    early_allocations.any? && early_allocations.last.awaiting_community_decision?
+  end
+
+  def early_allocation_approved?(early_allocations)
+    early_allocations.any? && early_allocations.last.community_decision_eligible_or_automatically_eligible?
+  end
 end

--- a/app/views/allocations/edit.html.erb
+++ b/app/views/allocations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Reallocate a Prison Offender Manager</h1>
 
-<%= render 'shared/basic_prisoner_info' %>
+<%= render 'shared/basic_prisoner_info', case_info: @case_info, prisoner: @prisoner %>
 
 <%= render 'pom_info' %>
 

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -6,7 +6,7 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a Prison Offender Manager</h1>
 
-<%= render 'shared/basic_prisoner_info' %>
+<%= render 'shared/basic_prisoner_info', case_info: @case_info, prisoner: @prisoner %>
 
 <%= render partial: 'shared/offence_info', locals: { editable_prd: true }  %>
 

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocation information</h1>
 
-<%= render 'shared/case_type_badge', offender: @prisoner %>
+<%= render 'shared/case_type_badge', offender: @prisoner, early_allocations: @case_info.early_allocations %>
 
 <div class="govuk-!-margin-top-1">
   <table class="govuk-table">

--- a/app/views/coworking/new.html.erb
+++ b/app/views/coworking/new.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a co-working Prison Offender Manager</h1>
 
-<%= render 'shared/basic_prisoner_info' %>
+<%= render 'shared/basic_prisoner_info', case_info: @case_info, prisoner: @prisoner %>
 
 <%= render 'allocations/pom_info' %>
 

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="case-type-badge">
-      <%= render 'shared/case_type_badge', offender: @prisoner %>
+      <%= render 'shared/case_type_badge', offender: @prisoner, early_allocations: @case_info.nil? ? [] : @case_info.early_allocations %>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">

--- a/app/views/shared/_basic_prisoner_info.html.erb
+++ b/app/views/shared/_basic_prisoner_info.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/case_type_badge', offender: @prisoner %>
+<%= render 'shared/case_type_badge', offender: prisoner, early_allocations: case_info.early_allocations %>
 
 <div class="govuk-!-margin-top-1">
   <table class="govuk-table">
@@ -9,17 +9,17 @@
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Name</td>
-      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.full_name %></td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= prisoner.full_name %></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Date of birth</td>
-      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= format_date(@prisoner.date_of_birth) %></td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= format_date(prisoner.date_of_birth) %></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Prisoner number</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= @prisoner.offender_no %>
-        <%= link_to 'View DPS Profile', digital_prison_service_profile_path(@prisoner.offender_no), class: "govuk-link pull-right", target: "_blank" %>
+        <%= prisoner.offender_no %>
+        <%= link_to 'View DPS Profile', digital_prison_service_profile_path(prisoner.offender_no), class: "govuk-link pull-right", target: "_blank" %>
     </tr>
     </tbody>
   </table>

--- a/app/views/shared/_case_type_badge.html.erb
+++ b/app/views/shared/_case_type_badge.html.erb
@@ -3,3 +3,6 @@
 <span id="prisoner-case-type" class="moj-badge moj-badge--<%=badge_colour(offender) %>"><%=badge_text(offender)%></span>
 <%= render('shared/recall_badge') if offender.recalled? %>
 <%= render('shared/parole_badge') if badge_for_parole?(offender) %>
+<%= render('shared/early_allocation_notes_badge') if early_allocation_notes?(offender, early_allocations)%>
+<%= render('shared/early_allocation_active_badge') if early_allocation_active?(early_allocations) %>
+<%= render('shared/early_allocation_approved_badge') if early_allocation_approved?(early_allocations) %>

--- a/app/views/shared/_early_allocation_active_badge.html.erb
+++ b/app/views/shared/_early_allocation_active_badge.html.erb
@@ -1,0 +1,1 @@
+<span id="early-allocation-badge" class="moj-badge moj-badge--blue">EARLY ALLOCATION ACTIVE</span>

--- a/app/views/shared/_early_allocation_approved_badge.html.erb
+++ b/app/views/shared/_early_allocation_approved_badge.html.erb
@@ -1,0 +1,1 @@
+<span id="early-allocation-badge" class="moj-badge moj-badge--blue">EARLY ALLOCATION APPROVED</span>

--- a/app/views/shared/_early_allocation_notes_badge.html.erb
+++ b/app/views/shared/_early_allocation_notes_badge.html.erb
@@ -1,0 +1,1 @@
+<span id="early-allocation-badge" class="moj-badge moj-badge--blue">EARLY ALLOCATION NOTES</span>

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -57,6 +57,10 @@ FactoryBot.define do
 
     trait :indeterminate do
       tariffDate { Time.zone.today + 1.year}
+     end
+
+    trait :outside_early_allocation_window do
+      conditionalReleaseDate { Time.zone.today + 19.months }
     end
   end
 end

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -167,6 +167,8 @@ feature "early allocation", type: :feature do
           end
 
           context 'with discretionary path' do
+            let(:early_allocation_badge) { page.find('#early-allocation-badge') }
+
             before do
               discretionary_discretionary_answers
               click_button 'Continue'
@@ -218,6 +220,7 @@ feature "early allocation", type: :feature do
               click_button('Save')
 
               # Profile page
+              expect(early_allocation_badge.text).to include 'EARLY ALLOCATION APPROVED'
               expect(page).to have_text 'Eligible - case handover date has been updated'
               expect(page).to have_link 'View assessment'
 
@@ -228,11 +231,11 @@ feature "early allocation", type: :feature do
           end
 
           scenario 'not eligible due to all answers false' do
-            find('#early-allocation-extremism-separation-field').click
-            find('#early-allocation-high-risk-of-serious-harm-field').click
-            find('#early-allocation-mappa-level-2-field').click
-            find('#early-allocation-pathfinder-process-field').click
-            find('#early-allocation-other-reason-field').click
+            find('label[for=early-allocation-extremism-separation-field]').click
+            find('label[for=early-allocation-high-risk-of-serious-harm-field]').click
+            find('label[for=early-allocation-mappa-level-2-field]').click
+            find('label[for=early-allocation-pathfinder-process-field]').click
+            find('label[for=early-allocation-other-reason-field]').click
 
             click_button 'Continue'
             expect(page).to have_text 'Not eligible for early allocation'

--- a/spec/views/allocations/new.html.erb_spec.rb
+++ b/spec/views/allocations/new.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "allocations/new", type: :view do
     assign(:recommended_poms, [])
     assign(:not_recommended_poms, [])
     assign(:unavailable_pom_count, 0)
+    assign(:case_info, build(:case_information))
     render
   end
 

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "allocations/show", type: :view do
     assign(:prisoner, build(:offender))
     assign(:allocation, create(:allocation))
     assign(:keyworker, build(:keyworker))
+    assign(:case_info, build(:case_information))
     render
   end
 

--- a/spec/views/shared/case_type_badge.html.erb_spec.rb
+++ b/spec/views/shared/case_type_badge.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "allocations/new", type: :view do
     assign(:not_recommended_poms, [])
     assign(:unavailable_pom_count, 0)
     assign(:prisoner, OffenderPresenter.new(offender))
+    assign(:case_info, build(:case_information))
     render
   end
 

--- a/spec/views/shared/early_allocation_badge.html.erb_spec.rb
+++ b/spec/views/shared/early_allocation_badge.html.erb_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe "prisoners/show", type: :view do
+  describe 'early allocation badges' do
+    let(:prison) { build(:prison) }
+    let(:page) { Nokogiri::HTML(rendered) }
+    let(:early_allocation_badge) { page.css('#early-allocation-badge').first }
+    let(:offender) { build(:offender, sentence: sentence).tap { |offender| offender.load_case_information(case_info) } }
+
+    before do
+      assign(:prison, prison)
+      assign(:prisoner, offender)
+      assign(:tasks, [])
+      assign(:keyworker, build(:keyworker))
+      assign(:case_info, case_info)
+      render
+    end
+
+    context 'with early allocation' do
+      let(:case_info) { create(:case_information, early_allocations: [early_allocation]) }
+
+      context 'when unsent' do
+        let(:early_allocation) { build(:early_allocation, :unsent) }
+        let(:sentence) { build(:sentence_detail, :outside_early_allocation_window) }
+
+        it 'displays a badge text EARLY ALLOCATION NOTES' do
+          expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
+          expect(early_allocation_badge.text).to include 'EARLY ALLOCATION NOTES'
+        end
+      end
+
+      context 'when submitted' do
+        # default sentence is inside EA 18 month window
+        let(:sentence) { build(:sentence_detail) }
+
+        context 'when rejected' do
+          let(:early_allocation) { build(:early_allocation, :discretionary_declined) }
+
+          it 'displays badge text EARLY ALLOCATION NOTES' do
+            expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
+            expect(early_allocation_badge.text).to include 'EARLY ALLOCATION NOTES'
+          end
+        end
+
+        context 'when it is awaiting review by NSD/LDU' do
+          let(:early_allocation) { build(:early_allocation, :discretionary) }
+
+          it 'displays badge text EARLY ALLOCATION ACTIVE' do
+            expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
+            expect(early_allocation_badge.text).to include 'EARLY ALLOCATION ACTIVE'
+          end
+        end
+
+        context 'when it has been approved by NSD/LDU' do
+          let(:early_allocation) { build(:early_allocation, :discretionary_accepted) }
+
+          it 'displays badge text EARLY ALLOCATION APPROVED' do
+            expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
+            expect(early_allocation_badge.text).to eq 'EARLY ALLOCATION APPROVED'
+          end
+        end
+
+        context 'when it is automatic' do
+          let(:early_allocation) { build(:early_allocation, :eligible) }
+
+          it 'displays badge text EARLY ALLOCATION APPROVED' do
+            expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
+            expect(early_allocation_badge.text).to include 'EARLY ALLOCATION APPROVED'
+          end
+        end
+      end
+    end
+
+    context 'without an early allocation' do
+      let(:case_info) { build(:case_information) }
+      let(:sentence) { build(:sentence_detail) }
+
+      it 'has no badge' do
+        expect(early_allocation_badge).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR displays an early allocation badge on a prisoner record which only shows if certain criteria have been met. 

_Early allocation assessment completed 18+ months. Or early allocation assessment submitted under 18 months and rejected.
Badge text: EARLY ALLOCATION NOTES 

Early allocation assessment completed under 18 months - submitted and awaiting review by NSD/LDU.
Badge text: EARLY ALLOCATION ACTIVE

Early allocation assessment completed under 18 months - submitted and approved by NSD/LDU. 
Badge text: EARLY ALLOCATION APPROVED_

It also had to add CaseInformation to a number of the controllers and this broke quite  a number of feature tests as case_info then had to be added to their assign setup. 

In addition it modified some of the partials to fit expected convention, so that values are passed to the partials as a parameters instead of being set inside. 