### PR TITLE
Add POM details to the auto early allocation email

### DIFF
--- a/app/jobs/auto_early_allocation_email_job.rb
+++ b/app/jobs/auto_early_allocation_email_job.rb
@@ -7,10 +7,14 @@ class AutoEarlyAllocationEmailJob < ApplicationJob
 
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)
+    allocation = Allocation.find_by!(nomis_offender_id: offender_no)
+    pom = PrisonOffenderManagerService.get_pom_at(prison, allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.auto_early_allocation(email: offender.ldu_email_address,
                                     prisoner_name: offender.full_name,
                                     prisoner_number: offender.offender_no,
+                                    pom_name: allocation.primary_pom_name,
+                                    pom_email: pom.email_address,
                                     prison_name: PrisonService.name_for(prison),
                                     pdf: pdf).deliver_now
     EmailHistory.create! nomis_offender_id: offender.offender_no,

--- a/app/jobs/auto_early_allocation_email_job.rb
+++ b/app/jobs/auto_early_allocation_email_job.rb
@@ -3,7 +3,7 @@
 # This is needed as a job as the (binary) PDF has to be
 # done with deliver_now
 class AutoEarlyAllocationEmailJob < ApplicationJob
-  queue_as :mailer
+  queue_as :mailers
 
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)

--- a/app/jobs/community_early_allocation_email_job.rb
+++ b/app/jobs/community_early_allocation_email_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CommunityEarlyAllocationEmailJob < ApplicationJob
-  queue_as :mailer
+  queue_as :mailers
 
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)

--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SuitableForEarlyAllocationEmailJob < ApplicationJob
-  queue_as :mailer
+  queue_as :mailers
 
   EQUIP_URL = 'https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777'
 

--- a/app/mailers/early_allocation_mailer.rb
+++ b/app/mailers/early_allocation_mailer.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class EarlyAllocationMailer < GovukNotifyRails::Mailer
-  def auto_early_allocation(email:, prisoner_name:, prisoner_number:, prison_name:, pdf:)
+  def auto_early_allocation(email:, prisoner_name:, prisoner_number:, pom_name:, pom_email:, prison_name:, pdf:)
     set_template('dfaeb1b1-26c3-4646-8ef4-1f0ebd18e2e7')
     set_personalisation(prisoner_name: prisoner_name,
                         prisoner_number: prisoner_number,
+                        pom_name: pom_name,
+                        pom_email_address: pom_email,
                         prison_name: prison_name,
                         link_to_document: Notifications.prepare_upload(StringIO.new(pdf)))
 


### PR DESCRIPTION
Both the 'auto' and 'discretionary' early allocation emails sent to LDUs now contain details of the allocated POM.