### PR TITLE
Prevent multiple early allocation badges from appearing

### DIFF
--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -34,6 +34,6 @@ module BadgeHelper
   end
 
   def early_allocation_approved?(early_allocations)
-    early_allocations.any? && early_allocations.last.community_decision_eligible_or_automatically_eligible?
+    early_allocations.any? && early_allocations.last.created_within_referral_window? && early_allocations.last.community_decision_eligible_or_automatically_eligible?
   end
 end

--- a/app/views/shared/_case_type_badge.html.erb
+++ b/app/views/shared/_case_type_badge.html.erb
@@ -3,6 +3,9 @@
 <span id="prisoner-case-type" class="moj-badge moj-badge--<%=badge_colour(offender) %>"><%=badge_text(offender)%></span>
 <%= render('shared/recall_badge') if offender.recalled? %>
 <%= render('shared/parole_badge') if badge_for_parole?(offender) %>
-<%= render('shared/early_allocation_notes_badge') if early_allocation_notes?(offender, early_allocations)%>
-<%= render('shared/early_allocation_active_badge') if early_allocation_active?(early_allocations) %>
-<%= render('shared/early_allocation_approved_badge') if early_allocation_approved?(early_allocations) %>
+<% if early_allocation_approved?(early_allocations) %>
+<%=  render('shared/early_allocation_approved_badge') %>
+<% else %>
+  <%= render('shared/early_allocation_notes_badge') if early_allocation_notes?(offender, early_allocations)%>
+  <%= render('shared/early_allocation_active_badge') if early_allocation_active?(early_allocations) %>
+<% end %>

--- a/spec/views/shared/early_allocation_badge.html.erb_spec.rb
+++ b/spec/views/shared/early_allocation_badge.html.erb_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe "prisoners/show", type: :view do
   describe 'early allocation badges' do
     let(:prison) { build(:prison) }
     let(:page) { Nokogiri::HTML(rendered) }
-    let(:early_allocation_badge) { page.css('#early-allocation-badge').first }
+    let(:early_allocation_css) { page.css('#early-allocation-badge') }
+    let(:early_allocation_badge) { early_allocation_css.first }
+    let(:badge_count) { early_allocation_css.size }
     let(:offender) { build(:offender, sentence: sentence).tap { |offender| offender.load_case_information(case_info) } }
 
     before do
@@ -24,8 +26,9 @@ RSpec.describe "prisoners/show", type: :view do
         let(:sentence) { build(:sentence_detail, :outside_early_allocation_window) }
 
         it 'displays a badge text EARLY ALLOCATION NOTES' do
+          expect(badge_count).to eq(1)
           expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
-          expect(early_allocation_badge.text).to include 'EARLY ALLOCATION NOTES'
+          expect(early_allocation_badge.text).to eq 'EARLY ALLOCATION NOTES'
         end
       end
 
@@ -37,8 +40,9 @@ RSpec.describe "prisoners/show", type: :view do
           let(:early_allocation) { build(:early_allocation, :discretionary_declined) }
 
           it 'displays badge text EARLY ALLOCATION NOTES' do
+            expect(badge_count).to eq(1)
             expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
-            expect(early_allocation_badge.text).to include 'EARLY ALLOCATION NOTES'
+            expect(early_allocation_badge.text).to eq 'EARLY ALLOCATION NOTES'
           end
         end
 
@@ -46,8 +50,9 @@ RSpec.describe "prisoners/show", type: :view do
           let(:early_allocation) { build(:early_allocation, :discretionary) }
 
           it 'displays badge text EARLY ALLOCATION ACTIVE' do
+            expect(badge_count).to eq(1)
             expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
-            expect(early_allocation_badge.text).to include 'EARLY ALLOCATION ACTIVE'
+            expect(early_allocation_badge.text).to eq 'EARLY ALLOCATION ACTIVE'
           end
         end
 
@@ -55,6 +60,7 @@ RSpec.describe "prisoners/show", type: :view do
           let(:early_allocation) { build(:early_allocation, :discretionary_accepted) }
 
           it 'displays badge text EARLY ALLOCATION APPROVED' do
+            expect(badge_count).to eq(1)
             expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
             expect(early_allocation_badge.text).to eq 'EARLY ALLOCATION APPROVED'
           end
@@ -65,7 +71,7 @@ RSpec.describe "prisoners/show", type: :view do
 
           it 'displays badge text EARLY ALLOCATION APPROVED' do
             expect(early_allocation_badge.attributes['class'].value).to include 'moj-badge--blue'
-            expect(early_allocation_badge.text).to include 'EARLY ALLOCATION APPROVED'
+            expect(early_allocation_badge.text).to eq 'EARLY ALLOCATION APPROVED'
           end
         end
       end


### PR DESCRIPTION
Bug fix to the early allocation badges code. If there is an approved early allocation, we should not display the badge indicating a past assessment