### PR TITLE
MO-225: Add release notes for Early Allocations

### DIFF
--- a/app/notifications/service_notifications.yaml
+++ b/app/notifications/service_notifications.yaml
@@ -28,17 +28,13 @@
 
 ---
 notifications:
-  - id: panel-signup-2-10-2020
-    start_date: 02/10/2020
+  - id: early-allocations-release
+    start_date: 11/02/2021
+    end_date: 21/02/2021 # 10 days
     role:
       - POM
       - SPO
-    end_date: 16/10/2020
-    text: 'You can help us improve this service by participating in research and giving us feedback. Sign up to the HMPPS Digital research panel <a href="https://www.surveymonkey.co.uk/r/79MHSJX">here</a>'
-  - id: vlo-banner-20-11-2020
-    start_date: 23/11/2020
-    role:
-      - POM
-      - SPO
-    end_date: 2/12/2020
-    text: 'NEW FEATURE: Prison Offender Managers and Heads of Offender Management Delivery will now be able to manually input the Victim Liaison Officer’s name and contact details.  <a href="/whats-new">Read more</a>'
+    text: >-
+      <span class="moj-badge moj-badge--blue govuk-!-margin-right-2">NEW FEATURE</span>
+      Early allocation assessment and referral now available!
+      <a href="/whats-new">Read more…</a>

--- a/app/views/pages/whats_new.html.erb
+++ b/app/views/pages/whats_new.html.erb
@@ -4,16 +4,42 @@
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="/">Home</a>
       </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">What's new</li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">What’s new</li>
     </ul>
     <br>
   </div>
 
   <div class="govuk-grid-column">
     <div class="govuk-body">
-      <h1 class="govuk-heading-xl">What's new</h1>
+      <h1 class="govuk-heading-xl">What’s new</h1>
 
-      <div>
+      <section class="govuk-!-margin-bottom-9">
+        <h2 class="govuk-heading-l">Release notes: 11 February 2021</h2>
+        <h3 class="govuk-heading-m">New feature</h3>
+        <p>
+          Prisoner Offender Managers can now complete early allocation assessments via the prisoner profile pages in the
+          Manage POM cases service.
+        </p>
+        <p>
+          An early allocation assessment has 2 important uses:
+        </p>
+        <ul>
+          <li>
+            <strong>If the case has 18 months or less until release</strong> - a completed assessment will be submitted
+            and reviewed for possible early allocation to the community.
+          </li>
+          <li>
+            <strong>If the case has 18 months or more until release</strong> - a completed assessment will be added to
+            the case record (capturing any notes, concerns or important information).
+          </li>
+        </ul>
+        <p>
+          For more information on the early allocation process,
+          <a href="https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777">search for ‘early allocation’ in EQuiP</a>.
+        </p>
+      </section>
+
+      <section class="govuk-!-margin-bottom-9">
         <h2 class="govuk-heading-l">Release notes: 8 September 2020</h2>
         <h3 class="govuk-heading-m">New feature</h3>
         <p>Case information pages for POM and SPO users now identify recall cases. If a case
@@ -23,8 +49,9 @@
 
         <p>Notify us of any issues you find by using the 'Contact us'
           form which is linked to at the bottom of every page.</p>
-      </div>
-      <div>
+      </section>
+
+      <section>
         <h2 class="govuk-heading-l">Release notes: 23 November 2020</h2>
         <h3 class="govuk-heading-m">New feature</h3>
         <p>Victim liaison officer details can now be manually added to
@@ -34,7 +61,7 @@
         <p>You are able to add, edit and delete these entries plus make multiple
           contacts if required. Notify us of any issues you find by using the
           'Contact us' form which is linked to at the bottom of every page. </p>
-      </div>
+      </section>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This commit adds a service-wide notification banner, which will be displayed for 10 days. It also updates the "What's New" page with release notes to tell people more about the Early Allocation feature.

The notification banner will display on the service for 10 days:
**From:** 11/02/2021 (expected launch date)
**Until:** 21/02/2021

### Notification banner

<img width="1041" alt="Screenshot 2021-02-11 at 16 22 24" src="https://user-images.githubusercontent.com/7735945/107665430-548e6380-6c85-11eb-844d-7fe3e3f502f1.png">

### What's New page

<img width="1002" alt="Screenshot 2021-02-11 at 16 23 01" src="https://user-images.githubusercontent.com/7735945/107665515-6a9c2400-6c85-11eb-901d-6cb8e08d4a11.png">
