### PR TITLE
MO-394 Part 1: Refactor handover date service

### DIFF
--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -30,11 +30,6 @@ class HandoverDateService
                        start_date: nil, handover_date: nil,
                        reason: 'Immigration Case'
 
-    elsif offender.nps_case? && offender.indeterminate_sentence? && (offender.tariff_date.nil? || offender.tariff_date < Time.zone.today)
-      HandoverData.new custody: RESPONSIBLE, community: NOT_INVOLVED,
-                       start_date: nil, handover_date: nil,
-                       reason: 'Indeterminate with no earliest release date'
-
     elsif offender.recent_prescoed_case? && offender.indeterminate_sentence? && offender.nps_case?
       handover_date = prescoed_handover_date(offender)
       HandoverData.new custody: SUPPORTING, community: RESPONSIBLE,

--- a/spec/features/handover_feature_spec.rb
+++ b/spec/features/handover_feature_spec.rb
@@ -7,15 +7,6 @@ feature "viewing upcoming handovers" do
   context 'when signed in as an SPO' do
     let(:offender) { build(:nomis_offender, latestLocationId: prison) }
     let!(:case_info) { create(:case_information, nomis_offender_id: offender.fetch(:offenderNo)) }
-    let(:handover_dates) {
-      HandoverDateService::HandoverData.new(
-        HandoverDateService::RESPONSIBLE,
-        HandoverDateService::NOT_INVOLVED,
-        handover_start_date,
-        responsibility_handover_date,
-        'Stubbed handover date'
-      )
-    }
 
     before do
       # Stub auth
@@ -27,7 +18,8 @@ feature "viewing upcoming handovers" do
       stub_offenders_for_prison(prison, [offender])
 
       # Stub handover dates for the offender
-      allow(HandoverDateService).to receive(:handover).and_return(handover_dates)
+      allow_any_instance_of(HmppsApi::OffenderBase).to receive(:handover_start_date).and_return(handover_start_date)
+      allow_any_instance_of(HmppsApi::OffenderBase).to receive(:responsibility_handover_date).and_return(responsibility_handover_date)
 
       visit prison_handovers_path(prison)
     end


### PR DESCRIPTION
This is the first in a series of PRs relating to MO-394, which is to implement OMIC rules in Open Prisons.

---

This PR refactors the Handover Date Service to make it nicer to work with. The intention is to improve code readability and remove redundant code.

### Summary of changes

1. Use keyword arguments on the `HandoverData` `Struct` to make the code more readable.
2. Remove a duplicate handover rule: when indeterminate with a TED in the past, force POM responsible.
3. Remove the `responsibility_override` method, which seemed to be making the code flow harder to follow and understand.

Read the commit messages for more details about each change.