### PR TITLE
MO-394 Part 3: Apply OMIC rules to all open prisons from 31/03/2021

### DIFF
--- a/spec/services/handover_date_service_old_spec.rb
+++ b/spec/services/handover_date_service_old_spec.rb
@@ -470,18 +470,21 @@ describe HandoverDateService do
     let(:tariff_date) { nil }
     let(:automatic_release_date) { nil }
 
+    let(:offender) {
+      build(:offender,
+            imprisonmentStatus: indeterminate_sentence ? 'LIFE' : 'SEC90',
+            sentence: build(:sentence_detail,
+                            automaticReleaseDate: automatic_release_date,
+                            conditionalReleaseDate: conditional_release_date,
+                            paroleEligibilityDate: parole_eligibility_date,
+                            tariffDate: tariff_date
+            )
+      )
+    }
+
     let(:result) do
       described_class.nps_start_date(
-        double(
-          automatic_release_date: automatic_release_date,
-          conditional_release_date: conditional_release_date,
-          "early_allocation?" => false,
-          "indeterminate_sentence?" => indeterminate_sentence,
-          parole_eligibility_date: parole_eligibility_date,
-          parole_review_date: nil,
-          release_date: tariff_date,
-          "recent_prescoed_case?" => false
-        )
+        HandoverDateService::OffenderWrapper.new(offender)
       )
     end
 

--- a/spec/services/handover_date_service_responsibility_spec.rb
+++ b/spec/services/handover_date_service_responsibility_spec.rb
@@ -5,8 +5,8 @@ describe HandoverDateService do
     subject { described_class.handover(offender).custody }
 
     context 'when prescoed' do
-      let(:recent_date) { HandoverDateService::PRESCOED_CUTOFF_DATE }
-      let(:past_date) { HandoverDateService::PRESCOED_CUTOFF_DATE - 1.day }
+      let(:recent_date) { HandoverDateService::PRESCOED_POLICY_START_DATE }
+      let(:past_date) { HandoverDateService::PRESCOED_POLICY_START_DATE - 1.day }
 
       context 'with recent arrival' do
         let(:arrival_date) { recent_date }
@@ -243,18 +243,6 @@ describe HandoverDateService do
     end
 
     context 'when NPS case' do
-      context 'when an open prison' do
-        let(:offender) {
-          build(:offender, latestLocationId: 'HDI').tap { |o|
-            o.load_case_information(build(:case_information, :nps))
-          }
-        }
-
-        it 'will show the POM as supporting' do
-          expect(subject).to eq HandoverDateService::SUPPORTING
-        end
-      end
-
       context 'when an English offender' do
         context 'when sentenced before policy start date' do
           let(:sentence_start_date) { Date.parse('15-09-2019') }


### PR DESCRIPTION
This is the third in a series of PRs relating to MO-394, which is to implement OMIC rules in Open Prisons.

---

This PR builds upon the existing HMP Prescoed rules and extends them to apply to the entire open prison estate.

One of the details around this implementation is that it doesn't _replace_ the HMP Prescoed pilot rules, but adds to them.

As of this PR, there are now three possible sets of rules which can apply to offenders in an open prison:

1. Existing functionality (pilot): OMIC rules apply to Welsh offenders entering HMP Prescoed after 19/10/2020
2. **New functionality (in this PR)**: any offender entering any open prison after 31/03/2021
3. Any offenders who don't fit the above criteria (e.g. an English offender who entered an open prison before 31/03/2021) will have the pre-OMIC policy rules applied – i.e. COM always responsible, POM always supporting, no OMIC handover dates.

### Summary of changes

- Apply OMIC rules to open prisons from 31/03/2021
- Rename methods and variables to make code less Prescoed-specific.