### PR TITLE
Keep test offenders far enough apart so they always sort uniquely

### DIFF
--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -47,6 +47,18 @@ FactoryBot.define do
       paroleEligibilityDate { Time.zone.today + 8.months + 46.days }
     end
 
+    trait :handover_in_28_days do
+      paroleEligibilityDate { Time.zone.today + 8.months + 28.days }
+    end
+
+    trait :handover_in_14_days do
+      paroleEligibilityDate { Time.zone.today + 8.months + 14.days }
+    end
+
+    trait :handover_in_21_days do
+      paroleEligibilityDate { Time.zone.today + 8.months + 21.days }
+    end
+
     trait :unsentenced do
       sentenceStartDate { nil }
     end

--- a/spec/features/handover_feature_spec.rb
+++ b/spec/features/handover_feature_spec.rb
@@ -76,14 +76,14 @@ feature "viewing upcoming handovers" do
       offenders = [
           build(:nomis_offender,
                 offenderNo: "A7514GW",
-                sentence: attributes_for(:sentence_detail, :handover_in_8_days)),
+                sentence: attributes_for(:sentence_detail, :handover_in_28_days)),
           build(:nomis_offender,
                 offenderNo: "B7514GW",
-                sentence: attributes_for(:sentence_detail, :handover_in_4_days)),
+                sentence: attributes_for(:sentence_detail, :handover_in_14_days)),
           build(:nomis_offender, offenderNo: "C7514GW",
-                sentence: attributes_for(:sentence_detail, :handover_in_6_days)),
+                sentence: attributes_for(:sentence_detail, :handover_in_21_days)),
           build(:nomis_offender, offenderNo: "D7514GW",
-                sentence: attributes_for(:sentence_detail, :handover_in_3_days))
+                sentence: attributes_for(:sentence_detail, :handover_in_6_days))
       ]
 
       stub_offenders_for_prison(prison, offenders)


### PR DESCRIPTION
This PR makes the offenders in the handover spec far enough apart so that their handover dates are always unique