### PR TITLE
fix rake task to call job correctly

### DIFF
--- a/lib/tasks/early_allocation_suitability_email.rake
+++ b/lib/tasks/early_allocation_suitability_email.rake
@@ -8,7 +8,7 @@ namespace :early_allocation_suitability_email do
     offenders = EarlyAllocation.suitable_offenders_pre_referral_window.pluck(:nomis_offender_id).uniq
 
     offenders.each do |offender|
-      SuitableForEarlyAllocationEmailJob(offender).perform_later
+      SuitableForEarlyAllocationEmailJob.perform_later(offender)
     end
   end
 end


### PR DESCRIPTION
Sentry reported that we had an error in our rake task: https://sentry.io/organizations/ministryofjustice/issues/2234360893/?environment=production&project=5584139&query=is%3Aunresolved

We were using the wrong syntax - this PR fixes it