### PR TITLE
Configure Sentry to use Heroku Review App names

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,6 +4,10 @@ if sentry_dsn
     config.dsn = sentry_dsn
     config.excluded_exceptions << 'JWT::ExpiredSignature'
     config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+
+    # If we're in Heroku, set the environment name to be the current app name
+    # This allows us to tell which PR/Review App an error came from
+    config.current_environment = ENV['HEROKU_APP_NAME'] if ENV['HEROKU_APP_NAME'].present?
   end
 else
   Rails.logger.warn '[WARN] Sentry is not configured (SENTRY_DSN)'


### PR DESCRIPTION
This commit configures Sentry to use the Heroku Review App name as the 'current environment' value.

This means that we'll be able to filter errors in Sentry by the name of the Heroku app – with an environment for each Pull Request / Review App.

I've tested this on an existing Heroku review app and it works as expected.