### PR TITLE
add rubocop -a to guard configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'flamegraph'
   gem 'guard-rspec'
+  gem 'guard-rubocop'
   gem 'listen', '>= 3.0.5', '< 3.3'
   gem 'memory_profiler'
   # prevent warnings from parser as we are using ruby 2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.4.0)
+      guard (~> 2.0)
+      rubocop (< 2.0)
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
@@ -511,6 +514,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (~> 2.1)
   govuk_notify_rails
   guard-rspec
+  guard-rubocop
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
   jbuilder (~> 2.10)
   jwt

--- a/Guardfile
+++ b/Guardfile
@@ -89,3 +89,8 @@ guard :rspec, cmd: 'bundle exec rspec' do
     Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance'
   end
 end
+
+guard :rubocop, cli: ['-a'] do
+  watch(%r{.+\.rb$})
+  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+end


### PR DESCRIPTION
This PR adds rubocop -a to the guard configuration.

This means that as well as running your tests, guard will behind-the-scenes check and auto-correct your code for rubocop violations