### PR TITLE
Don't retry nDelius API when we get a 500 error

### DIFF
--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -5,6 +5,8 @@ class ProcessDeliusDataJob < ApplicationJob
 
   # Not much point retrying a 404 error
   discard_on Faraday::ResourceNotFound
+  # nDelius API fails like this when trying to read a duplicate - so don't retry here either
+  discard_on Faraday::ServerError
 
   include ApplicationHelper
 


### PR DESCRIPTION
Stop retrying on nDelius 500 errors - we get them due to a duplicate record in nDelius.

This should help us to track whether nDelius errors are going down or up over time.