### PR TITLE
make recall flag less special

### DIFF
--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -8,17 +8,17 @@ module HmppsApi
 
     attr_reader :prison_id
 
-    def self.from_json(payload, recall_flag:, latest_temp_movement:)
-      Offender.new(payload, recall_flag: recall_flag, latest_temp_movement: latest_temp_movement)
+    def self.from_json(api_payload, search_payload, latest_temp_movement:)
+      Offender.new(api_payload, search_payload, latest_temp_movement: latest_temp_movement)
     end
 
     # This must only reference fields that are present in
     # https://https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//prisoners/getPrisonersOffenderNo
-    def initialize(payload, recall_flag:, latest_temp_movement:)
-      @booking_id = payload['latestBookingId']&.to_i
-      @prison_id = payload['latestLocationId']
+    def initialize(api_payload, search_payload, latest_temp_movement:)
+      @booking_id = api_payload['latestBookingId']&.to_i
+      @prison_id = api_payload['latestLocationId']
 
-      super(payload, recall_flag: recall_flag, latest_temp_movement: latest_temp_movement)
+      super(api_payload, search_payload, latest_temp_movement: latest_temp_movement)
     end
   end
 end

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -153,18 +153,18 @@ module HmppsApi
     # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//prisoners/getPrisonersOffenderNo
     # and also by
     # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//locations/getOffendersAtLocationDescription
-    def initialize(payload, recall_flag:, latest_temp_movement:)
+    def initialize(api_payload, search_payload, latest_temp_movement:)
       # It is expected that this method will be called by the subclass which
       # will have been given a payload at the class level, and will call this
       # method from it's own internal from_json
-      @first_name = payload.fetch('firstName')
-      @last_name = payload.fetch('lastName')
-      @offender_no = payload.fetch('offenderNo')
-      @convicted_status = payload['convictedStatus']
-      @recall_flag = recall_flag
-      @sentence_type = SentenceType.new(payload['imprisonmentStatus'])
-      @category_code = payload['categoryCode']
-      @date_of_birth = Date.parse(payload.fetch('dateOfBirth'))
+      @first_name = api_payload.fetch('firstName')
+      @last_name = api_payload.fetch('lastName')
+      @offender_no = api_payload.fetch('offenderNo')
+      @convicted_status = api_payload['convictedStatus']
+      @recall_flag = search_payload.fetch('recall', false)
+      @sentence_type = SentenceType.new(api_payload['imprisonmentStatus'])
+      @category_code = api_payload['categoryCode']
+      @date_of_birth = Date.parse(api_payload.fetch('dateOfBirth'))
       @latest_temp_movement = latest_temp_movement
     end
 

--- a/app/models/hmpps_api/offender_summary.rb
+++ b/app/models/hmpps_api/offender_summary.rb
@@ -20,18 +20,18 @@ module HmppsApi
       end
     end
 
-    def self.from_json(payload, recall_flag:, latest_temp_movement:)
-      OffenderSummary.new(payload, recall_flag: recall_flag, latest_temp_movement: latest_temp_movement)
+    def self.from_json(api_payload, search_payload, latest_temp_movement:)
+      OffenderSummary.new(api_payload, search_payload, latest_temp_movement: latest_temp_movement)
     end
 
     # This list must only contain values that are returned by
     # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//locations/getOffendersAtLocationDescription
-    def initialize(payload, recall_flag:, latest_temp_movement:)
-      @booking_id = payload.fetch('bookingId').to_i
-      @prison_id = payload.fetch('agencyId')
-      @facial_image_id = payload['facialImageId']&.to_i
+    def initialize(api_payload, search_payload, latest_temp_movement:)
+      @booking_id = api_payload.fetch('bookingId').to_i
+      @prison_id = api_payload.fetch('agencyId')
+      @facial_image_id = api_payload['facialImageId']&.to_i
 
-      super(payload, recall_flag: recall_flag, latest_temp_movement: latest_temp_movement)
+      super(api_payload, search_payload, latest_temp_movement: latest_temp_movement)
     end
   end
 end

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -23,13 +23,13 @@ module HmppsApi
         }
 
         offender_nos = data.map { |o| o.fetch('offenderNo') }
-        recall_data = get_recall_flags(offender_nos)
+        search_data = get_search_payload(offender_nos)
         temp_movements = HmppsApi::PrisonApi::MovementApi.latest_temp_movement_for(offender_nos)
 
         offenders = data.map do |payload|
           offender_no = payload.fetch('offenderNo')
           HmppsApi::OffenderSummary.from_json(payload,
-                                              recall_flag: recall_data.fetch(offender_no).fetch('recall'),
+                                              search_data.fetch(offender_no, {}),
                                               latest_temp_movement: temp_movements[offender_no])
         end
         ApiPaginatedResponse.new(total_pages, offenders)
@@ -44,10 +44,10 @@ module HmppsApi
         if response.empty?
           nil
         else
-          recall_data = get_recall_flags([url_offender_no])
+          search_data = get_search_payload([url_offender_no])
           temp_movements = HmppsApi::PrisonApi::MovementApi.latest_temp_movement_for([url_offender_no])
           HmppsApi::Offender.from_json(response.first,
-                                       recall_flag: recall_data.fetch(url_offender_no).fetch('recall'),
+                                       search_data.fetch(url_offender_no, {}),
                                        latest_temp_movement: temp_movements[url_offender_no]).tap do |offender|
             sentence_details = get_bulk_sentence_details([offender.booking_id])
             offender.sentence = sentence_details.fetch(offender.booking_id)
@@ -122,11 +122,10 @@ module HmppsApi
 
     private
 
-      def self.get_recall_flags(offender_nos)
+      def self.get_search_payload(offender_nos)
         search_route = '/prisoner-numbers'
-        search_result = search_client.post(search_route, { prisonerNumbers: offender_nos }, cache: true)
+        search_client.post(search_route, { prisonerNumbers: offender_nos }, cache: true)
                                      .index_by { |prisoner| prisoner.fetch('prisonerNumber') }
-        offender_nos.index_with { |nomis_id| { 'recall' => search_result.fetch(nomis_id, {}).fetch('recall', false) } }
       end
 
       def self.paging_headers(page_size, page_offset)

--- a/spec/factories/offender_summaries.rb
+++ b/spec/factories/offender_summaries.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :offender_summary, class: 'HmppsApi::OffenderSummary', parent: :offender_base do
     initialize_with do
       HmppsApi::OffenderSummary.from_json(attributes.stringify_keys,
-                                          recall_flag: attributes.fetch(:recall),
+                                          attributes.stringify_keys,
                                           latest_temp_movement: nil).tap { |offender|
         offender.sentence = attributes.fetch(:sentence)}
     end

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -50,7 +50,7 @@ FactoryBot.define do
   factory :offender, parent: :offender_base, class: 'HmppsApi::Offender' do
     initialize_with do
       HmppsApi::Offender.from_json(attributes.stringify_keys,
-                                   recall_flag: attributes.fetch(:recall),
+                                   attributes.stringify_keys,
                                    latest_temp_movement: nil).tap { |offender|
         offender.sentence = attributes.fetch(:sentence)
       }

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Prison, type: :model do

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -48,7 +48,6 @@ describe HmppsApi::PrisonApi::OffenderApi do
       let(:offender) { build(:nomis_offender, recall: true) }
       let(:offender_no) { offender.fetch(:offenderNo) }
 
-
       before do
         stub_auth_token
         stub_offender(offender)


### PR DESCRIPTION
Our usage of the Prisoner Search API is very recall-flag centric - this PR changes that so that the models can consume whatever values they want from the supplied data. Hopefully this makes it easier to bring in data items from the search API which should be our end goal.