### PR TITLE
Support ticket:  17 identical automated emails sent

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -127,12 +127,12 @@ class Allocation < ApplicationRecord
             :event_trigger,
             :prison, presence: true
 
-  def offender_released
-    deallocate_offender event: Allocation::DEALLOCATE_RELEASED_OFFENDER, event_trigger: Allocation::OFFENDER_RELEASED
+  def deallocate_offender_after_release
+    deallocate_offender event: Allocation::DEALLOCATE_RELEASED_OFFENDER, event_trigger: Allocation::OFFENDER_RELEASED if active?
   end
 
-  def offender_transferred
-    deallocate_offender event: Allocation::DEALLOCATE_PRIMARY_POM, event_trigger: Allocation::OFFENDER_TRANSFERRED
+  def dealloate_offender_after_transfer
+    deallocate_offender event: Allocation::DEALLOCATE_PRIMARY_POM, event_trigger: Allocation::OFFENDER_TRANSFERRED if active?
   end
 
 private

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -86,7 +86,7 @@ private
     # When an offender is released, we can no longer rely on their
     # case information (in case they come back one day), and we
     # should de-activate any current allocations.
-    alloc.offender_transferred if alloc
+    alloc.dealloate_offender_after_transfer if alloc
     true
   end
 
@@ -125,6 +125,6 @@ private
     # When an offender is released, we can no longer rely on their
     # case information (in case they come back one day), and we
     # should de-activate any current allocations.
-    alloc.offender_released if alloc
+    alloc.deallocate_offender_after_release if alloc
   end
 end

--- a/lib/allocation_validation.rb
+++ b/lib/allocation_validation.rb
@@ -23,7 +23,7 @@ class AllocationValidation
       offender = OffenderService.get_offender(allocation.nomis_offender_id)
       if offender.nil?
         puts "Can't find offender #{allocation.nomis_offender_id} - probably merged, deallocating"
-        allocation.offender_released
+        allocation.deallocate_offender_after_release
         next
       end
 
@@ -32,7 +32,7 @@ class AllocationValidation
         # be allocated to anybody We will de-allocate the offender so they can
         # be re-allocated against a new offense.
         puts "#{offender.offender_no} is not sentenced - deallocating"
-        allocation.offender_released
+        allocation.deallocate_offender_after_release
         next
       end
 
@@ -42,13 +42,13 @@ class AllocationValidation
       # If the offender is out, deallocate as a release
       if offender.prison_id == 'OUT'
         puts "#{offender.offender_no} appears to have been released - deallocating"
-        allocation.offender_released
+        allocation.deallocate_offender_after_release
         next
       end
 
       # The offender is at a different prison so deallocate as a transfer
       puts "#{offender.offender_no} (allocated) appears to have been transferred to #{offender.prison_id} - deallocating"
-      allocation.offender_transferred
+      allocation.dealloate_offender_after_transfer
     }
   end
 

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -68,7 +68,7 @@ feature 'Allocation History' do
                            updated_at: Time.zone.now - 7.days
         )
         Timecop.travel(deallocate_date) do
-          allocation.offender_transferred
+          allocation.dealloate_offender_after_transfer
         end
         Timecop.travel(Time.zone.now - 5.days) do
           allocation.update!(event: Allocation::ALLOCATE_PRIMARY_POM,
@@ -105,7 +105,7 @@ feature 'Allocation History' do
         end
 
         Timecop.travel(transfer_date) do
-          allocation.offender_transferred
+          allocation.dealloate_offender_after_transfer
         end
 
         Timecop.travel(Time.zone.now - 3.weeks) do
@@ -221,7 +221,7 @@ feature 'Allocation History' do
       stub_pom pom
       create(:case_information, nomis_offender_id: nomis_offender_id)
       allocation = create(:allocation, :primary, nomis_offender_id: nomis_offender_id, prison: prison, primary_pom_nomis_id: pom.staff_id)
-      allocation.offender_released
+      allocation.deallocate_offender_after_release
     end
 
     scenario 'visit allocation history page' do

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
                prison: closed_prison_code
         ).tap { |alloc|
           alloc.update(primary_pom_nomis_id: nomis_staff_id)
-          alloc.offender_transferred
+          alloc.dealloate_offender_after_transfer
         }
       }
 
@@ -181,7 +181,7 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
                prison: closed_prison_code
         ).tap { |alloc|
           alloc.update(primary_pom_nomis_id: nomis_staff_id)
-          alloc.offender_transferred
+          alloc.dealloate_offender_after_transfer
         }
       }
 

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Allocation, type: :model do
         AllocationService.create_or_update(params)
         alloc = described_class.find_by!(nomis_offender_id: nomis_offender_id)
 
-        alloc.offender_transferred
+        alloc.dealloate_offender_after_transfer
         deallocation = alloc.reload
 
         expect(deallocation.primary_pom_nomis_id).to be_nil
@@ -179,7 +179,7 @@ RSpec.describe Allocation, type: :model do
         AllocationService.create_or_update(params)
 
         alloc = described_class.find_by(nomis_offender_id: nomis_offender_id)
-        alloc.offender_released
+        alloc.deallocate_offender_after_release
         deallocation = alloc.reload
 
         expect(deallocation.primary_pom_nomis_id).to be_nil

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -130,12 +130,12 @@ RSpec.describe EmailService do
       create(:allocation,
              nomis_offender_id: original_allocation.nomis_offender_id,
              primary_pom_nomis_id: original_allocation.primary_pom_nomis_id).tap do |x|
-        x.offender_released
+        x.deallocate_offender_after_release
         x.reload
         x.update!(primary_pom_nomis_id: reallocation.primary_pom_nomis_id,
                   event: Allocation::REALLOCATE_PRIMARY_POM,
                   event_trigger: Allocation::USER)
-        x.offender_released
+        x.deallocate_offender_after_release
         x.reload
         x.update!(primary_pom_nomis_id: original_allocation.primary_pom_nomis_id,
                   event: Allocation::REALLOCATE_PRIMARY_POM,

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -74,6 +74,15 @@ describe MovementService, type: :feature do
       expect(processed).to be true
     end
 
+    it "can do an open prison transfer with an inactive allocation",
+       vcr: { cassette_name: :movement_service_transfer_to_open_spec }  do
+      open_prison_transfer = build(:movement, offenderNo: 'G4273GI', toAgency: 'HDI')
+
+      existing_allocation.dealloate_offender_after_transfer
+      processed = described_class.process_movement(open_prison_transfer)
+      expect(processed).to be true
+    end
+
     it "can process a movement with no 'to' agency",
        vcr: { cassette_name: :movement_service_admission_in_spec }  do
       processed = described_class.process_movement(admission)
@@ -125,6 +134,14 @@ describe MovementService, type: :feature do
         expect(CaseInformationService.get_case_information([valid_release.offender_no])).to be_empty
         expect(updated_allocation.event_trigger).to eq 'offender_released'
         expect(updated_allocation.prison).to eq 'LEI'
+        expect(processed).to be true
+      end
+
+      it "can do an open prison release with an inactive allocation",
+         vcr: { cassette_name: :movement_service_process_release_spec }  do
+        allocation.deallocate_offender_after_release
+        processed = described_class.process_movement(valid_release)
+
         expect(processed).to be true
       end
     end


### PR DESCRIPTION
This PR fixes a support request. 

_I monitor the northants-omic@justice.gov.uk mailbox. This weekend we have had a glitch with 17 identical automated emails sent from Saturday to Monday regarding one offender (E229139 Kenneth Smith A2361ED). Please could this glitch be investigated so that it does not reoccur?_ 

This was a result of Allocation not being deleted when a prisoner no longer has an allocation. When it tries to deallocate an an allocated offender it crashes when the allocation is not active. 