### PR TITLE
MO-421 move nomis vcr location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,11 @@
 
 # Ignore IDEs
 .idea/
+*.iml
 .vscode/
 
-# Ignore VCR cassettes
-/spec/fixtures/vcr_cassettes
+# Ignore Prison API / NOMIS VCR cassettes
+/spec/fixtures/vcr_cassettes/prison_api
 
 # Ignore VIM swap files
 *.swp

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --require spec_helper
--t ~vpn_only

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -9,7 +9,7 @@ require 'swagger_helper'
 # rubocop:disable RSpec/EmptyExampleGroup
 # Authorization 'method' needs to be defined for rswag
 # rubocop:disable RSpec/VariableName
-describe 'Allocation API', vcr: { cassette_name: :allocation_api } do
+describe 'Allocation API', vcr: { cassette_name: 'prison_api/allocation_api' } do
   let!(:private_key) { OpenSSL::PKey::RSA.generate 2048 }
   let!(:public_key) { Base64.strict_encode64(private_key.public_key.to_s) }
   let!(:payload) {

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -24,7 +24,7 @@ feature 'Allocation' do
     signin_spo_user
   end
 
-  scenario 'accepting a recommended allocation', vcr: { cassette_name: :create_new_allocation_feature } do
+  scenario 'accepting a recommended allocation', vcr: { cassette_name: 'prison_api/create_new_allocation_feature' } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
     expect(page).to have_content('Determinate')
@@ -44,7 +44,7 @@ feature 'Allocation' do
     expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Moic Integration-Tests (Probation POM)")
   end
 
-  scenario 'overriding an allocation', vcr: { cassette_name: :override_allocation_feature_ok } do
+  scenario 'overriding an allocation', vcr: { cassette_name: 'prison_api/override_allocation_feature_ok' } do
     # This is Amit's staff_id - he is top of the Prison POM list
     override_nomis_staff_id = 485_787
 
@@ -73,7 +73,7 @@ feature 'Allocation' do
     expect(Override.count).to eq(0)
   end
 
-  scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: :override_allocation_feature_validate_reasons } do
+  scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: 'prison_api/override_allocation_feature_validate_reasons' } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
     find('.govuk-details__summary-text').click
@@ -89,7 +89,7 @@ feature 'Allocation' do
     expect(Override.count).to eq(0)
   end
 
-  scenario 'overriding an allocation can validate missing Other detail', vcr: { cassette_name: :override_allocation_feature_validate_other } do
+  scenario 'overriding an allocation can validate missing Other detail', vcr: { cassette_name: 'prison_api/override_allocation_feature_validate_other' } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
     find('.govuk-details__summary-text').click
@@ -106,7 +106,7 @@ feature 'Allocation' do
     expect(Override.count).to eq(0)
   end
 
-  scenario 'overriding an allocation can validate missing suitability detail', vcr: { cassette_name: :override_suitability_allocation_feature } do
+  scenario 'overriding an allocation can validate missing suitability detail', vcr: { cassette_name: 'prison_api/override_suitability_allocation_feature' } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
     find('.govuk-details__summary-text').click
@@ -123,7 +123,7 @@ feature 'Allocation' do
     expect(Override.count).to eq(0)
   end
 
-  scenario 'overriding an allocation can validate the reason text area character limit', vcr: { cassette_name: :override_allocation__character_count_feature } do
+  scenario 'overriding an allocation can validate the reason text area character limit', vcr: { cassette_name: 'prison_api/override_allocation__character_count_feature' } do
     visit new_prison_allocation_path('LEI', nomis_offender_id)
 
     find('.govuk-details__summary-text').click
@@ -140,7 +140,7 @@ feature 'Allocation' do
     expect(page).to have_content('This reason cannot be more than 175 characters')
   end
 
-  scenario 're-allocating', vcr: { cassette_name: :re_allocate_feature } do
+  scenario 're-allocating', vcr: { cassette_name: 'prison_api/re_allocate_feature' } do
     create(
       :allocation,
       nomis_offender_id: nomis_offender_id,
@@ -176,7 +176,7 @@ feature 'Allocation' do
     expect(Allocation.find_by(nomis_offender_id: nomis_offender_id).event).to eq("reallocate_primary_pom")
   end
 
-  scenario 'allocation fails', vcr: { cassette_name: :allocation_fails_feature } do
+  scenario 'allocation fails', vcr: { cassette_name: 'prison_api/allocation_fails_feature' } do
     expect(AllocationService).to receive(:create_or_update).and_return(false)
 
     visit new_prison_allocation_path('LEI', nomis_offender_id)
@@ -195,7 +195,7 @@ feature 'Allocation' do
     )
   end
 
-  scenario 'cannot reallocate a non-allocated offender', vcr: { cassette_name: :allocation_attempt_bad_reallocate } do
+  scenario 'cannot reallocate a non-allocated offender', vcr: { cassette_name: 'prison_api/allocation_attempt_bad_reallocate' } do
     visit edit_prison_allocation_path('LEI', never_allocated_offender)
     expect(page).to have_current_path new_prison_allocation_path('LEI', never_allocated_offender)
   end
@@ -205,7 +205,7 @@ feature 'Allocation' do
       create(:responsibility, nomis_offender_id: never_allocated_offender)
     end
 
-    scenario 'removing a community override', vcr: { cassette_name: :allocation_remove_community_override } do
+    scenario 'removing a community override', vcr: { cassette_name: 'prison_api/allocation_remove_community_override' } do
       visit prison_dashboard_index_path('LEI')
 
       click_link 'Make new allocations'

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -35,7 +35,7 @@ feature 'Allocation History' do
   let(:ci) { create(:case_information, nomis_offender_id: 'G4273GI') }
   let(:nomis_offender_id) { ci.nomis_offender_id }
 
-  describe 'offender allocation history', vcr: { cassette_name: :offender_allocation_history } do
+  describe 'offender allocation history', vcr: { cassette_name: 'prison_api/offender_allocation_history' } do
     shared_context 'when on the allocation history page' do
       before do
         allocation = create(

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -34,7 +34,7 @@ feature "view an offender's allocation information" do
     end
 
     it "displays 'Data not available'",
-       vcr: { cassette_name: :show_allocation_information_keyworker_not_assigned } do
+       vcr: { cassette_name: 'prison_api/show_allocation_information_keyworker_not_assigned' } do
       visit prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id_without_keyworker)
 
       expect(page).to have_css('h1', text: 'Allocation information')
@@ -160,7 +160,7 @@ feature "view an offender's allocation information" do
         end
       end
 
-      it 'displays a link to the allocation history', vcr: { cassette_name: :show_allocation_information_history_link } do
+      it 'displays a link to the allocation history', vcr: { cassette_name: 'prison_api/show_allocation_information_history_link' } do
         table_row = page.find(:css, 'tr.govuk-table__row', text: 'Allocation history')
 
         within table_row do
@@ -169,13 +169,13 @@ feature "view an offender's allocation information" do
         end
       end
 
-      context 'without auto_delius_import enabled', vcr: { cassette_name: :allocation_auto_delius_off } do
+      context 'without auto_delius_import enabled', vcr: { cassette_name: 'prison_api/allocation_auto_delius_off' } do
         it 'displays change links' do
           expect(page).to have_content 'Change'
         end
       end
 
-      context 'with auto_delius_import enabled', vcr: { cassette_name: :allocation_auto_delius_on } do
+      context 'with auto_delius_import enabled', vcr: { cassette_name: 'prison_api/allocation_auto_delius_on' } do
         let(:test_strategy) { Flipflop::FeatureSet.current.test! }
 
         before do
@@ -199,7 +199,7 @@ feature "view an offender's allocation information" do
         visit prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id_with_keyworker)
       end
 
-      it 'displays the name of the allocated co-worker', vcr: { cassette_name: :show_allocation_information_display_coworker_name } do
+      it 'displays the name of the allocated co-worker', vcr: { cassette_name: 'prison_api/show_allocation_information_display_coworker_name' } do
         allocation = Allocation.find_by(nomis_offender_id: nomis_offender_id_with_keyworker)
 
         allocation.update!(event: Allocation::ALLOCATE_SECONDARY_POM,

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -8,12 +8,12 @@ feature 'summary summary feature' do
   end
 
   describe 'awaiting summary table' do
-    it 'redirects correctly', vcr: { cassette_name: :redirect_summary_index_feature } do
+    it 'redirects correctly', vcr: { cassette_name: 'prison_api/redirect_summary_index_feature' } do
       visit summary_prison_prisoners_path('LEI')
       expect(page).to have_current_path allocated_prison_prisoners_path('LEI')
     end
 
-    it 'displays offenders awaiting information', vcr: { cassette_name: :awaiting_information_feature } do
+    it 'displays offenders awaiting information', vcr: { cassette_name: 'prison_api/awaiting_information_feature' } do
       visit missing_information_prison_prisoners_path('LEI')
 
       expect(page).to have_css('.moj-sub-navigation__item')
@@ -21,7 +21,7 @@ feature 'summary summary feature' do
       expect(page).to have_css('.pagination ul.links li', count: 16)
     end
 
-    it 'displays offenders pending allocation', vcr: { cassette_name: :awaiting_allocation_feature } do
+    it 'displays offenders pending allocation', vcr: { cassette_name: 'prison_api/awaiting_allocation_feature' } do
       visit unallocated_prison_prisoners_path('LEI')
 
       expect(page).to have_css('.moj-sub-navigation__item')
@@ -43,7 +43,7 @@ feature 'summary summary feature' do
         end
       end
 
-      it 'displays offenders already allocated', vcr: { cassette_name: :allocated_offenders_feature } do
+      it 'displays offenders already allocated', vcr: { cassette_name: 'prison_api/allocated_offenders_feature' } do
         visit allocated_prison_prisoners_path('LEI')
         expect(page).to have_css('.moj-sub-navigation__item')
         expect(page).to have_content('See allocations')
@@ -62,14 +62,14 @@ feature 'summary summary feature' do
       end
     end
 
-    it 'displays offenders just arrived allocated', vcr: { cassette_name: :new_offenders_feature } do
+    it 'displays offenders just arrived allocated', vcr: { cassette_name: 'prison_api/new_offenders_feature' } do
       visit new_arrivals_prison_prisoners_path('LEI')
 
       expect(page).to have_css('.moj-sub-navigation__item')
       expect(page).to have_content('Newly arrived')
     end
 
-    it 'displays offenders approaching their handover date', vcr: { cassette_name: :approaching_handover_feature } do
+    it 'displays offenders approaching their handover date', vcr: { cassette_name: 'prison_api/approaching_handover_feature' } do
       visit prison_handovers_path('LEI')
 
       expect(page).to have_css('.moj-sub-navigation__item')

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -53,7 +53,7 @@ feature 'case information feature' do
       signin_spo_user
     end
 
-    it 'adds tiering and case information for a prisoner', :js, vcr: { cassette_name: :case_information_feature } do
+    it 'adds tiering and case information for a prisoner', :js, vcr: { cassette_name: 'prison_api/case_information_feature' } do
       # # This NOMIS id needs to appear on the first page of 'missing information'
       nomis_offender_id = 'G2911GD'
 
@@ -78,7 +78,7 @@ feature 'case information feature' do
     end
 
     it "clicking back link after viewing prisoner's case information, returns back the same paginated page",
-       vcr: { cassette_name: :case_information_back_link }, js: true do
+       vcr: { cassette_name: 'prison_api/case_information_back_link' }, js: true do
       visit missing_information_prison_prisoners_path('LEI', page: 3)
 
       within ".govuk-table tr:first-child td:nth-child(5)" do
@@ -90,7 +90,7 @@ feature 'case information feature' do
       expect(page).to have_selector('h1', text: 'Add missing information')
     end
 
-    it 'complains if allocation data is missing', vcr: { cassette_name: :case_information_missing_case_feature } do
+    it 'complains if allocation data is missing', vcr: { cassette_name: 'prison_api/case_information_missing_case_feature' } do
       nomis_offender_id = 'G1821VA'
 
       visit new_prison_case_information_path('LEI', nomis_offender_id)
@@ -104,7 +104,7 @@ feature 'case information feature' do
       expect(page).to have_content("Select yes if the prisoner’s last known address was in Wales")
     end
 
-    it 'complains if all data is missing', vcr: { cassette_name: :case_information_missing_all_feature } do
+    it 'complains if all data is missing', vcr: { cassette_name: 'prison_api/case_information_missing_all_feature' } do
       nomis_offender_id = 'G1821VA'
 
       visit new_prison_case_information_path('LEI', nomis_offender_id)
@@ -118,7 +118,7 @@ feature 'case information feature' do
       expect(page).to have_content("Select yes if the prisoner’s last known address was in Wales")
     end
 
-    it 'complains if tier data is missing', vcr: { cassette_name: :case_information_missing_tier_feature } do
+    it 'complains if tier data is missing', vcr: { cassette_name: 'prison_api/case_information_missing_tier_feature' } do
       nomis_offender_id = 'G1821VA'
 
       visit new_prison_case_information_path('LEI', nomis_offender_id)
@@ -131,7 +131,7 @@ feature 'case information feature' do
       expect(page).to have_content("Select the prisoner’s tier")
     end
 
-    it 'allows editing case information for a prisoner', vcr: { cassette_name: :case_information_editing_feature } do
+    it 'allows editing case information for a prisoner', vcr: { cassette_name: 'prison_api/case_information_editing_feature' } do
       nomis_offender_id = 'G1821VA'
 
       visit new_prison_case_information_path('LEI', nomis_offender_id)
@@ -158,7 +158,7 @@ feature 'case information feature' do
     end
 
     it 'returns to previously paginated page after saving',
-       vcr: { cassette_name: :case_information_return_to_previously_paginated_page } do
+       vcr: { cassette_name: 'prison_api/case_information_return_to_previously_paginated_page' } do
       visit missing_information_prison_prisoners_path('LEI', sort: "last_name desc", page: 3)
 
       within ".govuk-table tr:first-child td:nth-child(5)" do
@@ -175,7 +175,7 @@ feature 'case information feature' do
     end
 
     it 'does not show update link on view only case info',
-       vcr: { cassette_name: :case_information_no_update_feature } do
+       vcr: { cassette_name: 'prison_api/case_information_no_update_feature' } do
       # When auto-delius is on there should be no update link to modify the case info
       # as it may not exist yet. We run this test with an indeterminate and a determine offender
 

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "ChangeParoleReviewDates", type: :feature do
     signin_spo_user
   end
 
-  it 'updates the date',  vcr: { cassette_name: :change_parole_date } do
+  it 'updates the date',  vcr: { cassette_name: 'prison_api/change_parole_date' } do
     path = prison_allocation_path('LEI', nomis_offender_id)
     visit path
 
@@ -28,7 +28,7 @@ RSpec.feature "ChangeParoleReviewDates", type: :feature do
     expect(page).to have_current_path(path)
   end
 
-  it 'bounces properly', vcr: { cassette_name: :change_parole_date_bounce } do
+  it 'bounces properly', vcr: { cassette_name: 'prison_api/change_parole_date_bounce' } do
     visit prison_allocation_path('LEI', nomis_offender_id)
 
     click_link 'Update'

--- a/spec/features/contact_us_feature_spec.rb
+++ b/spec/features/contact_us_feature_spec.rb
@@ -10,7 +10,7 @@ feature 'Getting help' do
     expect(page).to have_button('Submit')
   end
 
-  it 'shows a pre-filled contact form when a user is signed in', vcr: { cassette_name: :help_logged_in } do
+  it 'shows a pre-filled contact form when a user is signed in', vcr: { cassette_name: 'prison_api/help_logged_in' } do
     signin_spo_user
     visit '/'
     click_link 'Contact us'

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -35,7 +35,7 @@ feature 'Co-working' do
       )
     }
 
-    scenario 'show allocate a co-working POM page', vcr: { cassette_name: :show_allocate_coworking_page } do
+    scenario 'show allocate a co-working POM page', vcr: { cassette_name: 'prison_api/show_allocate_coworking_page' } do
       visit new_prison_coworking_path('LEI', nomis_offender_id)
 
       expect(page).to have_link 'Back', href: prison_allocation_path('LEI', nomis_offender_id: nomis_offender_id)
@@ -61,7 +61,7 @@ feature 'Co-working' do
       expect(page).not_to have_content('unavailable POM')
     end
 
-    scenario 'show correct unavailable message', vcr: { cassette_name: :show_coworking_unavailable } do
+    scenario 'show correct unavailable message', vcr: { cassette_name: 'prison_api/show_coworking_unavailable' } do
       inactive_poms = [485_758, 485_833]
       inactive_texts = ['There is 1 unavailable POM for new allocation',
                         'There are 2 unavailable POMs for new allocation']
@@ -77,7 +77,7 @@ feature 'Co-working' do
       end
     end
 
-    scenario 'show confirm co-working POM allocation page', vcr: { cassette_name: :show_confirm_coworking_page } do
+    scenario 'show confirm co-working POM allocation page', vcr: { cassette_name: 'prison_api/show_confirm_coworking_page' } do
       visit prison_confirm_coworking_allocation_path(
         'LEI',
         nomis_offender_id, prison_pom[:staff_id], secondary_pom[:staff_id]
@@ -132,7 +132,7 @@ feature 'Co-working' do
       expect(page).to have_content "We will send a confirmation email to #{prison_pom[:email]}"
     end
 
-    scenario 'cancel removal of a co-working POM', vcr: { cassette_name: :coworking_pom_cancel } do
+    scenario 'cancel removal of a co-working POM', vcr: { cassette_name: 'prison_api/coworking_pom_cancel' } do
       visit prison_allocation_path('LEI', nomis_offender_id)
 
       within '#co-working-pom' do
@@ -145,7 +145,7 @@ feature 'Co-working' do
       expect(page).to have_current_path(prison_allocation_path('LEI', nomis_offender_id))
     end
 
-    scenario 'removing a co-working POM', vcr: { cassette_name: :coworking_pom_remove } do
+    scenario 'removing a co-working POM', vcr: { cassette_name: 'prison_api/coworking_pom_remove' } do
       visit prison_allocation_path('LEI', nomis_offender_id)
 
       within '#co-working-pom' do
@@ -185,7 +185,7 @@ feature 'Co-working' do
       )
     }
 
-    scenario 'allocating', vcr: { cassette_name: :coworking_with_another_pom } do
+    scenario 'allocating', vcr: { cassette_name: 'prison_api/coworking_with_another_pom' } do
       expect(allocation.secondary_pom_nomis_id).to eq(123456)
       visit prison_allocation_path('LEI', nomis_offender_id)
 

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -8,7 +8,7 @@ feature 'Provide debugging information for our team to use' do
   end
 
   context 'when debugging an individual offender' do
-    it 'returns information for an unallocated offender', vcr: { cassette_name: :debugging_feature } do
+    it 'returns information for an unallocated offender', vcr: { cassette_name: 'prison_api/debugging_feature' } do
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -25,7 +25,7 @@ feature 'Provide debugging information for our team to use' do
       end
     end
 
-    it 'returns information for an allocated offender', vcr: { cassette_name: :debugging_allocated_offender_feature } do
+    it 'returns information for an allocated offender', vcr: { cassette_name: 'prison_api/debugging_allocated_offender_feature' } do
       create(:allocation,
              nomis_offender_id: nomis_offender_id,
              primary_pom_name: "Rossana Spinka"
@@ -51,7 +51,7 @@ feature 'Provide debugging information for our team to use' do
       end
     end
 
-    it 'can handle an incorrect offender number', vcr: { cassette_name: :debugging_incorrect_offender_feature } do
+    it 'can handle an incorrect offender number', vcr: { cassette_name: 'prison_api/debugging_incorrect_offender_feature' } do
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -61,7 +61,7 @@ feature 'Provide debugging information for our team to use' do
       expect(page).to have_content("No offender was found, please check the offender number and try again")
     end
 
-    it 'can handle no offender number being entered', vcr: { cassette_name: :debugging_no_offender_feature } do
+    it 'can handle no offender number being entered', vcr: { cassette_name: 'prison_api/debugging_no_offender_feature' } do
       visit prison_debugging_path('LEI')
 
       expect(page).to have_text('Debugging')
@@ -72,7 +72,7 @@ feature 'Provide debugging information for our team to use' do
     end
 
     context 'when offender does not have a sentence start date',
-            vcr: { cassette_name: :debugging_no_sentence_start_date_for_offender_feature } do
+            vcr: { cassette_name: 'prison_api/debugging_no_sentence_start_date_for_offender_feature' } do
       let(:non_sentenced_offender) do
         build(:offender, offenderNo: nomis_offender_id,
               imprisonmentStatus: 'SEC90',
@@ -110,7 +110,7 @@ feature 'Provide debugging information for our team to use' do
     end
   end
 
-  context 'when debugging at a prison level', vcr: { cassette_name: :debugging_prison_level } do
+  context 'when debugging at a prison level', vcr: { cassette_name: 'prison_api/debugging_prison_level' } do
     it 'displays a dashboard' do
       visit prison_debugging_prison_path('LEI')
 

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -13,7 +13,7 @@ feature "edit a POM's details" do
     signin_spo_user
   end
 
-  it "setting unavailable shows selected on re-edit", vcr: { cassette_name: :edit_poms_unavailable_check } do
+  it "setting unavailable shows selected on re-edit", vcr: { cassette_name: 'prison_api/edit_poms_unavailable_check' } do
     visit edit_prison_pom_path('LEI', nomis_staff_id)
     expect(page).to have_css('h1', text: 'Edit profile')
 
@@ -27,7 +27,7 @@ feature "edit a POM's details" do
     expect(page).to have_field('status-conditional-2', checked: true)
   end
 
-  it "validates a POM when missing data", vcr: { cassette_name: :edit_poms_missing_check } do
+  it "validates a POM when missing data", vcr: { cassette_name: 'prison_api/edit_poms_missing_check' } do
     visit edit_prison_pom_path('LEI', fulltime_pom_id)
     expect(page).to have_css('h1', text: 'Edit profile')
 
@@ -42,7 +42,7 @@ feature "edit a POM's details" do
     expect(page).to have_content('Select number of days worked')
   end
 
-  it "makes an inactive POM active", vcr: { cassette_name: :edit_poms_activate_pom_feature } do
+  it "makes an inactive POM active", vcr: { cassette_name: 'prison_api/edit_poms_activate_pom_feature' } do
     visit "/prisons/LEI/poms#inactive"
     within('.probation_pom_row_0') do
       click_link 'View'
@@ -81,7 +81,7 @@ feature "edit a POM's details" do
           )
     end
 
-    it "de-allocates all a POM's cases", vcr: { cassette_name: :edit_poms_deactivate_pom_feature } do
+    it "de-allocates all a POM's cases", vcr: { cassette_name: 'prison_api/edit_poms_deactivate_pom_feature' } do
       visit "/prisons/LEI/poms/485926"
       click_link "Edit profile"
 

--- a/spec/features/errors_feature_spec.rb
+++ b/spec/features/errors_feature_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
 feature 'Errors' do
-  it "handles missing pages", vcr: { cassette_name: :errors_feature_missing } do
+  it "handles missing pages", vcr: { cassette_name: 'prison_api/errors_feature_missing' } do
     visit "/404"
     expect(page).to have_http_status(:not_found)
     expect(page).to have_content('Page not found')
   end
 
-  it "handles unauthorized access", vcr: { cassette_name: :errors_feature_unauthorized } do
+  it "handles unauthorized access", vcr: { cassette_name: 'prison_api/errors_feature_unauthorized' } do
     visit "/401"
     expect(page).to have_http_status(:unauthorized)
     expect(page).to have_content('This service is not available')
   end
 
-  it "handles errors", vcr: { cassette_name: :errors_feature_handles_500 } do
+  it "handles errors", vcr: { cassette_name: 'prison_api/errors_feature_handles_500' } do
     visit "/500"
     expect(page).to have_http_status(:error)
     expect(page).to have_content('We are experiencing technical difficulties')

--- a/spec/features/feedback_feature_spec.rb
+++ b/spec/features/feedback_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'feedback' do
-  it 'provides a link to the feedback form', vcr: { cassette_name: :feedback_link } do
+  it 'provides a link to the feedback form', vcr: { cassette_name: 'prison_api/feedback_link' } do
     signin_spo_user
 
     visit '/'

--- a/spec/features/help_feature_spec.rb
+++ b/spec/features/help_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Help' do
   context 'when accessing help page' do
-    it 'provides a link to the help pages', vcr: { cassette_name: :help_link } do
+    it 'provides a link to the help pages', vcr: { cassette_name: 'prison_api/help_link' } do
       signin_spo_user
 
       visit '/'
@@ -11,7 +11,7 @@ feature 'Help' do
   end
 
   context 'when visiting help page' do
-    it 'has links to help topics', vcr: { cassette_name: :help_page } do
+    it 'has links to help topics', vcr: { cassette_name: 'prison_api/help_page' } do
       visit '/help'
 
       help_topics = [
@@ -38,7 +38,7 @@ feature 'Help' do
       visit '/help_step0'
     end
 
-    scenario 'getting set up pages', vcr: { cassette_name: :help_getting_set_up_pages } do
+    scenario 'getting set up pages', vcr: { cassette_name: 'prison_api/help_getting_set_up_pages' } do
       help_links = [
           ['List everyone using the service', 'help_step1'],
           ['Set up access in Digital Prison Services', 'help_step2'],
@@ -71,7 +71,7 @@ feature 'Help' do
       end
     end
 
-    scenario 'help getting set up step_1 page', vcr: { cassette_name: :help_getting_set_up_step_1 } do
+    scenario 'help getting set up step_1 page', vcr: { cassette_name: 'prison_api/help_getting_set_up_step_1' } do
       title = 'List everyone using the service'
 
       click_link(title)
@@ -84,7 +84,7 @@ feature 'Help' do
       expect(page).to have_link('Task 2: Set up access in Digital Prison Services', href: 'help_step2')
     end
 
-    scenario 'help getting set up step_2 page', vcr: { cassette_name: :help_getting_set_up_step_2 } do
+    scenario 'help getting set up step_2 page', vcr: { cassette_name: 'prison_api/help_getting_set_up_step_2' } do
       title = 'Set up access in Digital Prison Services'
 
       click_link(title)
@@ -93,7 +93,7 @@ feature 'Help' do
       expect(page).to have_css('.govuk-inset-text', text: inset_text[:LSA])
     end
 
-    scenario 'help getting set up step_3 page', vcr: { cassette_name: :help_getting_set_up_step_3 } do
+    scenario 'help getting set up step_3 page', vcr: { cassette_name: 'prison_api/help_getting_set_up_step_3' } do
       title = 'Set up POMs in NOMIS'
 
       click_link(title)
@@ -110,7 +110,7 @@ feature 'Help' do
       end
     end
 
-    scenario 'help getting set up step_4 page', vcr: { cassette_name: :help_getting_set_up_step_4 } do
+    scenario 'help getting set up step_4 page', vcr: { cassette_name: 'prison_api/help_getting_set_up_step_4' } do
       title = 'Update POM profiles'
 
       click_link(title)
@@ -121,7 +121,7 @@ feature 'Help' do
       expect(page).to have_link('https://moic.service.justice.gov.uk')
     end
 
-    scenario 'help getting set up step_5 page', vcr: { cassette_name: :help_getting_set_up_step_5 } do
+    scenario 'help getting set up step_5 page', vcr: { cassette_name: 'prison_api/help_getting_set_up_step_5' } do
       title = 'Update prisoner information'
 
       click_link(title)
@@ -133,7 +133,7 @@ feature 'Help' do
       expect(page).to have_link('Home', href: '/')
     end
 
-    scenario 'help getting set up step_6 page', vcr: { cassette_name: :help_getting_set_up_step_6 } do
+    scenario 'help getting set up step_6 page', vcr: { cassette_name: 'prison_api/help_getting_set_up_step_6' } do
       title = 'Start making allocations'
 
       click_link(title)
@@ -149,12 +149,12 @@ feature 'Help' do
       visit update_case_information_path
     end
 
-    scenario 'help updating case information overview', vcr: { cassette_name: :help_update_case_info_overview } do
+    scenario 'help updating case information overview', vcr: { cassette_name: 'prison_api/help_update_case_info_overview' } do
       expect(page).to have_css('h1', text: 'Overview')
       expect(page).to have_link('Updating nDelius', href: updating_ndelius_path)
     end
 
-    scenario 'help updating nDelius', vcr: { cassette_name: :help_update_ndelius } do
+    scenario 'help updating nDelius', vcr: { cassette_name: 'prison_api/help_update_ndelius' } do
       title = 'Updating nDelius'
 
       click_link(title)
@@ -172,7 +172,7 @@ feature 'Help' do
       visit missing_cases_path
     end
 
-    scenario 'help when no POM allocation needed', vcr: { cassette_name: :help_missing_case_no_pom_allocation } do
+    scenario 'help when no POM allocation needed', vcr: { cassette_name: 'prison_api/help_missing_case_no_pom_allocation' } do
       expect(page).to have_link('Repatriated cases', href: repatriated_path)
       expect(page).to have_link('Scottish and Northern Irish prisoners', href: scottish_northern_irish_path)
       expect(page).to have_css('h1', text: 'No POM allocation needed')
@@ -180,7 +180,7 @@ feature 'Help' do
       expect(page).to have_link('Contact us', href: contact_us_path)
     end
 
-    scenario 'help with repatriated cases', vcr: { cassette_name: :help_with_repatriated_cases } do
+    scenario 'help with repatriated cases', vcr: { cassette_name: 'prison_api/help_with_repatriated_cases' } do
       title = 'Repatriated cases'
 
       click_link(title)
@@ -189,7 +189,7 @@ feature 'Help' do
       expect(page).to have_css('h1', text: title)
     end
 
-    scenario 'help with scottish/irish prisoners', vcr: { cassette_name: :help_with_scottish_irish } do
+    scenario 'help with scottish/irish prisoners', vcr: { cassette_name: 'prison_api/help_with_scottish_irish' } do
       title = 'Scottish and Northern Irish prisoners'
 
       click_link(title)

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Inactive POM' do
-  context 'when viewing an inactive POMs caseload', vcr: { cassette_name: :deallocate_non_pom_caseload } do
+  context 'when viewing an inactive POMs caseload', vcr: { cassette_name: 'prison_api/deallocate_non_pom_caseload' } do
     # We need an inactive POM to test this feature, Toby has had his POM role removed and therefore a good candidate!
     let(:inactive_pom)      { 485_595 }
     let(:nomis_offender_id) { "G4273GI" }

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -7,7 +7,7 @@ feature 'Navigation' do
 
   # This is a legitimate VCR test - we really don't care how/if the various
   # APIs are called in this test
-  describe 'navigation menus', vcr: { cassette_name: :navigation_menus } do
+  describe 'navigation menus', vcr: { cassette_name: 'prison_api/navigation_menus' } do
     context 'with an SPO user' do
       before do
         signin_spo_user
@@ -50,7 +50,7 @@ feature 'Navigation' do
     end
   end
 
-  context 'with a POM/SPO user', vcr: { cassette_name: :navigation_pom_spo_things } do
+  context 'with a POM/SPO user', vcr: { cassette_name: 'prison_api/navigation_pom_spo_things' } do
     before do
       signin_spo_pom_user
       visit prison_dashboard_index_path(prison.code)

--- a/spec/features/prison_switching_feature_spec.rb
+++ b/spec/features/prison_switching_feature_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 feature 'Switching prisons' do
   it 'Shows the switcher if the user has more than one prison',
-     vcr: { cassette_name: :prison_switching_feature_many_prisons_spec } do
+     vcr: { cassette_name: 'prison_api/prison_switching_feature_many_prisons_spec' } do
     signin_spo_user(['LEI', 'RSI'])
     visit root_path
 
     expect(page).to have_css('h2', text: 'HMP Leeds')
   end
 
-  it 'shows dashboard links if there is no referrer', vcr: { cassette_name: :nav_to_prison_switcher } do
+  it 'shows dashboard links if there is no referrer', vcr: { cassette_name: 'prison_api/nav_to_prison_switcher' } do
     signin_spo_user(['LEI', 'RSI'])
 
     visit root_path
@@ -26,7 +26,7 @@ feature 'Switching prisons' do
   end
 
   it 'Shows the list of prisons I can switch to',
-     vcr: { cassette_name: :prison_switching_feature_list_spec }do
+     vcr: { cassette_name: 'prison_api/prison_switching_feature_list_spec' }do
     signin_spo_user(['LEI', 'RSI'])
     visit root_path
 
@@ -37,7 +37,7 @@ feature 'Switching prisons' do
   end
 
   it 'Changes my prison when I choose one',
-     vcr: { cassette_name: :prison_switching_feature_change_prisons_spec }do
+     vcr: { cassette_name: 'prison_api/prison_switching_feature_change_prisons_spec' }do
     signin_spo_user(['LEI', 'RSI'])
     visit root_path
 
@@ -49,7 +49,7 @@ feature 'Switching prisons' do
   end
 
   it 'Can remember where I was',
-     vcr: { cassette_name: :prison_switching_feature_remember_prison_spec } do
+     vcr: { cassette_name: 'prison_api/prison_switching_feature_remember_prison_spec' } do
     signin_spo_user(['LEI', 'RSI'])
     visit prison_poms_path('LEI')
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -6,7 +6,7 @@ feature 'View a prisoner profile page' do
   end
 
   context 'without allocation or case information' do
-    it 'doesnt crash', vcr: { cassette_name: :show_unallocated_offender } do
+    it 'doesnt crash', vcr: { cassette_name: 'prison_api/show_unallocated_offender' } do
       visit prison_prisoner_path('LEI', 'G7998GJ')
 
       expect(page).to have_css('h1', text: 'Ahmonis, Okadonah')
@@ -17,7 +17,7 @@ feature 'View a prisoner profile page' do
     end
   end
 
-  context 'with an existing early allocation', vcr: { cassette_name: :early_allocation_banner } do
+  context 'with an existing early allocation', vcr: { cassette_name: 'prison_api/early_allocation_banner' } do
     before do
       create(:case_information, nomis_offender_id: 'G7998GJ', early_allocations: [build(:early_allocation, created_within_referral_window: within_window)])
       visit prison_prisoner_path('LEI', 'G7998GJ')
@@ -49,7 +49,7 @@ feature 'View a prisoner profile page' do
     let(:allocation) { Allocation.last }
     let(:initial_vlo) { VictimLiaisonOfficer.last }
 
-    context 'without anything extra', vcr: { cassette_name: :show_offender_spec }  do
+    context 'without anything extra', vcr: { cassette_name: 'prison_api/show_offender_spec' }  do
       before do
         visit prison_prisoner_path('LEI', 'G7998GJ')
       end
@@ -129,18 +129,18 @@ feature 'View a prisoner profile page' do
         expect(pom_name).to eq('Pobee-Norris, Kath')
       end
 
-      it 'shows the prisoner image', vcr: { cassette_name: :show_offender_spec_image } do
+      it 'shows the prisoner image', vcr: { cassette_name: 'prison_api/show_offender_spec_image' } do
         visit prison_prisoner_image_path('LEI', 'G7998GJ', format: :jpg)
         expect(page.response_headers['Content-Type']).to eq('image/jpg')
       end
 
-      it "has a link to the allocation history", vcr: { cassette_name: :link_to_allocation_history } do
+      it "has a link to the allocation history", vcr: { cassette_name: 'prison_api/link_to_allocation_history' } do
         visit prison_prisoner_path('LEI', 'G7998GJ')
         click_link "View"
         expect(page).to have_content('Prisoner allocated')
       end
 
-      it 'displays the non-disclosable badge on the VLO table', vcr: { cassette_name: :vlo_non_disclosable_badge } do
+      it 'displays the non-disclosable badge on the VLO table', vcr: { cassette_name: 'prison_api/vlo_non_disclosable_badge' } do
         visit prison_prisoner_path('LEI', 'G7998GJ')
         expect(page).to have_css('#non-disclosable-badge', text: 'Non-Disclosable')
       end
@@ -151,7 +151,7 @@ feature 'View a prisoner profile page' do
         create(:responsibility, nomis_offender_id: 'G7998GJ')
       end
 
-      it 'shows an overridden responsibility', vcr: { cassette_name: :show_offender_with_override_spec } do
+      it 'shows an overridden responsibility', vcr: { cassette_name: 'prison_api/show_offender_with_override_spec' } do
         visit prison_prisoner_path('LEI', 'G7998GJ')
 
         expect(page).to have_content('Supporting')
@@ -172,7 +172,7 @@ feature 'View a prisoner profile page' do
         )
       end
 
-      it "has community information", vcr: { cassette_name: :show_offender_community_info_full } do
+      it "has community information", vcr: { cassette_name: 'prison_api/show_offender_community_info_full' } do
         visit prison_prisoner_path('LEI', 'G7998GJ')
 
         expect(page).to have_content(ldu.name)
@@ -194,7 +194,7 @@ feature 'View a prisoner profile page' do
         visit prison_prisoner_path('LEI', 'G7998GJ')
       end
 
-      it "displays team and LDU as unknown", :js, vcr: { cassette_name: :show_offender_community_info_partial } do
+      it "displays team and LDU as unknown", :js, vcr: { cassette_name: 'prison_api/show_offender_community_info_partial' } do
         # Expect an Unknown for LDU Email and Team
         within '#community_information' do
           expect(page).to have_content('Unknown', count: 2)
@@ -204,7 +204,7 @@ feature 'View a prisoner profile page' do
   end
 
   context 'when offender does not have a sentence start date',
-          vcr: { cassette_name: :no_sentence_start_date_for_offender } do
+          vcr: { cassette_name: 'prison_api/no_sentence_start_date_for_offender' } do
     let(:non_sentenced_offender) do
       build(:offender, offenderNo: 'G7998GJ',
             imprisonmentStatus: 'SEC90',

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -10,7 +10,7 @@ feature 'Responsibility override' do
   let(:offender_id) { 'G8060UF' }
   let(:pom_id) { 485_926 }
 
-  context 'when overriding responsibility', vcr: { cassette_name: :override_responsibility } do
+  context 'when overriding responsibility', vcr: { cassette_name: 'prison_api/override_responsibility' } do
     before do
       ldu = create(:local_divisional_unit, email_address: 'ldu@test.com')
       team = create(:team, local_divisional_unit: ldu)
@@ -83,7 +83,7 @@ feature 'Responsibility override' do
     end
   end
 
-  context "when override isn't possible due to email address is nil", vcr: { cassette_name: :cant_override_responsibility_nil_email } do
+  context "when override isn't possible due to email address is nil", vcr: { cassette_name: 'prison_api/cant_override_responsibility_nil_email' } do
     before do
       ldu = create(:local_divisional_unit, email_address: nil)
       team = create(:team, local_divisional_unit: ldu)
@@ -101,7 +101,7 @@ feature 'Responsibility override' do
     end
   end
 
-  context "when override isn't possible due to email address is an empty string", vcr: { cassette_name: :cant_override_responsibility_blank_email } do
+  context "when override isn't possible due to email address is an empty string", vcr: { cassette_name: 'prison_api/cant_override_responsibility_blank_email' } do
     before do
       ldu = create(:local_divisional_unit, email_address: "")
       team = create(:team, local_divisional_unit: ldu)

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -65,7 +65,7 @@ feature 'Search for offenders' do
     end
   end
 
-  it 'Can search from the dashboard', vcr: { cassette_name: :dashboard_search_feature } do
+  it 'Can search from the dashboard', vcr: { cassette_name: 'prison_api/dashboard_search_feature' } do
     signin_spo_user
     visit root_path
 
@@ -77,7 +77,7 @@ feature 'Search for offenders' do
     expect(page).to have_css('tbody tr', count: 6)
   end
 
-  it 'Can search from the Allocations summary page', vcr: { cassette_name: :allocated_search_feature } do
+  it 'Can search from the Allocations summary page', vcr: { cassette_name: 'prison_api/allocated_search_feature' } do
     signin_spo_user
     visit allocated_prison_prisoners_path(prison)
 
@@ -89,7 +89,7 @@ feature 'Search for offenders' do
     expect(page).to have_css('tbody tr', count: 9)
   end
 
-  it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: :waiting_allocation_search_feature } do
+  it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: 'prison_api/waiting_allocation_search_feature' } do
     signin_spo_user
     visit unallocated_prison_prisoners_path(prison)
 
@@ -101,7 +101,7 @@ feature 'Search for offenders' do
     expect(page).to have_css('tbody tr', count: 1)
   end
 
-  it 'Can search from the Missing Information summary page', vcr: { cassette_name: :missing_info_search_feature } do
+  it 'Can search from the Missing Information summary page', vcr: { cassette_name: 'prison_api/missing_info_search_feature' } do
     signin_spo_user
     visit  missing_information_prison_prisoners_path(prison)
 

--- a/spec/features/service_notification_feature_spec.rb
+++ b/spec/features/service_notification_feature_spec.rb
@@ -6,7 +6,7 @@ feature 'Service Notification' do
   end
 
   it 'does not display service notification if none exist',
-     vcr: { cassette_name: :service_notifications_none_exist } do
+     vcr: { cassette_name: 'prison_api/service_notifications_none_exist' } do
     allow(ServiceNotificationsService).to receive(:notifications).and_return([])
 
     visit root_path
@@ -30,14 +30,14 @@ feature 'Service Notification' do
     end
 
     it 'does not display service notifications on static pages',
-       vcr: { cassette_name: :service_notifications_static_pages } do
+       vcr: { cassette_name: 'prison_api/service_notifications_static_pages' } do
       visit "/404"
 
       expect(page).not_to have_css('.service_banner')
     end
 
     it 'displays service notifications on dynamic pages',
-       vcr: { cassette_name: :service_notifications_dynamic_pages } do
+       vcr: { cassette_name: 'prison_api/service_notifications_dynamic_pages' } do
       visit root_path
 
       expect(page).to have_css('.service_banner')
@@ -46,7 +46,7 @@ feature 'Service Notification' do
 
     context 'when user clicks on close button', js: true do
       it 'permanently hides the notification',
-         vcr: { cassette_name: :service_notifications_close_button } do
+         vcr: { cassette_name: 'prison_api/service_notifications_close_button' } do
         visit root_path
 
         expect(page).to have_css('.service_banner')

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -7,7 +7,7 @@ feature "get poms list" do
     signin_spo_user
   end
 
-  it "shows the page", vcr: { cassette_name: :show_poms_feature_list } do
+  it "shows the page", vcr: { cassette_name: 'prison_api/show_poms_feature_list' } do
     visit prison_poms_path('LEI')
 
     expect(page).to have_css(".govuk-table", count: 4)
@@ -16,7 +16,7 @@ feature "get poms list" do
     expect(page).to have_content("Probation POM")
   end
 
-  it "handles missing sentence data", vcr: { cassette_name: :show_poms_feature_missing_sentence } do
+  it "handles missing sentence data", vcr: { cassette_name: 'prison_api/show_poms_feature_missing_sentence' } do
     visit prison_confirm_allocation_path('LEI', offender_missing_sentence_case_info.nomis_offender_id, 485_926)
     click_button 'Complete allocation'
 
@@ -27,7 +27,7 @@ feature "get poms list" do
     expect(page).to have_content(offender_missing_sentence_case_info.nomis_offender_id)
   end
 
-  it "allows viewing a POM", vcr: { cassette_name: :show_poms_feature_view } do
+  it "allows viewing a POM", vcr: { cassette_name: 'prison_api/show_poms_feature_view' } do
     visit "/prisons/LEI/poms/485926"
 
     expect(page).to have_css(".govuk-button", count: 1)
@@ -35,7 +35,7 @@ feature "get poms list" do
     expect(page).to have_content("Caseload")
   end
 
-  it "can sort offenders allocated to a POM", vcr: { cassette_name: :show_poms_feature_view_sorting } do
+  it "can sort offenders allocated to a POM", vcr: { cassette_name: 'prison_api/show_poms_feature_view_sorting' } do
     [['G7806VO', 754_207], ['G2911GD', 1_175_317]].each do |offender_id, booking|
       create(:case_information, nomis_offender_id: offender_id)
       AllocationService.create_or_update(
@@ -77,7 +77,7 @@ feature "get poms list" do
     check_for_order.call(['Ahmonis, Imanjah', 'Abdoria, Ongmetain'])
   end
 
-  it "allows editing a POM", vcr: { cassette_name: :show_poms_feature_edit } do
+  it "allows editing a POM", vcr: { cassette_name: 'prison_api/show_poms_feature_edit' } do
     visit "/prisons/LEI/poms/485926/edit"
 
     expect(page).to have_css(".govuk-button", count: 1)

--- a/spec/fixtures/vcr_cassettes/delius/get_community_data.yml
+++ b/spec/fixtures/vcr_cassettes/delius/get_community_data.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://community-api.test.delius.probation.hmpps.dsd.io/secure/offenders/nomsNumber/G0239GU/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Authorization:
+      - authorisation_header
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Date:
+      - Thu, 18 Mar 2021 08:52:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Request-Context:
+      - appId=cid-v1:0d5d6f09-1d07-47f5-9d3a-f9f473544e78
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Frame-Options:
+      - DENY
+      vary:
+      - accept-encoding
+    body:
+      encoding: UTF-8
+      string: '{"offenderId":2500423770,"firstName":"Izgyneing","surname":"Claytael","dateOfBirth":"1980-01-01","gender":"Male","otherIds":{"crn":"X362207","nomsNumber":"G0239GU"},"contactDetails":{},"offenderProfile":{"offenderLanguages":{},"previousConviction":{}},"offenderManagers":[{"trustOfficer":{"forenames":"Unallocated
+        Staff(N07)","surname":"Staff"},"staff":{"code":"N07UATU","forenames":"Unallocated
+        Staff(N07)","surname":"Staff","unallocated":true},"partitionArea":"National
+        Data","softDeleted":false,"team":{"code":"N07UAT","description":"Unallocated
+        Team(N07)","localDeliveryUnit":{"code":"N07NPSA","description":"N07 Division"},"district":{"code":"N07NPSA","description":"N07
+        Division"},"borough":{"code":"N07100","description":"N07 Cluster 1"}},"probationArea":{"code":"N07","description":"NPS
+        London","nps":true},"fromDate":"1900-01-01","active":true,"allocationReason":{"code":"IN1","description":"Initial
+        Allocation"}}],"softDeleted":false,"currentDisposal":"1","partitionArea":"National
+        Data","currentRestriction":false,"restrictionMessage":"This is a restricted
+        offender record. Please contact a system administrator","currentExclusion":false,"exclusionMessage":"You
+        are excluded from viewing this offender record. Please contact a system administrator","currentTier":"A-2","activeProbationManagedSentence":true}'
+  recorded_at: Thu, 18 Mar 2021 08:52:29 GMT
+- request:
+    method: get
+    uri: https://community-api.test.delius.probation.hmpps.dsd.io/secure/offenders/nomsNumber/G0239GU/registrations
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Authorization:
+      - authorisation_header
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      Date:
+      - Thu, 18 Mar 2021 08:52:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Request-Context:
+      - appId=cid-v1:0d5d6f09-1d07-47f5-9d3a-f9f473544e78
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Frame-Options:
+      - DENY
+      vary:
+      - accept-encoding
+    body:
+      encoding: UTF-8
+      string: '{"registrations":[{"registrationId":2500128258,"offenderId":2500423770,"register":{"code":"5","description":"Public
+        Protection"},"type":{"code":"MAPP","description":"MAPPA"},"riskColour":"Red","startDate":"2020-10-30","nextReviewDate":"2021-01-30","reviewPeriodMonths":3,"notes":"Please
+        Note - Category 3 offenders require multi-agency management at Level 2 or
+        3 and should not be recorded at Level 1.","registeringTeam":{"code":"N07UAT","description":"Unallocated
+        Team(N07)"},"registeringOfficer":{"code":"N07A003","forenames":"Unallocate","surname":"Unallocate","unallocated":false},"registeringProbationArea":{"code":"N07","description":"NPS
+        London"},"registerLevel":{"code":"M2","description":"MAPPA Level 2"},"registerCategory":{"code":"M2","description":"MAPPA
+        Cat 2"},"warnUser":false,"active":true,"numberOfPreviousDeregistrations":0}]}'
+  recorded_at: Thu, 18 Mar 2021 08:52:29 GMT
+recorded_with: VCR 6.0.0

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PomHelper do
     end
   end
 
-  describe 'fetch_pom_name', vcr: { cassette_name: :pom_helper_fetch_pom_name } do
+  describe 'fetch_pom_name', vcr: { cassette_name: 'prison_api/pom_helper_fetch_pom_name' } do
     it 'fetches the POM name from NOMIS' do
       expect(fetch_pom_name(485_926)).to eq('POM, MOIC')
     end

--- a/spec/lib/omni_auth/strategies/hmpps_sso_spec.rb
+++ b/spec/lib/omni_auth/strategies/hmpps_sso_spec.rb
@@ -1,7 +1,5 @@
 require 'rails_helper'
-
-# rubocop:disable RSpec/FilePath
-describe OmniAuth::Strategies::HmppsSso, vcr: { cassette_name: :hmpps_sso } do
+describe OmniAuth::Strategies::HmppsSso, vcr: { cassette_name: 'prison_api/hmpps_sso' } do
   subject(:strategy) do
     described_class.new(app, 'client_id', 'secret')
   end
@@ -67,4 +65,3 @@ describe OmniAuth::Strategies::HmppsSso, vcr: { cassette_name: :hmpps_sso } do
     end
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe 'when an offender moves prison', :allocation, vcr: { cassette_name: :allocation_deallocate_offender }  do
+    describe 'when an offender moves prison', :allocation, vcr: { cassette_name: 'prison_api/allocation_deallocate_offender' }  do
       it 'removes the primary pom details in an Offender\'s allocation' do
         nomis_offender_id = 'G2911GD'
         create(:case_information, nomis_offender_id: nomis_offender_id)
@@ -159,7 +159,7 @@ RSpec.describe Allocation, type: :model do
       end
     end
 
-    describe 'when an offender gets released from prison', :allocation, vcr: { cassette_name: :allocation_deallocate_offender_released }  do
+    describe 'when an offender gets released from prison', :allocation, vcr: { cassette_name: 'prison_api/allocation_deallocate_offender_released' }  do
       it 'removes the primary pom details in an Offender\'s allocation' do
         nomis_offender_id = 'G2911GD'
         create(:case_information, nomis_offender_id: nomis_offender_id)

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe Prison, type: :model do
     subject { described_class.new("LEI").offenders }
 
     it "get first page of offenders for a specific prison",
-       vcr: { cassette_name: :offender_service_offenders_by_prison_first_page_spec } do
+       vcr: { cassette_name: 'prison_api/offender_service_offenders_by_prison_first_page_spec' } do
       offender_array = subject.first(9)
       expect(offender_array).to be_kind_of(Array)
       expect(offender_array.length).to eq(9)
       expect(offender_array.first).to be_kind_of(HmppsApi::OffenderSummary)
     end
 
-    it "get last page of offenders for a specific prison", vcr: { cassette_name: :offender_service_offenders_by_prison_last_page_spec } do
+    it "get last page of offenders for a specific prison", vcr: { cassette_name: 'prison_api/offender_service_offenders_by_prison_last_page_spec' } do
       offender_array = subject.to_a
       expect(offender_array).to be_kind_of(Array)
       expect(offender_array.length).to be > 800

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe StaffMember, type: :model do
     end
   end
 
-  describe '#full_name', vcr: { cassette_name: :staff_member_things } do
+  describe '#full_name', vcr: { cassette_name: 'prison_api/staff_member_things' } do
     let(:pom) { described_class.new(build(:prison), 485_846) }
 
     it 'gets the full name' do

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -24,7 +24,7 @@ describe AllocationService do
              primary_pom_name: 'Pom, Moic')
     }
 
-    it 'sends an email to both primary and secondary POMS', vcr: { cassette_name: :allocation_service_allocate_secondary } do
+    it 'sends an email to both primary and secondary POMS', vcr: { cassette_name: 'prison_api/allocation_service_allocate_secondary' } do
       expect {
         described_class.allocate_secondary(nomis_offender_id: nomis_offender_id,
                                            secondary_pom_nomis_id: secondary_pom_id,
@@ -73,7 +73,7 @@ describe AllocationService do
         create(:case_information, nomis_offender_id: nomis_offender_id)
       end
 
-      it 'can create a new record', vcr: { cassette_name: :allocation_service_create_allocation__spec } do
+      it 'can create a new record', vcr: { cassette_name: 'prison_api/allocation_service_create_allocation__spec' } do
         params = {
           nomis_offender_id: nomis_offender_id,
           prison: 'LEI',
@@ -98,7 +98,7 @@ describe AllocationService do
         create(:allocation, nomis_offender_id: nomis_offender_id)
       end
 
-      it 'can update a record and store a version', vcr: { cassette_name: :allocation_service_update_allocation_spec } do
+      it 'can update a record and store a version', vcr: { cassette_name: 'prison_api/allocation_service_update_allocation_spec' } do
         update_params = {
           nomis_offender_id: nomis_offender_id,
           allocated_at_tier: 'B',
@@ -117,7 +117,7 @@ describe AllocationService do
   end
 
   describe '#allocations' do
-    it "Can get allocations by prison", vcr: { cassette_name: :allocation_service_get_allocations_by_prison } do
+    it "Can get allocations by prison", vcr: { cassette_name: 'prison_api/allocation_service_get_allocations_by_prison' } do
       first_offender_id = 'JSHD000NN'
       second_offender_id = 'SDHH87GD'
       leeds_prison = 'LEI'
@@ -142,13 +142,13 @@ describe AllocationService do
   end
 
   describe '#previously_allocated_poms' do
-    it "Can get previous poms for an offender where there are none", vcr: { cassette_name: :allocation_service_previous_allocations_none } do
+    it "Can get previous poms for an offender where there are none", vcr: { cassette_name: 'prison_api/allocation_service_previous_allocations_none' } do
       staff_ids = described_class.previously_allocated_poms('GDF7657')
 
       expect(staff_ids).to eq([])
     end
 
-    it "Can get previous poms for an offender where there are some", vcr: { cassette_name: :allocation_service_previous_allocations } do
+    it "Can get previous poms for an offender where there are some", vcr: { cassette_name: 'prison_api/allocation_service_previous_allocations' } do
       nomis_offender_id = 'GHF1234'
       previous_primary_pom_nomis_id = 345_567
       updated_primary_pom_nomis_id = 485_926
@@ -170,7 +170,7 @@ describe AllocationService do
     end
   end
 
-  it 'can get the current allocated primary POM', vcr: { cassette_name: 'current_allocated_primary_pom' }  do
+  it 'can get the current allocated primary POM', vcr: { cassette_name: 'prison_api/current_allocated_primary_pom' }  do
     previous_primary_pom_nomis_id = 485_637
     updated_primary_pom_nomis_id = 485_926
 
@@ -192,7 +192,7 @@ describe AllocationService do
   end
 
   describe '#allocation_history_pom_emails' do
-    it 'can retrieve all the POMs email addresses for ', vcr: { cassette_name: :allocation_service_history_spec } do
+    it 'can retrieve all the POMs email addresses for ', vcr: { cassette_name: 'prison_api/allocation_service_history_spec' } do
       previous_primary_pom_nomis_id = 485_637
       updated_primary_pom_nomis_id = 485_926
       secondary_pom_nomis_id = 485_833

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe EmailService do
   }
 
   context 'when queueing', :queueing do
-    it "Can send an allocation email", vcr: { cassette_name: :email_service_send_allocation_email }  do
+    it "Can send an allocation email", vcr: { cassette_name: 'prison_api/email_service_send_allocation_email' }  do
       expect {
         described_class.instance(allocation: allocation, message: "", pom_nomis_id: allocation.primary_pom_nomis_id).send_email
       }.to change(enqueued_jobs, :size).by(1)
     end
 
-    it "Can not crash when a pom has no email", vcr: { cassette_name: :email_service_send_allocation_email }  do
+    it "Can not crash when a pom has no email", vcr: { cassette_name: 'prison_api/email_service_send_allocation_email' }  do
       allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:fetch_email_addresses).and_return([])
 
       expect {
@@ -91,7 +91,7 @@ RSpec.describe EmailService do
       }.to change(enqueued_jobs, :size).by(0)
     end
 
-    it "Can send a reallocation email", vcr: { cassette_name: :email_service_send_deallocation_email }  do
+    it "Can send a reallocation email", vcr: { cassette_name: 'prison_api/email_service_send_deallocation_email' }  do
       allow(reallocation).to receive(:get_old_versions).and_return([original_allocation])
 
       expect {
@@ -100,7 +100,7 @@ RSpec.describe EmailService do
     end
 
     it "Can send a co-working de-allocation email",
-       vcr: { cassette_name: :email_service_send_coworking_deallocation_email } do
+       vcr: { cassette_name: 'prison_api/email_service_send_coworking_deallocation_email' } do
       allow(original_allocation).to receive(:get_old_versions).and_return([coworking_allocation])
 
       expect {
@@ -112,7 +112,7 @@ RSpec.describe EmailService do
     end
 
     it "Can not crash when primary pom has no email when deallocating a co-working pom",
-       vcr: { cassette_name: :email_service_send_coworking_deallocation_email_no_pom_email } do
+       vcr: { cassette_name: 'prison_api/email_service_send_coworking_deallocation_email_no_pom_email' } do
       allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:fetch_email_addresses).and_return([])
 
       expect {
@@ -143,7 +143,7 @@ RSpec.describe EmailService do
       end
     end
 
-    it "Can send a reallocation email", vcr: { cassette_name: :email_service_reallocation_crash } do
+    it "Can send a reallocation email", vcr: { cassette_name: 'prison_api/email_service_reallocation_crash' } do
       expect(PomMailer).to receive(:deallocation_email).with(
         previous_pom_name: 'Leigh',
         responsibility: 'supporting',

--- a/spec/services/hmpps_api/oauth/api_spec.rb
+++ b/spec/services/hmpps_api/oauth/api_spec.rb
@@ -8,7 +8,7 @@ describe HmppsApi::Oauth::Api do
     Singleton.__init__(described_class)
   end
 
-  it 'fetches an auth token', vcr: { cassette_name: :nomis_oauth_api_auth_token_spec } do
+  it 'fetches an auth token', vcr: { cassette_name: 'prison_api/nomis_oauth_api_auth_token_spec' } do
     token = described_class.fetch_new_auth_token
 
     expect(token).to be_kind_of(HmppsApi::Oauth::Token)

--- a/spec/services/hmpps_api/prison_api/movement_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/movement_api_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe HmppsApi::PrisonApi::MovementApi do
   describe 'Movements for date' do
     it 'can get movements on a specific date',
-       vcr: { cassette_name: :movement_api_on_date } do
+       vcr: { cassette_name: 'prison_api/movement_api_on_date' } do
       movements = described_class.movements_on_date(Date.iso8601('2019-02-20'))
 
       expect(movements).to be_kind_of(Array)
@@ -14,7 +14,7 @@ describe HmppsApi::PrisonApi::MovementApi do
 
   describe 'Movements for single offenders' do
     it 'can get movements for a specific_offender',
-       vcr: { cassette_name: :movement_api_for_offender } do
+       vcr: { cassette_name: 'prison_api/movement_api_for_offender' } do
       movements = described_class.movements_for('A5019DY')
 
       expect(movements).to be_kind_of(Array)
@@ -36,7 +36,7 @@ describe HmppsApi::PrisonApi::MovementApi do
     end
 
     it 'can return multiple movements for a specific offender',
-       vcr: { cassette_name: :movement_api_multiple_movements } do
+       vcr: { cassette_name: 'prison_api/movement_api_multiple_movements' } do
       movements = described_class.movements_for('G1670VU')
 
       expect(movements).to be_kind_of(Array)

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe HmppsApi::PrisonApi::OffenderApi do
   describe 'List of offenders' do
     it "can get a list of offenders",
-       vcr: { cassette_name: :offender_api_offender_list } do
+       vcr: { cassette_name: 'prison_api/offender_api_offender_list' } do
       response = described_class.list('LEI')
 
       expect(response.data).not_to be_nil
@@ -12,7 +12,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
 
     it "can get an offence description for a booking id",
-       vcr: { cassette_name: :offender_api_get_offence_ok } do
+       vcr: { cassette_name: 'prison_api/offender_api_get_offence_ok' } do
       booking_id = '1153753'
       response = described_class.get_offence(booking_id)
       expect(response).to be_instance_of(String)
@@ -20,7 +20,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
 
     it "returns category codes",
-       vcr: { cassette_name: :offender_api_offender_category_list } do
+       vcr: { cassette_name: 'prison_api/offender_api_offender_category_list' } do
       response = described_class.list('LEI')
       expect(response.data.first.category_code).not_to be_nil
     end
@@ -28,7 +28,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
 
   describe 'Bulk operations' do
     it 'can get bulk sentence details',
-       vcr: { cassette_name: :offender_api_bulk_sentence_details } do
+       vcr: { cassette_name: 'prison_api/offender_api_bulk_sentence_details' } do
       booking_ids = [1_153_753]
 
       response = described_class.get_bulk_sentence_details(booking_ids)
@@ -73,14 +73,14 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
 
     it 'can get category codes',
-       vcr: { cassette_name: :offender_api_cat_code_spec } do
+       vcr: { cassette_name: 'prison_api/offender_api_cat_code_spec' } do
       noms_id = 'G4273GI'
       response = described_class.get_category_code(noms_id)
       expect(response).to eq('C')
     end
 
     it 'returns nil if unable to find prisoner',
-       vcr: { cassette_name: :offender_api_null_offender_spec  } do
+       vcr: { cassette_name: 'prison_api/offender_api_null_offender_spec'  } do
       noms_id = 'AAA22D'
 
       response = described_class.get_offender(noms_id)
@@ -91,7 +91,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
 
   describe 'fetching an image' do
     it "can get a user's jpg",
-       vcr: { cassette_name: :offender_api_image_spec } do
+       vcr: { cassette_name: 'prison_api/offender_api_image_spec' } do
       booking_id = 1_153_753
       response = described_class.get_image(booking_id)
 
@@ -110,7 +110,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
 
     it "shows default image if there is no image available",
-       vcr: { cassette_name: :offender_api_image_not_found } do
+       vcr: { cassette_name: 'prison_api/offender_api_image_not_found' } do
       booking_id = 1_153_753
       image_id = 1_340_556
       uri = "#{ApiHelper::T3}/images/#{image_id}/data"
@@ -125,7 +125,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
 
     it "uses a default image if there is no available image",
-       vcr: { cassette_name: :offender_api_image_use_default_image } do
+       vcr: { cassette_name: 'prison_api/offender_api_image_use_default_image' } do
       booking_id = 1_153_753
       image_id = 1_340_556
       uri = "#{ApiHelper::T3}/images/#{image_id}/data"
@@ -145,7 +145,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
 
     it "uses the default image if no offender facialImageId found",
-       vcr: { cassette_name: :offender_api_no_facial_image_id } do
+       vcr: { cassette_name: 'prison_api/offender_api_no_facial_image_id' } do
       booking_id = 1_153_753
       uri = "#{ApiHelper::T3}/offender-sentences/bookings"
 

--- a/spec/services/hmpps_api/prison_api/prison_offender_manager_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/prison_offender_manager_api_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe HmppsApi::PrisonApi::PrisonOffenderManagerApi do
   it 'can get an Array of Prison Offender Managers (POMs)',
-     vcr: { cassette_name: :pom_api_list_spec  } do
+     vcr: { cassette_name: 'prison_api/pom_api_list_spec'  } do
     response = described_class.list('LEI')
 
     expect(response).to be_instance_of(Array)
@@ -10,7 +10,7 @@ describe HmppsApi::PrisonApi::PrisonOffenderManagerApi do
   end
 
   it 'can handle no POMs for a prison',
-     vcr: { cassette_name: :pom_api_list_spec_none  } do
+     vcr: { cassette_name: 'prison_api/pom_api_list_spec_none'  } do
     response = described_class.list('WEI')
 
     expect(response).to be_instance_of(Array)
@@ -20,21 +20,21 @@ describe HmppsApi::PrisonApi::PrisonOffenderManagerApi do
 
   describe '#fetch_email_addresses' do
     it "can get a user's single email address",
-       vcr: { cassette_name: :elite2_staff_api_get_email } do
+       vcr: { cassette_name: 'prison_api/elite2_staff_api_get_email' } do
       response = described_class.fetch_email_addresses(485_637)
 
       expect(response).to eq(["kath.pobee-norris@digital.justice.gov.uk"])
     end
 
     it "can get multiple email addresses for a user",
-       vcr: { cassette_name: :elite2_staff_api_get_emails } do
+       vcr: { cassette_name: 'prison_api/elite2_staff_api_get_emails' } do
       response = described_class.fetch_email_addresses(485_758)
 
       expect(response).to eq(["ommiicc@digital.justice.gov.uk", "omic@digital.justice.gov.uk"])
     end
 
     it "returns an empty list if a staff member doesn't have an email address",
-       vcr: { cassette_name: :elite2_staff_api_get_no_emails } do
+       vcr: { cassette_name: 'prison_api/elite2_staff_api_get_no_emails' } do
       response = described_class.fetch_email_addresses(485_636)
 
       expect(response).to eq([])

--- a/spec/services/hmpps_api/prison_api/user_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/user_api_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe HmppsApi::PrisonApi::UserApi do
   describe '#user_details' do
     it "can get a user's details",
-       vcr: { cassette_name: :elite2_staff_api } do
+       vcr: { cassette_name: 'prison_api/elite2_staff_api' } do
       response = described_class.user_details('RJONES')
 
       expect(response).not_to be_nil

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -6,7 +6,7 @@ describe MovementService, type: :feature do
   let(:transfer_out) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'TRN')   }
 
   it "can get recent movements",
-     vcr: { cassette_name: :movement_service_recent_spec }  do
+     vcr: { cassette_name: 'prison_api/movement_service_recent_spec' }  do
     movements = described_class.movements_on(Date.iso8601('2019-02-20'))
     expect(movements).to be_kind_of(Array)
     expect(movements.length).to eq(2)
@@ -14,19 +14,19 @@ describe MovementService, type: :feature do
   end
 
   it "can ignore movements OUT",
-     vcr: { cassette_name: :movement_service_ignore_out_spec }  do
+     vcr: { cassette_name: 'prison_api/movement_service_ignore_out_spec' }  do
     processed = described_class.process_movement(transfer_out)
     expect(processed).to be false
   end
 
   it "can ignore new offenders arriving at prison when from_agency is outside the prison estate",
-     vcr: { cassette_name: :movement_service_ignore_new__from_court_spec }  do
+     vcr: { cassette_name: 'prison_api/movement_service_ignore_new__from_court_spec' }  do
     processed = described_class.process_movement(new_offender_court)
     expect(processed).to be false
   end
 
   it "can ignore new offenders arriving at prison when from_agency is nil",
-     vcr: { cassette_name: :movement_service_ignore_new_from_nil_spec }  do
+     vcr: { cassette_name: 'prison_api/movement_service_ignore_new_from_nil_spec' }  do
     processed = described_class.process_movement(new_offender_nil)
     expect(processed).to be false
   end
@@ -40,7 +40,7 @@ describe MovementService, type: :feature do
     let(:existing_alloc_transfer) { build(:movement, offenderNo: 'G4273GI', fromAgency: 'PRI', toAgency: 'LEI')   }
 
     it "can process transfers were offender already allocated at new prison",
-       vcr: { cassette_name: :movement_service_transfer_in_existing_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_transfer_in_existing_spec' }  do
       expect(existing_allocation.prison).to eq('LEI')
       processed = described_class.process_movement(existing_alloc_transfer)
       expect(processed).to be false
@@ -51,7 +51,7 @@ describe MovementService, type: :feature do
       let(:updated_allocation) { existing_allocation.reload }
 
       it "can process transfer movements IN",
-         vcr: { cassette_name: :movement_service_transfer_in_spec }  do
+         vcr: { cassette_name: 'prison_api/movement_service_transfer_in_spec' }  do
         expect(described_class.process_movement(transfer_adm)).to eq(true)
 
         expect(updated_allocation.event).to eq 'deallocate_primary_pom'
@@ -61,13 +61,13 @@ describe MovementService, type: :feature do
     end
 
     it "can process a movement with invalid 'to' agency",
-       vcr: { cassette_name: :movement_service_transfer_in_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_transfer_in_spec' }  do
       processed = described_class.process_movement(transfer_adm_no_to_agency)
       expect(processed).to be false
     end
 
     it "can starts an open prison transfer",
-       vcr: { cassette_name: :movement_service_transfer_to_open_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_transfer_to_open_spec' }  do
       open_prison_transfer = build(:movement, offenderNo: 'G4273GI', toAgency: 'HDI')
 
       processed = described_class.process_movement(open_prison_transfer)
@@ -75,7 +75,7 @@ describe MovementService, type: :feature do
     end
 
     it "can do an open prison transfer with an inactive allocation",
-       vcr: { cassette_name: :movement_service_transfer_to_open_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_transfer_to_open_spec' }  do
       open_prison_transfer = build(:movement, offenderNo: 'G4273GI', toAgency: 'HDI')
 
       existing_allocation.dealloate_offender_after_transfer
@@ -84,13 +84,13 @@ describe MovementService, type: :feature do
     end
 
     it "can process a movement with no 'to' agency",
-       vcr: { cassette_name: :movement_service_admission_in_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_admission_in_spec' }  do
       processed = described_class.process_movement(admission)
       expect(processed).to be false
     end
 
     it "will not process offenders on remand",
-       vcr: { cassette_name: :movement_service_transfer_in__not_convicted_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_transfer_in__not_convicted_spec' }  do
       # Originally we did not want to process non-convicted offenders, so offenders on remand
       # who were moved were not de-allocated (as they should never have been allocated).  This
       # optimisation has come back to bite us as it is entirely possible someone who is allocated
@@ -101,7 +101,7 @@ describe MovementService, type: :feature do
     end
 
     it "will ignore an unknown movement type",
-       vcr: { cassette_name: :movement_service_unknown_spec }  do
+       vcr: { cassette_name: 'prison_api/movement_service_unknown_spec' }  do
       unknown_movement_type = build(:movement, offenderNo: 'G4273GI', movementType: 'TMP')
       processed = described_class.process_movement(unknown_movement_type)
       expect(processed).to be false
@@ -127,7 +127,7 @@ describe MovementService, type: :feature do
                     .and_call_original
       end
 
-      it "can process release movements", vcr: { cassette_name: :movement_service_process_release_spec }  do
+      it "can process release movements", vcr: { cassette_name: 'prison_api/movement_service_process_release_spec' }  do
         processed = described_class.process_movement(valid_release)
         updated_allocation = Allocation.find_by(nomis_offender_id: valid_release.offender_no)
 
@@ -138,7 +138,7 @@ describe MovementService, type: :feature do
       end
 
       it "can do an open prison release with an inactive allocation",
-         vcr: { cassette_name: :movement_service_process_release_spec }  do
+         vcr: { cassette_name: 'prison_api/movement_service_process_release_spec' }  do
         allocation.deallocate_offender_after_release
         processed = described_class.process_movement(valid_release)
 
@@ -150,7 +150,7 @@ describe MovementService, type: :feature do
       let(:invalid_release1) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'REL', toAgency: 'LEI')   }
       let(:invalid_release2) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'REL', fromAgency: 'COURT')   }
 
-      it "can ignore invalid release movements", vcr: { cassette_name: :movement_service_process_release_invalid_spec }  do
+      it "can ignore invalid release movements", vcr: { cassette_name: 'prison_api/movement_service_process_release_invalid_spec' }  do
         processed = described_class.process_movement(invalid_release1)
         expect(processed).to be false
 
@@ -183,7 +183,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'does not process movement',
-             vcr: { cassette_name: :immigration_transfer_from_MHI_to_prison_not_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_transfer_from_MHI_to_prison_not_successful' } do
             processed = described_class.process_movement(immigration_movement)
             expect(processed).to be false
           end
@@ -196,7 +196,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'can process release movement for offender',
-             vcr: { cassette_name: :immigration_transfer_from_MHI_to_IMM_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_transfer_from_MHI_to_IMM_successful' } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -212,7 +212,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'can process release movement for offender',
-             vcr: { cassette_name: :immigration_transfer_from_prison_to_IMM_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_transfer_from_prison_to_IMM_successful' } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -230,7 +230,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'does not process movement',
-             vcr: { cassette_name: :immigration_transfer_from_IMM_to_prison_not_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_transfer_from_IMM_to_prison_not_successful' } do
             processed = described_class.process_movement(immigration_movement)
             expect(processed).to be false
           end
@@ -243,7 +243,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'can process release movement for offender',
-             vcr: { cassette_name: :immigration_transfer_from_IMM_to_MHI_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_transfer_from_IMM_to_MHI_successful' } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -263,7 +263,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'OUT' }
 
           it 'can release movement',
-             vcr: { cassette_name: :immigration_release_from_MHI_to_OUT_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_release_from_MHI_to_OUT_successful' } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
@@ -279,7 +279,7 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'OUT' }
 
           it 'can release movement',
-             vcr: { cassette_name: :immigration_release_from_IMM_to_OUT_successful } do
+             vcr: { cassette_name: 'prison_api/immigration_release_from_IMM_to_OUT_successful' } do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe OffenderService, type: :feature do
   describe '#get_offender' do
-    it "gets a single offender", vcr: { cassette_name: :offender_service_single_offender_spec } do
+    it "gets a single offender", vcr: { cassette_name: 'prison_api/offender_service_single_offender_spec' } do
       nomis_offender_id = 'G4273GI'
 
       create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_offender: 'Yes')
@@ -15,7 +15,7 @@ describe OffenderService, type: :feature do
       expect(offender.case_allocation).to eq 'CRC'
     end
 
-    it "returns nil if offender record not found", vcr: { cassette_name: :offender_service_single_offender_not_found_spec } do
+    it "returns nil if offender record not found", vcr: { cassette_name: 'prison_api/offender_service_single_offender_not_found_spec' } do
       nomis_offender_id = 'AAA121212CV4G4GGVV'
 
       offender = described_class.get_offender(nomis_offender_id)
@@ -38,7 +38,7 @@ describe OffenderService, type: :feature do
                   offender_manager: nil,
                   service_provider: "NPS",
                   team_code: "N07UAT",
-                  tier: "A")
+                  tier: "A-2")
       end
     end
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -10,13 +10,13 @@ describe PrisonOffenderManagerService do
 
   context 'when using T3 and VCR' do
     describe '#get_pom_name' do
-      it "can get staff names", vcr: { cassette_name: :pom_service_staff_name } do
+      it "can get staff names", vcr: { cassette_name: 'prison_api/pom_service_staff_name' } do
         expect(described_class.get_pom_name(staff_id)). to eq ['ANDRIEN', 'RICKETTS']
       end
     end
 
     describe '#get_user_name' do
-      it "can get user names", vcr: { cassette_name: :pom_service_user_name } do
+      it "can get user names", vcr: { cassette_name: 'prison_api/pom_service_user_name' } do
         expect(described_class.get_user_name('RJONES')).to eq ['Ross', 'Jones']
       end
     end
@@ -28,7 +28,7 @@ describe PrisonOffenderManagerService do
 
       let(:moic_integration_tests) { subject.detect { |x| x.first_name == 'MOIC' } }
 
-      it "can get a list of POMs", vcr: { cassette_name: :pom_service_get_poms_list } do
+      it "can get a list of POMs", vcr: { cassette_name: 'prison_api/pom_service_get_poms_list' } do
         expect(subject).to be_kind_of(Enumerable)
         expect(subject.count { |pom| pom.status == 'active' }).to eq(subject.count)
         expect(moic_integration_tests.probation_officer?).to eq(true)
@@ -37,7 +37,7 @@ describe PrisonOffenderManagerService do
 
     describe '#get_pom_names' do
       it "can get the names for POMs when given IDs",
-         vcr: { cassette_name: :pom_service_get_poms_by_ids } do
+         vcr: { cassette_name: 'prison_api/pom_service_get_poms_by_ids' } do
         names = described_class.get_pom_names('LEI')
         expect(names).to be_kind_of(Hash)
         expect(names.count).to be > 10
@@ -46,13 +46,13 @@ describe PrisonOffenderManagerService do
 
     describe '#get_pom_at' do
       it "can fetch a single POM for a prison",
-         vcr: { cassette_name: :pom_service_get_pom_ok } do
+         vcr: { cassette_name: 'prison_api/pom_service_get_pom_ok' } do
         pom = described_class.get_pom_at('LEI', staff_id)
         expect(pom).not_to be nil
       end
 
       it "raises an exception when fetching a pom if they are not a POM",
-         vcr: { cassette_name: :pom_service_get_pom_none } do
+         vcr: { cassette_name: 'prison_api/pom_service_get_pom_none' } do
         expect {
           described_class.get_pom_at('CFI', 1234)
         }.to raise_exception(StandardError)

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
 describe SearchService do
-  it "will return all of the records if no search", vcr: { cassette_name: :search_service_all } do
+  it "will return all of the records if no search", vcr: { cassette_name: 'prison_api/search_service_all' } do
     offenders = described_class.search_for_offenders('', Prison.new('LEI'))
     expect(offenders.count).to be > 800
   end
 
-  it "will return a filtered list if there is a search", vcr: { cassette_name: :search_service_filtered } do
+  it "will return a filtered list if there is a search", vcr: { cassette_name: 'prison_api/search_service_filtered' } do
     offenders = described_class.search_for_offenders('Cal', Prison.new('LEI'))
     expect(offenders.count).to eq(6)
   end
 
-  it "will handle a nil search term", vcr: { cassette_name: :search_service_no_term } do
+  it "will handle a nil search term", vcr: { cassette_name: 'prison_api/search_service_no_term' } do
     offenders = described_class.search_for_offenders(nil, Prison.new('LEI'))
     expect(offenders.count).to eq(0)
   end


### PR DESCRIPTION
We need to capture a few VCR interactions between us and the Complexity service.

This PR moves the existing VCR cassettes into a new directory (which is then added to .gitignore) so that there is space to put new VCR cassettes into a different directory which can be checked into source control