### PR TITLE
Use Sass import instead of Sprockets require

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,14 +9,25 @@
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= stub "active_admin"
- *= require_self
  */
 
-@import "tables";
+// Import GOV.UK Design System first
+@import "gov_uk";
+
+// Then application specific components
+@import "case_type_badge";
+@import "hmpps_header";
+@import "notification";
+@import "pages";
 @import "pagination";
+@import "prison_switcher";
+@import "prisoner";
+@import "search";
+@import "service_banner";
+@import "sorting";
+@import "tables";
+@import "timeline";
+@import "vlo_information";
 
 a:visited {
     color: #005ea5;
@@ -63,7 +74,6 @@ a:visited {
 
 .sidebar-panel {
   border-top: 10px solid #1d70b8;
-  border-top-width: 10px;
   padding-top: 10px;
 }
 

--- a/app/assets/stylesheets/gov_uk.scss
+++ b/app/assets/stylesheets/gov_uk.scss
@@ -5,7 +5,6 @@ $govuk-font-url-function: "asset-url";
 @import "govuk/all";
 @import "moj/all";
 
-
 .govuk-data-value {
    @extend .govuk-heading-l;
    margin-bottom: 0;

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -4,12 +4,12 @@
   }
 
   table.responsive tr {
-    border-bottom: 2px solid govuk-colour("grey-2");
+    border-bottom: 2px solid govuk-colour("mid-grey");
     display: block;
   }
 
   table.responsive td {
-    border-bottom: 1px solid govuk-colour("grey-2");
+    border-bottom: 1px solid govuk-colour("mid-grey");
     display: block;
     text-align: right;
     &:last-child {


### PR DESCRIPTION
This is a prefactor for MO-489

---

This change makes our SCSS file more 'normal' and less Rails/Sprockets-specific.

Using the Sass `@import` feature, you gain the advantage of a shared scope for variables, mixins and functions. This is important for us to be able to use GOV.UK utilities such as the `govuk-colour()` function, which we get from the GOV.UK Frontend package.

The Ruby on Rails guide for the Asset Pipeline explains that SCSS files imported using the Sprockets `require` directives don't have a shared scope – so they can't share mixins, variables or functions. The recommendation is to use Sass `@import`s instead.

From https://guides.rubyonrails.org/asset_pipeline.html :
> If you want to use multiple Sass files, you should generally use the Sass @import rule instead of these Sprockets directives. When using Sprockets directives, Sass files exist within their own scope, making variables or mixins only available within the document they were defined in.

During the course of this change, there was a Sass compilation error where the GOV.UK colour `grey-2` – which has been in use since 2019 in our SCSS files – could not be found. It's a bit of a mystery why this ever worked, because it has never been available in the new GOV.UK Frontend package. It's a legacy colour from the old GOV.UK CSS framework. So I've switched this  to use `mid-grey` instead, which is a valid GOV.UK colour.

---

This is purely a refactor, and doesn't make any visual changes to the page. Therefore I've not included screenshots.

However to see the refactored CSS in action, take a look at the Heroku Review App for this PR.