### PR TITLE
Add UI components for displaying POM case mix

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
 //= link_tree ../../../node_modules/@ministryofjustice/frontend/moj/assets/images
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link application.css

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "gov_uk";
 
 // Then application specific components
+@import "case_mix";
 @import "case_type_badge";
 @import "hmpps_header";
 @import "notification";

--- a/app/assets/stylesheets/case_mix.scss
+++ b/app/assets/stylesheets/case_mix.scss
@@ -1,0 +1,70 @@
+/**
+ * Case mix key
+ */
+.case-mix-key {
+  margin: 0;
+
+  ul {
+    @extend .govuk-list;
+  }
+
+  li {
+    display: inline;
+    margin-right: 20px;
+  }
+
+  .case-mix-key__swatch {
+    border-radius: 2px;
+    margin-right: 10px;
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: middle;
+    margin-bottom: 0.2em;
+  }
+}
+
+/**
+ * Case mix bar
+ */
+.case-mix-bar {
+  display: grid;
+  grid-template-columns: var(--columns);
+  height: 30px;
+  margin: 0;
+
+  > dt {
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  > dd {
+    @include govuk-font(16);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/**
+ * Tier colours
+ */
+.case-mix__tier-a {
+  background: govuk-colour("dark-blue");
+  color: white;
+}
+.case-mix__tier-b {
+  background: govuk-colour("light-blue");
+}
+.case-mix__tier-c {
+  background: govuk-colour("pink");
+  color: white;
+}
+.case-mix__tier-d {
+  background: govuk-colour("light-pink");
+}
+.case-mix__tier-na {
+  background: govuk-colour("mid-grey");
+}

--- a/app/helpers/case_mix_helper.rb
+++ b/app/helpers/case_mix_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CaseMixHelper
+  CASE_MIX_TIERS = %i[a b c d na].freeze
+
+  def case_mix_key
+    render partial: 'poms/case-mix/key', locals: { tiers: CASE_MIX_TIERS }
+  end
+
+  def case_mix_bar(pom)
+    tiers = {
+      a: pom.tier_a,
+      b: pom.tier_b,
+      c: pom.tier_c,
+      d: pom.tier_d,
+      na: pom.no_tier,
+    }.reject { |_tier, count| count.zero? } # filter out zero-count tiers
+
+    css_columns = tiers.values.map { |count|
+      # Value for CSS property grid-template-columns
+      %W[0 #{count}fr]
+    }.join(' ')
+
+    render partial: 'poms/case-mix/bar', locals: { tiers: tiers, css_columns: css_columns }
+  end
+
+  def tier_label(tier)
+    if tier == :na
+      'Tier N/A'
+    else
+      "Tier #{tier.to_s.upcase}"
+    end
+  end
+end

--- a/app/views/poms/case-mix/_bar.html.erb
+++ b/app/views/poms/case-mix/_bar.html.erb
@@ -1,0 +1,9 @@
+<% # Use the Case Mix helper method `case_mix_bar(pom)` to render this partial %>
+<% if tiers.present? %>
+  <dl class="case-mix-bar" style="--columns: <%= css_columns %>;">
+    <% tiers.each do |tier, count| %>
+      <dt><%= tier_label(tier) %></dt>
+      <dd title="<%= tier_label(tier) %>" class="case-mix__tier-<%= tier %>"><%= count %></dd>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/poms/case-mix/_key.html.erb
+++ b/app/views/poms/case-mix/_key.html.erb
@@ -1,0 +1,12 @@
+<% # Use the Case Mix helper method `case_mix_key` to render this partial %>
+<figure class="case-mix-key">
+  <figcaption class="govuk-heading-s">Case mix by tier</figcaption>
+  <ul>
+    <% tiers.each do |tier| %>
+      <li>
+        <span class="case-mix-key__swatch case-mix__tier-<%= tier %>"></span>
+        <%= tier_label(tier) %>
+      </li>
+    <% end %>
+  </ul>
+</figure>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,7 +14,6 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules/govuk-fro
 Rails.application.config.assets.paths << Rails.root.join('node_modules/@ministryofjustice/frontend')
 Rails.application.config.assets.paths << Rails.root.join('node_modules/@ministryofjustice/frontend/moj/assets/images')
 
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in the app/assets
-# folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+# Precompiled assets
+# Configure which assets get precompiled in the Sprockets manifest file:
+# app/assets/config/manifest.js

--- a/spec/helpers/case_mix_helper_spec.rb
+++ b/spec/helpers/case_mix_helper_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CaseMixHelper, type: :helper do
+  let(:page) { Nokogiri::HTML(subject) }
+
+  describe '#case_mix_key' do
+    subject { helper.case_mix_key }
+
+    it 'renders the key' do
+      expect(page.css('.case-mix-key')).to be_present
+      expect(page.css('.govuk-heading-s').text.strip).to eq 'Case mix by tier'
+
+      tiers = [
+        { label: 'Tier A', swatch_class: 'case-mix__tier-a' },
+        { label: 'Tier B', swatch_class: 'case-mix__tier-b' },
+        { label: 'Tier C', swatch_class: 'case-mix__tier-c' },
+        { label: 'Tier D', swatch_class: 'case-mix__tier-d' },
+        { label: 'Tier N/A', swatch_class: 'case-mix__tier-na' },
+      ]
+
+      tiers.each_with_index do |tier, index|
+        li = page.css("li:nth-of-type(#{index + 1})")
+        swatch = li.css(".case-mix-key__swatch.#{tier.fetch(:swatch_class)}")
+        expect(li.text.strip).to eq tier.fetch(:label)
+        expect(swatch).to be_present
+      end
+    end
+  end
+
+  describe '#case_mix_bar' do
+    subject { helper.case_mix_bar(pom) }
+
+    let(:case_mix_bar) { page.css('.case-mix-bar') }
+
+    let(:pom) {
+      instance_double(PomPresenter,
+                      tier_a: tier_a_count,
+                      tier_b: tier_b_count,
+                      tier_c: tier_c_count,
+                      tier_d: tier_d_count,
+                      no_tier: tier_na_count)
+    }
+
+    # Randomise tier counts
+    let(:tier_a_count) { rand(1..15) }
+    let(:tier_b_count) { rand(1..15) }
+    let(:tier_c_count) { rand(1..15) }
+    let(:tier_d_count) { rand(1..15) }
+    let(:tier_na_count) { rand(1..15) }
+
+    def expect_rendered_tiers(tiers)
+      tiers.each_with_index do |tier, index|
+        dt = page.css("dt:nth-of-type(#{index + 1})")
+        dd = page.css("dd:nth-of-type(#{index + 1})")
+
+        expect(dt.text.strip).to eq tier.fetch(:label)
+        expect(dd.attr('title').value).to eq tier.fetch(:label)
+        expect(dd.css(".#{tier.fetch(:bar_class)}")).to be_present
+      end
+    end
+
+    it 'renders the case mix bar' do
+      expect(case_mix_bar).to be_present
+
+      tiers = [
+        { label: 'Tier A', bar_class: 'case-mix__tier-a', count: tier_a_count },
+        { label: 'Tier B', bar_class: 'case-mix__tier-b', count: tier_b_count },
+        { label: 'Tier C', bar_class: 'case-mix__tier-c', count: tier_c_count },
+        { label: 'Tier D', bar_class: 'case-mix__tier-d', count: tier_d_count },
+        { label: 'Tier N/A', bar_class: 'case-mix__tier-na', count: tier_na_count },
+      ]
+
+      expect_rendered_tiers(tiers)
+    end
+
+    it 'sets the CSS variable "columns" to style the bar correctly' do
+      expect_style = "--columns: 0 #{tier_a_count}fr 0 #{tier_b_count}fr 0 #{tier_c_count}fr 0 #{tier_d_count}fr 0 #{tier_na_count}fr;"
+      expect(case_mix_bar.attr('style').value).to eq expect_style
+    end
+
+    context 'when some tier counts are zero' do
+      let(:tier_c_count) { 0 }
+      let(:tier_d_count) { 0 }
+
+      it 'excludes them from the case mix bar' do
+        expect(page.text).not_to include 'Tier C'
+        expect(page.text).not_to include 'Tier D'
+
+        tiers = [
+          { label: 'Tier A', bar_class: 'case-mix__tier-a', count: tier_a_count },
+          { label: 'Tier B', bar_class: 'case-mix__tier-b', count: tier_b_count },
+          { label: 'Tier N/A', bar_class: 'case-mix__tier-na', count: tier_na_count },
+        ]
+
+        expect_rendered_tiers(tiers)
+      end
+
+      it 'sets the CSS variable "columns" to style the bar correctly' do
+        expect_style = "--columns: 0 #{tier_a_count}fr 0 #{tier_b_count}fr 0 #{tier_na_count}fr;"
+        expect(case_mix_bar.attr('style').value).to eq expect_style
+      end
+    end
+
+    context 'when all tier counts are zero' do
+      let(:tier_a_count) { 0 }
+      let(:tier_b_count) { 0 }
+      let(:tier_c_count) { 0 }
+      let(:tier_d_count) { 0 }
+      let(:tier_na_count) { 0 }
+
+      it 'renders nothing' do
+        expect(case_mix_bar).not_to be_present
+        expect(page.text).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a new `CaseMix` helper which can render the case mix bar and key for POM caseloads. It also adds the necessary HTML and CSS for them to display correctly.

### Usage

#### Key

To render the case mix key:

```erb
<%= case_mix_key %>
```

> ![case mix key](https://user-images.githubusercontent.com/7735945/112035953-fda76400-8b37-11eb-8b49-e918456154e6.png)

#### Bar

To render a case mix bar for a POM:

```erb
<%= case_mix_bar(pom) %>
```

**Note:** `pom` must be an instance of `PomPresenter`

> ![case mix bar](https://user-images.githubusercontent.com/7735945/112035983-05ff9f00-8b38-11eb-8cc4-fca5288afaa7.png)