### PR TITLE
MO-425 pre-factor - bind Allocation to the CaseInformation record

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -23,7 +23,7 @@ class AllocationsController < PrisonsApplicationController
     @prisoner = offender(nomis_offender_id_from_url)
 
     allocation = Allocation.find_by!(nomis_offender_id: @prisoner.offender_no)
-    @allocation = AllocationHistory.new(allocation, allocation.versions.last)
+    @allocation = AllocationHistory.new(allocation, allocation.last_version)
 
     @pom = StaffMember.new(@prison, @allocation.primary_pom_nomis_id)
     redirect_to prison_pom_non_pom_path(@prison.code, @pom.staff_id) unless @pom.has_pom_role?

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -32,14 +32,7 @@ class AllocatedOffender
     end
   end
 
-  # check for changes in the last week where the target value
-  # (item[1] in the array) is our staff_id
   def new_case?
-    @allocation.versions.where('created_at >= ?', 7.days.ago).map { |c|
-      YAML.load(c.object_changes)
-    }.select { |c|
-      c.key?('primary_pom_nomis_id') && c['primary_pom_nomis_id'][1] == @staff_id ||
-      c.key?('secondary_pom_nomis_id') && c['secondary_pom_nomis_id'][1] == @staff_id
-    }.any?
+    @allocation.new_case_for(@staff_id)
   end
 end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -12,6 +12,8 @@ class CaseInformation < ApplicationRecord
   # new mapping - don't need team data any more, only team_name for display purposes
   belongs_to :local_delivery_unit, optional: true
 
+  has_one :allocation, foreign_key: :nomis_offender_id, primary_key: :nomis_offender_id, dependent: :destroy, inverse_of: :case_information
+
   has_many :early_allocations,
            -> { order(created_at: :asc) },
            foreign_key: :nomis_offender_id,

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -110,7 +110,6 @@ private
   def self.release_offender(offender_no)
     Rails.logger.info("[MOVEMENT] Processing release for #{offender_no}")
 
-    CaseInformation.where(nomis_offender_id: offender_no).destroy_all
     alloc = Allocation.find_by(nomis_offender_id: offender_no)
     # We need to check whether the from_agency is from within the prison estate
     # to know whether it is a transfer.  If it isn't then we want to bail and
@@ -125,5 +124,8 @@ private
     # case information (in case they come back one day), and we
     # should de-activate any current allocations.
     alloc.deallocate_offender_after_release if alloc
+
+    # allocations belong to CaseInformation, so this has to come after the offender_released call
+    CaseInformation.where(nomis_offender_id: offender_no).destroy_all
   end
 end

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -54,7 +54,7 @@ describe 'Allocation API', vcr: { cassette_name: 'prison_api/allocation_api' } d
 
         let(:offender_no) { 'G4273GI' }
         let!(:allocation) {
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_name: 'OLD_NAME, MOIC')
+          create(:allocation, case_information: build(:case_information, nomis_offender_id: offender_no), primary_pom_name: 'OLD_NAME, MOIC')
         }
         let(:Authorization) { "Bearer #{token}" }
 

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe AllocationsController, :allocation, type: :controller do
     end
 
     it 'allows access to the Case History page' do
-      create(:case_information, nomis_offender_id: offender_no)
-      create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: poms.last.staffId)
+      case_info = create(:case_information, nomis_offender_id: offender_no)
+      create(:allocation, case_information: case_info, primary_pom_nomis_id: poms.last.staffId)
       get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
       expect(response).to have_http_status(:ok)
     end
@@ -48,15 +48,15 @@ RSpec.describe AllocationsController, :allocation, type: :controller do
 
     describe '#show' do
       let(:inactive_pom_staff_id) { 543_453 }
+      let!(:case_info) { create(:case_information, nomis_offender_id: offender_no) }
 
       before do
-        create(:case_information, nomis_offender_id: offender_no)
         stub_keyworker(prison, offender_no, staffId: 123_456)
       end
 
       context 'when POM has left' do
         before do
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: inactive_pom_staff_id)
+          create(:allocation, case_information: case_info, primary_pom_nomis_id: inactive_pom_staff_id)
         end
 
         it 'redirects to the inactive POM page' do
@@ -87,7 +87,7 @@ RSpec.describe AllocationsController, :allocation, type: :controller do
       context 'with a VictimLiasonOfficer' do
         before do
           case_info = create(:case_information, victim_liaison_officers: [build(:victim_liaison_officer)])
-          create(:allocation, nomis_offender_id: case_info.nomis_offender_id)
+          create(:allocation, case_information: case_info)
           stub_offender(build(:nomis_offender, offenderNo: case_info.nomis_offender_id))
           stub_pom_emails(485926, [])
         end

--- a/spec/controllers/api/allocation_api_controller_spec.rb
+++ b/spec/controllers/api/allocation_api_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Api::AllocationApiController, :allocation, type: :controller do
     let(:prison) { build(:prison) }
     let!(:co_working_allocation) {
       create(:allocation, :co_working, primary_pom_nomis_id: primary_pom.staff_id,
-                                          secondary_pom_nomis_id: secondary_pom.staff_id, nomis_offender_id: offender.fetch(:offenderNo))
+                                          secondary_pom_nomis_id: secondary_pom.staff_id,
+             case_information: build(:case_information, nomis_offender_id: offender.fetch(:offenderNo)))
     }
     let(:primary_pom) { build(:pom) }
     let(:secondary_pom) { build(:pom) }

--- a/spec/controllers/caseload_controller_spec.rb
+++ b/spec/controllers/caseload_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe CaseloadController, type: :controller do
 
       # Need to create history records because AllocatedOffender#new_case? doesn't cope otherwise
       offenders.each do |offender|
-        alloc = create(:allocation, nomis_offender_id: offender.fetch(:offenderNo), primary_pom_nomis_id: pom.staffId, prison: prison.code)
+        alloc = create(:allocation, case_information: build(:case_information, nomis_offender_id: offender.fetch(:offenderNo)), primary_pom_nomis_id: pom.staffId, prison: prison.code)
         alloc.update!(primary_pom_nomis_id: pom.staffId,
                       event: Allocation::REALLOCATE_PRIMARY_POM,
                       event_trigger: Allocation::USER)

--- a/spec/controllers/coworking_controller_spec.rb
+++ b/spec/controllers/coworking_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CoworkingController, :allocation, type: :controller do
       stub_pom_emails(user.staffId, [])
 
       create(:allocation, prison: prison,
-             nomis_offender_id: offender_no,
+             case_information: build(:case_information, nomis_offender_id: offender_no),
              primary_pom_nomis_id: primary_pom.staffId,
              secondary_pom_nomis_id: secondary_pom.staffId)
     end
@@ -40,7 +40,8 @@ RSpec.describe CoworkingController, :allocation, type: :controller do
 
   describe '#destroy' do
     before do
-      create(:allocation, prison: prison, nomis_offender_id: offender_no,
+      create(:allocation, prison: prison,
+             case_information: build(:case_information, nomis_offender_id: offender_no),
              primary_pom_nomis_id: primary_pom.staffId,
              secondary_pom_nomis_id: new_secondary_pom.staffId,
              secondary_pom_name: secondary_pom_name)

--- a/spec/controllers/female_prisoners_controller_spec.rb
+++ b/spec/controllers/female_prisoners_controller_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe FemalePrisonersController, type: :controller do
       create(:case_information, nomis_offender_id: offender_with_case_info_but_no_complexity_level.fetch(:offenderNo))
       create(:case_information, nomis_offender_id: offender_with_complexity_level_and_case_info.fetch(:offenderNo))
 
-      create(:allocation, nomis_offender_id: allocated_offender_one.fetch(:offenderNo), prison: prison.code)
-      create(:allocation, nomis_offender_id: allocated_offender_two.fetch(:offenderNo), prison: prison.code)
+      info_one = create(:case_information, nomis_offender_id: allocated_offender_one.fetch(:offenderNo))
+      info_two = create(:case_information, nomis_offender_id: allocated_offender_two.fetch(:offenderNo))
+      create(:allocation, case_information: info_one, prison: prison.code)
+      create(:allocation, case_information: info_two, prison: prison.code)
     end
 
     let(:offender_with_case_info_but_no_complexity_level) { build(:nomis_offender, complexityLevel: nil) }
@@ -229,10 +231,14 @@ RSpec.describe FemalePrisonersController, type: :controller do
 
     describe 'allocated' do
       before do
-        create(:allocation, primary_pom_name: pom_one.full_name,  nomis_offender_id: offender_a.fetch(:offenderNo), prison: prison.code)
-        create(:allocation, primary_pom_name: pom_two.full_name,  nomis_offender_id: offender_b.fetch(:offenderNo), prison: prison.code)
-        create(:allocation, primary_pom_name: pom_three.full_name, nomis_offender_id: offender_c.fetch(:offenderNo), prison: prison.code)
-        create(:allocation, primary_pom_name: pom_four.full_name,  nomis_offender_id: offender_d.fetch(:offenderNo), prison: prison.code)
+        info_a = create(:case_information, nomis_offender_id: offender_a.fetch(:offenderNo))
+        info_b = create(:case_information, nomis_offender_id: offender_b.fetch(:offenderNo))
+        info_c = create(:case_information, nomis_offender_id: offender_c.fetch(:offenderNo))
+        info_d = create(:case_information, nomis_offender_id: offender_d.fetch(:offenderNo))
+        create(:allocation, primary_pom_name: pom_one.full_name,  case_information: info_a, prison: prison.code)
+        create(:allocation, primary_pom_name: pom_two.full_name,  case_information: info_b, prison: prison.code)
+        create(:allocation, primary_pom_name: pom_three.full_name, case_information: info_c, prison: prison.code)
+        create(:allocation, primary_pom_name: pom_four.full_name,  case_information: info_d, prison: prison.code)
       end
 
       let(:offenders) { [offender_c, offender_a, offender_b, offender_d] }

--- a/spec/controllers/overrides_controller_spec.rb
+++ b/spec/controllers/overrides_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OverridesController, :allocation, type: :controller do
 
   context 'with an allocation' do
     it 'redirects to confirm#reallocation' do
-      create(:allocation, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
+      create(:allocation, case_information: build(:case_information, nomis_offender_id: nomis_offender_id), primary_pom_nomis_id: nomis_staff_id)
       post :create, params: params.merge(override_params)
 
       expect(response).to redirect_to prison_confirm_reallocation_path(prison, nomis_offender_id, nomis_staff_id)
@@ -43,7 +43,7 @@ RSpec.describe OverridesController, :allocation, type: :controller do
 
   context 'with an inactive allocation' do
     before do
-      create(:allocation, :release, nomis_offender_id: nomis_offender_id)
+      create(:allocation, :release, case_information: build(:case_information, nomis_offender_id: nomis_offender_id))
     end
 
     it 'redirects to confirm#allocation' do

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SearchController, type: :controller do
         PomDetail.create!(nomis_staff_id: nomis_staff_id, working_pattern: 1.0, status: 'active')
 
         create(:allocation,
-               nomis_offender_id: offenders.first.fetch(:offenderNo),
+               case_information: build(:case_information, nomis_offender_id: offenders.first.fetch(:offenderNo)),
                primary_pom_allocated_at: allocated_date,
                primary_pom_nomis_id: nomis_staff_id)
       end

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -28,10 +28,6 @@ FactoryBot.define do
       Faker::Number.number(digits: 7)
     end
 
-    # nomis_offender_id do
-    #   Faker::Alphanumeric.alpha(number: 10)
-    # end
-
     primary_pom_nomis_id do
       485_926
       # using fake POM numbers tends to cause crashes

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 require 'faker'
 
 FactoryBot.define do
   factory :allocation do
+    association :case_information
+
     allocated_at_tier do
       'A'
     end
@@ -24,9 +28,9 @@ FactoryBot.define do
       Faker::Number.number(digits: 7)
     end
 
-    nomis_offender_id do
-      Faker::Alphanumeric.alpha(number: 10)
-    end
+    # nomis_offender_id do
+    #   Faker::Alphanumeric.alpha(number: 10)
+    # end
 
     primary_pom_nomis_id do
       485_926

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -2,6 +2,8 @@ require 'faker'
 
 FactoryBot.define do
   factory :case_information do
+    # association :allocation
+
     tier do
       'A'
     end

--- a/spec/features/allocation_history_spec.rb
+++ b/spec/features/allocation_history_spec.rb
@@ -119,12 +119,10 @@ feature 'Allocation History' do
         current_date += 1.day
         Timecop.travel(current_date) do
           # offender got released - so have to re-create case information record
-          # and re-find allocation record as it has been updated
-          create(:case_information, nomis_offender_id: nomis_offender_id, local_delivery_unit: pontypool_ldu)
-          allocation = Allocation.find_by!(nomis_offender_id: nomis_offender_id)
+          # and allocation record as it has been updated
           allocation = create(:allocation,
                               event: Allocation::ALLOCATE_PRIMARY_POM,
-                              case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
+                              case_information: build(:case_information, nomis_offender_id: nomis_offender_id, local_delivery_unit: pontypool_ldu),
                               prison: second_prison.code,
                               primary_pom_nomis_id: prison_pom[:primary_pom_nomis_id],
                               primary_pom_name: prison_pom[:primary_pom_name],

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -27,7 +27,7 @@ feature 'Provide debugging information for our team to use' do
 
     it 'returns information for an allocated offender', vcr: { cassette_name: 'prison_api/debugging_allocated_offender_feature' } do
       create(:allocation,
-             nomis_offender_id: nomis_offender_id,
+             case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
              primary_pom_name: "Rossana Spinka"
              )
       visit prison_debugging_path('LEI')

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -66,7 +66,7 @@ feature "edit a POM's details" do
       # create an allocation with the POM as the primary POM
       create(
         :allocation,
-        nomis_offender_id: 'G7806VO',
+        case_information: build(:case_information, nomis_offender_id: 'G7806VO'),
         primary_pom_nomis_id: 485_926,
         prison: 'LEI'
       )
@@ -74,7 +74,7 @@ feature "edit a POM's details" do
       # create an allocation with the POM as the co-working POM
       create(
         :allocation,
-        nomis_offender_id: 'G1670VU',
+        case_information: build(:case_information, nomis_offender_id: 'G1670VU'),
         primary_pom_nomis_id: 485_833,
         secondary_pom_nomis_id: 485_926,
         prison: 'LEI'

--- a/spec/features/female_prisoners_add_missing_info_feature_spec.rb
+++ b/spec/features/female_prisoners_add_missing_info_feature_spec.rb
@@ -8,8 +8,11 @@ feature "add missing details page" do
     stub_signin_spo(pom, [prison.code, 'SDI'])
     stub_offenders_for_prison(prison.code, offenders)
 
-    create(:allocation, primary_pom_allocated_at: one_day_ago,  nomis_offender_id: allocated_offender_one.fetch(:offenderNo), prison: prison.code)
-    create(:allocation, primary_pom_allocated_at: two_days_ago, nomis_offender_id: allocated_offender_two.fetch(:offenderNo), prison: prison.code)
+    info_one = create(:case_information, nomis_offender_id: allocated_offender_one.fetch(:offenderNo))
+    info_two = create(:case_information, nomis_offender_id: allocated_offender_two.fetch(:offenderNo))
+
+    create(:allocation, primary_pom_allocated_at: one_day_ago,  case_information: info_one, prison: prison.code)
+    create(:allocation, primary_pom_allocated_at: two_days_ago, case_information: info_two, prison: prison.code)
     create(:case_information, nomis_offender_id: offender_ready_to_allocate.fetch(:offenderNo))
 
     test_strategy.switch!(:womens_estate, true)

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -13,7 +13,7 @@ feature 'Inactive POM' do
 
       create(
         :allocation,
-        nomis_offender_id: nomis_offender_id,
+        case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
         primary_pom_nomis_id: inactive_pom,
         secondary_pom_nomis_id: active_pom
       )

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -38,8 +38,9 @@ context 'when NOMIS is missing information' do
 
           stub_offenders_for_prison(prison_code, stub_offenders)
 
-          create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
-          create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+          create(:allocation,
+                 case_information: build(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS'),
+                 primary_pom_nomis_id: staff_id)
         end
 
         it 'does not error' do
@@ -68,8 +69,7 @@ context 'when NOMIS is missing information' do
 
         stub_offender(offender)
 
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
-        create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS')
+        create(:allocation, case_information: build(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS'), primary_pom_nomis_id: staff_id)
       end
 
       it 'does not error' do
@@ -90,7 +90,7 @@ context 'when NOMIS is missing information' do
       end
 
       it 'does not error' do
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
+        create(:allocation, case_information: build(:case_information, nomis_offender_id: offender_no), primary_pom_nomis_id: staff_id)
 
         visit prison_staff_caseload_handovers_path(prison_code, staff_id)
 
@@ -137,13 +137,12 @@ context 'when NOMIS is missing information' do
         stub_request(:get, "#{stub_keyworker_host}/key-worker/#{prison_code}/offender/#{offender_no}").
           to_return(body: {}.to_json)
 
-        create(:allocation, nomis_offender_id: offender_no, primary_pom_nomis_id: staff_id)
-        create(
+        create(:allocation, case_information: build(
           :case_information,
           nomis_offender_id: offender_no,
           case_allocation: 'NPS',
           welsh_offender: welsh
-        )
+        ), primary_pom_nomis_id: staff_id)
       end
 
       describe 'the pom details page' do

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe OffenderHelper do
     let!(:allocation) {
       create(
         :allocation,
-        nomis_offender_id: nomis_offender_id,
+        case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
         primary_pom_nomis_id: nomis_staff_id,
         event: 'allocate_primary_pom'
       )

--- a/spec/jobs/automatic_handover_email_job_spec.rb
+++ b/spec/jobs/automatic_handover_email_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
 
       let(:prison1) { build(:prison) }
       let(:case_info1) { build(:case_information) }
-      let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+      let!(:allocation1) { create(:allocation, prison: prison1.code, case_information: case_info1, primary_pom_nomis_id: staff_id) }
       let(:offender1) {
         build(:nomis_offender, agencyId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
               sentence: attributes_for(:sentence_detail, :handover_in_8_days, conditionalReleaseDate: Time.zone.today + 23.days + 8.months))
@@ -48,7 +48,7 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
       # This offender should come first as they have an earlier handover start date
       let(:prison3) { build(:prison) }
       let(:case_info3) { build(:case_information) }
-      let!(:allocation3) { create(:allocation, prison: prison3.code, nomis_offender_id: case_info3.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+      let!(:allocation3) { create(:allocation, prison: prison3.code, case_information: case_info3, primary_pom_nomis_id: staff_id) }
       let(:offender3) {
         build(:nomis_offender, agencyId: prison3.code, offenderNo: case_info3.nomis_offender_id, firstName: 'Three',
               sentence: attributes_for(:sentence_detail, :handover_in_6_days, conditionalReleaseDate: Time.zone.today + 21.days + 8.months))
@@ -67,7 +67,7 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
       # This offender has an inactive allocation - but still needs to be included
       let(:prison6) { build(:prison) }
       let(:case_info6) { build(:case_information) }
-      let!(:allocation6) { create(:allocation, :release, prison: prison6.code, nomis_offender_id: case_info6.nomis_offender_id) }
+      let!(:allocation6) { create(:allocation, :release, prison: prison6.code, case_information: case_info6) }
       let(:offender6) {
         build(:nomis_offender, agencyId: prison6.code, offenderNo: case_info6.nomis_offender_id, firstName: 'Six',
               sentence: attributes_for(:sentence_detail, :handover_in_3_days, conditionalReleaseDate: Time.zone.today + 18.days + 8.months))
@@ -150,7 +150,7 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
 
       let(:prison1) { build(:prison) }
       let(:case_info1) { build(:case_information, :with_com) }
-      let!(:allocation1) { create(:allocation, prison: prison1.code, nomis_offender_id: case_info1.nomis_offender_id, primary_pom_nomis_id: staff_id) }
+      let!(:allocation1) { create(:allocation, prison: prison1.code, case_information: case_info1, primary_pom_nomis_id: staff_id) }
       let(:offender1) {
         build(:nomis_offender, agencyId: prison1.code, offenderNo: case_info1.nomis_offender_id, firstName: 'One',
               sentence: attributes_for(:sentence_detail, :handover_in_46_days, conditionalReleaseDate: Time.zone.today + 61.days + 8.months))

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MovementsOnDateJob, type: :job do
   let(:nomis_offender_id) { 'G3462VT' }
-  let!(:alloc) { create(:allocation, nomis_offender_id: nomis_offender_id, secondary_pom_nomis_id: 123_435, prison: 'MDI') }
+  let!(:alloc) { create(:allocation, case_information: build(:case_information, nomis_offender_id: nomis_offender_id), secondary_pom_nomis_id: 123_435, prison: 'MDI') }
 
   before do
     stub_auth_token

--- a/spec/jobs/push_pom_to_delius_job_spec.rb
+++ b/spec/jobs/push_pom_to_delius_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PushPomToDeliusJob, type: :job, versioning: true do
   describe 'when a Primary POM is allocated' do
     let!(:allocation) {
       create(:allocation,
-             nomis_offender_id: offender_no,
+             case_information: build(:case_information, nomis_offender_id: offender_no),
              primary_pom_nomis_id: pom.staffId
       )
     }
@@ -36,7 +36,7 @@ RSpec.describe PushPomToDeliusJob, type: :job, versioning: true do
   describe 'when a Primary POM is de-allocated' do
     let!(:allocation) {
       create(:allocation, :transfer,
-             nomis_offender_id: offender_no
+             case_information: build(:case_information, nomis_offender_id: offender_no)
       )
     }
 

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StaffMember, type: :model do
@@ -29,7 +31,7 @@ RSpec.describe StaffMember, type: :model do
     before do
       # # Allocate all of the offenders to this POM
       offenders.each do |offender|
-        create(:allocation, nomis_offender_id: offender.offender_no, primary_pom_nomis_id: staff_id)
+        create(:allocation, case_information: build(:case_information, nomis_offender_id: offender.offender_no), primary_pom_nomis_id: staff_id)
       end
     end
 
@@ -58,7 +60,7 @@ RSpec.describe StaffMember, type: :model do
         create(
           :allocation,
           primary_pom_nomis_id: staff_id,
-          nomis_offender_id: 'G7514GW',
+          case_information: build(:case_information, nomis_offender_id: 'G7514GW'),
           nomis_booking_id: 1_153_753
         )
       end
@@ -69,7 +71,7 @@ RSpec.describe StaffMember, type: :model do
         create(
           :allocation,
           primary_pom_nomis_id: other_staff_id,
-          nomis_offender_id: 'G1234VV',
+          case_information: build(:case_information, nomis_offender_id: 'G1234VV'),
           nomis_booking_id: 971_856
         ).tap { |item|
           item.update!(secondary_pom_nomis_id: staff_id)
@@ -81,7 +83,7 @@ RSpec.describe StaffMember, type: :model do
       create(
         :allocation,
         primary_pom_nomis_id: staff_id,
-        nomis_offender_id: 'G1234AB',
+        case_information: build(:case_information, nomis_offender_id: 'G1234AB'),
         nomis_booking_id: 76_908
       )
     }
@@ -90,7 +92,7 @@ RSpec.describe StaffMember, type: :model do
       create(
         :allocation,
         primary_pom_nomis_id: other_staff_id,
-        nomis_offender_id: 'G1234GG',
+        case_information: build(:case_information, nomis_offender_id: 'G1234GG'),
         nomis_booking_id: 31_777,
         secondary_pom_nomis_id: staff_id
       ).tap { |item|

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe AllocationService do
@@ -10,7 +12,7 @@ describe AllocationService do
     signin_spo_user
   end
 
-  describe '#allocate_secondary', :queueing do
+  describe '#allocate_secondary' do
     let(:moic_test_id) { 485_758 }
     let(:ross_id) { 485_926 }
     let(:primary_pom_id) { ross_id }
@@ -19,7 +21,7 @@ describe AllocationService do
 
     let!(:allocation) {
       create(:allocation,
-             nomis_offender_id: nomis_offender_id,
+             case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
              primary_pom_nomis_id: primary_pom_id,
              primary_pom_name: 'Pom, Moic')
     }
@@ -95,7 +97,7 @@ describe AllocationService do
 
     context 'when one already exists' do
       before do
-        create(:allocation, nomis_offender_id: nomis_offender_id)
+        create(:allocation, case_information: build(:case_information, nomis_offender_id: nomis_offender_id))
       end
 
       it 'can update a record and store a version', vcr: { cassette_name: 'prison_api/allocation_service_update_allocation_spec' } do
@@ -124,13 +126,13 @@ describe AllocationService do
 
       create(
         :allocation,
-        nomis_offender_id: first_offender_id,
+        case_information: build(:case_information, nomis_offender_id: first_offender_id),
         prison: leeds_prison
       )
 
       create(
         :allocation,
-        nomis_offender_id: second_offender_id,
+        case_information: build(:case_information, nomis_offender_id: second_offender_id),
         prison: 'USK'
       )
 
@@ -155,7 +157,7 @@ describe AllocationService do
 
       allocation = create(
         :allocation,
-        nomis_offender_id: nomis_offender_id,
+        case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
         primary_pom_nomis_id: previous_primary_pom_nomis_id)
 
       allocation.update!(
@@ -176,7 +178,7 @@ describe AllocationService do
 
     allocation = create(
       :allocation,
-      nomis_offender_id: nomis_offender_id,
+      case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
       primary_pom_nomis_id: previous_primary_pom_nomis_id)
 
     allocation.update!(
@@ -199,7 +201,7 @@ describe AllocationService do
 
       allocation = create(
         :allocation,
-        nomis_offender_id: nomis_offender_id,
+        case_information: build(:case_information, nomis_offender_id: nomis_offender_id),
         primary_pom_nomis_id: previous_primary_pom_nomis_id)
 
       allocation.update!(

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe MovementService, type: :feature do
@@ -36,7 +38,7 @@ describe MovementService, type: :feature do
     let(:transfer_in) { build(:movement, offenderNo: 'G4273GI', directionCode: 'IN', movementType: 'ADM', fromAgency: 'VEI', toAgency: 'CFI')   }
     let(:admission) { build(:movement, offenderNo: 'G4273GI', toAgency: 'LEI', fromAgency: 'COURT')   }
 
-    let!(:existing_allocation) { create(:allocation, nomis_offender_id: 'G4273GI', prison: 'LEI')   }
+    let!(:existing_allocation) { create(:allocation, case_information: build(:case_information, nomis_offender_id: 'G4273GI'), prison: 'LEI')   }
     let(:existing_alloc_transfer) { build(:movement, offenderNo: 'G4273GI', fromAgency: 'PRI', toAgency: 'LEI')   }
 
     it "can process transfers were offender already allocated at new prison",
@@ -110,7 +112,7 @@ describe MovementService, type: :feature do
 
   describe "processing an offender release" do
     let!(:case_info) { create(:case_information, nomis_offender_id: 'G4273GI') }
-    let!(:allocation) { create(:allocation, nomis_offender_id: 'G4273GI') }
+    let!(:allocation) { create(:allocation, case_information: case_info) }
 
     context 'with a valid release movement' do
       let(:valid_release) { build(:movement, offenderNo: 'G4273GI', directionCode: 'OUT', movementType: 'REL', toAgency: 'OUT', fromAgency: 'BAI')   }
@@ -132,8 +134,9 @@ describe MovementService, type: :feature do
         updated_allocation = Allocation.find_by(nomis_offender_id: valid_release.offender_no)
 
         expect(CaseInformationService.get_case_information([valid_release.offender_no])).to be_empty
-        expect(updated_allocation.event_trigger).to eq 'offender_released'
-        expect(updated_allocation.prison).to eq 'LEI'
+        expect(updated_allocation).to be_nil
+        # expect(updated_allocation.event_trigger).to eq 'offender_released'
+        # expect(updated_allocation.prison).to eq 'LEI'
         expect(processed).to be true
       end
 
@@ -162,7 +165,7 @@ describe MovementService, type: :feature do
 
   describe "processing offenders moved to/from immigration estates" do
     before do
-      create(:allocation, nomis_offender_id: 'G4273GI')
+      create(:allocation, case_information: build(:case_information, nomis_offender_id: 'G4273GI'))
     end
 
     let(:allocation) { Allocation.find_by(nomis_offender_id: 'G4273GI') }
@@ -200,7 +203,7 @@ describe MovementService, type: :feature do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
+            # expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end
@@ -216,7 +219,7 @@ describe MovementService, type: :feature do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
+            # expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end
@@ -247,7 +250,7 @@ describe MovementService, type: :feature do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
+            # expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end
@@ -267,7 +270,7 @@ describe MovementService, type: :feature do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
+            # expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end
@@ -283,7 +286,7 @@ describe MovementService, type: :feature do
             processed = described_class.process_movement(immigration_movement)
 
             expect(CaseInformationService.get_case_information([immigration_movement.offender_no])).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
+            # expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end


### PR DESCRIPTION
This PR starts to create a data model for the service by attaching the Allocation model to the CaseInformation model via a Rails has_one relationship. It is perfectly possible to destroy Allocation records - they show up in the AllocationHistory just fine - although because of the metadata currently recorded on a release, we ignore the PaperTrail::Version record associated with a destroy in favour of our own change record.