### PR TITLE
Add whitespace between tiers in Case Mix bar

### DIFF
--- a/app/assets/stylesheets/case_mix.scss
+++ b/app/assets/stylesheets/case_mix.scss
@@ -30,6 +30,7 @@
 .case-mix-bar {
   display: grid;
   grid-template-columns: var(--columns);
+  column-gap: 1px;
   height: 30px;
   margin: 0;
 


### PR DESCRIPTION
I forgot to do this in #1613 – it's needed for accessibility to make the different tiers easier to differentiate.