### PR TITLE
Fix mimemagic, attempt 2: Use mimemagic 0.3.9

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,19 @@
-# Install the contents of this file
-# with the 'brew bundle' command
+# Brewfile: a Gemfile, but for Homebrew
 #
+# Install the dependencies in this file by running:
+# brew bundle
+#
+# Read more about Brewfiles here:
 # https://thoughtbot.com/blog/brewfile-a-gemfile-but-for-homebrew
-#
+
+# required by Rails Active Record
+brew 'postgres'
+
+# required by gem 'undercover'
 brew 'cmake'
+
+# required by Capybara to drive tests in Firefox
 brew 'geckodriver'
+
+# required by gem 'mimemagic' v0.3.9
+brew 'shared-mime-info'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ the hook should prevent you from committing.
 
 ### Running the application
 
-1. Install Postgres
+1. Install project dependencies using Homebrew
 
 ```sh
-$ brew install postgres
+$ brew bundle
 ```
 
 2. Install gems locally


### PR DESCRIPTION
The workaround in PR #1621 doesn't seem to work correctly in Heroku. As the mimemagic story unfolds, it looks like the approach in this PR is now the preferable fix.

This version of the gem is licenced under MIT, so it's fine for us to continue using.

It depends on a locally installed MIME database rather than it coming bundled with the gem.

This seems to be the approach that other development teams in MOJ are using, so I'm following their lead. See Slack thread here: https://mojdt.slack.com/archives/C7KCVJZSQ/p1616750434063200

### Local development

On local development machines, this means we'll need to install the homebrew package `shared-mime-info`. I've updated the `Brewfile` to include this as a project dependency – so developers will need to run `brew bundle` in their terminal to install it.

### Docker builds

`shared-mime-info` is already included in the `ruby:2.6.6-stretch` image which we build upon, so it's already accessible to the gem. No further action is required for this to work.