### PR TITLE
MO-493: Use the offender category descriptions from the Prison API

### DIFF
--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -228,6 +228,11 @@ module HmppsApi
         criminal_sentence? && convicted?
     end
 
+    def category_label
+      category_list = HmppsApi::PrisonApi::OffenderApi.get_category_labels
+      category_list.fetch(@category_code, 'N/A')
+    end
+
   private
 
     def age

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -89,6 +89,12 @@ module HmppsApi
         data.first['classificationCode']
       end
 
+      def self.get_category_labels
+        route = '/reference-domains/domains/SUP_LVL_TYPE'
+        data = client.get(route, extra_headers: { 'Page-Limit': '1000' })
+        data.map { |c| [c.fetch('code'), c.fetch('description')] }.to_h
+      end
+
       def self.get_bulk_sentence_details(booking_ids)
         return {} if booking_ids.empty?
 

--- a/spec/models/hmpps_api/offender_summary_spec.rb
+++ b/spec/models/hmpps_api/offender_summary_spec.rb
@@ -181,6 +181,27 @@ describe HmppsApi::OffenderSummary do
     end
   end
 
+  describe '#category_label' do
+    context 'with a category code' do
+      let(:offender) { build(:offender, convictedStatus: 'Convicted', sentence: build(:sentence_detail, :unsentenced)) }
+
+      before do
+        stub_auth_token
+        stub_category_label
+      end
+
+      it "can return the men's category description" do
+        subject.category_code = 'A'
+        expect(subject.category_label).to eq 'Cat A'
+      end
+
+      it "can return the women's category description" do
+        subject.category_code = 'T'
+        expect(subject.category_label).to eq 'Fem Open'
+      end
+    end
+  end
+
   describe '#sentenced?' do
     context 'with sentence detail with a release date' do
       before do

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -167,4 +167,18 @@ describe HmppsApi::PrisonApi::OffenderApi do
       expect(bytes[-2, 2]).to eq(jpeg_end_sentinel)
     end
   end
+
+  describe 'Fetching category descriptions' do
+    before do
+      stub_auth_token
+      stub_category_label
+    end
+
+    it 'returns a hash of category codes and descriptions' do
+      response = described_class.get_category_labels
+      expect(response).to be_a(Hash)
+      expect(response['A']).to eq 'Cat A'
+      expect(response['T']).to eq 'Fem Open'
+    end
+  end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -198,4 +198,20 @@ module ApiHelper
     stub_request(:get, "#{COMMUNITY_HOST}/offenders/nomsNumber/#{nomis_offender_id}/registrations").
         to_return(body: { registrations: registrations }.to_json)
   end
+
+  def stub_category_label
+    categories = [
+      { code: 'A', description: 'Cat A' },
+      { code: 'B', description: 'Cat B' },
+      { code: 'C', description: 'Cat C' },
+      { code: 'D', description: 'Cat D' },
+      { code: 'Q', description: 'Fem Restricted' },
+      { code: 'R', description: 'Fem Closed' },
+      { code: 'S', description: 'Fem Semi' },
+      { code: 'T', description: 'Fem Open' }
+    ]
+
+    stub_request(:get, "#{T3}/reference-domains/domains/SUP_LVL_TYPE").
+    to_return(body: categories.to_json)
+  end
 end


### PR DESCRIPTION
This commit retrieves the offender category labels from the Prison API
(cached for an hour by default) which includes the category codes and the label
associated with that code.

We will then be able to use these labels which users are familiar with instead
of holding a separate list which we would be responsible for maintaining which is not
ideal in the event of changes made to the list.