### PR TITLE
Rename and tidy up female prison index spec

### DIFF
--- a/spec/features/female_prison_index_page_feature_spec.rb
+++ b/spec/features/female_prison_index_page_feature_spec.rb
@@ -2,10 +2,9 @@
 
 require "rails_helper"
 
-feature "add missing details page" do
+feature "female prison index page" do
   before do
-    signin_spo_user([prison.code, 'SDI'])
-    stub_signin_spo(pom, [prison.code, 'SDI'])
+    stub_signin_spo(pom, [prison.code])
     stub_offenders_for_prison(prison.code, offenders)
 
     create(:allocation, primary_pom_allocated_at: one_day_ago,  nomis_offender_id: allocated_offender_one.fetch(:offenderNo), prison: prison.code)


### PR DESCRIPTION
There are 2 female specs and their names are confusing - the spec 'add_missing_info' (which this PR changes) does not do the missing info journey. This renamed it to 'female prison indecx page' which better reflects the scenarios under test