### PR TITLE
Reduce Circle:CI parallelism to cope with occasional OOM failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ references:
           PGUSER: ubuntu
           RACK_ENV: test
           VCR: 1
-          PARALLEL_TEST_PROCESSORS: 7
+          PARALLEL_TEST_PROCESSORS: 6
           COMPLEXITY_API_HOST: https://complexity-of-need-staging.hmpps.service.justice.gov.uk
       - image: circleci/postgres:10.5-alpine
         environment:


### PR DESCRIPTION
We have been getting occasional circle failures due to losing one of our child processes and getting coverage failures as a result. This happened before when we were on a small instance, and the choices are to reduce parallelism or increase the size of Docker image in use on circle:ci