### PR TITLE
POM-511 Legacy bugfix

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -36,7 +36,7 @@ class CaseInformationController < PrisonsApplicationController
     @case_info = CaseInformation.create(
       nomis_offender_id: case_information_params[:nomis_offender_id],
       tier: case_information_params[:tier],
-      welsh_offender: case_information_params[:welsh_offender],
+      probation_service: case_information_params[:probation_service],
       case_allocation: case_information_params[:case_allocation],
       manual_entry: true
     )
@@ -88,7 +88,7 @@ private
 
   def case_information_params
     params.require(:case_information).
-      permit(:nomis_offender_id, :tier, :case_allocation, :welsh_offender,
+      permit(:nomis_offender_id, :tier, :case_allocation, :probation_service,
              :parole_review_date_dd, :parole_review_date_mm, :parole_review_date_yyyy)
   end
 

--- a/app/controllers/female_missing_infos_controller.rb
+++ b/app/controllers/female_missing_infos_controller.rb
@@ -85,7 +85,7 @@ private
     if step == :complexity_level
       params.fetch(:complexity_form, {}).permit(:complexity_level)
     else
-      params.fetch(:case_information, {}).permit(:case_allocation, :welsh_offender, :tier)
+      params.fetch(:case_information, {}).permit(:case_allocation, :probation_service, :tier)
     end
   end
 end

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -61,7 +61,7 @@ private
         team: team,
         team_name: team&.name,
         case_allocation: delius_record.service_provider,
-        welsh_offender: map_welsh_offender(delius_record.ldu_code),
+        probation_service: map_probation_service(delius_record.ldu_code),
         mappa_level: map_mappa_level(delius_record.mappa_levels)
       )
     end
@@ -88,8 +88,8 @@ private
     delius_mappa_levels.empty? ? 0 : delius_mappa_levels.max
   end
 
-  def map_welsh_offender(ldu_code)
-    LocalDivisionalUnit.find_by(code: ldu_code)&.in_wales? ? 'Yes' : 'No'
+  def map_probation_service(ldu_code)
+    LocalDivisionalUnit.find_by(code: ldu_code)&.in_wales? ? 'Wales' : 'England'
   end
 
   def map_tier(tier)

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -45,7 +45,7 @@ class CaseInformation < ApplicationRecord
            inverse_of: :case_information,
            dependent: :destroy
 
-  before_validation :set_probation_service
+  before_validation :set_welsh_offender
 
   def nps?
     case_allocation == NPS
@@ -65,11 +65,6 @@ class CaseInformation < ApplicationRecord
 
   validates :team, presence: true, unless: -> { manual_entry || local_delivery_unit.present? }
 
-  validates :welsh_offender, inclusion: {
-    in: %w[Yes No],
-    allow_nil: false,
-    message: 'Select yes if the prisoner’s last known address was in Wales'
-  }
   # Don't think this is as simple as allowing nil. In the specific case of Scot/NI
   # prisoners it makes sense to have N/A (as this is genuine) but not otherwise
   validates :tier, inclusion: { in: %w[A B C D N/A], message: 'Select the prisoner’s tier' }
@@ -86,13 +81,13 @@ class CaseInformation < ApplicationRecord
 
   validates :probation_service, inclusion: {
     in: ['Wales', 'England'],
-    allow_nil: false
+    allow_nil: false,
+    message: 'Select yes if the prisoner’s last known address was in Wales'
   }
 
 private
 
-  def set_probation_service
-    self.probation_service = 'England' if welsh_offender == 'No'
-    self.probation_service = 'Wales' if welsh_offender == 'Yes'
+  def set_welsh_offender
+    self.welsh_offender = (probation_service == 'Wales') ? 'Yes' : 'No'
   end
 end

--- a/app/models/hmpps_api/offender_base.rb
+++ b/app/models/hmpps_api/offender_base.rb
@@ -69,7 +69,7 @@ module HmppsApi
     def welsh_offender
       return nil if @case_information.blank?
 
-      @case_information.welsh_offender == 'Yes'
+      @case_information.probation_service == 'Wales'
     end
 
     def ldu_name

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -1,94 +1,42 @@
-
-<%= form_tag(action, method: method, id: "case_info_form") do %>
-    <%= hidden_field_tag("case_information[nomis_offender_id]", @prisoner.offender_no) %>
+<%= form_for(@case_info,
+             url: action,
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+             method: method) do |form| %>
+  <%= form.govuk_error_summary %>
+    <%= form.hidden_field(:nomis_offender_id) %>
     <%= hidden_field_tag("sort", params[:sort])%>
     <%= hidden_field_tag("page", params[:page]) %>
 
-    <div class="govuk-form-group <% if @case_info.errors[:welsh_offender].present? %>govuk-form-group--error<% end %>">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-2">
-          Was this prisoner's last known address in Wales?
-        </legend>
+    <%= form.govuk_collection_radio_buttons(
+          :probation_service,
+          [OpenStruct.new(name: 'Yes', value: 'Wales'), OpenStruct.new(name: 'No', value: 'England')],
+          :value,
+          :name,
+          legend: { text: "Was this prisoner's last known address in Wales?" }
+      ) %>
 
-        <% if @case_info.errors[:welsh_offender].present? %>
-          <span class="govuk-error-message">
-            <%= @case_info.errors[:welsh_offender].first %>
-          </span>
-        <% end %>
+  <%= form.govuk_collection_radio_buttons(
+          :case_allocation,
+          [OpenStruct.new(name: 'National Probation Service (NPS)', value: 'NPS'),
+           OpenStruct.new(name: 'Community Rehabilitation Company (CRC)', value: 'CRC')],
+          :value,
+          :name,
+          legend: { text: "Who is the service provider for this case?" }
+      ) %>
 
-        <div class="govuk-radios">
-          <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[welsh_offender]", 'Yes', @case_info.welsh_offender == 'Yes', class: "govuk-radios__input") %>
-            <%= label_tag "case_information_welsh_offender_Yes", 'Yes', class: "govuk-label govuk-radios__label" %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[welsh_offender]", 'No', @case_info.welsh_offender == 'No', class: "govuk-radios__input") %>
-            <%= label_tag "case_information_welsh_offender_No", "No", class: "govuk-label govuk-radios__label" %>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
-    <div class="govuk-!-margin-top-8 govuk-form-group <% if @case_info.errors[:case_allocation].present? %>govuk-form-group--error<% end %>">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend--s govuk-!-margin-bottom-4">
-            Who is the service provider for this case?
-        </legend>
-        <% if @case_info.errors[:case_allocation].present? %>
-          <span class="govuk-error-message">
-            <%= @case_info.errors[:case_allocation].first %>
-          </span>
-        <% end %>
-
-        <div class="govuk-radios">
-          <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[case_allocation]", "NPS", @case_info.case_allocation == 'NPS', class: "govuk-radios__input") %>
-            <%= label_tag "case_information_case_allocation_NPS", "National Probation Service (NPS)", class: "govuk-label govuk-radios__label" %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= radio_button_tag("case_information[case_allocation]", "CRC", @case_info.case_allocation == 'CRC', class: "govuk-radios__input") %>
-            <%= label_tag "case_information_case_allocation_CRC", "Community Rehabilitation Company (CRC)", class: "govuk-label govuk-radios__label" %>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
-  <div class="govuk-!-margin-top-8 govuk-form-group <% if @case_info.errors[:tier].present? %>govuk-form-group--error<% end %>">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend--s  govuk-!-margin-bottom-4">
-        What tier has the prisoner been assigned to?
-      </legend>
-
-      <% if @case_info.errors[:tier].present? %>
-        <span class="govuk-error-message">
-          <%= @case_info.errors[:tier].first %>
-        </span>
-      <% end %>
-
-      <div class="govuk-radios">
-        <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "A", @case_info[:tier] == 'A', class: "govuk-radios__input") %>
-          <%= label_tag "case_information_tier_A", "A", class: "govuk-label govuk-radios__label" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "B", @case_info[:tier] == 'B', class: "govuk-radios__input") %>
-          <%= label_tag "case_information_tier_B", "B", class: "govuk-label govuk-radios__label" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "C", @case_info[:tier] == 'C', class: "govuk-radios__input") %>
-          <%= label_tag "case_information_tier_C", "C", class: "govuk-label govuk-radios__label" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= radio_button_tag("case_information[tier]", "D", @case_info[:tier] == 'D', class: "govuk-radios__input") %>
-          <%= label_tag "case_information_tier_D", "D", class: "govuk-label govuk-radios__label" %>
-        </div>
-      </div>
-    </fieldset>
-  </div>
+  <%= form.govuk_collection_radio_buttons(
+          :tier,
+          [OpenStruct.new(name: 'A', value: 'A'),
+           OpenStruct.new(name: 'B', value: 'B'),
+           OpenStruct.new(name: 'C', value: 'C'),
+           OpenStruct.new(name: 'D', value: 'D')],
+          :value,
+          :name,
+          legend: { text: "What tier has the prisoner been assigned to?" }
+      ) %>
 
   <% buttons.each do  |button| %>
-    <%= submit_tag button.fetch(:text), role: "button", draggable: "false", class: "govuk-button govuk-!-margin-top-4 #{button.fetch(:class)}" %>
-
+    <%= form.submit button.fetch(:text), role: "button", draggable: "false", class: "govuk-button govuk-!-margin-top-4 #{button.fetch(:class)}" %>
   <% end %>
 
 <% end %>

--- a/app/views/case_information/edit.html.erb
+++ b/app/views/case_information/edit.html.erb
@@ -1,9 +1,5 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
-<% if @case_info.errors.count > 0 %>
-  <%= render :partial => "/shared/validation_errors", :locals => { :errors => @case_info.errors } %>
-<% end %>
-
 <h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Case information</h1>
 <h2 class="govuk-heading-m"><%= @prisoner.full_name %> - <%= @prisoner.offender_no %></h2>
 <p class="govuk-!-margin-bottom-8">You can find this information in NDelius.</p>

--- a/app/views/female_missing_infos/_delius_information_form.html.erb
+++ b/app/views/female_missing_infos/_delius_information_form.html.erb
@@ -7,10 +7,10 @@
   <%= form.govuk_error_summary %>
 
   <%= form.govuk_collection_radio_buttons(
-          :welsh_offender,
-          [OpenStruct.new(name: 'Yes'),
-           OpenStruct.new(name: 'No')],
-          :name,
+          :probation_service,
+          [OpenStruct.new(value: 'Wales', name: 'Yes'),
+           OpenStruct.new(value: 'England', name: 'No')],
+          :value,
           :name,
           legend: { text: "Was this prisoner's last known address in Wales?" }
       )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -103,19 +103,19 @@ team3 = Team.find_or_create_by!(
 # responsibility override workflow
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G7658UL') do |info|
-    info.tier = 'A'
-    info.case_allocation = 'NPS'
-    info.welsh_offender = 'Yes'
-    info.manual_entry =  true
-    info.team_id = team1.id
+  info.tier = 'A'
+  info.case_allocation = 'NPS'
+  info.manual_entry =  true
+  info.team_id = team1.id
+  info.probation_service = "Wales"
 end
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G7517GF') do |info|
   info.tier = 'B'
-    info.case_allocation = 'NPS'
-    info.welsh_offender = 'Yes'
-    info.manual_entry = true
-    info.team_id = team2.id
+  info.case_allocation = 'NPS'
+  info.manual_entry = true
+  info.team_id = team2.id
+  info.probation_service = "Wales"
 end
 
 # 3 Test offenders which have handovers in Dec 2020
@@ -123,7 +123,7 @@ end
   CaseInformation.find_or_create_by!(nomis_offender_id: offender_no) do |info|
     info.assign_attributes(tier: 'B',
                            case_allocation:'CRC',
-                           welsh_offender: 'Yes',
+                           probation_service: 'Wales',
                            manual_entry: true,
                            team: team2)
   end
@@ -134,7 +134,7 @@ end
   CaseInformation.find_or_create_by!(nomis_offender_id: offender_no) do |info|
     info.assign_attributes(tier: 'B',
                            case_allocation:'NPS',
-                           welsh_offender: 'Yes',
+                           probation_service: 'Wales',
                            manual_entry: true,
                            team: team2)
   end
@@ -144,7 +144,7 @@ end
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G7281UH') do |info|
   info.assign_attributes(tier: 'B',
                          case_allocation:'NPS',
-                         welsh_offender: 'Yes',
+                         probation_service: 'Wales',
                          manual_entry: true,
                          team: team2)
 end
@@ -152,15 +152,15 @@ end
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G3536UF') do |info|
   info.tier = 'A'
   info.case_allocation = 'NPS'
-  info.welsh_offender = 'No'
   info.manual_entry = true
   info.team_id = team2.id
+  info.probation_service = "England"
 end
 
 CaseInformation.find_or_create_by!(nomis_offender_id: 'G2260UO') do |info|
   info.tier = 'B'
   info.case_allocation = 'NPS'
-  info.welsh_offender = 'No'
   info.manual_entry = true
   info.team_id = team3.id
+  info.probation_service = "England"
 end

--- a/lib/onboard_prison.rb
+++ b/lib/onboard_prison.rb
@@ -22,14 +22,13 @@ class OnboardPrison
       end
 
       # Create a CaseInformation .....
-      CaseInformation.find_or_create_by(
-        nomis_offender_id: offender_id,
-        welsh_offender: record[:welsh_offender] ? 'Yes' : 'No',
-        tier: record[:tier],
-        case_allocation: record[:provider_cd],
-        crn: record[:crn],
-        manual_entry: true
-      )
+      CaseInformation.find_or_create_by(nomis_offender_id: offender_id) do |ci|
+        ci.tier = record[:tier]
+        ci.case_allocation = record[:provider_cd]
+        ci.crn = record[:crn]
+        ci.probation_service = record[:welsh_offender] ? 'England' : 'Wales'
+        ci.manual_entry = true
+      end
 
       @additions += 1
     }

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -6,10 +6,6 @@ FactoryBot.define do
       'A'
     end
 
-    welsh_offender do
-      'Yes'
-    end
-
     case_allocation do
       CaseInformation::NPS
     end
@@ -30,12 +26,14 @@ FactoryBot.define do
 
     crn { Faker::Alphanumeric.alpha(number: 10) }
 
+    probation_service { 'Wales' }
+
     trait :welsh do
-      welsh_offender { 'Yes' }
+      probation_service { 'Wales' }
     end
 
     trait :english do
-      welsh_offender { 'No' }
+      probation_service { 'England' }
     end
 
     trait :nps do

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -16,7 +16,7 @@ feature 'Allocation' do
   }
 
   let!(:case_information) {
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'No')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', probation_service: 'England')
     create(:case_information, nomis_offender_id: never_allocated_offender)
   }
 

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -18,9 +18,9 @@ feature 'case information feature' do
     context 'when add missing information the first time (create journey)' do
       before do
         visit new_prison_case_information_path(prison.code, offender.fetch(:offenderNo))
-        find('label[for=case_information_welsh_offender_No]').click
-        find('label[for=case_information_case_allocation_NPS]').click
-        find('label[for=case_information_tier_A]').click
+        find('label[for=case-information-probation-service-england-field]').click
+        find('label[for=case-information-case-allocation-nps-field]').click
+        find('label[for=case-information-tier-a-field]').click
       end
 
       it 'allows spo to save case information and then returns to add missing info page' do
@@ -65,9 +65,9 @@ feature 'case information feature' do
         click_link 'Edit'
       end
 
-      find('label[for=case_information_welsh_offender_No]').click
-      find('label[for=case_information_case_allocation_NPS]').click
-      find('label[for=case_information_tier_A]').click
+      find('label[for=case-information-probation-service-england-field]').click
+      find('label[for=case-information-case-allocation-nps-field]').click
+      find('label[for=case-information-tier-a-field]').click
       click_button 'Save'
 
       expect(CaseInformation.count).to eq(1)
@@ -97,7 +97,7 @@ feature 'case information feature' do
       visit new_prison_case_information_path('LEI', nomis_offender_id)
       expect(page).to have_current_path new_prison_case_information_path('LEI', nomis_offender_id)
 
-      find('label[for=case_information_tier_A]').click
+      find('label[for=case-information-tier-a-field]').click
       click_button 'Save'
 
       expect(CaseInformation.count).to eq(0)
@@ -125,7 +125,7 @@ feature 'case information feature' do
       visit new_prison_case_information_path('LEI', nomis_offender_id)
       expect(page).to have_current_path new_prison_case_information_path('LEI', nomis_offender_id)
 
-      find('label[for=case_information_case_allocation_NPS]').click
+      find('label[for=case-information-case-allocation-nps-field]').click
       click_button 'Save'
 
       expect(CaseInformation.count).to eq(0)
@@ -136,17 +136,17 @@ feature 'case information feature' do
       nomis_offender_id = 'G1821VA'
 
       visit new_prison_case_information_path('LEI', nomis_offender_id)
-      find('label[for=case_information_welsh_offender_No]').click
-      find('label[for=case_information_case_allocation_NPS]').click
-      find('label[for=case_information_tier_A]').click
+      find('label[for=case-information-probation-service-england-field]').click
+      find('label[for=case-information-case-allocation-nps-field]').click
+      find('label[for=case-information-tier-a-field]').click
       click_button 'Save'
 
       visit edit_prison_case_information_path('LEI', nomis_offender_id)
 
       expect(page).to have_content('Case information')
       expect(page).to have_content('G1821VA')
-      find('label[for=case_information_welsh_offender_No]').click
-      find('label[for=case_information_case_allocation_CRC]').click
+      find('label[for=case-information-probation-service-england-field]').click
+      find('label[for=case-information-case-allocation-crc-field]').click
       click_button 'Update'
 
       expect(CaseInformation.count).to eq(1)
@@ -167,9 +167,9 @@ feature 'case information feature' do
       end
       expect(page).to have_selector('h1', text: 'Case information')
 
-      find('label[for=case_information_welsh_offender_No]').click
-      find('label[for=case_information_case_allocation_NPS]').click
-      find('label[for=case_information_tier_A]').click
+      find('label[for=case-information-probation-service-england-field]').click
+      find('label[for=case-information-case-allocation-nps-field]').click
+      find('label[for=case-information-tier-a-field]').click
       click_button 'Save'
 
       expect(current_url).to have_content(missing_information_prison_prisoners_path('LEI') + "?page=3&sort=last_name+desc")

--- a/spec/features/female_missing_info_feature_spec.rb
+++ b/spec/features/female_missing_info_feature_spec.rb
@@ -51,12 +51,10 @@ feature "womens missing info journey" do
                 "Select yes if the prisoner’s last known address was in Wales",
                 "Select the prisoner’s tier",
                 "Select the service provider for this case",
-                # Yes this is a defect - we validate both Probation Service and Welshness
-                "is not included in the list"
               ])
         end
 
-        find('label[for=case-information-welsh-offender-no-field]').click
+        find('label[for=case-information-probation-service-england-field]').click
         click_button 'Update'
         # defect goes away once we fill in welshness correctly
         within '.govuk-error-summary' do
@@ -114,7 +112,7 @@ feature "womens missing info journey" do
       visit missing_information_prison_prisoners_path prison.code
       click_link 'Add missing details'
 
-      find('label[for=case-information-welsh-offender-no-field]').click
+      find('label[for=case-information-probation-service-england-field]').click
       find('label[for=case-information-case-allocation-nps-field]').click
       find('label[for=case-information-tier-a-field]').click
       click_button 'Update'

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -94,7 +94,7 @@ feature "view POM's caseload" do
       create(:case_information, nomis_offender_id: nomis_offender_id)
       create(:allocation, prison: prison.code, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
     end
-    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', welsh_offender: 'Yes')
+    create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'A', case_allocation: 'NPS', probation_service: 'Wales')
     create(:allocation, prison: prison.code, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: nomis_staff_id)
 
     offenders.last(15).each do |o|

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -142,7 +142,7 @@ context 'when NOMIS is missing information' do
           :case_information,
           nomis_offender_id: offender_no,
           case_allocation: 'NPS',
-          welsh_offender: welsh
+          probation_service: welsh == 'Yes' ? 'Wales' : 'England'
         )
       end
 

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -36,11 +36,10 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
           described_class.perform_now nomis_offender_id
         }.to change(CaseInformation, :count).by(1)
 
-        expect(case_info.attributes.symbolize_keys.except(:created_at, :id, :updated_at, :parole_review_date))
+        expect(case_info.attributes.symbolize_keys.except(:created_at, :id, :updated_at, :parole_review_date, :welsh_offender))
             .to eq(case_allocation: "NPS", crn: "X362207", manual_entry: false, mappa_level: 0,
                    nomis_offender_id: "G4281GV",
                    probation_service: "England",
-                   welsh_offender: 'No',
                    local_delivery_unit_id: nil,
                    team_id: team.id,
                    team_name: team.name,
@@ -138,7 +137,7 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
       end
     end
 
-    describe '#welsh_offender' do
+    describe '#probation_service' do
       before do
         stub_offender(build(:nomis_offender, offenderNo: nomis_offender_id))
         stub_community_offender(nomis_offender_id, build(:community_data, offenderManagers: [build(:community_offender_manager, team: { code: team.code, localDeliveryUnit: { code: ldu.code } })]))
@@ -149,7 +148,7 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
 
         it 'maps to false' do
           described_class.perform_now(nomis_offender_id)
-          expect(case_info.welsh_offender).to eq('No')
+          expect(case_info.probation_service).to eq('England')
         end
       end
 
@@ -158,7 +157,7 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
 
         it 'maps to true' do
           described_class.perform_now(nomis_offender_id)
-          expect(case_info.welsh_offender).to eq('Yes')
+          expect(case_info.probation_service).to eq('Wales')
         end
       end
     end

--- a/spec/lib/onboard_prison_spec.rb
+++ b/spec/lib/onboard_prison_spec.rb
@@ -17,13 +17,13 @@ describe OnboardPrison do
              nomis_offender_id: 'G5054VN',
              tier: 'A',
              case_allocation: 'NPS',
-             welsh_offender: 'Yes'
+             probation_service: 'Wales'
       )
       create(:case_information,
              nomis_offender_id: 'G9468UN',
              tier: 'C',
              case_allocation: 'CRC',
-             welsh_offender: 'Yes'
+             probation_service: 'Wales'
       )
 
       op = described_class.new('PVI', offender_ids, nil)

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -104,4 +104,23 @@ RSpec.describe CaseInformation, type: :model do
       expect(build(:case_information, manual_entry: nil)).not_to be_valid
     end
   end
+
+  context 'when probation service' do
+    subject {
+      build(:case_information, probation_service: nil)
+    }
+
+    it 'gives the correct validation error message' do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages).
+        to eq(probation_service: ["Select yes if the prisoner’s last known address was in Wales"])
+    end
+
+    it 'allows England, Wales' do
+      ['England', 'Wales'].each do |service|
+        subject.probation_service = service
+        expect(subject).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -277,14 +277,14 @@ describe HmppsApi::Offender do
       describe '#welsh_offender' do
         let(:field) { :welsh_offender }
 
-        context 'when the welsh_offender field is "Yes"' do
-          let(:case_info) { create(:case_information, welsh_offender: 'Yes') }
+        context 'with a welsh_offender' do
+          let(:case_info) { create(:case_information, probation_service: 'Wales') }
 
           it { is_expected.to be(true) }
         end
 
-        context 'when the welsh_offender field is "No"' do
-          let(:case_info) { create(:case_information, welsh_offender: 'No') }
+        context 'with and english offender' do
+          let(:case_info) { create(:case_information, probation_service: 'England') }
 
           it { is_expected.to be(false) }
         end

--- a/spec/services/case_information_service_spec.rb
+++ b/spec/services/case_information_service_spec.rb
@@ -6,7 +6,7 @@ describe CaseInformationService do
            nomis_offender_id: 'X1000XX',
            tier: 'A',
            case_allocation: 'NPS',
-           welsh_offender: 'Yes'
+           probation_service: 'Wales'
     )
   }
 

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -54,7 +54,7 @@ describe HandoverDateService do
     }
 
     context 'when NPS' do
-      let(:case_info) { build(:case_information, :nps, welsh_offender: welsh? ? 'Yes' : 'No') }
+      let(:case_info) { build(:case_information, :nps, probation_service: welsh? ? 'Wales' : 'England') }
 
       it 'handover starts 7.5 months before CRD/ARD' do
         expect(start_date).to eq(crd - (7.months + 15.days))
@@ -276,7 +276,7 @@ describe HandoverDateService do
     end
 
     context 'when CRC' do
-      let(:case_info) { build(:case_information, :crc, welsh_offender: welsh? ? 'Yes' : 'No') }
+      let(:case_info) { build(:case_information, :crc, probation_service: welsh? ? 'Wales' : 'England') }
 
       it 'handover starts 12 weeks before CRD/ARD' do
         expect(start_date).to eq(crd - 12.weeks)
@@ -386,7 +386,7 @@ describe HandoverDateService do
   context 'when indeterminate' do
     context 'with tariff date in the future' do
       let(:tariff_date) { Date.parse('01/09/2022') }
-      let(:case_info) { build(:case_information, :nps, welsh_offender: welsh? ? 'Yes' : 'No') }
+      let(:case_info) { build(:case_information, :nps, probation_service: welsh? ? 'Wales' : 'England') }
       let(:offender) {
         build(:offender, :indeterminate,
               latestLocationId: prison,

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -5,7 +5,7 @@ describe OffenderService, type: :feature do
     it "gets a single offender", vcr: { cassette_name: 'prison_api/offender_service_single_offender_spec' } do
       nomis_offender_id = 'G4273GI'
 
-      create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', welsh_offender: 'Yes')
+      create(:case_information, nomis_offender_id: nomis_offender_id, tier: 'C', case_allocation: 'CRC', probation_service: 'Wales')
       offender = described_class.get_offender(nomis_offender_id)
 
       expect(offender).to be_kind_of(HmppsApi::OffenderBase)


### PR DESCRIPTION
- make probation_service the primary field in case_information, so that welsh_offender Yes/No can be removed.

This fixes a bug in the new (and old) data flow - we were validating both probation service and welsh_offender, despite one being derived from the other. When welsh offender was missing, it complained about both fields being unset