### PR TITLE
MO-560 -Change complexity level | Change copy and link to guidance PDF

### DIFF
--- a/app/views/female_missing_infos/_complexity_level_form.html.erb
+++ b/app/views/female_missing_infos/_complexity_level_form.html.erb
@@ -1,11 +1,11 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Add complexity level</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Add complexity of need level</h1>
 
 <p class="govuk-body">
   This information can be found within 'NOMIS MIS reporting'. In the folder '085 - OASys & BCS' click on 'Female Complexity Report'.
 </p>
 <p class="govuk-body">
   If the individual is not listed in the report you will need to complete a manual assessment.
-  See EQUIP guidance on how to manually reassess a person's complexity of need.
+  See guidance on <%= link_to "how to manually assess a person's complexity of need",asset_path("docs/complexity-of-need/assessment-guidance.pdf", skip_pipeline: true), target: "_blank"%>. Download the manual <%= link_to "assessment form",  asset_path("docs/complexity-of-need/assessment-template.pdf",  skip_pipeline: true), target: "_blank"%>.
 </p>
 
 <%= form_for(@missing_info,

--- a/app/views/shared/_prisoner_info_sidebar.html.erb
+++ b/app/views/shared/_prisoner_info_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-one-third">
   <aside class="sidebar-panel" role="complementary">
     <nav role="navigation" aria-labelledby="subsection-title">
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--m">
       <h2 class="govuk-heading-m" id="subsection-title">
         Prisoner information
       </h2>


### PR DESCRIPTION
 This PR changes some of the content for the 'Add complexity of need level' form. It also adds down load links for 'Complexity of need assessment manual' and 'Manual assessment guidance'
 
Part of this ticket was also to make the same changes to the update journey. However the code that needed changing is still in the branch MO-434 
 [MO-434](https://github.com/ministryofjustice/offender-management-allocation-manager/pull/1624)