### PR TITLE
MO-433  - prisoner details were missing from main women's allocation screen

### DIFF
--- a/app/views/female_allocations/index.html.erb
+++ b/app/views/female_allocations/index.html.erb
@@ -6,6 +6,17 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Allocate a POM</h1>
 
+<%= render 'shared/basic_prisoner_info', case_info: @case_info, prisoner: @prisoner %>
+
+<%= render partial: 'shared/offence_info', locals: { editable_prd: true }  %>
+
+<%= render 'allocations/case_information' %>
+
+<%= render 'prisoners/community_information' %>
+<%= render 'shared/vlo_information' %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--invisible" />
+
 <div class="govuk-inset-text">
   For this case we recommend that you allocate a <b><%= recommended_pom_type_label(@prisoner) %> POM</b>.<br/>
   This takes into account <%= @prisoner.first_name %> <%= @prisoner.last_name %>'s current tier and time left to serve.

--- a/spec/views/female_allocations/index.html.erb_spec.rb
+++ b/spec/views/female_allocations/index.html.erb_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe "female_allocations/index", type: :view do
 
     assign(:prison, prison)
     assign(:previous_poms, poms.map { |p| StaffMember.new(prison, p.staff_id) })
-    assign(:prisoner, build(:offender))
+    assign(:prisoner, offender)
+    assign(:case_info, case_info)
     assign(:probation_poms, poms.map { |p| StaffMember.new(prison, p.staff_id) })
     assign(:prison_poms, [])
     render
   end
 
+  let(:case_info) { build(:case_information) }
+  let(:offender) { build(:offender, offenderNo: case_info.nomis_offender_id).tap { |o| o.load_case_information(case_info) } }
   let(:prison) { build(:prison) }
   let(:pom) { build(:pom) }
   let(:page) { Nokogiri::HTML(rendered) }


### PR DESCRIPTION
add existing tables to the front of the female allocation selection page.

Better version coming during design sprint