### PR TITLE
MO-411: Transform complexity values on CSV import

### DIFF
--- a/lib/complexity_importer.rb
+++ b/lib/complexity_importer.rb
@@ -10,7 +10,9 @@ class ComplexityImporter
     def import(stream)
       CSV.new(stream, headers: true).each do |row|
         offender_no = row.fetch(NOMS_HEADER)
-        complexity = row.fetch(COMPLEXITY_HEADER)
+        complexity = row.fetch(COMPLEXITY_HEADER).downcase
+
+        next if complexity == 'unassessed' # skip these rows
 
         HmppsApi::ComplexityApi.save offender_no, level: complexity, reason: nil, username: nil
       end

--- a/lib/tasks/import_complexity.rake
+++ b/lib/tasks/import_complexity.rake
@@ -6,16 +6,18 @@ require 'complexity_importer'
 namespace :complexity do
   desc 'import complexity records from CSV file'
   task :import, [:filename] => [:environment] do |_task, args|
-    if defined?(Rails) && Rails.env.development?
-      Rails.logger = Logger.new(STDOUT)
-    end
+    Rails.logger = Logger.new(STDOUT)
 
     if args[:filename].blank?
       Rails.logger.error('No CSV file specified') if args[:filename].blank?
     else
+      Rails.logger.info('Beginning import')
+
       File.open args[:filename] do |f|
         ComplexityImporter.import f
       end
+
+      Rails.logger.info('Import complete')
     end
   end
 end


### PR DESCRIPTION
The complexity values that we're expecting to import via CSV need to be transformed to match what the Complexity of Need API expects.

```
"High" => "high"
"Medium" => "medium"
"Low" => "low"
"Unassigned" => ignore
```