### PR TITLE
MO-64 Part 1. Refactor tests to support sending email when less than 10 months left to serve

### DIFF
--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -39,6 +39,12 @@ class CaseInformation < ApplicationRecord
           inverse_of: :case_information,
           dependent: :destroy
 
+  has_many :email_histories,
+           foreign_key: :nomis_offender_id,
+           primary_key: :nomis_offender_id,
+           inverse_of: :case_information,
+           dependent: :destroy
+
   before_validation :set_probation_service
 
   def nps?

--- a/app/models/email_history.rb
+++ b/app/models/email_history.rb
@@ -6,7 +6,13 @@ class EmailHistory < ApplicationRecord
   SUITABLE_FOR_EARLY_ALLOCATION = 'suitable_for_early_allocation'
   OPEN_PRISON_COMMUNITY_ALLOCATION = 'open_prison_community_allocation'
 
-  validates_presence_of :name, :nomis_offender_id
+  belongs_to :case_information,
+             primary_key: :nomis_offender_id,
+             foreign_key: :nomis_offender_id,
+             inverse_of: :email_histories
+
+  # name is the name of the person/LDU being emailed
+  validates_presence_of :name
 
   validates :event, inclusion: { in: [AUTO_EARLY_ALLOCATION,
                                       DISCRETIONARY_EARLY_ALLOCATION,

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -288,27 +288,7 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
 
     shared_examples 'recalculate handover dates' do
       it "recalculates the offender's handover dates, using the new Case Information data" do
-        expect(CalculatedHandoverDate).to receive(:recalculate_for) do |received_offender|
-          expect(received_offender).to be_an_instance_of(HmppsApi::Offender)
-
-          expected_fields = {
-            crn: crn,
-            tier: 'C',
-            case_allocation: 'NPS',
-            welsh_offender: false,
-            mappa_level: 0
-          }
-
-          received_fields = {
-            crn: received_offender.crn,
-            tier: received_offender.tier,
-            case_allocation: received_offender.case_allocation,
-            welsh_offender: received_offender.welsh_offender,
-            mappa_level: received_offender.mappa_level
-          }
-
-          expect(received_fields).to eq(expected_fields)
-        end
+        expect(RecalculateHandoverDateJob).to receive(:perform_later).with(offender_no)
         described_class.perform_now offender_no
       end
     end
@@ -326,7 +306,7 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
 
       it 'does not re-calculate if CaseInformation is unchanged' do
         described_class.perform_now offender_no
-        expect(CalculatedHandoverDate).not_to receive(:recalculate_for)
+        expect(RecalculateHandoverDateJob).not_to receive(:perform_later)
         described_class.perform_now offender_no
       end
     end

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -17,21 +17,23 @@ RSpec.describe CalculatedHandoverDate, type: :model do
 
   it { is_expected.to belong_to(:case_information) }
 
-  it 'allows nil handover dates' do
-    case_info = create(:case_information)
-    com_responsibility = HandoverDateService::NO_HANDOVER_DATE
+  context 'with nil handover dates' do
+    let(:case_info) {
+      build(:case_information,
+            calculated_handover_date: build(:calculated_handover_date,
+                                            start_date: com_responsibility.start_date,
+                                            handover_date: com_responsibility.handover_date,
+                                            reason: com_responsibility.reason))
+    }
+    let(:com_responsibility) { HandoverDateService::NO_HANDOVER_DATE }
+    let(:record) { case_info.calculated_handover_date }
 
-    record = described_class.create!(
-      nomis_offender_id: case_info.nomis_offender_id,
-      start_date: com_responsibility.start_date,
-      handover_date: com_responsibility.handover_date,
-      reason: com_responsibility.reason
-    )
-
-    record.reload
-    expect(record.start_date).to be_nil
-    expect(record.handover_date).to be_nil
-    expect(record.reason).to eq('COM Responsibility')
+    it 'allows nil handover dates' do
+      expect(record).to be_valid
+      expect(record.start_date).to be_nil
+      expect(record.handover_date).to be_nil
+      expect(record.reason).to eq('COM Responsibility')
+    end
   end
 
   describe "when nomis_offender_id is set but an associated case information record doesn't exist" do
@@ -44,135 +46,6 @@ RSpec.describe CalculatedHandoverDate, type: :model do
 
     it 'is not valid' do
       expect(subject.valid?).to be(false)
-      expect(subject.save).to be(false)
-    end
-  end
-
-  describe '#recalculate_for(offender)' do
-    let(:offender) { build(:offender) }
-    let!(:case_info) { create(:case_information, :nps, nomis_offender_id: offender.offender_no) }
-
-    before { offender.load_case_information(case_info) }
-
-    describe "when calculated handover dates don't exist yet for the offender" do
-      it 'creates a new record' do
-        expect {
-          described_class.recalculate_for(offender)
-        }.to change(described_class, :count).from(0).to(1)
-
-        record = described_class.find_by(nomis_offender_id: offender.offender_no)
-        expect(record.start_date).to eq(offender.handover_start_date)
-        expect(record.handover_date).to eq(offender.responsibility_handover_date)
-        expect(record.reason).to eq(offender.handover_reason)
-      end
-    end
-
-    describe 'when calculated handover dates already exist for the offender' do
-      let!(:existing_record) {
-        create(:calculated_handover_date,
-               case_information: case_info,
-               start_date: existing_start_date,
-               handover_date: existing_handover_date,
-               reason: existing_reason
-        )
-      }
-
-      before do
-        expect(existing_record.start_date).to eq(existing_start_date)
-        expect(existing_record.handover_date).to eq(existing_handover_date)
-        expect(existing_record.reason).to eq(existing_reason)
-      end
-
-      describe 'when the dates have changed' do
-        let(:existing_start_date) { today + 1.week }
-        let(:existing_handover_date) { existing_start_date + 7.months }
-        let(:existing_reason) { 'CRC Case' }
-
-        it 'updates the existing record' do
-          described_class.recalculate_for(offender)
-
-          existing_record.reload
-          expect(existing_record.start_date).to eq(offender.handover_start_date)
-          expect(existing_record.handover_date).to eq(offender.responsibility_handover_date)
-          expect(existing_record.reason).to eq(offender.handover_reason)
-        end
-      end
-
-      describe "when the dates haven't changed" do
-        let(:existing_start_date) { offender.handover_start_date }
-        let(:existing_handover_date) { offender.responsibility_handover_date }
-        let(:existing_reason) { offender.handover_reason }
-
-        it "does nothing" do
-          old_updated_at = existing_record.updated_at
-
-          travel_to(Time.zone.now + 15.minutes) do
-            described_class.recalculate_for(offender)
-          end
-
-          new_updated_at = existing_record.reload.updated_at
-          expect(new_updated_at).to eq(old_updated_at)
-        end
-      end
-    end
-  end
-
-  describe 'after save' do
-    subject {
-      create(:calculated_handover_date,
-             start_date: today + 1.day,
-             handover_date: today + 3.months,
-             reason: 'CRC Case',
-             case_information: case_info
-      )
-    }
-
-    context 'when the associated CaseInformation record was sourced from nDelius' do
-      # manual_entry false means the record came from nDelius
-      let(:case_info) { create(:case_information, manual_entry: false) }
-
-      context 'when the dates have changed' do
-        before do
-          # Change the handover dates
-          subject.assign_attributes(
-            start_date: today + 6.months,
-            handover_date: today + 13.months,
-            reason: 'NPS - MAPPA level unknown'
-          )
-        end
-
-        it 'pushes them to nDelius' do
-          expect(subject.changed?).to be(true)
-          expect(HmppsApi::CommunityApi).to receive(:set_handover_dates).with(
-            offender_no: subject.nomis_offender_id,
-            handover_start_date: subject.start_date,
-            responsibility_handover_date: subject.handover_date
-          )
-          subject.save!
-        end
-      end
-
-      context "when the dates haven't changed" do
-        before do
-          # Change the reason, but not the dates
-          subject.reason = 'NPS - MAPPA level unknown'
-        end
-
-        it "doesn't push to nDelius" do
-          expect(HmppsApi::CommunityApi).not_to receive(:set_handover_dates)
-          subject.save!
-        end
-      end
-    end
-
-    context 'when the associated CaseInformation record was a manual entry' do
-      # manual_entry true means the record did not match against nDelius
-      let(:case_info) { create(:case_information, manual_entry: true) }
-
-      it "doesn't attempt to push to nDelius (to avoid a 404 Not Found error)" do
-        expect(HmppsApi::CommunityApi).not_to receive(:set_handover_dates)
-        subject.save!
-      end
     end
   end
 end

--- a/spec/models/email_history_spec.rb
+++ b/spec/models/email_history_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe EmailHistory, type: :model do
     let(:event) { EmailHistory::OPEN_PRISON_COMMUNITY_ALLOCATION }
     let(:some_other_event) { EmailHistory::AUTO_EARLY_ALLOCATION }
 
+    let(:case_info) { create(:case_information, nomis_offender_id: offender.offender_no) }
+
     # An old email sent before the offender's current sentence
     let!(:old_email) {
       create(:email_history,
-             nomis_offender_id: offender.offender_no,
+             case_information: case_info,
              event: event,
              created_at: 1.year.ago)
     }
@@ -23,7 +25,7 @@ RSpec.describe EmailHistory, type: :model do
     # An email sent within the offender's current sentence
     let!(:recent_email) {
       create(:email_history,
-             nomis_offender_id: offender.offender_no,
+             case_information: case_info,
              event: event,
              created_at: 5.days.ago)
     }
@@ -31,7 +33,7 @@ RSpec.describe EmailHistory, type: :model do
     # A recent email but for a different event
     let!(:recent_email_different_event) {
       create(:email_history,
-             nomis_offender_id: offender.offender_no,
+             case_information: case_info,
              event: some_other_event,
              created_at: 5.days.ago)
     }
@@ -39,7 +41,7 @@ RSpec.describe EmailHistory, type: :model do
     # A recent email sent for a different offender
     let!(:recent_email_different_offender) {
       create(:email_history,
-             nomis_offender_id: some_other_offender.offender_no,
+             case_information: build(:case_information, nomis_offender_id: some_other_offender.offender_no),
              event: event,
              created_at: 5.days.ago)
     }

--- a/spec/services/handover_date_service_old_spec.rb
+++ b/spec/services/handover_date_service_old_spec.rb
@@ -290,18 +290,18 @@ describe HandoverDateService do
       context 'with normal allocation' do
         let(:case_info) { build(:case_information, :nps, mappa_level: mappa_level) }
 
-        let(:tariff_date) { Date.new(2020, 11, 1) }
-        let(:conditional_release_date) { Date.new(2020, 7, 16) }
-        let(:automatic_release_date) { Date.new(2020, 8, 16) }
+        let(:tariff_date) { Date.new(2021, 11, 1) }
+        let(:conditional_release_date) { Date.new(2021, 7, 16) }
+        let(:automatic_release_date) { Date.new(2021, 8, 16) }
 
         context 'with determinate sentence' do
           let(:indeterminate_sentence) { false }
 
           context 'with parole eligibility' do
-            let(:parole_date) { Date.new(2019, 9, 30) }
+            let(:parole_date) { Date.new(2020, 9, 30) }
 
             it 'is 8 months before parole date' do
-              expect(result).to eq(Date.new(2019, 1, 30))
+              expect(result).to eq(Date.new(2020, 1, 30))
             end
           end
 
@@ -311,14 +311,14 @@ describe HandoverDateService do
 
               context 'when crd before ard' do
                 it 'is 4.5 months before CRD' do
-                  expect(result).to eq(Date.new(2020, 3, 1))
+                  expect(result).to eq(Date.new(2021, 3, 1))
                 end
               end
 
               context 'when HDCED is present and earlier than the ARD/CRD calculated date' do
-                let(:home_detention_curfew_eligibility_date) {  Date.new(2020, 6, 16) }
-                let(:automatic_release_date) { Date.new(2020, 11, 10) }
-                let(:conditional_release_date) { Date.new(2020, 12, 5) }
+                let(:home_detention_curfew_eligibility_date) {  Date.new(2021, 6, 16) }
+                let(:automatic_release_date) { Date.new(2021, 11, 10) }
+                let(:conditional_release_date) { Date.new(2021, 12, 5) }
 
                 it 'is set to HDCED' do
                   expect(result).to eq(home_detention_curfew_eligibility_date)
@@ -326,8 +326,8 @@ describe HandoverDateService do
               end
 
               context 'when HDCAD is present' do
-                let(:home_detention_curfew_eligibility_date) { Date.new(2020, 6, 16) }
-                let(:home_detention_curfew_actual_date) { Date.new(2020, 6, 20) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2021, 6, 16) }
+                let(:home_detention_curfew_actual_date) { Date.new(2021, 6, 20) }
 
                 it 'is set to HDCAD' do
                   expect(result).to eq(home_detention_curfew_actual_date)
@@ -340,40 +340,40 @@ describe HandoverDateService do
 
               context 'when crd before ard' do
                 it 'is 4.5 months before CRD' do
-                  expect(result).to eq(Date.new(2020, 3, 1))
+                  expect(result).to eq(Date.new(2021, 3, 1))
                 end
               end
 
               context 'when crd after ard' do
-                let(:conditional_release_date) { Date.new(2020, 8, 17) }
+                let(:conditional_release_date) { Date.new(2021, 8, 17) }
 
                 it 'is 4.5 months before ARD' do
-                  expect(result).to eq(Date.new(2020, 4, 1))
+                  expect(result).to eq(Date.new(2021, 4, 1))
                 end
               end
 
               context 'when HDC date earlier than the CRD/ARD calculated date' do
-                let(:home_detention_curfew_eligibility_date) { Date.new(2020, 2, 28) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2021, 2, 28) }
 
                 it 'is on HDC date' do
-                  expect(result).to eq(Date.new(2020, 2, 28))
+                  expect(result).to eq(Date.new(2021, 2, 28))
                 end
               end
 
               context 'when HDCED date later than date indicated by CRD/ARD' do
-                let(:home_detention_curfew_eligibility_date) { Date.new(2021, 2, 14) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2022, 2, 14) }
 
                 it 'is 4.5 months before CRD' do
-                  expect(result).to eq(Date.new(2020, 3, 1))
+                  expect(result).to eq(Date.new(2021, 3, 1))
                 end
               end
 
               context 'when HDCAD is present' do
-                let(:home_detention_curfew_actual_date) { Date.new(2020, 2, 15) }
-                let(:home_detention_curfew_eligibility_date) { Date.new(2020, 2, 28) }
+                let(:home_detention_curfew_actual_date) { Date.new(2021, 2, 15) }
+                let(:home_detention_curfew_eligibility_date) { Date.new(2021, 2, 28) }
 
                 it 'is on HDCAD date' do
-                  expect(result).to eq(Date.new(2020, 2, 15))
+                  expect(result).to eq(Date.new(2021, 2, 15))
                 end
               end
             end
@@ -382,7 +382,7 @@ describe HandoverDateService do
               let(:mappa_level) { 1 }
 
               it 'is 4.5 months before CRD/ARD date or on HDC date' do
-                expect(result).to eq(Date.new(2020, 3, 1))
+                expect(result).to eq(Date.new(2021, 3, 1))
               end
             end
 

--- a/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
+++ b/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "shared/notifications/offender_needs_a_com", type: :view do
 
   context 'when an email has been sent to the LDU' do
     let(:date_sent) { Time.zone.today }
-    let(:email_history) { [create(:email_history, :open_prison_community_allocation, created_at: date_sent)] }
+    let(:email_history) { [create(:email_history, :open_prison_community_allocation, case_information: case_info, created_at: date_sent)] }
 
     it 'says "You may need to contact the community probation office"' do
       expect(title).to eq(I18n.t('views.notifications.offender_needs_a_com.maybe_contact_ldu'))


### PR DESCRIPTION
This PR refactors some tests to help with MO-64.

The main change is to alter a handover date service test so that it doesn't fall (accidentally) inside the 10 month left to serve window, by moving all the dates up by 1 year.