### PR TITLE
Add defensive nil check to user API call to prevent calling the wrong API

### DIFF
--- a/app/services/hmpps_api/prison_api/user_api.rb
+++ b/app/services/hmpps_api/prison_api/user_api.rb
@@ -6,6 +6,8 @@ module HmppsApi
       extend PrisonApiClient
 
       def self.user_details(username)
+        raise ArgumentError, 'PrisonApiClient#user_details(blank)' if username.blank?
+
         route = "/users/#{username}"
         response = client.get(route)
 


### PR DESCRIPTION
This PR is driven from a Sentry entry whereby for some reason we have a current_user of nil (mostly when entering VLO information) and try to convert that to a user id. This results in us calling the wrong API and generating a 403 as we are not allowed to enumerate all users.

Hopefully this change will help us diagnose the actual problem 