### PR TITLE
MO-64 Part 3 - move push handover to delius out to its own (retriable) job

### DIFF
--- a/app/jobs/push_handover_dates_to_delius_job.rb
+++ b/app/jobs/push_handover_dates_to_delius_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PushHandoverDatesToDeliusJob < ApplicationJob
+  queue_as :default
+
+  def perform record
+    HmppsApi::CommunityApi.set_handover_dates(
+      offender_no: record.nomis_offender_id,
+      handover_start_date: record.start_date,
+      responsibility_handover_date: record.handover_date
+    )
+  end
+end

--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -5,16 +5,34 @@ class RecalculateHandoverDateJob < ApplicationJob
 
   def perform(nomis_offender_id)
     offender = OffenderService.get_offender(nomis_offender_id)
-    return if offender.nil? || offender.sentenced? == false
-
-    begin
+    if offender&.inside_omic_policy?
       # Recalculate handover dates, which will trigger a push to the Community API after_save
-      CalculatedHandoverDate.recalculate_for(offender)
-    rescue Faraday::ClientError # rubocop:disable Lint/SuppressedException
-      # Swallow Community API errors to allow this job to complete successfully.
-      # The calculated handover date will not be saved, and we'll retry again in tomorrow night's cron.
-      # Without this, bad data in nDelius will cause our retry queue to continually grow as fresh jobs
-      # are queued every night alongside old failed jobs continually retrying.
+      recalculate_dates_for(offender)
+    end
+  end
+
+private
+
+  def recalculate_dates_for(offender)
+    # we have to go direct to handover data to avoid being blocked when COM is responsible
+    handover = HandoverDateService.handover(offender)
+    case_info = CaseInformation.find_by!(nomis_offender_id: offender.offender_no)
+    record = case_info.calculated_handover_date.presence || case_info.build_calculated_handover_date
+    record.assign_attributes(
+      start_date: handover.start_date,
+      handover_date: handover.handover_date,
+      reason: handover.reason
+    )
+    record.save! if record.changed?
+    # Don't push if the CaseInformation record is a manual entry (meaning it didn't match against nDelius)
+    # This avoids 404 Not Found errors for offenders who don't exist in nDelius (they could be Scottish, etc.)
+    push_to_delius record unless case_info.manual_entry
+  end
+
+  def push_to_delius record
+    # Don't push if the dates haven't changed
+    if record.saved_change_to_start_date? || record.saved_change_to_handover_date?
+      PushHandoverDatesToDeliusJob.perform_later record
     end
   end
 end

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -8,36 +8,8 @@ class CalculatedHandoverDate < ApplicationRecord
   belongs_to :case_information,
              primary_key: :nomis_offender_id,
              foreign_key: :nomis_offender_id,
-             inverse_of: :responsibility
+             inverse_of: :calculated_handover_date
 
   validates :nomis_offender_id, uniqueness: true, presence: true
   validates :reason, presence: true
-
-  after_save :push_to_delius
-
-  def self.recalculate_for(offender)
-    record = self.find_or_initialize_by(nomis_offender_id: offender.offender_no)
-    record.update!(
-      start_date: offender.handover_start_date,
-      handover_date: offender.responsibility_handover_date,
-      reason: offender.handover_reason
-    )
-  end
-
-private
-
-  def push_to_delius
-    # Don't push if the dates haven't changed
-    return unless saved_change_to_start_date? || saved_change_to_handover_date?
-
-    # Don't push if the CaseInformation record is a manual entry (meaning it didn't match against nDelius)
-    # This avoids 404 Not Found errors for offenders who don't exist in nDelius (they could be Scottish, etc.)
-    return if case_information.manual_entry
-
-    HmppsApi::CommunityApi.set_handover_dates(
-      offender_no: nomis_offender_id,
-      handover_start_date: start_date,
-      responsibility_handover_date: handover_date
-    )
-  end
 end

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -80,45 +80,6 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
     end
   end
 
-  context 'when the Community API returns an error' do
-    let(:nomis_offender) { build(:nomis_offender) }
-    let(:api_host) { Rails.configuration.community_api_host }
-    let(:stub_base_url) { "#{api_host}/secure/offenders/nomsNumber/#{offender_no}/custody/keyDates" }
-    let(:start_date_url) { "#{stub_base_url}/#{HmppsApi::CommunityApi::KeyDate::HANDOVER_START_DATE}" }
-    let(:handover_date_url) { "#{stub_base_url}/#{HmppsApi::CommunityApi::KeyDate::RESPONSIBILITY_HANDOVER_DATE}" }
-    let(:status) { nil }
-
-    before do
-      stub_offender(nomis_offender)
-      create(:case_information, nomis_offender_id: offender_no, case_allocation: 'NPS', manual_entry: false)
-
-      # Stub HTTP requests to the Community API
-      stub_request(:any, start_date_url).to_return(status: status)
-      stub_request(:any, handover_date_url).to_return(status: status)
-    end
-
-    describe 'HTTP 400: offender has multiple active custodial events' do
-      let(:status) { 400 }
-
-      it 'rescues the error to stop the job going into the retry queue' do
-        expect {
-          described_class.perform_now(offender_no)
-        }.not_to raise_error
-      end
-    end
-
-    describe 'HTTP 409: multiple offenders with the same NOMIS ID exist in nDelius' do
-      let(:nomis_offender) { build(:nomis_offender) }
-      let(:status) { 409 }
-
-      it 'rescues the error to stop the job going into the retry queue' do
-        expect {
-          described_class.perform_now(offender_no)
-        }.not_to raise_error
-      end
-    end
-  end
-
   describe 're-calculation' do
     let!(:case_info) { create(:case_information, :nps, nomis_offender_id: offender_no) }
     let(:offender) { OffenderService.get_offender(offender_no) }


### PR DESCRIPTION
This change moves the push handover to delius operation out to its own job (and out of the save action of the model). 

This allows the job to be retry-able once more and not to catch exceptions - if after N retries the job fails, its not going to work so it is fine for it to be discarded