### PR TITLE
MO-64 expose custody_responsible? etc rather than custody.responsible? 

### DIFF
--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -7,9 +7,9 @@ module OffenderHelper
   end
 
   def pom_responsibility_label(offender)
-    if offender.pom_responsibility.responsible?
+    if offender.pom_responsible?
       'Responsible'
-    elsif offender.pom_responsibility.supporting?
+    elsif offender.pom_supporting?
       'Supporting'
     else
       'Unknown'
@@ -17,9 +17,9 @@ module OffenderHelper
   end
 
   def case_owner_label(offender)
-    if offender.pom_responsibility.responsible?
+    if offender.pom_responsible?
       'Custody'
-    elsif offender.pom_responsibility.supporting?
+    elsif offender.pom_supporting?
       'Community'
     else
       'Unknown'

--- a/app/jobs/open_prison_transfer_job.rb
+++ b/app/jobs/open_prison_transfer_job.rb
@@ -18,13 +18,13 @@ class OpenPrisonTransferJob < ApplicationJob
 
     Rails.logger.info("[MOVEMENT] Processing move to open prison for #{offender.offender_no}")
 
-    if offender.com_responsibility.responsible?
+    if offender.com_responsible?
       # Assumption: COM is responsible, so we are following pre-policy rules
       #   (i.e. OMIC rules don't apply in this open prison yet)
       # Action: Email the LDU asking for a Responsible COM to be allocated because OMIC rules don't apply.
       send_email_prepolicy(offender, movement)
 
-    elsif offender.com_responsibility.supporting?
+    elsif offender.com_supporting?
       # Assumption: OMIC rules apply in this prison and the offender's sentence is indeterminate,
       # therefore a COM is needed from the moment they move into the prison.
       # Action: Email the LDU asking for a Supporting COM to be allocated, as per OMIC rules.

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -31,7 +31,7 @@ class AllocatedOffender
 
   def pom_responsibility
     if @allocation.primary_pom_nomis_id == @staff_id
-      @offender.pom_responsibility.responsible? ? 'Responsible' : 'Supporting'
+      @offender.pom_responsible? ? 'Responsible' : 'Supporting'
     else
       'Co-Working'
     end

--- a/app/models/hmpps_api/offender_summary.rb
+++ b/app/models/hmpps_api/offender_summary.rb
@@ -13,7 +13,7 @@ module HmppsApi
     end
 
     def case_owner
-      if pom_responsibility.responsible?
+      if pom_responsible?
         'Custody'
       else
         'Community'

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -74,7 +74,7 @@ private
   end
 
   def current_responsibility
-    @offender.pom_responsibility.responsible? ? 'responsible' : 'supporting'
+    @offender.pom_responsible? ? 'responsible' : 'supporting'
   end
 
   def previous_pom

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -34,7 +34,7 @@ class HandoverDateService
       less_than_10_months_left_to_serve: 'Less than 10 months left to serve'
     }.freeze
 
-    attr_reader :custody, :community, :start_date, :handover_date
+    attr_reader :start_date, :handover_date
 
     def initialize custody:, community:, start_date:, handover_date:, reason:
       @custody = custody
@@ -42,6 +42,22 @@ class HandoverDateService
       @start_date = start_date
       @handover_date = handover_date
       @reason = reason
+    end
+
+    def custody_responsible?
+      @custody.responsible?
+    end
+
+    def custody_supporting?
+      @custody.supporting?
+    end
+
+    def community_responsible?
+      @community.responsible?
+    end
+
+    def community_supporting?
+      @community.supporting?
     end
 
     def reason

--- a/app/services/recommendation_service.rb
+++ b/app/services/recommendation_service.rb
@@ -9,7 +9,7 @@ class RecommendationService
   def self.recommended_pom_type(offender)
     if offender.immigration_case?
       PRISON_POM
-    elsif offender.pom_responsibility.responsible?
+    elsif offender.pom_responsible?
       if %w[A B].include?(offender.tier)
         PROBATION_POM
       else

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -8,7 +8,7 @@
     <td class="govuk-table__cell govuk-!-width-one-half">Current case owner</td>
     <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half responsibility_change">
       <%= case_owner_label(@prisoner) %>
-      <% if @prisoner.pom_responsibility.responsible? %>
+      <% if @prisoner.pom_responsible? %>
         <%= link_to 'Change', new_prison_responsibility_path(@prison.code, nomis_offender_id: @prisoner.offender_no), class: 'govuk-link pull-right' %>
       <% elsif @prisoner.responsibility_override? %>
         <%= link_to 'Change', confirm_removal_prison_responsibility_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' %>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -48,7 +48,7 @@
       <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half responsibility_change">
         <%= case_owner_label(@prisoner) %>
-        <% if @prisoner.pom_responsibility.responsible? %>
+        <% if @prisoner.pom_responsible? %>
           <%= link_to 'Change', new_prison_responsibility_path(@prison.code, nomis_offender_id: @prisoner.offender_no), class: 'govuk-link pull-right' %>
         <% end %>
       </td>

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -193,16 +193,16 @@ RSpec.describe SummaryController, type: :controller do
 
         get :unallocated, params: { prison_id: prison, sort: 'case_owner asc' }
 
-        expect(assigns(:offenders).first.pom_responsibility.supporting?).to eq(true)
-        expect(assigns(:offenders).last.pom_responsibility.responsible?).to eq(true)
+        expect(assigns(:offenders).first.pom_supporting?).to eq(true)
+        expect(assigns(:offenders).last.pom_responsible?).to eq(true)
       end
 
       it 'can sort by case owner in descending order' do
         stub_offenders_for_prison(prison, offenders)
 
         get :unallocated, params: { prison_id: prison, sort: 'case_owner desc' }
-        expect(assigns(:offenders).first.pom_responsibility.responsible?).to eq(true)
-        expect(assigns(:offenders).last.pom_responsibility.supporting?).to eq(true)
+        expect(assigns(:offenders).first.pom_responsible?).to eq(true)
+        expect(assigns(:offenders).last.pom_supporting?).to eq(true)
       end
     end
   end

--- a/spec/jobs/open_prison_transfer_job_spec.rb
+++ b/spec/jobs/open_prison_transfer_job_spec.rb
@@ -229,7 +229,8 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
         described_class.perform_now(movement_json)
         email_job = enqueued_jobs.first
         expect(email_job).to be_nil
-        expect(offender.com_responsibility).not_to be_involved
+        expect(offender.com_responsible?).to eq(false)
+        expect(offender.com_supporting?).to eq(false)
       end
     end
 
@@ -244,7 +245,8 @@ RSpec.describe OpenPrisonTransferJob, type: :job do
         described_class.perform_now(movement_json)
         email_job = enqueued_jobs.first
         expect(email_job).to be_nil
-        expect(offender.com_responsibility).not_to be_involved
+        expect(offender.com_responsible?).to eq(false)
+        expect(offender.com_supporting?).to eq(false)
       end
     end
 

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -143,7 +143,7 @@ describe HmppsApi::Offender do
   end
 
   describe '#pom_responsibility' do
-    subject { offender.pom_responsibility }
+    subject { HandoverDateService::Responsibility.new offender.pom_responsible?, offender.pom_supporting? }
 
     let(:offender) { build(:offender, :indeterminate, latestLocationId: 'LEI') }
 
@@ -185,7 +185,7 @@ describe HmppsApi::Offender do
   end
 
   describe '#com_responsibility' do
-    subject { offender.com_responsibility }
+    subject { HandoverDateService::Responsibility.new offender.com_responsible?, offender.com_supporting? }
 
     let(:offender) { build(:offender, :indeterminate, latestLocationId: 'LEI') }
 

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe StaffMember, type: :model do
   let(:offenders) {
     [
       OpenStruct.new(offender_no: 'G7514GW', prison_id: prison, convicted?: true, sentenced?: true,
-                     indeterminate_sentence?: true, nps_case?: true, pom_responsibility: HandoverDateService::SUPPORTING,
+                     indeterminate_sentence?: true, nps_case?: true, pom_supporting?: true,
                      sentence_start_date: Time.zone.today - 1.month, conditional_release_date: Time.zone.today + 12.months),
       OpenStruct.new(offender_no: 'G1234VV', prison_id: prison, convicted?: true, sentenced?: true,
-                     nps_case?: true, pom_responsibility: HandoverDateService::RESPONSIBLE, sentence_start_date: Time.zone.today - 1.month,
+                     nps_case?: true, pom_responsible?: true, sentence_start_date: Time.zone.today - 1.month,
                      conditional_release_date: Time.zone.today + 12.months),
       OpenStruct.new(offender_no: 'G1234AB', prison_id: prison, convicted?: true, sentenced?: true,
-                     nps_case?: true, pom_responsibility: HandoverDateService::RESPONSIBLE, sentence_start_date: Time.zone.today - 10.months,
+                     nps_case?: true, pom_responsible?: true, sentence_start_date: Time.zone.today - 10.months,
                      conditional_release_date: Time.zone.today + 2.years),
       OpenStruct.new(offender_no: 'G1234GG', prison_id: prison, convicted?: true, sentenced?: true,
-                     nps_case?: true, pom_responsibility: HandoverDateService::RESPONSIBLE, sentence_start_date: Time.zone.today - 10.months,
+                     nps_case?: true, pom_responsible?: true, sentence_start_date: Time.zone.today - 10.months,
                      conditional_release_date: Time.zone.today + 2.years)
     ]
   }

--- a/spec/services/handover_date_service_old_spec.rb
+++ b/spec/services/handover_date_service_old_spec.rb
@@ -40,7 +40,7 @@ describe HandoverDateService do
         end
 
         describe 'com_supporting?' do
-          subject { described_class.handover(offender).community.supporting? }
+          subject { described_class.handover(offender).community_supporting? }
 
           context 'when before start' do
             it 'is false' do
@@ -83,7 +83,7 @@ describe HandoverDateService do
           end
 
           it 'is not community supporting' do
-            expect(described_class.handover(offender).community.supporting?).to eq(false)
+            expect(described_class.handover(offender).community_supporting?).to eq(false)
           end
         end
       end

--- a/spec/services/handover_date_service_responsibility_spec.rb
+++ b/spec/services/handover_date_service_responsibility_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 describe HandoverDateService do
   describe '#calculate_pom_responsibility' do
-    subject { described_class.handover(offender).custody }
+    subject {
+      HandoverDateService::Responsibility.new described_class.handover(offender).custody_responsible?,
+                                              described_class.handover(offender).custody_supporting?
+    }
 
     context 'when prescoed' do
       let(:recent_date) { HandoverDateService::PRESCOED_POLICY_START_DATE }
@@ -747,7 +750,7 @@ describe HandoverDateService do
         it 'will show the same date for responsibility handover and handover start date' do
           handover_service = described_class.handover(offender)
 
-          expect(handover_service.custody.responsible?).to eq true
+          expect(handover_service.custody_responsible?).to eq true
           expect(handover_service.handover_date).not_to eq(offender.home_detention_curfew_eligibility_date)
           expect(handover_service.handover_date).to eq(handover_service.start_date)
         end
@@ -762,7 +765,7 @@ describe HandoverDateService do
         it 'will show the same date for responsibility handover and handover start date' do
           handover_service = described_class.handover(offender)
 
-          expect(handover_service.custody.responsible?).to eq true
+          expect(handover_service.custody_responsible?).to eq true
           expect(handover_service.handover_date).not_to eq(offender.home_detention_curfew_eligibility_date)
           expect(handover_service.handover_date).to eq(handover_service.start_date)
         end

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 describe HandoverDateService do
   subject { described_class.handover(offender) }
 
+
   let(:test_strategy) { Flipflop::FeatureSet.current.test! }
-  let(:pom) { subject.custody }
-  let(:com) { subject.community }
+  let(:pom) { HandoverDateService::Responsibility.new subject.custody_responsible?, subject.custody_supporting?  }
+  let(:com) { HandoverDateService::Responsibility.new subject.community_responsible?, subject.community_supporting? }
   let(:start_date) { subject.start_date }
   let(:handover_date) { subject.handover_date }
   let(:reason) { subject.reason }


### PR DESCRIPTION
 expose custody_responsible?, custody_supporting? etc rather than custody and community objects

This is a good idea anyway (Law of Demeter) but will be needed when we have a single 'handover' object and want to ask it questions - community_responsible === custody_supporting