### PR TITLE
MO-607 Error during women's missing info journey

### DIFF
--- a/spec/features/female_missing_info_feature_spec.rb
+++ b/spec/features/female_missing_info_feature_spec.rb
@@ -5,15 +5,17 @@ require "rails_helper"
 feature "womens missing info journey" do
   let(:test_strategy) { Flipflop::FeatureSet.current.test! }
   let(:prison) { build(:womens_prison) }
-  let(:offender) { build(:nomis_offender, agencyId: prison.code, complexityLevel: complexity) }
+  let(:offenders) { build_list(:nomis_offender, 2, agencyId: prison.code, complexityLevel: complexity) }
+  let(:offender) { offenders.first }
   let(:prisoner_id) { offender.fetch(:offenderNo) }
+  let(:second_prisoner_id) { offenders.last.fetch(:offenderNo) }
   let(:user) { build(:pom) }
   let(:username) { 'MOIC_POM' }
 
   before do
     stub_signin_spo user, [prison.code]
     stub_poms(prison.code, [user])
-    stub_offenders_for_prison(prison.code, [offender])
+    stub_offenders_for_prison(prison.code, offenders)
     test_strategy.switch!(:womens_estate, true)
   end
 
@@ -30,8 +32,9 @@ feature "womens missing info journey" do
 
     it 'has a happy path' do
       visit missing_information_prison_prisoners_path prison.code
-      click_link 'Add missing details'
-
+      within "#edit_#{prisoner_id}" do
+        click_link 'Add missing details'
+      end
       # bang the update button - expect a big red error message
       click_button 'Update'
       within '.govuk-error-summary' do
@@ -40,6 +43,7 @@ feature "womens missing info journey" do
       end
 
       find('label[for=complexity-form-complexity-level-low-field]').click
+
       click_button 'Update'
       expect {
         #  again should have lots of error messages
@@ -84,7 +88,9 @@ feature "womens missing info journey" do
       expect(HmppsApi::ComplexityApi).to receive(:save).with(prisoner_id, level: 'medium', username: username, reason: nil)
 
       visit missing_information_prison_prisoners_path prison.code
-      click_link 'Add missing details'
+      within "#edit_#{prisoner_id}" do
+        click_link 'Add missing details'
+      end
 
       find('label[for=complexity-form-complexity-level-medium-field]').click
     end
@@ -110,13 +116,53 @@ feature "womens missing info journey" do
 
     it 'will skip collecting complexity' do
       visit missing_information_prison_prisoners_path prison.code
-      click_link 'Add missing details'
+      within "#edit_#{prisoner_id}" do
+        click_link 'Add missing details'
+      end
 
       find('label[for=case-information-probation-service-england-field]').click
       find('label[for=case-information-case-allocation-nps-field]').click
       find('label[for=case-information-tier-a-field]').click
       click_button 'Update'
       wait_for { page.current_path == missing_information_prison_prisoners_path(prison.code) }
+    end
+  end
+
+  context 'when multiple tabs are opened', :js do
+    # Complexity is prefilled so that this part of the journey does not have to be implemented
+    # It would have required an extra stub_request for complexity level
+    let(:complexity) { 'medium' }
+
+    it 'can complete forms in parallel' do
+      visit missing_information_prison_prisoners_path prison.code
+
+      within "#edit_#{prisoner_id}" do
+        click_link 'Add missing details'
+      end
+
+      execute_in_new_tab do
+        visit missing_information_prison_prisoners_path prison.code
+
+        within "#edit_#{second_prisoner_id}" do
+          click_link 'Add missing details'
+        end
+
+        fill_in_missing_case_information
+      end
+
+      fill_in_missing_case_information
+
+      # check both updates work
+      expect(CaseInformation.find_by(nomis_offender_id: prisoner_id)).not_to be_nil
+      expect(CaseInformation.find_by(nomis_offender_id: second_prisoner_id)).not_to be_nil
+    end
+
+    def fill_in_missing_case_information
+      find('label[for=case-information-probation-service-england-field]').click
+      find('label[for=case-information-case-allocation-nps-field]').click
+      find('label[for=case-information-tier-a-field]').click
+
+      click_button 'Update'
     end
   end
 end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -50,4 +50,17 @@ module FeaturesHelper
   def wait_for(maximum_wait_in_seconds = 10)
     Selenium::WebDriver::Wait.new(timeout: maximum_wait_in_seconds).until { yield }
   end
+
+  def execute_in_new_tab
+    current_tab = page.current_window
+    new_tab = page.open_new_window
+
+    switch_to_window(new_tab)
+
+    yield
+
+    switch_to_window(current_tab)
+
+    new_tab.close
+  end
 end


### PR DESCRIPTION
 
This PR fixes a bug where HOMD had been opening multiple tabs to allow them to complete the missing info for several prisoners at once. 
Because the session keys in the new action were static this meant that having multiple tabs open overrode the session keys causing a crash. 

The fix was to create dynamic session keys for complexity and case info in the new action. 