### PR TITLE
MO-623 re-organize SentenceDetail model

### DIFF
--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -11,7 +11,10 @@ module HmppsApi
                 :licence_expiry_date,
                 :sentence_start_date,
                 :tariff_date,
-                :actual_parole_date
+                :actual_parole_date,
+                :recall
+
+    delegate :criminal_sentence?, :immigration_case?, :indeterminate_sentence?, :civil_sentence?, to: :@sentence_type
 
     # Note - this is hiding a defect - we never get sentence_expiry_date from NOMIS (but maybe we should?)
     attr_accessor :sentence_expiry_date
@@ -65,11 +68,7 @@ module HmppsApi
       future_dates.any? ? future_dates.min.to_date : past_dates.max.try(:to_date)
     end
 
-    def self.from_json(payload)
-      SentenceDetail.new(payload)
-    end
-
-    def initialize(payload)
+    def initialize(payload, imprisonment_status:, recall_flag:)
       @parole_eligibility_date = deserialise_date(payload, 'paroleEligibilityDate')
       @release_date = deserialise_date(payload, 'releaseDate')
       @sentence_start_date = deserialise_date(payload, 'sentenceStartDate')
@@ -95,6 +94,13 @@ module HmppsApi
       )
       @actual_parole_date = deserialise_date(payload, 'actualParoleDate')
       @licence_expiry_date = deserialise_date(payload, 'licenceExpiryDate')
+
+      @sentence_type = SentenceType.new imprisonment_status
+      @recall = recall_flag
+    end
+
+    def describe_sentence
+      "#{@sentence_type.code} - #{@sentence_type.description}"
     end
   end
 end

--- a/app/models/sentence_type.rb
+++ b/app/models/sentence_type.rb
@@ -21,7 +21,11 @@ class SentenceType
     @duration_type == INDETERMINATE
   end
 
-  def civil?
+  def criminal_sentence?
+    !civil_sentence?
+  end
+
+  def civil_sentence?
     %w[
       CIVIL
       CIVIL_CON

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DebuggingController, :allocation, type: :controller do
+RSpec.describe DebuggingController, type: :controller do
   let(:prison) { build(:prison) }
   let(:prison_id) { prison.code }
 

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -2,8 +2,6 @@
 
 FactoryBot.define do
   factory :offender_base, class: 'HmppsApi::OffenderBase' do
-    imprisonmentStatus { 'SENT03' }
-
     # cell location is the format <1 letter>-<1 number>-<3 numbers> e.g 'E-4-014'
     internalLocation {
       block = Faker::Alphanumeric.alpha(number: 1).upcase
@@ -36,25 +34,6 @@ FactoryBot.define do
 
     complexityLevel { 'medium' }
 
-    trait :determinate do
-      imprisonmentStatus {'SEC90'}
-    end
-    trait :indeterminate do
-      imprisonmentStatus {'LIFE'}
-      sentence {build :sentence_detail, :indeterminate}
-    end
-    trait :indeterminate_recall do
-      imprisonmentStatus {'LR_LIFE'}
-      recall { true }
-      sentence {build :sentence_detail, :indeterminate}
-    end
-    trait :determinate_recall do
-      imprisonmentStatus {'LR_EPP'}
-      recall { true }
-    end
-    trait :civil_sentence do
-      imprisonmentStatus {'CIVIL'}
-    end
   end
 
   factory :offender, parent: :offender_base, class: 'HmppsApi::Offender' do

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -4,14 +4,25 @@ FactoryBot.define do
   factory :sentence_detail, class: 'HmppsApi::SentenceDetail' do
     initialize_with do
       # remove nils (as it confuses HmppsApi::SentenceDetail) and convert dates to strings (just in case test forgets)
-      values_hash = attributes.reject { |_k, v| v.nil? }.map { |k, v| [k.to_s, v.to_s] }.to_h
-      HmppsApi::SentenceDetail.from_json(values_hash)
+      values_hash = attributes.except(:imprisonmentStatus).reject { |_k, v| v.nil? }.map { |k, v| [k.to_s, v.to_s] }.to_h
+      HmppsApi::SentenceDetail.new(values_hash,
+                                   imprisonment_status: attributes.fetch(:imprisonmentStatus),
+                                   recall_flag: attributes.fetch(:recall) )
     end
+
+    imprisonmentStatus { 'SEC90' }
+    recall { false }
 
     # 1 day after policy start in Wales
     sentenceStartDate { '2019-02-05' }
     releaseDate { "2021-01-28" }
     conditionalReleaseDate { "2022-01-28" }
+
+    trait :blank do
+      sentenceStartDate { nil }
+      releaseDate { nil }
+      conditionalReleaseDate { nil }
+    end
 
     trait :welsh_policy_sentence do
       sentenceStartDate { '2019-02-05' }
@@ -72,11 +83,34 @@ FactoryBot.define do
     end
 
     trait :indeterminate do
+      imprisonmentStatus { 'LIFE' }
       tariffDate { Time.zone.today + 1.year}
      end
 
     trait :outside_early_allocation_window do
       conditionalReleaseDate { Time.zone.today + 19.months }
+    end
+
+    trait :determinate do
+      imprisonmentStatus {'SEC90'}
+    end
+
+    trait :indeterminate do
+      imprisonmentStatus {'LIFE'}
+    end
+
+    trait :indeterminate_recall do
+      imprisonmentStatus {'LR_LIFE'}
+      recall { true }
+    end
+
+    trait :determinate_recall do
+      imprisonmentStatus {'LR_EPP'}
+      recall { true }
+    end
+
+    trait :civil_sentence do
+      imprisonmentStatus {'CIVIL'}
     end
   end
 end

--- a/spec/helpers/badge_helper_spec.rb
+++ b/spec/helpers/badge_helper_spec.rb
@@ -1,18 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-# Specs in this file have access to a helper object that includes
-# the BadgeHelper. For example:
-#
-# describe BadgeHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe BadgeHelper, type: :helper do
   context 'when determinate' do
-    let(:offender) { build(:offender, :determinate) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :determinate)) }
 
     it 'is blue' do
       expect(helper.badge_colour(offender)).to eq 'blue'
@@ -24,7 +16,7 @@ RSpec.describe BadgeHelper, type: :helper do
   end
 
   context 'when indeterminate' do
-    let(:offender) { build(:offender, :indeterminate) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate)) }
 
     it 'is purple' do
       expect(helper.badge_colour(offender)).to eq 'purple'

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe OffenderHelper do
     end
 
     context 'when supporting' do
-      let(:offender) { build(:offender, :determinate_recall) }
+      let(:offender) { build(:offender, sentence: build(:sentence_detail, :determinate_recall)) }
 
       it 'shows supporting' do
         expect(helper.pom_responsibility_label(offender)).to eq('Supporting')
@@ -59,8 +59,9 @@ RSpec.describe OffenderHelper do
     it 'can show Custody for Prison' do
       off = build(:offender).tap { |o|
         o.load_case_information(build(:case_information))
-        o.sentence = HmppsApi::SentenceDetail.from_json('sentenceStartDate' => (Time.zone.today - 20.months).to_s,
-                                                         'automaticReleaseDate' => (Time.zone.today + 20.months).to_s)
+        o.sentence = build(:sentence_detail,
+                           sentenceStartDate: Time.zone.today - 20.months,
+                           automaticReleaseDate: Time.zone.today + 20.months)
       }
 
       expect(helper.case_owner_label(off)).to eq('Custody')
@@ -68,7 +69,7 @@ RSpec.describe OffenderHelper do
 
     it 'can show Community for Probation' do
       off = build(:offender).tap { |o|
-        o.sentence = HmppsApi::SentenceDetail.from_json("automaticReleaseDate" => Time.zone.today.to_s)
+        o.sentence = build(:sentence_detail, automaticReleaseDate: Time.zone.today)
       }
 
       expect(helper.case_owner_label(off)).to eq('Community')
@@ -116,7 +117,7 @@ RSpec.describe OffenderHelper do
 
     context 'when a probation POM' do
       it "can get for a probation owned offender" do
-        offender = build(:offender,  :indeterminate)
+        offender = build(:offender, sentence: build(:sentence_detail, :indeterminate))
         case_info = build(:case_information, tier: 'A')
         offender.load_case_information(case_info)
         expect(helper.complex_reason_label(offender)).to eq('Prisoner assessed as suitable for a prison officer POM despite tiering calculation')

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -209,8 +209,9 @@ private
 
   def build_offender(release_date = nil, prison: nil, sentence_type:, ard_crd_release:, ted:)
     prison = prison || active_prison
-    build(:offender, sentence_type, latestLocationId: prison.code,
+    build(:offender, latestLocationId: prison.code,
           sentence: build(:sentence_detail,
+                          sentence_type,
                           sentenceStartDate: Time.zone.today - 11.months,
                           conditionalReleaseDate: ard_crd_release,
                           automaticReleaseDate: ard_crd_release,

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
   let(:pom) { build(:pom) }
 
   let(:offender) do
-    build(:offender, :determinate, latestLocationId: 'LEI',
+    build(:offender, latestLocationId: 'LEI',
           sentence: build(:sentence_detail,
+                          :determinate,
                           sentenceStartDate: Time.zone.today - 10.months,
                           conditionalReleaseDate: release_date,
                           automaticReleaseDate: release_date,

--- a/spec/models/allocated_offender_spec.rb
+++ b/spec/models/allocated_offender_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AllocatedOffender, type: :model do
     end
 
     it 'will calculate responsibility if there is no override' do
-      indeterminate_offender = build(:offender,  :indeterminate, offenderNo: 'G7514GW', latestLocationId: 'WEI')
+      indeterminate_offender = build(:offender, sentence: build(:sentence_detail, :indeterminate), offenderNo: 'G7514GW', latestLocationId: 'WEI')
       ao = described_class.new(staff_id, primary_allocation, indeterminate_offender)
       expect(ao.pom_responsibility).to eq('Responsible')
 

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -6,7 +6,7 @@ describe HmppsApi::Offender do
   describe '#responsibility_override?' do
     it 'returns false when no responsibility found for offender' do
       # build an offender, by default this does not have any case information or responsibility record
-      subject = build(:offender, :indeterminate)
+      subject = build(:offender, sentence: build(:sentence_detail, :indeterminate))
       expect(subject.responsibility_override?).to eq(false)
     end
 
@@ -16,7 +16,7 @@ describe HmppsApi::Offender do
       create(:responsibility, nomis_offender_id: 'A1234XX')
 
       # build an offender
-      offender = build(:offender, :indeterminate, offenderNo: 'A1234XX')
+      offender = build(:offender, sentence: build(:sentence_detail, :indeterminate), offenderNo: 'A1234XX')
 
       # load the case information and responsibility record into the offender object
       offender.load_case_information(case_info)
@@ -117,8 +117,10 @@ describe HmppsApi::Offender do
     context 'when in custody' do
       let(:offender) {
         build(:offender).tap { |o|
-          o.sentence = HmppsApi::SentenceDetail.from_json('automaticReleaseDate' => (Time.zone.today + 1.year).to_s,
-                                                          'sentenceStartDate' => Time.zone.today.to_s)
+          o.sentence = build(:sentence_detail,
+                             conditionalReleaseDate: nil,
+                             automaticReleaseDate: Time.zone.today + 1.year,
+                             sentenceStartDate: Time.zone.today)
           o.load_case_information(build(:case_information, case_allocation: 'NPS', mappa_level: 0))
         }
       }
@@ -145,7 +147,7 @@ describe HmppsApi::Offender do
   describe '#pom_responsibility' do
     subject { HandoverDateService::Responsibility.new offender.pom_responsible?, offender.pom_supporting? }
 
-    let(:offender) { build(:offender, :indeterminate, latestLocationId: 'LEI') }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate), latestLocationId: 'LEI') }
 
     context 'when the responsibility has not been overridden' do
       it "calculates the responsibility based on the offender's sentence" do
@@ -187,7 +189,7 @@ describe HmppsApi::Offender do
   describe '#com_responsibility' do
     subject { HandoverDateService::Responsibility.new offender.com_responsible?, offender.com_supporting? }
 
-    let(:offender) { build(:offender, :indeterminate, latestLocationId: 'LEI') }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate), latestLocationId: 'LEI') }
 
     context 'when the responsibility has not been overridden' do
       it "calculates the responsibility based on the offender's sentence" do

--- a/spec/models/hmpps_api/sentence_detail_spec.rb
+++ b/spec/models/hmpps_api/sentence_detail_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe HmppsApi::SentenceDetail, model: true do
@@ -7,7 +9,9 @@ describe HmppsApi::SentenceDetail, model: true do
   describe "#automatic_release_date" do
     context "when override present" do
       subject {
-        described_class.from_json 'automaticRelease_date' => date.to_s, 'automaticReleaseOverrideDate' => override.to_s
+        build :sentence_detail,
+              automaticReleaseDate: date.to_s,
+              automaticReleaseOverrideDate: override.to_s
       }
 
       it "overrides" do
@@ -17,7 +21,7 @@ describe HmppsApi::SentenceDetail, model: true do
 
     context "without override" do
       subject {
-        described_class.from_json('automaticReleaseDate' => date.to_s)
+        build :sentence_detail, automaticReleaseDate: date
       }
 
       it "uses original" do
@@ -29,7 +33,9 @@ describe HmppsApi::SentenceDetail, model: true do
   describe "#conditional_release_date" do
     context "when override present" do
       subject {
-        described_class.from_json 'conditionalReleaseDate' => date.to_s, 'conditionalReleaseOverrideDate' => override.to_s
+        build :sentence_detail,
+              conditionalReleaseDate: date,
+              conditionalReleaseOverrideDate: override
       }
 
       it "overrides" do
@@ -39,7 +45,7 @@ describe HmppsApi::SentenceDetail, model: true do
 
     context "without override" do
       subject {
-        described_class.from_json('conditionalReleaseDate' => date.to_s)
+        build :sentence_detail, conditionalReleaseDate: date.to_s
       }
 
       it "uses original" do
@@ -51,7 +57,9 @@ describe HmppsApi::SentenceDetail, model: true do
   describe "#nomis_post_recall_release_date" do
     context "when override present" do
       subject do
-        described_class.from_json('postRecallReleaseDate' => date.to_s, 'postRecallReleaseOverrideDate' => override.to_s)
+        build :sentence_detail,
+              postRecallReleaseDate: date.to_s,
+              postRecallReleaseOverrideDate: override.to_s
       end
 
       it "overrides" do
@@ -61,7 +69,7 @@ describe HmppsApi::SentenceDetail, model: true do
 
     context "without override" do
       subject do
-        described_class.from_json('postRecallReleaseDate' => date.to_s)
+        build :sentence_detail, postRecallReleaseDate: date.to_s
       end
 
       it "uses original" do
@@ -72,20 +80,14 @@ describe HmppsApi::SentenceDetail, model: true do
 
   describe "#post_recall_release_date" do
     subject {
-      if actual_parole_date.nil?
-        described_class.from_json 'automaticReleaseDate' => date.to_s,
-                                  'automaticReleaseOverrideDate' => override.to_s
-      else
-        described_class.from_json 'automaticReleaseDate' => date.to_s,
-                                  'automaticReleaseOverrideDate' => override.to_s,
-                                  'actualParoleDate' => actual_parole_date.to_s
-      end
+      build :sentence_detail, automaticReleaseDate: date,
+            automaticReleaseOverrideDate: override,
+            actualParoleDate: actual_parole_date
     }
 
     let(:earliest_date) { Date.new(2019, 1, 2) }
     let(:latest_date) { Date.new(2019, 5, 4) }
     let(:no_date) { nil }
-
 
     before do
       allow(subject).to receive(:nomis_post_recall_release_date).and_return(nomis_post_recall_release_date)

--- a/spec/models/sentence_type_spec.rb
+++ b/spec/models/sentence_type_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe SentenceType, type: :model do
   end
 
   it 'knows what a civil sentence is' do
-    expect(described_class.new('CIVIL').civil?).to be true
-    expect(described_class.new('IPP').civil?).to be false
+    expect(described_class.new('CIVIL').civil_sentence?).to be true
+    expect(described_class.new('IPP').civil_sentence?).to be false
   end
 
   it "can determine determinate sentences" do

--- a/spec/services/handover_date_service_old_spec.rb
+++ b/spec/services/handover_date_service_old_spec.rb
@@ -99,7 +99,7 @@ describe HandoverDateService do
 
     context 'when incorrect service provider entered for indeterminate offender' do
       let(:offender) {
-        build(:offender, :indeterminate, sentence: build(:sentence_detail, tariffDate: tariff_date)).tap { |o|
+        build(:offender, sentence: build(:sentence_detail, :indeterminate, tariffDate: tariff_date)).tap { |o|
           o.load_case_information(build(:case_information, :crc))
         }
       }
@@ -116,8 +116,8 @@ describe HandoverDateService do
 
       context 'when outside referral window' do
         let(:offender) {
-          build(:offender, :determinate,
-                sentence: build(:sentence_detail, :english_policy_sentence,
+          build(:offender,
+                sentence: build(:sentence_detail, :determinate, :english_policy_sentence,
                                 automaticReleaseDate: ard,
                                 conditionalReleaseDate: crd)).tap { |o|
             o.load_case_information(case_info)
@@ -136,7 +136,7 @@ describe HandoverDateService do
         let(:ted15) { ted - 15.months }
 
         let(:offender) {
-          build(:offender, :indeterminate,
+          build(:offender,
                 sentence: build(:sentence_detail, :indeterminate,
                                 paroleEligibilityDate: ped,
                                 tariffDate: ted)).tap { |o|
@@ -164,8 +164,8 @@ describe HandoverDateService do
 
       context 'when determinate' do
         let(:offender) {
-          build(:offender, :determinate,
-                sentence: build(:sentence_detail, :english_policy_sentence,
+          build(:offender,
+                sentence: build(:sentence_detail, :determinate, :english_policy_sentence,
                                 automaticReleaseDate: ard,
                                 conditionalReleaseDate: crd)).tap { |o|
             o.load_case_information(case_info)
@@ -206,7 +206,7 @@ describe HandoverDateService do
 
   describe 'handover dates' do
     let(:result) { described_class.handover(offender).handover_date }
-    let(:trait) {
+    let(:sentence_type_trait) {
       if indeterminate_sentence
         recall? ? :indeterminate_recall : :indeterminate
       else
@@ -215,8 +215,8 @@ describe HandoverDateService do
     }
 
     let(:offender) do
-      build(:offender, trait,
-            sentence: build(:sentence_detail,
+      build(:offender,
+            sentence: build(:sentence_detail, sentence_type_trait,
                             automaticReleaseDate: automatic_release_date,
                             conditionalReleaseDate: conditional_release_date,
                             paroleEligibilityDate: parole_date,
@@ -472,8 +472,8 @@ describe HandoverDateService do
 
     let(:offender) {
       build(:offender,
-            imprisonmentStatus: indeterminate_sentence ? 'LIFE' : 'SEC90',
             sentence: build(:sentence_detail,
+                            imprisonmentStatus: indeterminate_sentence ? 'LIFE' : 'SEC90',
                             automaticReleaseDate: automatic_release_date,
                             conditionalReleaseDate: conditional_release_date,
                             paroleEligibilityDate: parole_eligibility_date,
@@ -556,9 +556,9 @@ describe HandoverDateService do
   context 'with an NPS and indeterminate case with a PRD and no TED' do
     let(:case_info) { build(:case_information, :with_prd, :nps) }
     let(:offender) {
-      build(:offender, :indeterminate, sentence: build(:sentence_detail,
-                                                       :indeterminate,
-                                                       tariffDate: nil)).tap {  |offender|
+      build(:offender, sentence: build(:sentence_detail,
+                                       :indeterminate,
+                                       tariffDate: nil)).tap {  |offender|
         offender.load_case_information(case_info)
       }
     }

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -45,9 +45,9 @@ describe HandoverDateService do
     let(:today) { Date.parse('01/01/2021') }
     let(:crd) { Date.parse('01/09/2022') }
     let(:offender) {
-      build(:offender, :determinate,
+      build(:offender,
             latestLocationId: prison,
-            sentence: build(:sentence_detail, sentenceStartDate: sentence_start_date, conditionalReleaseDate: crd)
+            sentence: build(:sentence_detail, :determinate, sentenceStartDate: sentence_start_date, conditionalReleaseDate: crd)
       ).tap { |o|
         o.load_case_information(case_info)
         o.prison_arrival_date = arrival_date
@@ -389,10 +389,10 @@ describe HandoverDateService do
       let(:tariff_date) { Date.parse('01/09/2022') }
       let(:case_info) { build(:case_information, :nps, probation_service: welsh? ? 'Wales' : 'England') }
       let(:offender) {
-        build(:offender, :indeterminate,
+        build(:offender,
               latestLocationId: prison,
               categoryCode: category,
-              sentence: build(:sentence_detail, tariffDate: tariff_date, sentenceStartDate: sentence_start_date)
+              sentence: build(:sentence_detail, :indeterminate, tariffDate: tariff_date, sentenceStartDate: sentence_start_date)
         ).tap { |o|
           o.load_case_information(case_info)
           o.prison_arrival_date = arrival_date

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -36,8 +36,7 @@ describe HmppsApi::PrisonApi::OffenderApi do
       expect(response).to be_instance_of(Hash)
 
       records = response.values
-      expect(records.first).to be_instance_of(HmppsApi::SentenceDetail)
-      expect(records.first.conditional_release_date).to eq(Date.new(2020, 3, 16))
+      expect(records.first.fetch('conditionalReleaseDate')).to eq(Date.new(2020, 3, 16).to_s)
     end
   end
 

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -4,9 +4,9 @@ describe RecommendationService do
   context 'when tier A' do
     let(:tier_a) {
       build(:offender,
-            sentence: HmppsApi::SentenceDetail.from_json(
-              'sentenceStartDate' => Time.zone.today.to_s,
-              'automaticReleaseRate' => (Time.zone.today + 15.months).to_s)).tap { |o|
+            sentence: build(:sentence_detail, :blank,
+                            sentenceStartDate: Time.zone.today,
+                            automaticReleaseRate: Time.zone.today + 15.months)).tap { |o|
         o.load_case_information(build(:case_information, tier: 'A'))
       }
     }
@@ -19,9 +19,9 @@ describe RecommendationService do
   context 'when tier D' do
     let(:tier_d) {
       build(:offender,
-            sentence: HmppsApi::SentenceDetail.from_json(
-              'sentenceStartDate' => Time.zone.today.to_s,
-              'automaticReleaseDate' => (Time.zone.today + 10.months).to_s)).tap { |o|
+            sentence: build(:sentence_detail,
+                            sentenceStartDate: Time.zone.today,
+                            automaticReleaseDate: Time.zone.today + 10.months)).tap { |o|
         o.load_case_information(build(:case_information, tier: 'D'))
       }
     }
@@ -34,7 +34,7 @@ describe RecommendationService do
   context 'when tier A immigration case' do
     let(:tier_a_and_immigration_case) {
       build(:offender,
-            imprisonmentStatus: 'DET', sentence: HmppsApi::SentenceDetail.from_json('sentenceStartDate' => Time.zone.today.to_s)).tap { |o|
+            imprisonmentStatus: 'DET', sentence: build(:sentence_detail, sentenceStartDate: Time.zone.today)).tap { |o|
         o.load_case_information(build(:case_information, tier: 'A'))
       }
     }

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe "debugging/debugging", type: :view do
   let(:offender) do
     build(:offender, firstName: 'John', lastName: 'Dory').tap { |offender|
-      offender.sentence = HmppsApi::SentenceDetail.from_json(
-        'sentenceStartDate' => Time.zone.today.to_s,
-        'automaticReleaseDate' => (Time.zone.today + 10.months).to_s,
-        'tariffDate' => Date.new(2033, 8, 1).to_s,
-        'postRecallReleaseDate' => Date.new(2028, 11, 8).to_s,
-        'licenceExpiryDate' => Date.new(2025, 10, 7).to_s)
+      offender.sentence = build(:sentence_detail,
+                                sentenceStartDate: Time.zone.today,
+                                automaticReleaseDate: Time.zone.today + 10.months,
+                                tariffDate: Date.new(2033, 8, 1),
+                                postRecallReleaseDate: Date.new(2028, 11, 8),
+                                licenceExpiryDate: Date.new(2025, 10, 7))
     }
   end
 

--- a/spec/views/shared/case_type_badge.html.erb_spec.rb
+++ b/spec/views/shared/case_type_badge.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when indeterminate" do
-    let(:offender) { build(:offender, :indeterminate) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate)) }
 
     it "displays an indeterminate case type badge" do
       assert_you_have_an_indeterminate_badge
@@ -27,7 +27,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when determinate" do
-    let(:offender) { build(:offender, :determinate) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :determinate)) }
 
     it "displays an determinate case type badge" do
       assert_you_have_a_determinate_badge
@@ -35,7 +35,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when recall" do
-    let(:offender) { build(:offender, :indeterminate_recall) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate_recall)) }
 
     it "displays a recall case type badge and a indeterminate badge" do
       expect(case_type_badge.first.attributes['class'].value).to include 'moj-badge--purple'
@@ -45,7 +45,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when parole eligibility(PED)" do
-    let(:offender) { build(:offender, :indeterminate, sentence: build(:sentence_detail, paroleEligibilityDate: Time.zone.today.to_s)) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate, paroleEligibilityDate: Time.zone.today.to_s)) }
 
     it "displays an parole eligibility case type badge" do
       assert_you_have_a_parole_eligibility_badge
@@ -54,7 +54,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when parole eligibility(TED)" do
-    let(:offender) { build(:offender, :determinate, sentence: build(:sentence_detail, tariffDate: Time.zone.today.to_s)) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :determinate, tariffDate: Time.zone.today.to_s)) }
 
     it "displays an parole eligibility case type badge and determinate badge" do
       assert_you_have_a_parole_eligibility_badge
@@ -66,7 +66,7 @@ RSpec.describe "allocations/index", type: :view do
     let(:offender_no) { 'G7514GW' }
     let(:case_information) { build(:case_information,  nomis_offender_id: offender_no, parole_review_date: Date.new(2019, 0o1, 3).to_s) }
     let(:offender) {
-      offender = build(:offender, :indeterminate, offenderNo: offender_no)
+      offender = build(:offender, sentence: build(:sentence_detail, :indeterminate), offenderNo: offender_no)
       offender.load_case_information(case_information)
       offender
     }
@@ -82,8 +82,8 @@ RSpec.describe "allocations/index", type: :view do
     let(:offender_no) { 'G7514GW' }
     let(:case_information) { build(:case_information,  nomis_offender_id: offender_no) }
     let(:offender) {
-      offender = build(:offender, :indeterminate, offenderNo: offender_no,
-       sentence: build(:sentence_detail, tariffDate: nil))
+      offender = build(:offender, offenderNo: offender_no,
+       sentence: build(:sentence_detail, :indeterminate, tariffDate: nil))
       offender.load_case_information(case_information)
       offender
     }
@@ -98,7 +98,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when indeterminate, a recall case and parole eligibility(PED)" do
-    let(:offender) { build(:offender, :indeterminate_recall, sentence: build(:sentence_detail, paroleEligibilityDate: Time.zone.today.to_s)) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :indeterminate_recall, paroleEligibilityDate: Time.zone.today.to_s)) }
 
     it "displays an indeterminate, parole eligibility and recall case type badges" do
       assert_you_have_an_indeterminate_badge
@@ -108,7 +108,7 @@ RSpec.describe "allocations/index", type: :view do
   end
 
   context "when determinate, a recall case and parole eligibility(PED)" do
-    let(:offender) { build(:offender, :determinate_recall, sentence: build(:sentence_detail, paroleEligibilityDate: Time.zone.today.to_s)) }
+    let(:offender) { build(:offender, sentence: build(:sentence_detail, :determinate_recall, paroleEligibilityDate: Time.zone.today)) }
 
     it "displays an determinate, parole eligibility and recall case type badges" do
       assert_you_have_a_determinate_badge

--- a/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
+++ b/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "shared/notifications/offender_needs_a_com", type: :view do
   let(:email_history) { [] }
 
   let(:offender) {
-    build(:offender, :determinate, sentence: build(:sentence_detail, :inside_handover_window)).tap { |o|
+    build(:offender, sentence: build(:sentence_detail, :determinate, :inside_handover_window)).tap { |o|
       o.load_case_information(case_info)
     }
   }


### PR DESCRIPTION
Move recall_flag and imprisonmentStatus into SentenceDetail where they belong. 

All information about sentences are now stored and looked after by the SentenceDetail class