### PR TITLE
MO-486 pre-cursor: add extra column to pom_detail table

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -137,7 +137,7 @@ class Allocation < ApplicationRecord
 private
 
   def deallocate_offender event:, event_trigger:
-    primary_pom = StaffMember.new prison, primary_pom_nomis_id
+    primary_pom = StaffMember.new Prison.new(prison), primary_pom_nomis_id
     offender = OffenderService.get_offender(nomis_offender_id)
     mail_params = {
         email: primary_pom.email_address,

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -8,7 +8,7 @@ class StaffMember
   delegate :position_description, :probation_officer?, :prison_officer?, to: :pom
   delegate :working_pattern, :status, to: :@pom_detail
 
-  def initialize(prison, staff_id, pom_detail = default_pom_detail(staff_id))
+  def initialize(prison, staff_id, pom_detail = default_pom_detail(prison.code, staff_id))
     @prison = prison
     @staff_id = staff_id.to_i
     @pom_detail = pom_detail
@@ -99,8 +99,10 @@ private
     }
   end
 
-  def default_pom_detail(staff_id)
+  # Attempt to forward-populate the PomDetail table for new records
+  def default_pom_detail(prison_code, staff_id)
     @pom_detail = PomDetail.find_or_create_by!(nomis_staff_id: staff_id) { |pom|
+      pom.prison_code = prison_code
       pom.working_pattern = 0.0
       pom.status = 'active'
     }

--- a/db/migrate/20210419085828_add_prison_id_to_pom_detail.rb
+++ b/db/migrate/20210419085828_add_prison_id_to_pom_detail.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPrisonIdToPomDetail < ActiveRecord::Migration[6.0]
+  def change
+    change_table :pom_details do |t|
+      t.string :prison_code, length: 3
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_115125) do
+ActiveRecord::Schema.define(version: 2021_04_19_085828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2021_03_31_115125) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "prison_code"
     t.index ["nomis_staff_id"], name: "index_pom_details_on_nomis_staff_id", unique: true
   end
 

--- a/lib/tasks/backfill_pom_details.rake
+++ b/lib/tasks/backfill_pom_details.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :backfill do
+  desc 'Back-fill pom_details with prison_code'
+  task pom_details: :environment do
+    Rails.logger = Logger.new(STDOUT)
+
+    Prison.all.each do |prison|
+      PrisonOffenderManagerService.get_poms_for(prison.code).map(&:staff_id).each { |staff_id|
+        pom = PomDetail.find_by! nomis_staff_id: staff_id
+        pom.update! prison_code: prison.code
+      }
+    end
+  end
+end


### PR DESCRIPTION
This PR needs to go to production ahead of MO-486, so that the POMDetail records can be updated with the correct prison code before the main PR is brought online