### PR TITLE
MO-199 remove dependency on imprisonmentStatus to decide indeterminate/determinate sentences

### DIFF
--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -14,7 +14,7 @@ module HmppsApi
                 :actual_parole_date,
                 :recall
 
-    delegate :criminal_sentence?, :immigration_case?, :indeterminate_sentence?, :civil_sentence?, to: :@sentence_type
+    delegate :criminal_sentence?, :immigration_case?, :civil_sentence?, to: :@sentence_type
 
     # Note - this is hiding a defect - we never get sentence_expiry_date from NOMIS (but maybe we should?)
     attr_accessor :sentence_expiry_date
@@ -97,10 +97,16 @@ module HmppsApi
 
       @sentence_type = SentenceType.new search_payload.fetch('imprisonmentStatus', 'UNK_SENT')
       @recall = search_payload.fetch('recall', false)
+      @indeterminate_sentence = search_payload['indeterminateSentence']
+      @description = search_payload.fetch('imprisonmentStatusDescription', 'Unknown Sentenced')
+    end
+
+    def indeterminate_sentence?
+      @indeterminate_sentence
     end
 
     def describe_sentence
-      "#{@sentence_type.code} - #{@sentence_type.description}"
+      "#{@sentence_type.code} - #{@description}"
     end
   end
 end

--- a/app/models/sentence_type.rb
+++ b/app/models/sentence_type.rb
@@ -1,24 +1,15 @@
 # frozen_string_literal: true
 
 class SentenceType
-  DETERMINATE = :determinate
-  INDETERMINATE = :indeterminate
-
-  attr_reader :code, :description
+  attr_reader :code
 
   def initialize(imprisonment_status)
     @code = imprisonment_status
     @code = 'UNK_SENT' if @code.nil?
-
-    @description, @duration_type, = SENTENCE_TYPES.fetch(@code)
   end
 
   def immigration_case?
     @code == 'DET'
-  end
-
-  def indeterminate_sentence?
-    @duration_type == INDETERMINATE
   end
 
   def criminal_sentence?
@@ -37,171 +28,3 @@ class SentenceType
     ].include? @code
   end
 end
-
-SENTENCE_TYPES = {
-  'IPP' => ['Indeterminate Sent for Public Protection', :indeterminate],
-  'LIFE' => ['Serving Life Imprisonment', :indeterminate],
-  'HMPL' => ['Detention During Her Majesty\'s Pleasure', :indeterminate],
-  'ALP' => ['Automatic', :indeterminate],
-  'DFL' => ['Detention For Life - Under 18', :indeterminate],
-  'DLP' => ['Adult Discretionary', :indeterminate],
-  'DPP' => ['Detention For Public Protection', :indeterminate],
-  'MLP' => ['Adult Mandatory Life', :indeterminate],
-  'LR_LIFE' => ['Recall to Custody Indeterminate Sentence', :indeterminate],
-  'LR_IPP' => ['Licence recall from IPP Sentence', :indeterminate],
-  'LR_EPP' => ['Licence recall from EPP Sentence', :determinate],
-  'LR_DPP' => ['Licence recall from DPP Sentence', :indeterminate],
-  'CFLIFE' => ['Custody for life S8 CJA82 (18-21 Yrs)', :determinate],
-  'SEC90' => ['Life - Murder Under 18', :determinate],
-  'SEC90_03' => ['Life - Murder Under 18 CJA03', :determinate],
-  'SEC93' => ['Custody For Life - Under 21', :indeterminate],
-  'SEC93_03' => ['Custody For Life - Under 21 CJA03', :indeterminate],
-  # 2020 version of SEC93_03
-  'SEC275' => ['Custody For Life Sec 275 2020 Murder U21', :indeterminate],
-  'SEC94' => ['Custody Life (18-21 Years Old)', :indeterminate],
-  # 2020 version of SEC94
-  'SEC272' => ['Custody For Life Sec 272 2020 (18-20)', :indeterminate],
-  'EXSENT' => ['Extended Sentence CJA91', :determinate],
-  'EXSENT03' => ['Extended Sentence CJA03', :determinate],
-  'EXSENT08' => ['Extended Sentence CJ&I Act 2008', :determinate],
-  'LR_ES' => ['Recalled to Prison frm Extended Sentence', :determinate],
-  'SENT_EXL' => ['Sentenced - Extended Licence', :determinate],
-  'CUSTPLUS' => ['Custody Plus Sentence', :determinate],
-  'INT_CUST' => ['Intermittent Custody', :determinate],
-  'SENT' => ['Adult Imprisonment Without Option', :determinate],
-  'SENT03' => ['Adult Imprisonment Without Option CJA03', :determinate],
-  'CJCON08' => ['Adult Imprisonment Release Conversion', :determinate],
-  'LR' => ['Recalled to Prison from Parole (Non HDC)', :determinate],
-  'FTR/08' => ['Fixed Term Recall CJ&I Act 2008', :determinate],
-  'LR_HDC' => ['Recalled to Prison breach HDC Conditions', :determinate],
-  'BOAR' => ['Breach Of At Risk CJA 1991', :determinate],
-  'S47MHA' => ['Home Sec Order to Psych Hosp (SENT)', :determinate],
-  'CRIM_CON' => ['Criminal Contempt', :determinate],
-  'SEC91' => ['Serious Offence -18 POCCA 2000', :determinate],
-  'SEC91_03' => ['Serious Offence -18 CJA03 POCCA 2000', :determinate],
-  # 2020 version of SEC91_03
-  'SEC250' => ['Recall Serious Offence Sec 250 2020 U18', :determinate],
-  'YOI' => ['Detention In Young Offender Institution', :determinate],
-  'REFER' => ['DTO_YOI Referal', :determinate],
-  'DTO' => ['Detention Training Order', :determinate],
-  'LR_YOI' => ['Recalled to YOI from fixed sentence', :determinate],
-  'UNK_SENT' => ['Unknown Sentenced', :determinate],
-  'A_FINE' => ['Adult Imprisonment In Default Of Fine', :determinate],
-  'AFIXED' => ['Adult Imprisonment - Fixed Penalty', :determinate],
-  'YOFINE' => ['Detention (Young Offender) Fine Payment', :determinate],
-  'YOFIXED' => ['Y O Imprisonment - Fixed Penalty', :determinate],
-  'A_FINE1' => ['Adult Imprisonment Fine Payment (Time)', :determinate],
-  'A_FINE2' => ['Adult Imprisonment Fine Payment No Time', :determinate],
-  'JR' => ['Conv - Judgement Respited', :determinate],
-  'SEC38' => ['Convicted_Committed to Crown Court', :determinate],
-  'SEC37' => ['Conv - YO Comm to CC for Sentence', :determinate],
-  'SEC39' => ['Convicted_Remitted to Magistrates Court', :determinate],
-  'S41MHA' => ['Conv - Hospital Order with Restrictions', :determinate],
-  'S45MHA' => ['Conv. Hosp. Direction Sec45A MHA 83', :determinate],
-  'S37MHA' => ['Removal to Psych. Hosp under order', :determinate],
-  'UNK_CONV' => ['Unknown Convicted and Unsentenced', :determinate],
-  'SEC56' => ['Conv - Breached Non-Cust Alternatives', :determinate],
-  'S43MHA' => ['Conv-Comm to CC for Order (Restrictions)', :determinate],
-  'SEC43' => ['Committed to Crown Court Sec43MHA 1983', :determinate],
-  'SEC42' => ['Conv -Comm to CC For Sentence 1973 Act', :determinate],
-  'SEC24_2A' => ['Conv - Comm to CC Breach Susp. Sent', :determinate],
-  'SEC19_3B' => ['Conv-Comm to CC Breach Attendance Order', :determinate],
-  'SEC18_2' => ['Conv - Comm to cc Revoke amend CSO', :determinate],
-  'SEC17_3' => ['Conv - Breach Of CSO - CJA 1972', :determinate],
-  'SEC8_6' => ['Conv-comm to cc breached PO new offence', :determinate],
-  'SEC6_4' => ['Conv-Comm to CC Breach PO Requirements', :determinate],
-  'SEC6B' => ['Conv - Comm to CC Breached Bail', :determinate],
-  'SEC45' => ['Conv - Awaiting Social Inquiry Reports', :determinate],
-  'S38MHA' => ['Conv-Await Removal to Hosp interim order', :determinate],
-  'SEC5' => ['Conv Under Sec5 Vagrancy Act 1824', :determinate],
-  'SEC30' => ['Conv - Awaiting Medical Reports MCA 1980', :determinate],
-  'SEC10_3' => ['Conv - Adjourned For Reports MCA 1980', :determinate],
-  'SEC2_1' => ['Conv - YO Awaiting Reports CJA 1982', :determinate],
-  'CIVIL' => ['Civil Committal (Adult)', :determinate],
-  'CIVIL_CON' => ['Adult Civil Contempt', :determinate],
-  'YOC_CONT' => ['Y O Civil Contempt', :determinate],
-  'CIVIL_DT' => ['Civil Committal Detention 17-20 year old', :determinate],
-  'A_CFINE' => ['Civil Prisoner Fine (Adult)', :determinate],
-  'YO_CFINE' => ['Civil Prisoner Fine (Young Offender)', :determinate],
-  'DEPORT' => ['Awaiting Deportation Only', :determinate],
-  'EXTRAD' => ['Awaiting Extradition Only', :determinate],
-  'DET' => ['Immigration Detainee', :determinate],
-  'TRL' => ['Committed to Crown Court for Trial', :determinate],
-  'S48MHA' => ['Psychiatric Hospital from Prison (RX)', :determinate],
-  'S36MHA' => ['Remand to Psychiatric Hospital by CC', :determinate],
-  'S35MHA' => ['Remanded to Psychiatric Hosp by CC or MC', :determinate],
-  'CIV_RMD' => ['Civil Remand Family Law Act 1996', :determinate],
-  'RX' => ['Remanded to Magistrates Court', :determinate],
-  'REC_DEP' => ['Recommended For Deportation', :determinate],
-  'UNK_CUST' => ['Unknown Custodial Undisposed', :determinate],
-  'DISCHARGED' => ['Freed On The Rising Of The Court', :determinate],
-  'POLICE' => ['In Police Cells (not police remand)', :determinate],
-  'SUSP_SEN' => ['Suspended Sentence', :determinate],
-  'DTTO' => ['Drug Treatment and Testing Order', :determinate],
-  'SUP_ORD' => ['Supervision Order', :determinate],
-  'REST_ORD' => ['Restriction Order Attending Football', :determinate],
-  'NON-CUST' => ['Non Custodial Punishment', :determinate],
-  'DEF_SENT' => ['Deferred Sentence', :determinate],
-  'UNFIT' => ['Unfit To Plead', :determinate],
-  'DISCONT' => ['Case Withdrawn Or Not Tried', :determinate],
-  'SINE DIE' => ['Adjourned Sine Die - To Lie On File', :determinate],
-  'BOBC' => ['Breach of Bail Conditions - FTA', :determinate],
-  'UNKNOWN' => ['Disposal Not Known', :determinate],
-  'DIED' => ['Died', :determinate],
-  'LASPO_AR' => ['EDS LASPO Automatic Release', :determinate],
-  'LR_LASPO_AR' => ['LR - EDS LASPO Automatic Release', :determinate],
-  'LASPO_DR' => ['EDS LASPO Discretionary Release', :determinate],
-  # 2020 versions of LASPO_DR (6 of)
-  'LR_EDS18' => ['LR - EDS Sec 266 2020 (18-20)', :determinate],
-  'LR_EDS21' => ['LR - EDS Sec 279 2020 (21+)', :determinate],
-  'LR_EDSU18' => ['LR - EDS Sec 254 2020 (U18)', :determinate],
-  'EDS18' => ['EDS Sec 266 2020 (18-20)', :determinate],
-  'EDS21' => ['EDS Sec 266 2020 (21+)', :determinate],
-  'EDSU18' => ['EDS Sec 254 2020 (U18)', :determinate],
-  'LR_LASPO_DR' => ['LR - EDS LASPO Discretionary Release', :determinate],
-  'FTR_HDC' => ['Fixed Term Recall while on HDC', :determinate],
-  'LR_MLP' => ['Recall to Custody Mandatory Life', :indeterminate],
-  'LR_ALP' => ['Recall from Automatic Life', :indeterminate],
-  'LR_DLP' => ['Recall from Discretionary Life', :indeterminate],
-  'ALP_LASPO' => ['Automatic Life Sec 224A 03', :indeterminate],
-  # 2020 verskions of ALP_LASPO
-  'ALP_CODE18' => ['Automatic Life Sec 273 2020 (18-20)', :indeterminate],
-  'ALP_CODE21' => ['Automatic Life Sec 273 2020 (21+)', :indeterminate],
-  'LR_ALP_LASPO' => ['Recall from Automatic Life Sec 224A 03', :indeterminate],
-  # 2020 versions of LR_ALP_LASPO
-  'LR_ALP_CDE18' => ['Recall Auto. Life Sec 273 2020 (18-20)', :indeterminate],
-  'LR_ALP_CDE21' => ['Recall Auto. Life Sec 283 2020 (21+)', :indeterminate],
-  'FTR_SCH15' => ['FTR Schedule 15 Offender', :determinate],
-  # 2020 version of FTR_SCH15
-  'FTRSCH18' => ['FTR Sch 18 2020 Offender', :determinate],
-  'ADIMP_ORA' => ['ORA CJA03 Standard Determinate Sentence', :determinate],
-  # 2020 version of ADIMP_ORA
-  'ADIMP_ORA20' => ['ORA 2020 Standard Determinate Sentence', :determinate],
-  'CUR_ORA' => ['ORA Recalled from Curfew Conditions', :determinate],
-  'DTO_ORA' => ['ORA Detention and Training Order', :determinate],
-  'FTR_ORA' => ['ORA 28 Day Fixed Term Recall', :determinate],
-  'FTR_HDC_ORA' => ['ORA Fixed Term Recall while on HDC', :determinate],
-  'FTRSCH15_ORA' => ['ORA FTR Schedule 15 Offender', :determinate],
-  # 2020 version of FTRSCH15_ORA
-  'FTRSCH18_ORA' => ['ORA FTR Sch 18 2020 Offender', :determinate],
-  'HDR_ORA' => ['ORA HDC Recall (not curfew violation)', :determinate],
-  'LR_ORA' => ['ORA Licence Recall', :determinate],
-  'SEC91_03_ORA' => ['ORA Serious Offence -18 CJA03 POCCA 2000', :determinate],
-  # 2020 version of SEC91_03_ORA
-  'SEC250_ORA' => ['ORA Serious Offence Sec 250 2020 U18', :determinate],
-  'YOI_ORA' => ['ORA Young Offender Institution', :determinate],
-  'BOTUS' => ['ORA Breach Top Up Supervision', :determinate],
-  '14FTR_ORA' => ['ORA 14 Day Fixed Term Recall', :determinate],
-  'LR_YOI_ORA' => ['Recall from YOI', :determinate],
-  'LR_SEC91_ORA' => ['Recall Serious Off -18 CJA03 POCCA 2000', :determinate],
-  'LR_SEC250' => ['Recall Serious Offence Sec 250 2020 (U18)', :determinate],
-  '14FTRHDC_ORA' => ['14 Day Fixed Term Recall from HDC', :determinate],
-  'SEC236A' => ['Section 236A SOPC CJA03', :determinate],
-  # 2020 versions of SEC236A
-  'SOPC18' => ['SOPC Sec 265 2020 (18-20)', :determinate],
-  'SOPC21' => ['SOPC Sec 265 2020 (21+)', :determinate],
-  'LR_SEC236A' => ['LR - Section 236A SOPC CJA03', :determinate],
-  # 2020 versions of LR_SEC236A
-  'LR_SOPC18' => ['LR - SOPC Sec 265 2020 (18-20)', :determinate],
-  'LR_SOPC21' => ['LR - SOPC Sec 265 2020 (21+)', :determinate],
-}.freeze

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -75,7 +75,6 @@ module HmppsApi
             sentence = HmppsApi::SentenceDetail.new sentence_details.fetch(offender.booking_id),
                                                     search_payload
 
-
             offender.sentence = sentence
             add_arrival_dates([offender])
           end

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
     end
 
     imprisonmentStatus { 'SEC90' }
+    imprisonmentStatusDescription { 'Did a really bad thing' }
+    indeterminateSentence { false }
     recall { false }
 
     # 1 day after policy start in Wales
@@ -82,7 +84,7 @@ FactoryBot.define do
     end
 
     trait :indeterminate do
-      imprisonmentStatus { 'LIFE' }
+      indeterminateSentence { true }
       tariffDate { Time.zone.today + 1.year}
      end
 
@@ -91,20 +93,16 @@ FactoryBot.define do
     end
 
     trait :determinate do
-      imprisonmentStatus {'SEC90'}
-    end
-
-    trait :indeterminate do
-      imprisonmentStatus {'LIFE'}
+      indeterminateSentence { false }
     end
 
     trait :indeterminate_recall do
-      imprisonmentStatus {'LR_LIFE'}
+      indeterminateSentence { true }
       recall { true }
     end
 
     trait :determinate_recall do
-      imprisonmentStatus {'LR_EPP'}
+      indeterminateSentence { false }
       recall { true }
     end
 

--- a/spec/models/sentence_type_spec.rb
+++ b/spec/models/sentence_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SentenceType, type: :model do
@@ -5,39 +7,16 @@ RSpec.describe SentenceType, type: :model do
     sentence_type = described_class.new('IPP')
 
     expect(sentence_type.code).to eq('IPP')
-    expect(sentence_type.description).to eq('Indeterminate Sent for Public Protection')
-    expect(sentence_type.indeterminate_sentence?).to eq(true)
   end
 
   it 'can handle offenders with no sentence' do
     sentence_type = described_class.new(nil)
 
     expect(sentence_type.code).to eq('UNK_SENT')
-    expect(sentence_type.description).to eq('Unknown Sentenced')
-    expect(sentence_type.indeterminate_sentence?).to eq(false)
   end
 
   it 'knows what a civil sentence is' do
     expect(described_class.new('CIVIL').civil_sentence?).to be true
     expect(described_class.new('IPP').civil_sentence?).to be false
-  end
-
-  it "can determine determinate sentences" do
-    off = described_class.new 'CRIM_CON'
-
-    expect(off.indeterminate_sentence?).to eq false
-  end
-
-  it "can determine indeterminate sentences" do
-    off = described_class.new 'IPP'
-
-    expect(off.indeterminate_sentence?).to eq true
-  end
-
-  it "can describe a sentence for an offender" do
-    off = described_class.new 'IPP'
-    desc = off.description
-
-    expect(desc).to eq('Indeterminate Sent for Public Protection')
   end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -25,6 +25,8 @@ module ApiHelper
           prisonerNumber: offender_no,
           recall: offender.fetch(:recall),
           imprisonmentStatus: offender.fetch(:sentence).fetch(:imprisonmentStatus),
+          indeterminateSentence: offender.fetch(:sentence).fetch(:indeterminateSentence),
+          imprisonmentStatusDescription: offender.fetch(:sentence).fetch(:imprisonmentStatusDescription),
           cellLocation: offender.fetch(:internalLocation)
         }
       ].to_json)
@@ -140,6 +142,8 @@ module ApiHelper
                           prisonerNumber: offender.fetch(:offenderNo),
                           recall: offender.fetch(:recall),
                           imprisonmentStatus: offender.fetch(:sentence).fetch(:imprisonmentStatus),
+                          indeterminateSentence: offender.fetch(:sentence).fetch(:indeterminateSentence),
+                          imprisonmentStatusDescription: offender.fetch(:sentence).fetch(:imprisonmentStatusDescription),
                           cellLocation: offender.fetch(:internalLocation)
                         }
                       }.to_json)


### PR DESCRIPTION
This changes our sentence detail object so that rather than relying on sentenceType  / imprisonmentStatus to decide whether the offence is determinate or indeterminate, it uses a value provided by the PrisonerSearch API instead