### PR TITLE
MO-199 pre-cursor - dont default prisoner search result

### DIFF
--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -68,7 +68,7 @@ module HmppsApi
       future_dates.any? ? future_dates.min.to_date : past_dates.max.try(:to_date)
     end
 
-    def initialize(payload, imprisonment_status:, recall_flag:)
+    def initialize(payload, search_payload)
       @parole_eligibility_date = deserialise_date(payload, 'paroleEligibilityDate')
       @release_date = deserialise_date(payload, 'releaseDate')
       @sentence_start_date = deserialise_date(payload, 'sentenceStartDate')
@@ -95,8 +95,8 @@ module HmppsApi
       @actual_parole_date = deserialise_date(payload, 'actualParoleDate')
       @licence_expiry_date = deserialise_date(payload, 'licenceExpiryDate')
 
-      @sentence_type = SentenceType.new imprisonment_status
-      @recall = recall_flag
+      @sentence_type = SentenceType.new search_payload.fetch('imprisonmentStatus', 'UNK_SENT')
+      @recall = search_payload.fetch('recall', false)
     end
 
     def describe_sentence

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -34,17 +34,18 @@ module HmppsApi
                        else
                          {}
                        end
-        offenders = data.map do |payload|
+        # need to ignore any offenders who don't show up in the search API
+        offenders = data.select { |p| search_data.key? p.fetch('offenderNo') }.map do |payload|
           offender_no = payload.fetch('offenderNo')
+          search_payload = search_data.fetch(offender_no)
           HmppsApi::OffenderSummary.new(payload,
-                                        search_data.fetch(offender_no, {}),
+                                        search_payload,
                                         latest_temp_movement: temp_movements[offender_no],
                                         complexity_level: complexities[offender_no]).tap { |offender|
             sentencing = sentence_details[offender.booking_id]
             if sentencing.present?
               offender.sentence = HmppsApi::SentenceDetail.new sentencing,
-                                                               imprisonment_status: payload.fetch('imprisonmentStatus'),
-                                                               recall_flag: search_data.fetch(offender_no, {}).fetch('recall', false)
+                                                               search_payload
             end
           }
         end
@@ -56,24 +57,24 @@ module HmppsApi
         offender_no = URI.encode_www_form_component(raw_offender_no)
         route = "/prisoners/#{offender_no}"
         api_response = client.get(route).first
+        search_payload = get_search_payload([offender_no])[offender_no] unless api_response.nil?
 
-        if api_response.nil?
+        if api_response.nil? || search_payload.nil?
           nil
         else
-          search_data = get_search_payload([offender_no])
           temp_movements = HmppsApi::PrisonApi::MovementApi.latest_temp_movement_for([offender_no])
           complexity_level = if api_response.fetch('currentlyInPrison') == 'Y' && PrisonService::womens_prison?(api_response.fetch('latestLocationId'))
                                HmppsApi::ComplexityApi.get_complexity(offender_no)
                              end
           prisoner = HmppsApi::Offender.new api_response,
-                                            search_data.fetch(offender_no, {}),
+                                            search_payload,
                                             latest_temp_movement: temp_movements[offender_no],
                                             complexity_level: complexity_level
           prisoner.tap do |offender|
             sentence_details = get_bulk_sentence_details([offender.booking_id])
             sentence = HmppsApi::SentenceDetail.new sentence_details.fetch(offender.booking_id),
-                                                    imprisonment_status: api_response.fetch('imprisonmentStatus'),
-                                                    recall_flag: search_data.fetch(offender_no, {}).fetch('recall', false)
+                                                    search_payload
+
 
             offender.sentence = sentence
             add_arrival_dates([offender])

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DebuggingController, type: :controller do
     let(:primary_pom_name) { 'Jenae Sporer' }
 
     it 'can show debugging information for a specific offender' do
-      stub_offender(build(:nomis_offender, offenderNo: offender_no, imprisonmentStatus: 'LIFE'))
+      stub_offender(build(:nomis_offender, :indeterminate, offenderNo: offender_no))
 
       stub_request(:post, "#{ApiHelper::T3}/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false").
         with(

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TasksController, :allocation, type: :controller do
     stub_poms(prison, pom)
     stub_signed_in_pom(prison, staff_id)
 
-    offenders = [build(:nomis_offender, imprisonmentStatus: 'LIFE', offenderNo: 'G7514GW', firstName: "Alice", lastName: "Aliceson"),
+    offenders = [build(:nomis_offender, :indeterminate, offenderNo: 'G7514GW', firstName: "Alice", lastName: "Aliceson"),
                  build(:nomis_offender, offenderNo: 'G1234VV', firstName: "Bob", lastName: "Bibby"),
                  build(:nomis_offender, offenderNo: 'G1234AB', firstName: "Carole", lastName: "Caroleson"),
                  build(:nomis_offender, offenderNo: 'G1234GG', firstName: "David", lastName: "Davidson")
@@ -58,7 +58,7 @@ RSpec.describe TasksController, :allocation, type: :controller do
     end
 
     it 'can show offenders needing parole review date updates' do
-      stub_offender(build(:nomis_offender, offenderNo: offender_no, imprisonmentStatus: 'LIFE'))
+      stub_offender(build(:nomis_offender, :indeterminate, offenderNo: offender_no))
 
       get :index, params: { prison_id: prison }
 

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -5,9 +5,8 @@ FactoryBot.define do
     initialize_with do
       # remove nils (as it confuses HmppsApi::SentenceDetail) and convert dates to strings (just in case test forgets)
       values_hash = attributes.except(:imprisonmentStatus).reject { |_k, v| v.nil? }.map { |k, v| [k.to_s, v.to_s] }.to_h
-      HmppsApi::SentenceDetail.new(values_hash,
-                                   imprisonment_status: attributes.fetch(:imprisonmentStatus),
-                                   recall_flag: attributes.fetch(:recall) )
+      HmppsApi::SentenceDetail.new values_hash,
+                                   attributes.stringify_keys
     end
 
     imprisonmentStatus { 'SEC90' }

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -91,7 +91,11 @@ RSpec.describe Prison, type: :model do
     end
 
     context 'when the search API misses someone' do
-      let(:offenders) { [build(:nomis_offender, recall: true), build(:nomis_offender, recall: false), build(:nomis_offender, recall: true)] }
+      let(:offenders) {
+        [build(:nomis_offender, recall: true),
+         build(:nomis_offender, recall: false),
+         build(:nomis_offender, recall: true)]
+      }
       let(:offender_nos) { offenders.map { |o| o.fetch(:offenderNo) } }
 
       before do
@@ -111,7 +115,7 @@ RSpec.describe Prison, type: :model do
           to_return(body: offenders.first(2).map { |o|
             { prisonerNumber: o.fetch(:offenderNo),
               recall: o.fetch(:recall) }
-          }                          .to_json)
+          }.to_json)
 
         stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=true&movementTypes=TAP").
           with(body: offender_nos.to_json).
@@ -124,7 +128,7 @@ RSpec.describe Prison, type: :model do
 
         stub_request(:post, "#{ApiHelper::T3}/movements/offenders?latestOnly=false&movementTypes=TRN").
             with(
-              body: offenders.map { |o| o.fetch(:offenderNo) }.to_json,
+              body: offenders.first(2).map { |o| o.fetch(:offenderNo) }.to_json,
             ).
             to_return(body: [].to_json)
 
@@ -133,8 +137,8 @@ RSpec.describe Prison, type: :model do
         )
       end
 
-      it 'returns falses when missing' do
-        expect(subject.map(&:recalled?)).to eq([true, false, false])
+      it 'skips the missing offender record' do
+        expect(subject.map(&:offender_no)).to eq(offender_nos.first(2))
       end
     end
 

--- a/spec/services/handover_date_service_old_spec.rb
+++ b/spec/services/handover_date_service_old_spec.rb
@@ -472,14 +472,21 @@ describe HandoverDateService do
 
     let(:offender) {
       build(:offender,
-            sentence: build(:sentence_detail,
-                            imprisonmentStatus: indeterminate_sentence ? 'LIFE' : 'SEC90',
-                            automaticReleaseDate: automatic_release_date,
-                            conditionalReleaseDate: conditional_release_date,
-                            paroleEligibilityDate: parole_eligibility_date,
-                            tariffDate: tariff_date
+            sentence: if indeterminate_sentence
+                        build(:sentence_detail,
+                              :indeterminate,
+                              paroleEligibilityDate: parole_eligibility_date,
+                              tariffDate: tariff_date
+                        )
+                      else
+                        build(:sentence_detail,
+                              :determinate,
+                              automaticReleaseDate: automatic_release_date,
+                              conditionalReleaseDate: conditional_release_date,
+                              paroleEligibilityDate: parole_eligibility_date
+                        )
+                      end
             )
-      )
     }
 
     let(:result) do

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -65,8 +65,8 @@ describe HmppsApi::PrisonApi::OffenderApi do
             to_return(body: [].to_json)
         end
 
-        it "defaults the recall flag to false" do
-          expect(subject.recalled?).to eq(false)
+        it "fails the search" do
+          expect(subject).to be_nil
         end
       end
     end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -24,6 +24,7 @@ module ApiHelper
         {
           prisonerNumber: offender_no,
           recall: offender.fetch(:recall),
+          imprisonmentStatus: offender.fetch(:sentence).fetch(:imprisonmentStatus),
           cellLocation: offender.fetch(:internalLocation)
         }
       ].to_json)
@@ -138,6 +139,7 @@ module ApiHelper
                         {
                           prisonerNumber: offender.fetch(:offenderNo),
                           recall: offender.fetch(:recall),
+                          imprisonmentStatus: offender.fetch(:sentence).fetch(:imprisonmentStatus),
                           cellLocation: offender.fetch(:internalLocation)
                         }
                       }.to_json)


### PR DESCRIPTION
Previously we were only sourcing the recall_flag from the PrisonerSearch API, so therefore could default it to false. Now we want to source more data from there, so this PR changes thia behaviour to consider the offender as not found if the prisoner search fails