### PR TITLE
MO-629 make PrisonOffenderManageService a bit smaller

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -130,9 +130,7 @@ class AllocationsController < PrisonsApplicationController
 private
 
   def unavailable_pom_count
-    @unavailable_pom_count ||= PrisonOffenderManagerService.unavailable_pom_count(
-      active_prison_id
-    )
+    PrisonOffenderManagerService.get_poms_for(active_prison_id).count { |pom| pom.status != 'active' }
   end
 
   def allocation_attributes(offender)

--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -23,7 +23,7 @@ module Api
     def primary_pom_details
       {
         staff_id: @allocation.primary_pom_nomis_id,
-        name: helpers.fetch_pom_name(@allocation.primary_pom_nomis_id)
+        name: PrisonOffenderManagerService.fetch_pom_name(@allocation.primary_pom_nomis_id)
       }
     end
 
@@ -32,7 +32,7 @@ module Api
 
       {
         staff_id: @allocation.secondary_pom_nomis_id,
-        name: helpers.fetch_pom_name(@allocation.secondary_pom_nomis_id)
+        name: PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id)
       }
     end
 

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -64,8 +64,12 @@ private
   # Takes a list of OffenderSummary or Offender objects, and returns them with their
   # allocated POM name set in :allocated_pom_name.
   def set_allocated_pom_names(offenders, prison_id)
-    pom_names = PrisonOffenderManagerService.get_pom_names(prison_id)
+    pom_names = PrisonOffenderManagerService.get_poms_for(prison_id).each_with_object({}) { |p, hsh|
+      hsh[p.staff_id] = p.full_name
+    }
+
     nomis_offender_ids = offenders.map(&:offender_no)
+
     offender_to_staff_hash = Allocation.
       where(nomis_offender_id: nomis_offender_ids).
       map { |a|

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -15,12 +15,12 @@ class PrisonersController < PrisonsApplicationController
     @allocation = Allocation.find_by(nomis_offender_id: @prisoner.offender_no)
 
     if @allocation.present?
-      @primary_pom_name = helpers.fetch_pom_name(@allocation.primary_pom_nomis_id).
+      @primary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.primary_pom_nomis_id).
           titleize
     end
 
     if @allocation.present? && @allocation.secondary_pom_name.present?
-      @secondary_pom_name = helpers.fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
+      @secondary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
     end
 
     @keyworker = HmppsApi::KeyworkerApi.get_keyworker(

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,10 +28,10 @@ private
   end
 
   def load_pom
-    @pom = PrisonOffenderManagerService.get_signed_in_pom_details(
-      current_user,
-      active_prison_id
-    )
+    user = HmppsApi::PrisonApi::UserApi.user_details(current_user)
+    poms_list = PrisonOffenderManagerService.get_poms_for(active_prison_id)
+
+    @pom = poms_list.find { |p| p.staff_id.to_i == user.staff_id.to_i }
   end
 
   def page

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -36,9 +36,8 @@ module PomHelper
   end
 
   def fetch_pom_name(staff_id)
-    pom_firstname, pom_secondname =
-      PrisonOffenderManagerService.get_pom_name(staff_id)
-    "#{pom_secondname}, #{pom_firstname}"
+    staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(staff_id)
+    "#{staff.last_name}, #{staff.first_name}"
   end
 
   def status(pom)

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -35,11 +35,6 @@ module PomHelper
     "#{pom.position_description.split(' ').first} POM"
   end
 
-  def fetch_pom_name(staff_id)
-    staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(staff_id)
-    "#{staff.last_name}, #{staff.first_name}"
-  end
-
   def status(pom)
     # we are now displaying 'Available', instead of 'Active' which is stored in the database
     pom.status == 'active' ? 'available' : pom.status

--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -36,7 +36,7 @@ class AutomaticHandoverEmailJob < ApplicationJob
                     [offender.conditional_release_date, offender.parole_eligibility_date, offender.tariff_date].compact.min,
                     PrisonService.name_for(offender.prison_id),
                     allocation&.primary_pom_name,
-                    allocation&.active? ? PrisonOffenderManagerService.get_pom_emails(allocation.primary_pom_nomis_id).first : nil,
+                    allocation&.active? ? HmppsApi::PrisonApi::PrisonOffenderManagerApi.fetch_email_addresses(allocation.primary_pom_nomis_id).first : nil,
                     offender.allocated_com_name
                 ]
           end

--- a/app/jobs/push_pom_to_delius_job.rb
+++ b/app/jobs/push_pom_to_delius_job.rb
@@ -14,13 +14,13 @@ class PushPomToDeliusJob < ApplicationJob
 
       # The allocation model has formatted pom names ‘firstname, surname’ that PrisonOffenderManagerService
       # splits up to allow them to be pushed separately.
-      pom_firstname, pom_secondname = PrisonOffenderManagerService.get_pom_name(allocation.primary_pom_nomis_id)
+      staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(allocation.primary_pom_nomis_id)
 
       HmppsApi::CommunityApi.set_pom(
         offender_no: allocation.nomis_offender_id,
         prison: allocation.prison,
-        forename: pom_firstname,
-        surname: pom_secondname
+        forename: staff.first_name,
+        surname: staff.last_name
       )
     end
   end

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -31,41 +31,6 @@ class PrisonOffenderManagerService
     StaffMember.new(Prison.new(prison_id), pom.staff_id)
   end
 
-  def self.get_pom_emails(nomis_staff_id)
-    HmppsApi::PrisonApi::PrisonOffenderManagerApi.fetch_email_addresses(nomis_staff_id)
-  end
-
-  def self.get_pom_names(prison)
-    poms_list = get_poms_for(prison)
-    poms_list.each_with_object({}) { |p, hsh|
-      hsh[p.staff_id] = p.full_name
-    }
-  end
-
-  def self.get_pom_name(nomis_staff_id)
-    staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(nomis_staff_id)
-    [staff.first_name, staff.last_name]
-  end
-
-  def self.get_user_name(username)
-    user = HmppsApi::PrisonApi::UserApi.user_details(username)
-    [user.first_name, user.last_name]
-  end
-
-  def self.unavailable_pom_count(prison)
-    poms = get_poms_for(prison).reject { |pom|
-      pom.status == 'active'
-    }
-    poms.count
-  end
-
-  def self.get_signed_in_pom_details(current_user, prison)
-    user = HmppsApi::PrisonApi::UserApi.user_details(current_user)
-
-    poms_list = get_poms_for(prison)
-    poms_list.find { |p| p.staff_id.to_i == user.staff_id.to_i }
-  end
-
 private
 
   # Attempt to forward-populate the PomDetail table for new records

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -31,6 +31,13 @@ class PrisonOffenderManagerService
     StaffMember.new(Prison.new(prison_id), pom.staff_id)
   end
 
+  class << self
+    def fetch_pom_name(staff_id)
+      staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(staff_id)
+      "#{staff.last_name}, #{staff.first_name}"
+    end
+  end
+
 private
 
   # Attempt to forward-populate the PomDetail table for new records

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -62,11 +62,11 @@ FactoryBot.define do
     trait :co_working do
       event {Allocation:: ALLOCATE_SECONDARY_POM}
       event_trigger { Allocation::USER }
-      primary_pom_nomis_id {345_456}
+      primary_pom_nomis_id { 485_637 }
       # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"
       # So we also .titleize the last name here to avoid breaking tests
       primary_pom_name {"#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"}
-      secondary_pom_nomis_id {234_567}
+      secondary_pom_nomis_id { 485_926 }
       secondary_pom_name {"#{Faker::Name.last_name.titleize}, #{Faker::Name.first_name}"}
     end
 

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -43,7 +43,7 @@ feature 'View a prisoner profile page' do
   context 'with an allocation', :allocation do
     before do
       create(:case_information, nomis_offender_id: 'G7998GJ', victim_liaison_officers: [build(:victim_liaison_officer)])
-      create(:allocation, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637', primary_pom_name: 'Pobno, Kath')
+      create(:allocation, :co_working, nomis_offender_id: 'G7998GJ', primary_pom_nomis_id: '485637', primary_pom_name: 'Pobno, Kath')
     end
 
     let(:allocation) { Allocation.last }

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -7,12 +7,6 @@ RSpec.describe PomHelper do
     end
   end
 
-  describe 'fetch_pom_name', vcr: { cassette_name: 'prison_api/pom_helper_fetch_pom_name' } do
-    it 'fetches the POM name from NOMIS' do
-      expect(fetch_pom_name(485_926)).to eq('POM, MOIC')
-    end
-  end
-
   describe 'status' do
     it "renames 'active' status to available" do
       pom = build(:pom, staffId: 2005,  status: 'active')

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Allocation, type: :model do
 
     context 'when a new allocation is created and a POM is set' do
       before do
-        expect(PrisonOffenderManagerService).to receive(:get_pom_name).with(nomis_staff_id).and_return ['Bill', 'Jones']
+        expect(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:staff_detail).with(nomis_staff_id).and_return build(:pom, firstName: 'Bill', lastName: 'Jones')
         expect(HmppsApi::CommunityApi).to receive(:set_pom).with offender_no: nomis_offender_id, prison: prison, forename: 'Bill', surname: 'Jones'
       end
 
@@ -276,7 +276,7 @@ RSpec.describe Allocation, type: :model do
 
     context 'with an existing allocation' do
       before do
-        expect(PrisonOffenderManagerService).to receive(:get_pom_name).with(nomis_staff_id).and_return ['Bill', 'Jones']
+        expect(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:staff_detail).with(nomis_staff_id).and_return build(:pom, firstName: 'Bill', lastName: 'Jones')
         expect(HmppsApi::CommunityApi).to receive(:set_pom).with offender_no: nomis_offender_id, prison: prison, forename: 'Bill', surname: 'Jones'
         create(:allocation, :primary, nomis_offender_id: nomis_offender_id, prison: prison, primary_pom_nomis_id: nomis_staff_id)
       end
@@ -301,7 +301,7 @@ RSpec.describe Allocation, type: :model do
 
       describe 're-allocated POM ' do
         before do
-          expect(PrisonOffenderManagerService).to receive(:get_pom_name).with(updated_nomis_staff_id).and_return ['Sally', 'Albright']
+          expect(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:staff_detail).with(updated_nomis_staff_id).and_return build(:pom, firstName: 'Sally', lastName: 'Albright')
           expect(HmppsApi::CommunityApi).to receive(:set_pom).with offender_no: nomis_offender_id, prison: prison, forename: 'Sally', surname: 'Albright'
         end
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -39,6 +39,12 @@ describe PrisonOffenderManagerService do
         }.to raise_exception(StandardError)
       end
     end
+
+    describe 'fetch_pom_name', vcr: { cassette_name: 'prison_api/pom_helper_fetch_pom_name' } do
+      it 'fetches the POM name from NOMIS' do
+        expect(described_class.fetch_pom_name(485_926)).to eq('POM, MOIC')
+      end
+    end
   end
 
   context 'without T3 fixtures' do

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -11,18 +11,6 @@ describe PrisonOffenderManagerService do
   }
 
   context 'when using T3 and VCR' do
-    describe '#get_pom_name' do
-      it "can get staff names", vcr: { cassette_name: 'prison_api/pom_service_staff_name' } do
-        expect(described_class.get_pom_name(staff_id)). to eq ["MOIC", "INTEGRATION-TESTS"]
-      end
-    end
-
-    describe '#get_user_name' do
-      it "can get user names", vcr: { cassette_name: 'prison_api/pom_service_user_name' } do
-        expect(described_class.get_user_name('RJONES')).to eq ['Ross', 'Jones']
-      end
-    end
-
     describe '#get_poms_for' do
       subject {
         described_class.get_poms_for('LEI')
@@ -34,15 +22,6 @@ describe PrisonOffenderManagerService do
         expect(subject).to be_kind_of(Enumerable)
         expect(subject.count { |pom| pom.status == 'active' }).to eq(subject.count)
         expect(moic_integration_tests.probation_officer?).to eq(true)
-      end
-    end
-
-    describe '#get_pom_names' do
-      it "can get the names for POMs when given IDs",
-         vcr: { cassette_name: 'prison_api/pom_service_get_poms_by_ids' } do
-        names = described_class.get_pom_names('LEI')
-        expect(names).to be_kind_of(Hash)
-        expect(names.count).to be > 10
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,8 @@ SimpleCov.start 'rails' do
   add_group "Services", "app/services"
 
   # Try to set this to current coverage levels so that it never goes down after a PR
-  # 18 lines uncovered at 99.5% coverage
-  minimum_coverage 99.50
+  # 18 lines uncovered at 99.54% coverage
+  minimum_coverage 99.54
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,8 @@ SimpleCov.start 'rails' do
   add_group "Services", "app/services"
 
   # Try to set this to current coverage levels so that it never goes down after a PR
-  # 18 lines uncovered at 99.54% coverage
-  minimum_coverage 99.54
+  # 17 lines uncovered at 99.56% coverage
+  minimum_coverage 99.56
   # sometimes coverage drops between branches - don't fail in these cases
   maximum_coverage_drop 0.5
 


### PR DESCRIPTION
remove small single-use methods that do nothing to help abstraction for the code base.

This PR helps PrisonOffenderManagerService tremendously, in that it shrinks it down to 2 methods - get_pom_at and get_poms_for. It should be reviewed and merged ahead of MO-486, which struggles to cope with the complexity of this class - simplifying it should make some of the issues with that PR go away
