### PR TITLE
MO-486 Part II - improve backfill poms task to cover all POM records

### DIFF
--- a/lib/tasks/backfill_pom_details.rake
+++ b/lib/tasks/backfill_pom_details.rake
@@ -10,8 +10,18 @@ namespace :backfill do
     Prison.all.each do |prison|
       PrisonOffenderManagerService.get_poms_for(prison.code).map(&:staff_id).each { |staff_id|
         pom = PomDetail.find_by! nomis_staff_id: staff_id
-        pom.update! prison_code: prison.code
+        pom.update! prison_code: prison.code if pom.prison_code.nil?
       }
+    end
+
+    PomDetail.where(prison_code: nil).each do |pom_detail|
+      prims = Allocation.where(primary_pom_nomis_id: pom_detail.nomis_staff_id)
+      allocs = Allocation.where(secondary_pom_nomis_id: pom_detail.nomis_staff_id).or(prims)
+      if allocs.count == 0
+        pom_detail.destroy
+      else
+        pom_detail.update! prison_code: allocs.last.prison
+      end
     end
   end
 end


### PR DESCRIPTION
This PR improves the backfill:pom_details rake task so that all old PomDetail records will have a prison code associated with them. Any POM which is not in a prison but does not have any allocations will have their PomDetails record removed