### PR TITLE
MO-426 pre-factor: Use female category for start of handover date

### DIFF
--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -9,12 +9,12 @@ module HmppsApi
     attr_reader :prison_id
 
     # This must only reference fields that are present in
-    # https://https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//prisoners/getPrisonersOffenderNo
-    def initialize(api_payload, search_payload, latest_temp_movement:, complexity_level:)
+    # https://api-dev.prison.service.justice.gov.uk/swagger-ui/#/prisoners/getPrisonersOffenderNo
+    def initialize(api_payload, search_payload, category:, latest_temp_movement:, complexity_level:)
       @booking_id = api_payload['latestBookingId']&.to_i
       @prison_id = api_payload['latestLocationId']
 
-      super(api_payload, search_payload, latest_temp_movement: latest_temp_movement, complexity_level: complexity_level)
+      super(api_payload, search_payload, category: category, latest_temp_movement: latest_temp_movement, complexity_level: complexity_level)
     end
   end
 end

--- a/app/models/hmpps_api/offender_category.rb
+++ b/app/models/hmpps_api/offender_category.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module HmppsApi
+  class OffenderCategory
+    attr_reader :code,
+                :label,
+                :active_since
+
+    def initialize(payload)
+      # Category code – e.g. "A", "B", "C", etc.
+      @code = payload.fetch('classificationCode')
+
+      # Human-readable name for the category – e.g. "Cat A", "Female Open", etc.
+      @label = payload.fetch('classification')
+
+      # Date the offender's category assessment was approved
+      # This denotes the date it became 'active' as the offender's category
+      @active_since = payload.fetch('approvalDate').to_date
+    end
+  end
+end

--- a/app/models/hmpps_api/offender_summary.rb
+++ b/app/models/hmpps_api/offender_summary.rb
@@ -22,12 +22,12 @@ module HmppsApi
 
     # This list must only contain values that are returned by
     # https://api-dev.prison.service.justice.gov.uk/swagger-ui.html#//locations/getOffendersAtLocationDescription
-    def initialize(api_payload, search_payload, latest_temp_movement:, complexity_level:)
+    def initialize(api_payload, search_payload, category:, latest_temp_movement:, complexity_level:)
       @booking_id = api_payload.fetch('bookingId').to_i
       @prison_id = api_payload.fetch('agencyId')
       @facial_image_id = api_payload['facialImageId']&.to_i
 
-      super(api_payload, search_payload, latest_temp_movement: latest_temp_movement, complexity_level: complexity_level)
+      super(api_payload, search_payload, category: category, latest_temp_movement: latest_temp_movement, complexity_level: complexity_level)
     end
   end
 end

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -165,7 +165,13 @@ private
 
   def self.nps_start_date(offender)
     if offender.open_prison_rules_apply? && offender.indeterminate_sentence?
-      offender.prison_arrival_date
+      if offender.in_womens_prison?
+        # Women's estate: the day the offender's category changed to "open"
+        offender.category_active_since
+      else
+        # Men's estate: the day the offender arrived in the open prison
+        offender.prison_arrival_date
+      end
     elsif offender.early_allocation?
       early_allocation_handover_date(offender)
     elsif offender.indeterminate_sentence?
@@ -250,6 +256,7 @@ private
              :early_allocation?, :mappa_level, :prison_arrival_date, :sentence_start_date,
              :parole_eligibility_date, :conditional_release_date, :automatic_release_date,
              :home_detention_curfew_eligibility_date, :home_detention_curfew_actual_date,
+             :category_active_since,
              to: :@offender
 
     def initialize(offender)

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -8,7 +8,6 @@ class OffenderService
       record = CaseInformation.find_by(nomis_offender_id: offender_no)
       o.load_case_information(record)
 
-      o.category_code = HmppsApi::PrisonApi::OffenderApi.get_category_code(o.offender_no)
       o.main_offence = HmppsApi::PrisonApi::OffenderApi.get_offence(o.booking_id)
     }
   end

--- a/spec/factories/offender_categories.rb
+++ b/spec/factories/offender_categories.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :offender_category, class: HmppsApi::OffenderCategory do
+    initialize_with { HmppsApi::OffenderCategory.new(attributes.stringify_keys) }
+
+    classificationCode { 'A' }
+    classification { 'Cat A' }
+    approvalDate { 3.days.ago }
+
+    # Men's categories
+
+    trait :cat_a do
+      classificationCode { 'A' }
+      classification { 'Cat A' }
+    end
+
+    trait :cat_b do
+      classificationCode { 'B' }
+      classification { 'Cat B' }
+    end
+
+    trait :cat_c do
+      classificationCode { 'C' }
+      classification { 'Cat C' }
+    end
+
+    trait :cat_d do
+      classificationCode { 'D' }
+      classification { 'Cat D' }
+    end
+
+    # Women's categories
+
+    trait :female_restricted do
+      classificationCode { 'Q' }
+      classification { 'Female Restricted' }
+    end
+
+    trait :female_closed do
+      classificationCode { 'R' }
+      classification { 'Female Closed' }
+    end
+
+    trait :female_semi do
+      classificationCode { 'S' }
+      classification { 'Female Semi' }
+    end
+
+    trait :female_open do
+      classificationCode { 'T' }
+      classification { 'Female Open' }
+    end
+  end
+end

--- a/spec/factories/offender_summaries.rb
+++ b/spec/factories/offender_summaries.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     initialize_with do
       HmppsApi::OffenderSummary.new(attributes.stringify_keys,
                                     attributes.stringify_keys,
+                                    category: attributes.fetch(:category),
                                     latest_temp_movement: nil,
                                     complexity_level: attributes.fetch(:complexityLevel)).tap { |offender|
         offender.sentence = attributes.fetch(:sentence)}

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     # also ensure uniqueness as duplicate last names can cause issues
     # in tests, as ruby sort isn't stable by default
     sequence(:lastName) { |c| "#{Faker::Name.last_name.titleize}_#{c}" }
-    categoryCode { 'C' }
+    category { build(:offender_category, :cat_c) }
     recall {  false }
 
     sentence { association :sentence_detail }
@@ -40,6 +40,7 @@ FactoryBot.define do
     initialize_with do
       HmppsApi::Offender.new(attributes.stringify_keys,
                              attributes.stringify_keys,
+                             category: attributes.fetch(:category),
                              latest_temp_movement: nil,
                              complexity_level: attributes.fetch(:complexityLevel)).tap { |offender|
         offender.sentence = attributes.fetch(:sentence)
@@ -83,7 +84,7 @@ FactoryBot.define do
     # also ensure uniqueness as duplicate last names can cause issues
     # in tests, as ruby sort isn't stable by default
     sequence(:lastName) { |c| "#{Faker::Name.last_name.titleize}_#{c}" }
-    categoryCode { 'C' }
+    category { attributes_for(:offender_category, :cat_c) }
     recall { false }
 
     sentence do

--- a/spec/features/pom_staff_female_feature_spec.rb
+++ b/spec/features/pom_staff_female_feature_spec.rb
@@ -10,13 +10,15 @@ feature "female estate POMs list" do
 
   let(:nomis_offender) {
     build(:nomis_offender,
-          agencyId: female_prison, complexityLevel: 'high', categoryCode: 'T',
+          agencyId: female_prison, complexityLevel: 'high',
+          category: attributes_for(:offender_category, :female_closed),
           sentence: attributes_for(:sentence_detail))
   }
 
   let(:offenders_in_prison) {
     build_list(:nomis_offender, 14,
-               agencyId: female_prison, categoryCode: 'T',
+               agencyId: female_prison,
+               category: attributes_for(:offender_category, :female_closed),
                sentence: attributes_for(:sentence_detail))
   }
 

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -400,4 +400,52 @@ describe HmppsApi::Offender do
       end
     end
   end
+
+  describe 'offender category' do
+    subject { build(:offender, category: category) }
+
+    context 'with a male offender (Cat B)' do
+      let(:category) { build(:offender_category, :cat_b) }
+
+      it 'knows the category code' do
+        expect(subject.category_code).to eq('B')
+      end
+
+      it 'knows the category label' do
+        expect(subject.category_label).to eq('Cat B')
+      end
+
+      it 'knows when the category became active for this offender' do
+        expect(subject.category_active_since).to be_a(Date)
+      end
+    end
+
+    context 'with a female offender (Female Open)' do
+      let(:category) { build(:offender_category, :female_open) }
+
+      it 'knows the category code' do
+        expect(subject.category_code).to eq('T')
+      end
+
+      it 'knows the category label' do
+        expect(subject.category_label).to eq('Female Open')
+      end
+
+      it 'knows when the category became active for this offender' do
+        expect(subject.category_active_since).to be_a(Date)
+      end
+    end
+
+    # This is a legitimate state for an offender to be in
+    # They could be in the prison, but a categorisation assessment hasn't been completed yet
+    context "when the offender doesn't have a category" do
+      let(:category) { nil }
+
+      it 'returns nil' do
+        expect(subject.category_code).to be_nil
+        expect(subject.category_label).to be_nil
+        expect(subject.category_active_since).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/hmpps_api/offender_summary_spec.rb
+++ b/spec/models/hmpps_api/offender_summary_spec.rb
@@ -196,27 +196,6 @@ describe HmppsApi::OffenderSummary do
     end
   end
 
-  describe '#category_label' do
-    context 'with a category code' do
-      let(:offender) { build(:offender, convictedStatus: 'Convicted', sentence: build(:sentence_detail, :unsentenced)) }
-
-      before do
-        stub_auth_token
-        stub_category_label
-      end
-
-      it "can return the men's category description" do
-        subject.category_code = 'A'
-        expect(subject.category_label).to eq 'Cat A'
-      end
-
-      it "can return the women's category description" do
-        subject.category_code = 'T'
-        expect(subject.category_label).to eq 'Fem Open'
-      end
-    end
-  end
-
   describe '#sentenced?' do
     context 'with sentence detail with a release date' do
       before do

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Prison, type: :model do
 
       before do
         stub_auth_token
-        stub_request(:get, "#{ApiHelper::T3}/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+        stub_request(:get, "#{ApiHelper::T3}/locations/description/LEI/inmates?convictedStatus=Convicted").
           with(
             headers: {
               'Page-Limit' => '200',
@@ -135,6 +135,8 @@ RSpec.describe Prison, type: :model do
         allow(HmppsApi::ComplexityApi).to receive(:get_complexities).with(offender_nos).and_return(
           offenders.map { |offender| [offender.fetch(:offenderNo), offender.fetch(:complexityLevel)] }.to_h
         )
+
+        stub_offender_categories(offenders)
       end
 
       it 'skips the missing offender record' do
@@ -148,7 +150,7 @@ RSpec.describe Prison, type: :model do
 
       before do
         stub_auth_token
-        stub_request(:get, "#{ApiHelper::T3}/locations/description/LEI/inmates?convictedStatus=Convicted&returnCategory=true").
+        stub_request(:get, "#{ApiHelper::T3}/locations/description/LEI/inmates?convictedStatus=Convicted").
           with(
             headers: {
               'Page-Limit' => '200',
@@ -182,6 +184,8 @@ RSpec.describe Prison, type: :model do
         allow(HmppsApi::ComplexityApi).to receive(:get_complexities).with(offender_nos).and_return(
           offenders.map { |offender| [offender.fetch(:offenderNo), offender.fetch(:complexityLevel)] }.to_h
         )
+
+        stub_offender_categories(offenders)
       end
 
       it 'fetches one page only' do

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -20,7 +20,7 @@ describe HandoverDateService do
   let(:prescoed_policy_start_date) { Date.new(2020, 10, 19) } # 19th October 2020
   let(:open_policy_start_date) { Date.new(2021, 3, 31) } # 31st March 2021
   let(:womens_policy_start_date) { Date.parse('30th April 2021') }
-  let(:category) { 'C' }
+  let(:category) { build(:offender_category, :cat_c) }
 
   # Set the current date by changing the value of `today`
   let(:today) { Time.zone.today }
@@ -391,7 +391,7 @@ describe HandoverDateService do
       let(:offender) {
         build(:offender,
               latestLocationId: prison,
-              categoryCode: category,
+              category: category,
               sentence: build(:sentence_detail, :indeterminate, tariffDate: tariff_date, sentenceStartDate: sentence_start_date)
         ).tap { |o|
           o.load_case_information(case_info)
@@ -510,7 +510,7 @@ describe HandoverDateService do
           end
 
           context 'when transferred to open conditions (Cat T)' do
-            let(:category) { 'T' }
+            let(:category) { build(:offender_category, :female_open) }
 
             it 'follows pre-policy rules' do
               expect(pom).to be_supporting
@@ -531,7 +531,7 @@ describe HandoverDateService do
           end
 
           context 'when transferred to open conditions (Cat T)' do
-            let(:category) { 'T' }
+            let(:category) { build(:offender_category, :female_open) }
 
             it 'invokes open prison rules and COM is supporting' do
               expect(com).to be_supporting

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 describe HandoverDateService do
   subject { described_class.handover(offender) }
 
-
   let(:test_strategy) { Flipflop::FeatureSet.current.test! }
   let(:pom) { HandoverDateService::Responsibility.new subject.custody_responsible?, subject.custody_supporting?  }
   let(:com) { HandoverDateService::Responsibility.new subject.community_responsible?, subject.community_supporting? }
@@ -531,10 +530,19 @@ describe HandoverDateService do
           end
 
           context 'when transferred to open conditions (Cat T)' do
-            let(:category) { build(:offender_category, :female_open) }
+            let(:category) { build(:offender_category, :female_open, approvalDate: 3.days.ago) }
 
             it 'invokes open prison rules and COM is supporting' do
               expect(com).to be_supporting
+              expect(pom).to be_responsible
+            end
+
+            it 'handover starts the day their category changed to "female open"' do
+              expect(start_date).to eq(offender.category_active_since)
+            end
+
+            it 'handover happens 8 months before TED/PED/PRD' do
+              expect(handover_date).to eq(tariff_date - 8.months)
             end
           end
         end

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -166,18 +166,4 @@ describe HmppsApi::PrisonApi::OffenderApi do
       expect(bytes[-2, 2]).to eq(jpeg_end_sentinel)
     end
   end
-
-  describe 'Fetching category descriptions' do
-    before do
-      stub_auth_token
-      stub_category_label
-    end
-
-    it 'returns a hash of category codes and descriptions' do
-      response = described_class.get_category_labels
-      expect(response).to be_a(Hash)
-      expect(response['A']).to eq 'Cat A'
-      expect(response['T']).to eq 'Fem Open'
-    end
-  end
 end


### PR DESCRIPTION
In the women's estate, use the date that their category became "female open" to determine when their handover starts.
    
This replicates the behaviour of the men's estate, where their start of handover date is the day that they moved into a male open prison.

---

Based upon #1674 pre-factor. The only commit of interest in this branch is 11b788c.