### PR TITLE
MO-646: Show human-friendly label for offender's category

### DIFF
--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -49,6 +49,10 @@
       <%= link_to 'Change', edit_prison_case_information_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' if @prisoner.manual_entry? %>
     </td>
   </tr>
+  <tr class="govuk-table__row" id="offender-category">
+    <td class="govuk-table__cell govuk-!-width-one-half">Category</td>
+    <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.category_label || "Unknown" %></td>
+  </tr>
   <tr class="govuk-table__row" id="tier-row">
     <td class="govuk-table__cell">Tiering calculation</td>
     <td class="govuk-table__cell table_cell__left_align">

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -28,9 +28,9 @@
       <td class="govuk-table__cell govuk-!-width-one-half">Date of birth</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= format_date(@prisoner.date_of_birth) %></td>
     </tr>
-    <tr class="govuk-table__row">
+    <tr class="govuk-table__row" id="offender-category">
       <td class="govuk-table__cell govuk-!-width-one-half">Category</td>
-      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">Cat <%= @prisoner.category_code %></td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.category_label %></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Tiering calculation</td>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -30,7 +30,7 @@
     </tr>
     <tr class="govuk-table__row" id="offender-category">
       <td class="govuk-table__cell govuk-!-width-one-half">Category</td>
-      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.category_label %></td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.category_label || "Unknown" %></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Tiering calculation</td>

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -136,7 +136,13 @@
     </tr>
     <tr class="govuk-table__row" id="category">
       <td class="govuk-table__cell govuk-!-width-one-half">Category</td>
-      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">Cat <%= @offender.category_code %></td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
+        <% if @offender.category_code %>
+          <%= @offender.category_label %> (<%= @offender.category_code %>) (since <%= format_date(@offender.category_active_since) %>)
+        <% else %>
+          Unknown
+        <% end %>
+      </td>
     </tr>
     <tr class="govuk-table__row" id="imprisonment-status">
       <td class="govuk-table__cell govuk-!-width-one-half">Imprisonment status</td>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -50,7 +50,7 @@
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Category</span>
-        <h3 class="govuk-heading-m" id="category-code"><%= @prisoner.category_code %></h3>
+        <h3 class="govuk-heading-m" id="category-code"><%= @prisoner.category_label %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Tier calculation</span>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -50,7 +50,7 @@
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Category</span>
-        <h3 class="govuk-heading-m" id="category-code"><%= @prisoner.category_label %></h3>
+        <h3 class="govuk-heading-m" id="category-code"><%= @prisoner.category_label || "Unknown" %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Tier calculation</span>

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -12,7 +12,7 @@ feature 'View a prisoner profile page' do
       expect(page).to have_css('h1', text: 'Ahmonis, Okadonah')
       expect(page).to have_content('07/07/1968')
       cat_code = find('h3#category-code').text
-      expect(cat_code).to eq('C')
+      expect(cat_code).to eq('Cat C')
       expect(page).to have_css('#prisoner-case-type', text: 'Determinate')
     end
   end
@@ -117,7 +117,7 @@ feature 'View a prisoner profile page' do
         expect(page).to have_css('h1', text: 'Ahmonis, Okadonah')
         expect(page).to have_content('07/07/1968')
         cat_code = find('h3#category-code').text
-        expect(cat_code).to eq('C')
+        expect(cat_code).to eq('Cat C')
       end
 
       it 'shows the POM name (fetched from NOMIS)' do

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -180,7 +180,8 @@ module ApiHelper
 
   def stub_offender_categories(offenders)
     offender_nos = offenders.map { |offender| offender.fetch(:offenderNo) }
-    categories = offenders.map { |offender| offender.fetch(:category).merge(offenderNo: offender.fetch(:offenderNo)) }
+    categories = offenders.reject { |offender| offender[:category].nil? }
+                   .map { |offender| offender.fetch(:category).merge(offenderNo: offender.fetch(:offenderNo)) }
 
     stub_request(:post, "#{T3}/offender-assessments/CATEGORY?activeOnly=true&latestOnly=true&mostRecentOnly=true").
       with(

--- a/spec/views/allocations/index.html.erb_spec.rb
+++ b/spec/views/allocations/index.html.erb_spec.rb
@@ -3,9 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe "allocations/index", type: :view do
+  let(:page) { Nokogiri::HTML(rendered) }
+  let(:offender) { build(:offender) }
+
   before do
     assign(:prison, build(:prison))
-    assign(:prisoner, build(:offender))
+    assign(:prisoner, offender)
     assign(:previously_allocated_pom_ids, [])
     assign(:recommended_poms, [])
     assign(:not_recommended_poms, [])
@@ -14,13 +17,44 @@ RSpec.describe "allocations/index", type: :view do
     render
   end
 
-  let(:page) { Nokogiri::HTML(rendered) }
-
   it 'shows handover dates' do
     expect(page.css('#handover-start-date-row')).to have_text('Handover start date')
     expect(page.css('#handover-start-date-row')).to have_text('05/11/2021')
 
     expect(page.css('#responsibility-handover-date-row')).to have_text('Responsibility handover')
     expect(page.css('#responsibility-handover-date-row')).to have_text('05/11/2021')
+  end
+
+  describe 'category label' do
+    let(:key) { page.css('#offender-category > td:nth-child(1)').text }
+    let(:value) { page.css('#offender-category > td:nth-child(2)').text }
+
+    context 'when a male offender category' do
+      let(:offender) { build(:offender, category: build(:offender_category, :cat_d)) }
+
+      it 'shows the category label' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Cat D')
+      end
+    end
+
+    context 'when a female offender category' do
+      let(:offender) { build(:offender, category: build(:offender_category, :female_open)) }
+
+      it 'shows the category label' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Female Open')
+      end
+    end
+
+    context 'when category is unknown' do
+      # This happens when an offender's category assessment hasn't been completed yet
+      let(:offender) { build(:offender, category: nil) }
+
+      it 'shows "Unknown"' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Unknown')
+      end
+    end
   end
 end

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -3,17 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe "allocations/show", type: :view do
+  let(:page) { Nokogiri::HTML(rendered) }
+  let(:offender) { build(:offender) }
+
   before do
     assign(:prison, build(:prison))
     assign(:pom, build(:pom))
-    assign(:prisoner, build(:offender))
+    assign(:prisoner, offender)
     assign(:allocation, create(:allocation))
     assign(:keyworker, build(:keyworker))
     assign(:case_info, build(:case_information))
     render
   end
-
-  let(:page) { Nokogiri::HTML(rendered) }
 
   it 'shows handover dates' do
     expect(page.css('#handover-start-date-row')).to have_text('Handover start date')
@@ -21,5 +22,28 @@ RSpec.describe "allocations/show", type: :view do
 
     expect(page.css('#responsibility-handover-date-row')).to have_text('Responsibility handover')
     expect(page.css('#responsibility-handover-date-row')).to have_text('05/11/2021')
+  end
+
+  describe 'category label' do
+    let(:key) { page.css('#offender-category > td:nth-child(1)').text }
+    let(:value) { page.css('#offender-category > td:nth-child(2)').text }
+
+    context 'when a male offender category' do
+      let(:offender) { build(:offender, category: build(:offender_category, :cat_d)) }
+
+      it 'shows the category label' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Cat D')
+      end
+    end
+
+    context 'when a female offender category' do
+      let(:offender) { build(:offender, category: build(:offender_category, :female_open)) }
+
+      it 'shows the category label' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Female Open')
+      end
+    end
   end
 end

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -45,5 +45,15 @@ RSpec.describe "allocations/show", type: :view do
         expect(value).to eq('Female Open')
       end
     end
+
+    context 'when category is unknown' do
+      # This happens when an offender's category assessment hasn't been completed yet
+      let(:offender) { build(:offender, category: nil) }
+
+      it 'shows "Unknown"' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Unknown')
+      end
+    end
   end
 end

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "debugging/debugging", type: :view do
 
   let(:prison) { build(:prison) }
 
+  let(:page) { Nokogiri::HTML(rendered) }
+
   before do
     assign(:offender, offender)
     assign(:prison, prison)
@@ -22,27 +24,47 @@ RSpec.describe "debugging/debugging", type: :view do
   end
 
   it "displays offender full_name" do
-    page = Nokogiri::HTML(rendered)
     full_name = page.css('#prisoner-information').css('#name').first
     expect(full_name.text).to match(/Dory, John/)
   end
 
   it "displays tariff date" do
-    page = Nokogiri::HTML(rendered)
     tariff_date = page.css('#sentence-information').css('#tariff-date').first
     expect(tariff_date.text).to match '01/08/2033'
   end
 
   it "displays post recall release date" do
-    page = Nokogiri::HTML(rendered)
     post_recall_release_date = page.css('#sentence-information').css('#post-recall-release-date').first
     expect(post_recall_release_date.text).to match '08/11/2028'
   end
 
   it "displays licence end date" do
-    page = Nokogiri::HTML(rendered)
     licence_expiry_date = page.css('#sentence-information').css('#licence-expiry-date').first
 
     expect(licence_expiry_date.text).to match '07/10/2025'
+  end
+
+  describe 'category label' do
+    let(:key) { page.css('#category > td:nth-child(1)').text }
+    let(:value) { page.css('#category > td:nth-child(2)').text.strip }
+
+    context 'when the offender has a category' do
+      let(:offender) { build(:offender, category: build(:offender_category, :female_open, approvalDate: '17/06/2021'.to_date)) }
+
+      it 'shows category details' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Female Open (T) (since 17/06/2021)')
+      end
+    end
+
+    context 'when category is unknown' do
+      # This happens when an offender's category assessment hasn't been completed yet
+      let(:offender) { build(:offender, category: nil) }
+
+      it 'shows "Unknown"' do
+        expect(key).to eq('Category')
+        expect(value).to eq('Unknown')
+      end
+    end
   end
 end

--- a/spec/views/prisoners/show.html.erb_spec.rb
+++ b/spec/views/prisoners/show.html.erb_spec.rb
@@ -3,20 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe "prisoners/show", type: :view do
+  let(:page) { Nokogiri::HTML(rendered) }
+  let(:case_info) { build(:case_information) }
+  let(:prison) { build(:prison) }
+
+  before do
+    offender.load_case_information(case_info)
+    assign(:prison, prison)
+    assign(:prisoner, offender)
+    assign(:tasks, [])
+    assign(:keyworker, build(:keyworker))
+    assign(:case_info, case_info)
+  end
+
   describe 'complexity badges' do
     let(:prison) { build(:womens_prison) }
-    let(:page) { Nokogiri::HTML(rendered) }
-    let(:offender) { build(:offender, complexityLevel: complexity).tap { |offender| offender.load_case_information(case_info) } }
-    let(:case_info) { create(:case_information) }
+    let(:offender) { build(:offender, complexityLevel: complexity) }
     let(:test_strategy) { Flipflop::FeatureSet.current.test! }
 
     before do
       test_strategy.switch!(:womens_estate, true)
-      assign(:prison, prison)
-      assign(:prisoner, offender)
-      assign(:tasks, [])
-      assign(:keyworker, build(:keyworker))
-      assign(:case_info, case_info)
       render
     end
 
@@ -45,6 +51,28 @@ RSpec.describe "prisoners/show", type: :view do
 
       it 'shows high complexity badge' do
         expect(page).to have_content 'HIGH COMPLEXITY'
+      end
+    end
+  end
+
+  describe 'offender category' do
+    subject { page.css('#category-code').text }
+
+    before { render }
+
+    context "with a male category" do
+      let(:offender) { build(:offender, category: build(:offender_category, :cat_a)) }
+
+      it 'shows the category label' do
+        expect(subject).to eq('Cat A')
+      end
+    end
+
+    context "with a female category" do
+      let(:offender) { build(:offender, category: build(:offender_category, :female_closed)) }
+
+      it 'shows the category label' do
+        expect(subject).to eq('Female Closed')
       end
     end
   end

--- a/spec/views/prisoners/show.html.erb_spec.rb
+++ b/spec/views/prisoners/show.html.erb_spec.rb
@@ -75,5 +75,14 @@ RSpec.describe "prisoners/show", type: :view do
         expect(subject).to eq('Female Closed')
       end
     end
+
+    context 'when category is unknown' do
+      # This happens when an offender's category assessment hasn't been completed yet
+      let(:offender) { build(:offender, category: nil) }
+
+      it 'shows "Unknown"' do
+        expect(subject).to eq('Unknown')
+      end
+    end
   end
 end


### PR DESCRIPTION
Jira ticket: MO-646

---

We were previously showing the category code, but this meant we displayed confusing category codes in female prisons.

We should actually have been displaying the category label all along – this is how offender categories are displayed in NOMIS and DPS, so this is the consistent approach.