### PR TITLE
Store production user sessions in the Redis cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,5 +103,9 @@ Rails.application.configure do
                                                           }
                      }
     }
+
+    # Store user sessions in the Redis cache
+    # This avoids the 4KB limit of cookie-backed sessions, which has affected users in production
+    config.session_store :cache_store, key: 'manage_pom_cases_session'
   end
 end


### PR DESCRIPTION
Until now, user sessions used encrypted cookies as the store for session data. This is the default Rails session store. However it means that sessions are limited to 4KB in size, since that's the generally accepted size limit of cookies.

This application is using sessions more heavily now with the recent introduction of multi-stage forms, which hold data in the user session between stages. If multiple form journeys are started at once (e.g. the user opens multiple browser tabs), or if journeys aren't completed before new ones are started, the session can easily grow beyond 4KB. This has caused problems for some users in production, who have started to experience errors caused by 'cookie overflows' – where the session cookie grows to more than 4KB in size, and causes the HTTP request to fail.

This commit enables the CacheStore in production, which will store session data in the Redis cache instead. Redis is already used by our service, so it seems safe to utilise it for sessions too. This avoids the problem of cookie overflows, as this store doesn't have the same limit on session size.

---

Fixes bug MO-675