### PR TITLE
MO-648 allocation history bug - dealloc after altering vlo data

### DIFF
--- a/app/controllers/female_allocations_controller.rb
+++ b/app/controllers/female_allocations_controller.rb
@@ -12,7 +12,7 @@ class FemaleAllocationsController < PrisonsApplicationController
     @case_info = CaseInformation.find_by!(nomis_offender_id: nomis_offender_id_from_url)
     previous_allocation = Allocation.find_by nomis_offender_id: nomis_offender_id_from_url
     previous_pom_ids = if previous_allocation
-                         previous_allocation.history.map { |h| [h.primary_pom_nomis_id, h.secondary_pom_nomis_id] }.flatten.compact.uniq
+                         previous_allocation.previously_allocated_poms
                        else
                          []
                        end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -84,12 +84,8 @@ class Allocation < ApplicationRecord
     versions.map(&:reify).compact
   end
 
-  # Gets the versions in *forward* order - so often we want to reverse
-  # this list as we're interested in recent rather than ancient history
-  def history
-    get_old_versions.append(self).zip(versions).map do |alloc, raw_version|
-      AllocationHistory.new(alloc, raw_version)
-    end
+  def previously_allocated_poms
+    get_old_versions.map { |h| [h.primary_pom_nomis_id, h.secondary_pom_nomis_id] }.flatten.compact.uniq
   end
 
   # note: this creates an allocation where the co-working POM is set, but the primary

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -75,14 +75,6 @@ class AllocationService
     }
   end
 
-  def self.previously_allocated_poms(nomis_offender_id)
-    allocation = Allocation.find_by(nomis_offender_id: nomis_offender_id)
-
-    return [] if allocation.nil?
-
-    allocation.get_old_versions.map(&:primary_pom_nomis_id)
-  end
-
   def self.allocation_history_pom_emails(allocation)
     history = allocation.get_old_versions.append(allocation)
     pom_ids = history.map { |h| [h.primary_pom_nomis_id, h.secondary_pom_nomis_id] }.flatten.compact.uniq

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -2,12 +2,12 @@
 
 <h1 class="govuk-heading-l"><%= @prisoner.full_name %></h1>
 
-<% allocation_list(@history, @early_allocations, @email_histories).each do |prison, allocations| %>
+<% allocation_list(@history, @early_allocations, @email_histories).each do |prison, case_histories| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column">
       <h2 class="govuk-heading-m"><%= prison_title(prison) %></h2>
       <div class="moj-timeline">
-        <%= render allocations, allocations: allocations %>
+        <%= render case_histories %>
       </div>
     </div>
   </div>

--- a/app/views/case_history/allocation/_deallocate_primary_pom.html.erb
+++ b/app/views/case_history/allocation/_deallocate_primary_pom.html.erb
@@ -8,7 +8,7 @@
   <% description = capture do %>
     <% unless deallocate_primary_pom.event_trigger == 'offender_transferred' %>
       Prisoner unallocated POM
-      <%= allocations[deallocate_primary_pom_counter + 1].primary_pom_name.titleize %> - <%= format_email(@pom_emails[allocations[deallocate_primary_pom_counter + 1].primary_pom_nomis_id]) %>
+      <%= deallocate_primary_pom.previous_primary_pom_name.titleize %> - <%= format_email(@pom_emails[deallocate_primary_pom.previous_primary_pom_id]) %>
     <% end %>
   <% end %>
   <%= render 'case_history/case_history',

--- a/app/views/case_history/allocation/_deallocate_secondary_pom.html.erb
+++ b/app/views/case_history/allocation/_deallocate_secondary_pom.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   <% description = capture do %>
     Prisoner unallocated co-working POM
-    <%= allocations[deallocate_secondary_pom_counter + 1].secondary_pom_name.titleize %> - <%= format_email(@pom_emails[allocations[deallocate_secondary_pom_counter + 1].secondary_pom_nomis_id]) %>
+    <%= deallocate_secondary_pom.previous_secondary_pom_name.titleize %> - <%= format_email(@pom_emails[deallocate_secondary_pom.previous_secondary_pom_id]) %>
   <% end %>
   <%= render 'case_history/case_history',
              title: 'Co-working unallocated',

--- a/app/views/case_history/allocation/_reallocate_primary_pom.html.erb
+++ b/app/views/case_history/allocation/_reallocate_primary_pom.html.erb
@@ -1,29 +1,20 @@
-<!--
-  If we have a 'first' reallocation, (it is size-1 because the list is displayed backwards)
-   then show it as an allocation because it is - incorrect data caused by a defect is too
-   hard to change as it is YAML
--->
-<% if reallocate_primary_pom_counter == allocations.size - 1 %>
-  <%= render 'case_history/allocation/allocate_primary_pom', allocations: allocations, allocate_primary_pom: reallocate_primary_pom %>
-<% else %>
-  <% description = capture do %>
-    Prisoner reallocated to <%= reallocate_primary_pom.primary_pom_name.titleize %>
-    - <%= format_email(@pom_emails[reallocate_primary_pom.primary_pom_nomis_id]) %>
-    <br/>
-    Tier: <%= reallocate_primary_pom.allocated_at_tier %>
-    <% if reallocate_primary_pom.override_reasons.present? %>
-      <p class="govuk-body govuk-!-margin-bottom-1"><%= display_override_pom(reallocate_primary_pom) %></p>
-      <p class="govuk-body govuk-!-margin-bottom-1">Reason(s):</p>
-      <div id="override-reason-reallocation">
-        <% reallocate_primary_pom.override_reasons.each do | reason| %>
-          <%= display_override_details(reason, reallocate_primary_pom) %>
-        <% end %>
-      </div>
-    <% end %>
+<% description = capture do %>
+  Prisoner reallocated to <%= reallocate_primary_pom.primary_pom_name.titleize %>
+  - <%= format_email(@pom_emails[reallocate_primary_pom.primary_pom_nomis_id]) %>
+  <br/>
+  Tier: <%= reallocate_primary_pom.allocated_at_tier %>
+  <% if reallocate_primary_pom.override_reasons.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-1"><%= display_override_pom(reallocate_primary_pom) %></p>
+    <p class="govuk-body govuk-!-margin-bottom-1">Reason(s):</p>
+    <div id="override-reason-reallocation">
+      <% reallocate_primary_pom.override_reasons.each do | reason| %>
+        <%= display_override_details(reason, reallocate_primary_pom) %>
+      <% end %>
+    </div>
   <% end %>
-  <%= render 'case_history/case_history',
-             title: 'Prisoner reallocated',
-             description: description,
-             object: reallocate_primary_pom %>
 <% end %>
+<%= render 'case_history/case_history',
+           title: 'Prisoner reallocated',
+           description: description,
+           object: reallocate_primary_pom %>
 

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe AllocationsController, type: :controller do
             get :history, params: { prison_id: prison, nomis_offender_id: offender_no }
             allocation_list = assigns(:history)
 
-            expect(allocation_list.map { |item| [item.prison, item.event] }).to eq([['PVI', 'allocate_primary_pom'], ['LEI', 'reallocate_primary_pom']])
+            expect(allocation_list.map { |item| [item.prison, item.event] }).to eq([['PVI', 'allocate_primary_pom'], ['LEI', 'allocate_primary_pom']])
           end
         end
       end

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -258,6 +258,29 @@ RSpec.describe Allocation, type: :model do
         expect(described_class.active_pom_allocations(nomis_staff_id, allocation.prison)).to match_array [secondary_allocation, allocation]
       end
     end
+
+    describe '#previously_allocated_poms' do
+      it "Can get previous poms for an offender where there are some" do
+        nomis_offender_id = 'GHF1234'
+        previous_primary_pom_nomis_id = 345_567
+        updated_primary_pom_nomis_id = 485_926
+
+        allocation = create(
+          :allocation,
+          nomis_offender_id: nomis_offender_id,
+          primary_pom_nomis_id: previous_primary_pom_nomis_id)
+
+        allocation.update!(
+          primary_pom_nomis_id: updated_primary_pom_nomis_id,
+          event: Allocation::REALLOCATE_PRIMARY_POM
+        )
+
+        staff_ids = allocation.previously_allocated_poms
+
+        expect(staff_ids.count).to eq(1)
+        expect(staff_ids.first).to eq(previous_primary_pom_nomis_id)
+      end
+    end
   end
 
   describe 'automate pushing the primary pom to ndelius', :push_pom_to_delius do

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -149,35 +149,6 @@ describe AllocationService do
     end
   end
 
-  describe '#previously_allocated_poms' do
-    it "Can get previous poms for an offender where there are none", vcr: { cassette_name: 'prison_api/allocation_service_previous_allocations_none' } do
-      staff_ids = described_class.previously_allocated_poms('GDF7657')
-
-      expect(staff_ids).to eq([])
-    end
-
-    it "Can get previous poms for an offender where there are some", vcr: { cassette_name: 'prison_api/allocation_service_previous_allocations' } do
-      nomis_offender_id = 'GHF1234'
-      previous_primary_pom_nomis_id = 345_567
-      updated_primary_pom_nomis_id = 485_926
-
-      allocation = create(
-        :allocation,
-        nomis_offender_id: nomis_offender_id,
-        primary_pom_nomis_id: previous_primary_pom_nomis_id)
-
-      allocation.update!(
-        primary_pom_nomis_id: updated_primary_pom_nomis_id,
-        event: Allocation::REALLOCATE_PRIMARY_POM
-      )
-
-      staff_ids = described_class.previously_allocated_poms(nomis_offender_id)
-
-      expect(staff_ids.count).to eq(1)
-      expect(staff_ids.first).to eq(previous_primary_pom_nomis_id)
-    end
-  end
-
   it 'can get the current allocated primary POM', vcr: { cassette_name: 'prison_api/current_allocated_primary_pom' }  do
     previous_primary_pom_nomis_id = 485_637
     updated_primary_pom_nomis_id = 485_926

--- a/spec/views/allocations/allocation_history.html.erb_spec.rb
+++ b/spec/views/allocations/allocation_history.html.erb_spec.rb
@@ -176,10 +176,16 @@ RSpec.describe "allocations/history", type: :view do
 
     context 'when allocator completes an override against the recommendation (allocation)' do
       before do
-        assign(:history, [
+        old_versions =
+          [
             build(:allocation, override_reasons: ["suitability"], suitability_detail: "Too high risk"),
             build(:allocation, override_reasons: ["suitability"], event: Allocation::REALLOCATE_PRIMARY_POM, suitability_detail: "Continuity")
-        ].map { |ah| AllocationHistory.new(ah, dummy_version) })
+          ]
+
+        assign(:history, [
+          CaseHistory.new(nil, old_versions[0], dummy_version),
+          CaseHistory.new(old_versions[0], old_versions[1], dummy_version),
+        ])
       end
 
       it 'shows a reason why in the allocation history' do
@@ -193,11 +199,18 @@ RSpec.describe "allocations/history", type: :view do
     # cannot easily be altered so to get around this it has been modified at the view level.
     context 'when a prisoner has moved to another prison' do
       before do
-        assign(:history, [
+        old_versions =
+          [
             build(:allocation, :primary, prison: prison_one),
             build(:allocation, :transfer, prison: prison_one),
             build(:allocation, :reallocation, :override, prison: prison_two)
-        ].map { |ah| AllocationHistory.new(ah, dummy_version) })
+          ]
+
+        assign(:history, [
+          CaseHistory.new(nil, old_versions[0], dummy_version),
+          CaseHistory.new(old_versions[0], old_versions[1], dummy_version),
+          CaseHistory.new(old_versions[1], old_versions[2], dummy_version),
+        ])
       end
 
       let(:prison_one) { build(:prison).code }
@@ -213,7 +226,7 @@ RSpec.describe "allocations/history", type: :view do
       before do
         assign(:history, [build(:allocation, :primary),
                           build(:allocation, :release)].
-            map { |ah| AllocationHistory.new(ah, released_version) })
+            map { |ah| CaseHistory.new(nil, ah, released_version) })
       end
 
       let(:released_version) { Struct.new(:object_changes).new({ 'updated_at' => [release_date_and_time, release_date_and_time] }.to_yaml) }


### PR DESCRIPTION
When viewing case/allocation history, the 'deallocate' view assumed that the previous record was an allocation containing the name of the person involved in the allocation. Since creating case history, this assumption is false. 

This PR fixes the issue by pairing up allocations rather than giving them access to the entire history collection - then the name of the person is in an explicit place rather than being grabbed from the N+1 (N-1 but reversed) record