### PR TITLE
MO-674 search returning missing info results in crash when following link

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -84,7 +84,7 @@ private
   end
 
   def nomis_offender_id_from_url
-    params.require(:nomis_offender_id)
+    params.require(:prisoner_id)
   end
 
   def case_information_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,8 +115,8 @@ Rails.application.routes.draw do
     get('/coworking/confirm/:nomis_offender_id/:primary_pom_id/:secondary_pom_id' => 'coworking#confirm', as: 'confirm_coworking_allocation')
     resource :overrides,  only: %i[ new create ], path_names: { new: 'new/:nomis_offender_id/:nomis_staff_id'}
 
-    resources :case_information, only: %i[new create edit update show], param: :nomis_offender_id, controller: 'case_information', path_names: {
-        new: 'new/:nomis_offender_id',
+    resources :case_information, only: %i[new create edit update show], param: :prisoner_id, controller: 'case_information', path_names: {
+        new: 'new/:prisoner_id',
     } do
       get('edit_prd' => 'case_information#edit_prd', as: 'edit_prd', on: :member)
       put('update_prd' => 'case_information#update_prd', as: 'update_prd', on: :member)

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -3,60 +3,98 @@
 require 'rails_helper'
 
 feature 'Search for offenders' do
-  let(:prison) { 'LEI' }
-
-  it 'Can search from the dashboard', vcr: { cassette_name: 'prison_api/dashboard_search_feature' } do
-    signin_spo_user
-    visit root_path
-
-    expect(page).to have_text('Dashboard')
-    fill_in 'q', with: 'Cal'
-    click_on('search-button')
-
-    expect(page).to have_current_path(search_prison_prisoners_path(prison), ignore_query: true)
-    expect(page).to have_css('tbody tr', count: 6)
+  before do
+    signin_spo_user [prison_code]
   end
 
-  context 'when on the Allocations summary page' do
+  context 'when male prison' do
+    let(:prison_code) { 'LEI' }
+
+    it 'Can search from the dashboard', vcr: { cassette_name: 'prison_api/dashboard_search_feature' } do
+      visit root_path
+
+      expect(page).to have_text('Dashboard')
+      fill_in 'q', with: 'Cal'
+      click_on('search-button')
+
+      expect(page).to have_current_path(search_prison_prisoners_path(prison_code), ignore_query: true)
+      expect(page).to have_css('tbody tr', count: 6)
+
+      # Just check that link can be clicked on without crashing
+      within '.allocated_offender_row_0' do
+        click_link 'Add missing details'
+      end
+    end
+  end
+
+  context "with female prison" do
+    let(:test_strategy) { Flipflop::FeatureSet.current.test! }
+    let(:prison) { build(:womens_prison) }
+    let(:prison_code) { prison.code }
+    let(:offenders) { build_list(:nomis_offender, 5, agencyId: prison.code, complexityLevel: 'high') }
+    let(:pom) { build(:pom) }
+
+    before do
+      test_strategy.switch!(:womens_estate, true)
+      stub_auth_token
+      stub_offenders_for_prison(prison_code, offenders)
+      stub_spo_user pom
+      stub_poms prison_code, [pom]
+    end
+
+    after do
+      test_strategy.switch!(:womens_estate, false)
+    end
+
+    it 'has a valid missing info link' do
+      visit search_prison_prisoners_path(prison_code)
+
+      # Just check that link can be clicked on without crashing
+      within '.allocated_offender_row_0' do
+        click_link 'Add missing details'
+      end
+    end
+  end
+
+  context 'with a single allocation' do
     before do
       create(:case_information, nomis_offender_id: 'G5359UP')
       create(:allocation, nomis_offender_id: 'G5359UP')
     end
 
+    let(:prison_code) { 'LEI' }
+
     it 'Can search from the Allocations summary page', vcr: { cassette_name: 'prison_api/allocated_search_feature' } do
-      signin_spo_user
-      visit allocated_prison_prisoners_path(prison)
+      visit allocated_prison_prisoners_path(prison_code)
 
       expect(page).to have_text('See allocations')
       fill_in 'q', with: 'Fra'
       click_on('search-button')
 
-      expect(page).to have_current_path(search_prison_prisoners_path(prison), ignore_query: true)
+      expect(page).to have_current_path(search_prison_prisoners_path(prison_code), ignore_query: true)
       expect(page).to have_css('tbody tr', count: 9)
     end
-  end
 
-  it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: 'prison_api/waiting_allocation_search_feature' } do
-    signin_spo_user
-    visit unallocated_prison_prisoners_path(prison)
+    it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: 'prison_api/waiting_allocation_search_feature' } do
+      visit unallocated_prison_prisoners_path(prison_code)
 
-    expect(page).to have_text('Make allocations')
-    fill_in 'q', with: 'Tre'
-    click_on('search-button')
+      expect(page).to have_text('Make allocations')
+      fill_in 'q', with: 'Tre'
+      click_on('search-button')
 
-    expect(page).to have_current_path(search_prison_prisoners_path(prison), ignore_query: true)
-    expect(page).to have_css('tbody tr', count: 1)
-  end
+      expect(page).to have_current_path(search_prison_prisoners_path(prison_code), ignore_query: true)
+      expect(page).to have_css('tbody tr', count: 1)
+    end
 
-  it 'Can search from the Missing Information summary page', vcr: { cassette_name: 'prison_api/missing_info_search_feature' } do
-    signin_spo_user
-    visit  missing_information_prison_prisoners_path(prison)
+    it 'Can search from the Missing Information summary page', vcr: { cassette_name: 'prison_api/missing_info_search_feature' } do
+      visit  missing_information_prison_prisoners_path(prison_code)
 
-    expect(page).to have_text('Make allocations')
-    fill_in 'q', with: 'Ste'
-    click_on('search-button')
+      expect(page).to have_text('Make allocations')
+      fill_in 'q', with: 'Ste'
+      click_on('search-button')
 
-    expect(page).to have_current_path(search_prison_prisoners_path(prison), ignore_query: true)
-    expect(page).to have_css('tbody tr', count: 4)
+      expect(page).to have_current_path(search_prison_prisoners_path(prison_code), ignore_query: true)
+      expect(page).to have_css('tbody tr', count: 4)
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the case information controller to use prisoner_id as its Id field, as this is more in line with the routes (and is being used by the female missing information journey)