### PR TITLE
MO-462 pre-cursor: change nDelius API hostname

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ references:
           VCR: 1
           PARALLEL_TEST_PROCESSORS: 6
           COMPLEXITY_API_HOST: https://complexity-of-need-staging.hmpps.service.justice.gov.uk
+          COMMUNITY_API_HOST: https://community-api-secure.test.delius.probation.hmpps.dsd.io
       - image: circleci/postgres:10.5-alpine
         environment:
           POSTGRES_USER: ubuntu

--- a/spec/fixtures/vcr_cassettes/delius/get_community_data.yml
+++ b/spec/fixtures/vcr_cassettes/delius/get_community_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://community-api.test.delius.probation.hmpps.dsd.io/secure/offenders/nomsNumber/G0239GU/all
+    uri: https://community-api-secure.test.delius.probation.hmpps.dsd.io/secure/offenders/nomsNumber/G0239GU/all
     body:
       encoding: US-ASCII
       string: ''
@@ -56,7 +56,7 @@ http_interactions:
   recorded_at: Thu, 18 Mar 2021 08:52:29 GMT
 - request:
     method: get
-    uri: https://community-api.test.delius.probation.hmpps.dsd.io/secure/offenders/nomsNumber/G0239GU/registrations
+    uri: https://community-api-secure.test.delius.probation.hmpps.dsd.io/secure/offenders/nomsNumber/G0239GU/registrations
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
The hostname for the nDelius API has changed and is stored in the circle:ci config. This PR moves it into the circle config so that it can be changed on a per-branch basis