### PR TITLE
Make Community API import more verbose

### DIFF
--- a/lib/tasks/community_api_import.rake
+++ b/lib/tasks/community_api_import.rake
@@ -16,6 +16,7 @@ namespace :community_api do
 
       offender_count = prison.offenders.each do |offender|
         ProcessDeliusDataJob.perform_later offender.offender_no
+        Rails.logger.info("#{prison_log_prefix} Queued job for offender #{offender.offender_no}")
       end.count
 
       Rails.logger.info("#{prison_log_prefix} Queued jobs for #{offender_count} offenders")


### PR DESCRIPTION
We've seen some behaviour which suggests offenders in prison aren't always imported correctly overnight.

This commit logs each offender ID as they're added to the queue, so we can debug when it looks like an offender has been missed.