### PR TITLE
MO-298 follow-up: remove old Teams/LDU remnants

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -4,14 +4,12 @@ ActiveAdmin.register_page 'Dashboard' do
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
   content title: proc { I18n.t('active_admin.dashboard') } do
-    panel 'Offenders w/o LDU EMail Addresses' do
+    panel 'Offenders w/o LDU Email Addresses' do
       allocations = Allocation.without_ldu_emails
-      case_infos_hash = CaseInformationService.get_case_information(allocations.map(&:nomis_offender_id))
       para "Total: #{allocations.count}"
       ul do
         allocations.each do |allocation|
-          ldu_code = case_infos_hash.fetch(allocation.nomis_offender_id).team.try(:local_divisional_unit).try(:code)
-          li "Prison #{allocation.prison} Offender #{allocation.nomis_offender_id} LDU Code #{ldu_code}"
+          li "Prison #{allocation.prison} Offender #{allocation.nomis_offender_id}"
         end
       end
     end

--- a/app/helpers/case_information_helper.rb
+++ b/app/helpers/case_information_helper.rb
@@ -22,7 +22,7 @@ private
       the case information has not yet been updated. This prisoner needs to be
       matched with an nDelius record before you can allocate.',
     DeliusImportError::MISSING_LDU => 'nDelius record with matching prisoner number
-       but no local divisional unit (LDU) information found. You need to update nDelius
+       but no local delivery unit (LDU) information found. You need to update nDelius
        with the LDU before you can allocate.',
     DeliusImportError::MISSING_TEAM => 'nDelius record found with matching prisoner
        number but no community team information found. You need to update nDelius with the

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -92,7 +92,7 @@ private
     {
       tier: DeliusImportError::INVALID_TIER,
       case_allocation: DeliusImportError::INVALID_CASE_ALLOCATION,
-      local_divisional_unit: DeliusImportError::MISSING_LDU,
+      local_delivery_unit: DeliusImportError::MISSING_LDU,
       team: DeliusImportError::MISSING_TEAM
     }.fetch(field)
   end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -65,8 +65,8 @@ class Allocation < ApplicationRecord
 
   # find all allocations which cannot be handed over as there is no LDU email address
   def self.without_ldu_emails
-    blank_team_cases = CaseInformation.where(local_delivery_unit: nil)
-    offenders = blank_team_cases.nps.pluck(:nomis_offender_id)
+    blank_ldu_cases = CaseInformation.where(local_delivery_unit: nil)
+    offenders = blank_ldu_cases.nps.pluck(:nomis_offender_id)
     Allocation.where(nomis_offender_id: offenders)
   end
 

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -6,10 +6,6 @@ class CaseInformation < ApplicationRecord
   NPS = 'NPS'
   CRC = 'CRC'
 
-  #  Old mapping - will be going away in Feb 2021
-  belongs_to :team, optional: true, counter_cache: :case_information_count
-
-  # new mapping - don't need team data any more, only team_name for display purposes
   belongs_to :local_delivery_unit, optional: true
 
   has_many :early_allocations,
@@ -49,18 +45,10 @@ class CaseInformation < ApplicationRecord
     case_allocation == NPS
   end
 
-  def local_divisional_unit
-    team.try(:local_divisional_unit)
-  end
-
-  # Take either the new LocalDeliveryUnit (if available and enabled) and
-  # fall back to the old local_divisional_unit if not. This should all go away
-  # in Feb 2021 after the PDU changes have been rolled out in nDelius
+  # Only return the LDU if it's enabled
   def ldu
     if local_delivery_unit&.enabled?
       local_delivery_unit
-    else
-      local_divisional_unit
     end
   end
 
@@ -72,7 +60,7 @@ class CaseInformation < ApplicationRecord
   validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }
   validates :nomis_offender_id, presence: true, uniqueness: true
 
-  validates :team, presence: true, unless: -> { manual_entry || local_delivery_unit.present? }
+  validates :local_delivery_unit, presence: true, unless: -> { manual_entry }
 
   # Don't think this is as simple as allowing nil. In the specific case of Scot/NI
   # prisoners it makes sense to have N/A (as this is genuine) but not otherwise

--- a/spec/features/delius_process_data_feature_spec.rb
+++ b/spec/features/delius_process_data_feature_spec.rb
@@ -77,7 +77,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
       end
     end
 
-    context 'with non-existant team' do
+    context 'with non-existent team' do
       let(:offender_no) { 'G2911GD' }
       let(:offender) { build(:nomis_offender, offenderNo: offender_no) }
 
@@ -94,7 +94,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
       it 'displays the correct error message' do
         visit prison_case_information_path('LEI', offender_no)
         within '.govuk-error-summary' do
-          expect(page).to have_content 'no community team information found'
+          expect(page).to have_content 'no local delivery unit (LDU) information found'
         end
       end
     end


### PR DESCRIPTION
There were a few remaining references to the old Team and Local 'Divisional' Unit models. These were mostly cleared up in MO-298, but I just stumbled across a few more.

These have been replaced by the new Local 'Delivery' Unit model, so are no longer needed.