### PR TITLE
disable survey monkey banner temporarily

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,7 +11,7 @@
             <%= link_to("Contact us", contact_us_path) %>
           </li>
           <li class="govuk-footer__list-item">
-            <%= link_to("Feedback", "https://www.research.net/r/MM8TNLW", target: "_blank") %>
+            <%= link_to("Feedback", "https://eu.surveymonkey.com/r/3BJ9M5K", target: "_blank") %>
           </li>
           <li class="govuk-footer__list-item">
             <%= link_to("What's new", whats_new_path) %>

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -2,7 +2,7 @@
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag hmpps-tag__beta govuk-phase-banner__content__tag ">beta</strong>
     <span class="govuk-phase-banner__text">
-      This is a new service – your <%= link_to("feedback", "https://www.surveymonkey.co.uk/r/8R8HP8K", target: "_blank") %> will help us to improve it.
+      This is a new service – your <%= link_to("feedback", "https://eu.surveymonkey.com/r/3BJ9M5K", target: "_blank") %> will help us to improve it.
     </span>
   </p>
 </div>

--- a/spec/features/feedback_feature_spec.rb
+++ b/spec/features/feedback_feature_spec.rb
@@ -1,16 +1,20 @@
 require 'rails_helper'
 
 feature 'feedback' do
+  let(:feedback_link) { 'https://eu.surveymonkey.com/r/3BJ9M5K' }
+
   it 'provides a link to the feedback form', vcr: { cassette_name: 'prison_api/feedback_link' } do
     signin_spo_user
 
     visit '/'
 
-    feedback_link = 'https://www.research.net/r/MM8TNLW'
-
     footer = page.find(:css, '.govuk-footer')
     within footer do
       expect(page).to have_link('Feedback', href: feedback_link)
+    end
+
+    within '.govuk-phase-banner__text' do
+      expect(page).to have_link('feedback', href: feedback_link)
     end
   end
 end


### PR DESCRIPTION
The survey monkey account for MoJ has been closed (or something) so this PR disables the feedback link until the survey monkey link can be setup again