### PR TITLE
Mo 685 join up the prison and pom detail models

### DIFF
--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -4,7 +4,7 @@ class CoworkingController < PrisonsApplicationController
   def new
     @prisoner = offender(nomis_offender_id_from_url)
     current_pom_id = Allocation.find_by!(nomis_offender_id: nomis_offender_id_from_url).primary_pom_nomis_id
-    poms = PrisonOffenderManagerService.get_poms_for(active_prison_id)
+    poms = @prison.get_list_of_poms
     @current_pom = poms.detect { |pom| pom.staff_id == current_pom_id }
 
     @active_poms, @unavailable_poms = poms.reject { |p| p.staff_id == current_pom_id }.partition { |pom|
@@ -18,20 +18,13 @@ class CoworkingController < PrisonsApplicationController
 
   def confirm
     @prisoner = offender(nomis_offender_id_from_url)
-    @primary_pom = PrisonOffenderManagerService.get_pom_at(
-      active_prison_id, primary_pom_id_from_url
-    )
-    @secondary_pom = PrisonOffenderManagerService.get_pom_at(
-      active_prison_id, secondary_pom_id_from_url
-    )
+    @primary_pom = @prison.get_single_pom(primary_pom_id_from_url)
+    @secondary_pom = @prison.get_single_pom(secondary_pom_id_from_url)
   end
 
   def create
     offender = offender(allocation_params[:nomis_offender_id])
-    pom = PrisonOffenderManagerService.get_pom_at(
-      active_prison_id,
-      allocation_params[:nomis_staff_id]
-    )
+    pom = @prison.get_single_pom(allocation_params[:nomis_staff_id])
 
     AllocationService.allocate_secondary(
       nomis_offender_id: allocation_params[:nomis_offender_id],
@@ -49,8 +42,7 @@ class CoworkingController < PrisonsApplicationController
     @allocation = Allocation.find_by!(
       nomis_offender_id: coworking_nomis_offender_id_from_url
     )
-    @primary_pom = PrisonOffenderManagerService.get_pom_at(
-      active_prison_id, @allocation.primary_pom_nomis_id
+    @primary_pom = @prison.get_single_pom(@allocation.primary_pom_nomis_id
     )
   end
 

--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -36,7 +36,7 @@ class EarlyAllocationsController < PrisonsApplicationController
       if @early_allocation.eligible?
         @early_allocation.save!
         if @offender.within_early_allocation_window?
-          AutoEarlyAllocationEmailJob.perform_later(@prison.code, @offender.offender_no, Base64.encode64(pdf_as_string))
+          AutoEarlyAllocationEmailJob.perform_later(@prison, @offender.offender_no, Base64.encode64(pdf_as_string))
         end
         render 'landing_eligible'
       else
@@ -70,7 +70,7 @@ class EarlyAllocationsController < PrisonsApplicationController
     @early_allocation = EarlyAllocation.new early_allocation_params.merge(offender_id_from_url)
     if @early_allocation.save
       if @offender.within_early_allocation_window?
-        CommunityEarlyAllocationEmailJob.perform_later(@prison.code,
+        CommunityEarlyAllocationEmailJob.perform_later(@prison,
                                                        @offender.offender_no,
                                                        Base64.encode64(pdf_as_string))
       end
@@ -117,7 +117,7 @@ private
 
   def pdf_as_string
     allocation = Allocation.find_by!(offender_id_from_url)
-    pom = PrisonOffenderManagerService.get_pom_at(@prison.code, allocation.primary_pom_nomis_id)
+    pom = @prison.get_single_pom(allocation.primary_pom_nomis_id)
 
     view_context.render_early_alloc_pdf(early_allocation: @early_allocation,
                                         offender: @offender,

--- a/app/controllers/female_allocations_controller.rb
+++ b/app/controllers/female_allocations_controller.rb
@@ -16,9 +16,9 @@ class FemaleAllocationsController < PrisonsApplicationController
                        else
                          []
                        end
-    poms = PrisonOffenderManagerService.get_poms_for(active_prison_id).index_by(&:staff_id)
+    poms = @prison.get_list_of_poms.index_by(&:staff_id)
     @previous_poms = previous_pom_ids.map { |staff_id| poms[staff_id] }.compact
-    @current_pom = PrisonOffenderManagerService.get_pom_at(active_prison_id, previous_allocation.primary_pom_nomis_id) if previous_allocation&.primary_pom_nomis_id
+    @current_pom = @prison.get_single_pom(previous_allocation.primary_pom_nomis_id) if previous_allocation&.primary_pom_nomis_id
   end
 
   def new
@@ -99,7 +99,7 @@ private
   end
 
   def load_pom_types
-    poms = PrisonOffenderManagerService.get_poms_for(active_prison_id).map { |pom| StaffMember.new(@prison, pom.staff_id) }
+    poms = @prison.get_list_of_poms.map { |pom| StaffMember.new(@prison, pom.staff_id) }
     @probation_poms, @prison_poms = poms.partition(&:probation_officer?)
   end
 

--- a/app/controllers/overrides_controller.rb
+++ b/app/controllers/overrides_controller.rb
@@ -3,7 +3,7 @@
 class OverridesController < PrisonsApplicationController
   def new
     @prisoner = offender(params.require(:nomis_offender_id))
-    @pom = PrisonOffenderManagerService.get_pom_at(active_prison_id, params[:nomis_staff_id])
+    @pom = @prison.get_single_pom(params[:nomis_staff_id])
 
     @override = Override.new
   end
@@ -14,8 +14,7 @@ class OverridesController < PrisonsApplicationController
     return redirect_on_success if @override.valid?
 
     @prisoner = offender(override_params[:nomis_offender_id])
-    @pom = PrisonOffenderManagerService.get_pom_at(
-      active_prison_id, override_params[:nomis_staff_id])
+    @pom = @prison.get_single_pom(override_params[:nomis_staff_id])
 
     render :new
   end

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -6,7 +6,7 @@ class PomsController < PrisonStaffApplicationController
   before_action :load_pom_staff_member, only: [:show, :edit, :update]
 
   def index
-    @poms = PrisonOffenderManagerService.get_poms_for(active_prison_id).sort_by(&:last_name)
+    @poms = @prison.get_list_of_poms.sort_by(&:last_name)
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,7 +29,7 @@ private
 
   def load_pom
     user = HmppsApi::PrisonApi::UserApi.user_details(current_user)
-    poms_list = PrisonOffenderManagerService.get_poms_for(active_prison_id)
+    poms_list = @prison.get_list_of_poms
 
     @pom = poms_list.find { |p| p.staff_id.to_i == user.staff_id.to_i }
   end

--- a/app/jobs/auto_early_allocation_email_job.rb
+++ b/app/jobs/auto_early_allocation_email_job.rb
@@ -5,22 +5,22 @@
 class AutoEarlyAllocationEmailJob < ApplicationJob
   queue_as :mailers
 
-  def perform(prison_code, offender_no, encoded_pdf)
+  def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)
     allocation = Allocation.find_by!(nomis_offender_id: offender_no)
-    pom = PrisonOffenderManagerService.get_pom_at(prison_code, allocation.primary_pom_nomis_id)
+    pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.auto_early_allocation(email: offender.ldu_email_address,
                                     prisoner_name: offender.full_name,
                                     prisoner_number: offender.offender_no,
                                     pom_name: allocation.primary_pom_name,
                                     pom_email: pom.email_address,
-                                    prison_name: Prison.find(prison_code).name,
+                                    prison_name: prison.name,
                                     pdf: pdf).deliver_now
     EmailHistory.create! nomis_offender_id: offender.offender_no,
                          name: offender.ldu_name,
                          email: offender.ldu_email_address,
                          event: EmailHistory::AUTO_EARLY_ALLOCATION,
-                         prison: prison_code
+                         prison: prison.code
   end
 end

--- a/app/jobs/community_early_allocation_email_job.rb
+++ b/app/jobs/community_early_allocation_email_job.rb
@@ -6,19 +6,19 @@ class CommunityEarlyAllocationEmailJob < ApplicationJob
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)
     allocation = Allocation.find_by!(nomis_offender_id: offender_no)
-    pom = PrisonOffenderManagerService.get_pom_at(prison, allocation.primary_pom_nomis_id)
+    pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.community_early_allocation(email: offender.ldu_email_address,
                                          prisoner_name: offender.full_name,
                                          prisoner_number: offender.offender_no,
                                          pom_name: allocation.primary_pom_name,
                                          pom_email: pom.email_address,
-                                         prison_name: Prison.find(prison).name,
+                                         prison_name: prison.name,
                                          pdf: pdf).deliver_now
     EmailHistory.create! nomis_offender_id: offender.offender_no,
                          name: offender.ldu_name,
                          email: offender.ldu_email_address,
                          event: EmailHistory::DISCRETIONARY_EARLY_ALLOCATION,
-                         prison: prison
+                         prison: prison.code
   end
 end

--- a/app/jobs/handover_follow_up_job.rb
+++ b/app/jobs/handover_follow_up_job.rb
@@ -16,7 +16,8 @@ class HandoverFollowUpJob < ApplicationJob
       allocation = Allocation.find_by(nomis_offender_id: offender.offender_no)
 
       if allocation.present? && allocation.active?
-        pom = PrisonOffenderManagerService.get_pom_at(offender.prison_id, allocation.primary_pom_nomis_id)
+        prison = Prison.find(offender.prison_id)
+        pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
         pom_name = full_name(pom)
         pom_email = pom.email_address
       else

--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -16,8 +16,8 @@ class SuitableForEarlyAllocationEmailJob < ApplicationJob
       already_emailed = EmailHistory.sent_within_current_sentence(prisoner,  EmailHistory::SUITABLE_FOR_EARLY_ALLOCATION)
 
       if already_emailed.empty?
-
-        pom = PrisonOffenderManagerService.get_pom_at(prisoner.prison_id, allocation.primary_pom_nomis_id)
+        prison = Prison.find(prisoner.prison_id)
+        pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
         EarlyAllocationMailer.review_early_allocation(
           email: pom.email_address,
           prisoner_name: prisoner.full_name,

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -6,7 +6,8 @@ class PomDetail < ApplicationRecord
   validates :working_pattern, presence: {
     message: 'Select number of days worked'
   }
-  validates_presence_of :prison_code
+
+  belongs_to :prison, foreign_key: :prison_code, primary_key: :code, inverse_of: :pom_details
 
   def allocations
     @allocations ||= begin

--- a/app/models/pom_wrapper.rb
+++ b/app/models/pom_wrapper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# The return value from get_poms_for - a combo of PomDetails and PrisonOffenderManager from the API
+# The return value from get_list_of_poms - a combo of PomDetails and PrisonOffenderManager from the API
 class PomWrapper
   delegate :email_address, :full_name, :position_description, :first_name, :last_name, :probation_officer?, :prison_officer?,
            :staff_id, :agency_id, to: :@pom

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -8,7 +8,7 @@ class StaffMember
   delegate :position_description, :probation_officer?, :prison_officer?, to: :pom
   delegate :working_pattern, :status, to: :@pom_detail
 
-  def initialize(prison, staff_id, pom_detail = default_pom_detail(prison.code, staff_id))
+  def initialize(prison, staff_id, pom_detail = default_pom_detail(prison, staff_id))
     @prison = prison
     @staff_id = staff_id.to_i
     @pom_detail = pom_detail
@@ -68,12 +68,8 @@ private
   end
 
   # Attempt to forward-populate the PomDetail table for new records
-  def default_pom_detail(prison_code, staff_id)
-    @pom_detail = PomDetail.find_or_create_by!(prison_code: prison_code, nomis_staff_id: staff_id) { |pom|
-      pom.prison_code = prison_code
-      pom.working_pattern = 0.0
-      pom.status = 'active'
-    }
+  def default_pom_detail(prison, staff_id)
+    prison.pom_details.find_by(nomis_staff_id: staff_id) || prison.pom_details.create!(working_pattern: 0.0, status: 'active', nomis_staff_id: staff_id)
   end
 
   def staff_detail

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -10,10 +10,7 @@ class EmailService
     @allocation = allocation
 
     @offender = OffenderService.get_offender(@allocation[:nomis_offender_id])
-    @pom = PrisonOffenderManagerService.get_pom_at(
-      @allocation.prison,
-      pom_nomis_id
-    )
+    @pom = Prison.find(@allocation.prison).get_single_pom(pom_nomis_id)
   end
 
   def send_email

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -1,50 +1,10 @@
 # frozen_string_literal: true
 
 class PrisonOffenderManagerService
-  # Note - get_poms_for and get_pom_at return different data...
-  def self.get_poms_for(prison_code)
-    # This API call doesn't do what it says on the tin. It can return duplicate
-    # staff_ids in the situation where someone has more than one role.
-    poms = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(prison_code).
-      select { |pom| pom.prison_officer? || pom.probation_officer? }.uniq(&:staff_id)
-
-    pom_details = PomDetail.where(prison_code: prison_code, nomis_staff_id: poms.map(&:staff_id))
-
-    poms.map { |pom| PomWrapper.new(pom, get_pom_detail(pom_details, prison_code,  pom.staff_id.to_i)) }
-  end
-
-  def self.get_pom_at(prison_id, nomis_staff_id)
-    raise ArgumentError, 'PrisonOffenderManagerService#get_pom_at(nil)' if nomis_staff_id.nil?
-
-    poms_list = get_poms_for(prison_id)
-    pom = poms_list.find { |p| p.staff_id == nomis_staff_id.to_i }
-    if pom.blank?
-      log_missing_pom(prison_id, nomis_staff_id)
-      pom_staff_ids = poms_list.map(&:staff_id)
-      raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{prison_id} - list is #{pom_staff_ids}"
-    end
-
-    pom
-  end
-
   class << self
     def fetch_pom_name(staff_id)
       staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(staff_id)
       "#{staff.last_name}, #{staff.first_name}"
     end
-  end
-
-private
-
-  def self.get_pom_detail(pom_details, prison_code, nomis_staff_id)
-    pom_details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
-      PomDetail.find_or_create_by!(prison_code: prison_code, nomis_staff_id: nomis_staff_id) do |pom|
-        pom.working_pattern = 0.0
-        pom.status = 'active'
-      end
-  end
-
-  def self.log_missing_pom(caseload, nomis_staff_id)
-    Rails.logger.warn("POM #{nomis_staff_id} does not work at prison #{caseload}")
   end
 end

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe HandoverFollowUpJob, type: :job do
     before do
       Timecop.travel today
 
-      allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+      allow_any_instance_of(Prison).to receive(:get_single_pom).and_return(pom)
 
       allow(OffenderService).to receive(:get_offender).and_return(offender)
       offender.load_case_information(case_info) unless offender.nil?

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
   let(:pom) { build(:pom) }
+  let!(:prison) { create(:prison) }
 
   let(:offender) do
-    build(:hmpps_api_offender, latestLocationId: 'LEI',
+    build(:hmpps_api_offender, latestLocationId: prison.code,
           sentence: build(:sentence_detail,
                           :determinate,
                           sentenceStartDate: Time.zone.today - 10.months,
@@ -78,7 +79,7 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
 
       context 'when offender has 18 months or less of sentence remaining' do
         before do
-          allow(PrisonOffenderManagerService).to receive(:get_pom_at).and_return(pom)
+          allow_any_instance_of(Prison).to receive(:get_single_pom).and_return(pom)
         end
 
         context 'when no previous Early Allocation reminder email sent for this offender' do

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe PomDetail, type: :model do
+  let!(:prison) { create(:prison) }
+
   it { is_expected.to validate_presence_of(:nomis_staff_id) }
-  it { expect(create(:pom_detail, prison_code: build(:prison).code)).to validate_uniqueness_of(:nomis_staff_id).scoped_to(:prison_code) }
+  it { expect(create(:pom_detail, prison: prison)).to validate_uniqueness_of(:nomis_staff_id).scoped_to(:prison_code) }
   it { is_expected.to validate_presence_of(:working_pattern).with_message('Select number of days worked') }
   it { is_expected.to validate_presence_of(:status) }
 end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -213,5 +213,17 @@ RSpec.describe Prison, type: :model do
         expect(subject).to be_valid
       end
     end
+
+    describe 'Associations with PomDetail' do
+      let!(:prison) { create(:prison) }
+
+      before do
+        create_list(:pom_detail, 5, prison: prison)
+      end
+
+      it 'has many pom details' do
+        expect(described_class.find(prison.code).pom_details.size).to be(5)
+      end
+    end
   end
 end

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe StaffMember, type: :model do
-  let(:prison) { build(:prison, code: 'LEI') }
+  let(:prison) { create(:prison) }
   let(:staff_id) { 123 }
   let(:user) { described_class.new(prison, staff_id) }
   let(:offenders) {
     [
-      build(:nomis_offender, offenderNo: 'G7514GW', prison_id: prison),
-      build(:nomis_offender, offenderNo: 'G1234VV', prison_id: prison),
-      build(:nomis_offender, offenderNo: 'G1234AB', prison_id: prison),
-      build(:nomis_offender, offenderNo: 'G1234GG', prison_id: prison)
+      build(:nomis_offender, offenderNo: 'G7514GW', prison_id: prison.code),
+      build(:nomis_offender, offenderNo: 'G1234VV', prison_id: prison.code),
+      build(:nomis_offender, offenderNo: 'G1234AB', prison_id: prison.code),
+      build(:nomis_offender, offenderNo: 'G1234GG', prison_id: prison.code)
     ]
   }
 
@@ -25,7 +25,7 @@ RSpec.describe StaffMember, type: :model do
     before do
       # # Allocate all of the offenders to this POM
       offenders.each do |offender|
-        create(:allocation, nomis_offender_id: offender.fetch(:offenderNo), primary_pom_nomis_id: staff_id)
+        create(:allocation, nomis_offender_id: offender.fetch(:offenderNo), primary_pom_nomis_id: staff_id, prison: prison.code)
       end
     end
 
@@ -49,7 +49,8 @@ RSpec.describe StaffMember, type: :model do
         create(
           :allocation,
           primary_pom_nomis_id: staff_id,
-          nomis_offender_id: 'G7514GW'
+          nomis_offender_id: 'G7514GW',
+          prison: prison.code
         )
       end
     }
@@ -60,6 +61,7 @@ RSpec.describe StaffMember, type: :model do
           :allocation,
           primary_pom_nomis_id: other_staff_id,
           nomis_offender_id: 'G1234VV',
+          prison: prison.code
         ).tap { |item|
           item.update!(secondary_pom_nomis_id: staff_id)
         }
@@ -71,6 +73,7 @@ RSpec.describe StaffMember, type: :model do
         :allocation,
         primary_pom_nomis_id: staff_id,
         nomis_offender_id: 'G1234AB',
+        prison: prison.code
       )
     }
 
@@ -79,7 +82,8 @@ RSpec.describe StaffMember, type: :model do
         :allocation,
         primary_pom_nomis_id: other_staff_id,
         nomis_offender_id: 'G1234GG',
-        secondary_pom_nomis_id: staff_id
+        secondary_pom_nomis_id: staff_id,
+        prison: prison.code
       ).tap { |item|
         item.update!(secondary_pom_nomis_id: staff_id)
       }


### PR DESCRIPTION
This PR moves  get_pom_for and get_pom_at methods from the PrisonOffenderManagerService into the Prison model.
Because controllers have @prison in their hand it meant that PrisonOffenderManagerService.get_poms_for could be replaced with @prison.get_poms_for. 

This was not the case in the Service and Job classes but the new database backed Prison model meant that Prison.find could be used here instead - which made the refactor a lot easier as EmailService was quite intwined with AllocationService . 