### PR TITLE
Remove :inderminate trait for offender, keeping it on sentence_detail

### DIFF
--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe DebuggingController, type: :controller do
     let(:primary_pom_name) { 'Jenae Sporer' }
 
     it 'can show debugging information for a specific offender' do
-      stub_offender(build(:nomis_offender, :indeterminate, offenderNo: offender_no))
+      stub_offender(build(:nomis_offender, sentence: attributes_for(:sentence_detail, :indeterminate), offenderNo: offender_no))
 
       stub_request(:post, "#{ApiHelper::T3}/movements/offenders?movementTypes=ADM&movementTypes=TRN&movementTypes=REL&latestOnly=false").
         with(

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TasksController, :allocation, type: :controller do
     stub_poms(prison, pom)
     stub_signed_in_pom(prison, staff_id)
 
-    offenders = [build(:nomis_offender, :indeterminate, offenderNo: 'G7514GW', firstName: "Alice", lastName: "Aliceson"),
+    offenders = [build(:nomis_offender, sentence: attributes_for(:sentence_detail, :indeterminate), offenderNo: 'G7514GW', firstName: "Alice", lastName: "Aliceson"),
                  build(:nomis_offender, offenderNo: 'G1234VV', firstName: "Bob", lastName: "Bibby"),
                  build(:nomis_offender, offenderNo: 'G1234AB', firstName: "Carole", lastName: "Caroleson"),
                  build(:nomis_offender, offenderNo: 'G1234GG', firstName: "David", lastName: "Davidson")
@@ -58,7 +58,7 @@ RSpec.describe TasksController, :allocation, type: :controller do
     end
 
     it 'can show offenders needing parole review date updates' do
-      stub_offender(build(:nomis_offender, :indeterminate, offenderNo: offender_no))
+      stub_offender(build(:nomis_offender, sentence: attributes_for(:sentence_detail, :indeterminate), offenderNo: offender_no))
 
       get :index, params: { prison_id: prison }
 

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -92,17 +92,6 @@ FactoryBot.define do
 
     complexityLevel { 'medium' }
 
-    trait :indeterminate do
-      imprisonmentStatus {'LIFE'}
-      sentence { attributes_for(:sentence_detail, :indeterminate) }
-    end
-
-    # the default release date and conditional release date will force the offender to be POM supporting and requiring a COM
-    # this trait makes sure the determinate offender has a release date long into the future
-    trait :determinate_release_in_three_years do
-      sentence { attributes_for(:sentence_detail, releaseDate: Time.zone.today + 3.years, conditionalReleaseDate: Time.zone.today + 3.years) }
-    end
-
     sequence(:bookingId) { |c| c + 100_000 }
   end
 end

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -114,6 +114,13 @@ FactoryBot.define do
       sentenceStartDate { Time.zone.today - 2.months }
       conditionalReleaseDate { Time.zone.today + 7.months }
     end
+
+    # the default release date and conditional release date will force the offender to be POM supporting and requiring a COM
+    # this trait makes sure the determinate offender has a release date long into the future
+    trait :determinate_release_in_three_years do
+      releaseDate { Time.zone.today + 3.years }
+      conditionalReleaseDate { Time.zone.today + 3.years }
+    end
   end
 end
 

--- a/spec/features/case_history_spec.rb
+++ b/spec/features/case_history_spec.rb
@@ -37,12 +37,12 @@ feature 'Case History' do
   let(:spo) { build(:pom) }
 
   let(:nomis_offender) {
-    build(:nomis_offender, :indeterminate,
+    build(:nomis_offender,
           agencyId: open_prison.code,
             sentence: attributes_for(:sentence_detail, :indeterminate, :welsh_open_policy))
   }
   let(:nomis_pentonville_offender) {
-    build(:nomis_offender, :indeterminate, offenderNo: nomis_offender.fetch(:offenderNo),
+    build(:nomis_offender, offenderNo: nomis_offender.fetch(:offenderNo),
           agencyId: second_prison.code,
             sentence: attributes_for(:sentence_detail, :indeterminate, :welsh_open_policy))
   }

--- a/spec/features/female_allocation_journey_feature_spec.rb
+++ b/spec/features/female_allocation_journey_feature_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 feature "womens allocation journey" do
   let(:prison) { create(:womens_prison) }
-  let(:offenders) { build_list(:nomis_offender, 5, agencyId: 'BZI', complexityLevel: 'high') }
-  let(:offender) { build(:nomis_offender, :determinate_release_in_three_years, agencyId: 'BZI') }
+  let(:offenders) { build_list(:nomis_offender, 5, agencyId: prison.code, complexityLevel: 'high') }
+  let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, :determinate_release_in_three_years), agencyId: prison.code) }
   let(:nomis_offender_id) { offender.fetch(:offenderNo) }
   let(:user) { build(:pom) }
   let(:probation_pom) { build(:pom, :probation_officer) }

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
 
   context 'when an indeterminate offender has moved into open conditions' do
     let(:nomis_offender) {
-      build(:nomis_offender, :indeterminate,
+      build(:nomis_offender,
             agencyId: prison.code,
                 category: category,
                 sentence: attributes_for(:sentence_detail,


### PR DESCRIPTION
It is confusing to have an :indeterminate trait for an offender, as it can now be contradicted by an :indeterminate sentence. Hence the :indeterminate trait for an offender has been removed.