### PR TITLE
Bugfix: don't calculate dates if missing case info

### DIFF
--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -5,7 +5,7 @@ class RecalculateHandoverDateJob < ApplicationJob
 
   def perform(nomis_offender_id)
     offender = OffenderService.get_offender(nomis_offender_id)
-    if offender&.inside_omic_policy?
+    if offender&.inside_omic_policy? && offender&.has_case_information?
       # Recalculate handover dates, which will trigger a push to the Community API after_save
       recalculate_dates_for(offender)
     end

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
     end
   end
 
+  context "when the offender doesn't have a CaseInformation record" do
+    before do
+      stub_offender(nomis_offender)
+    end
+
+    let(:nomis_offender) { build(:nomis_offender) }
+
+    it 'does nothing' do
+      expect(HmppsApi::CommunityApi).not_to receive(:set_handover_dates)
+      expect { described_class.perform_now(offender_no) }.not_to change(CalculatedHandoverDate, :count)
+    end
+  end
+
   context 'when the Prison API returns an error' do
     let(:nomis_offender) { build(:nomis_offender) }
     let(:api_host) { Rails.configuration.prison_api_host }


### PR DESCRIPTION
This fixes a bug in the `RecalculateHandoverDateJob` which was attempting to calculate handover dates for offenders who were missing nDelius case information. This was causing jobs to raise an error, resulting in our job runner (Sidekiq) continually retrying them.

This was affecting offenders who are in prison, but are missing probation data, so fall into the 'Add missing information' category.

In this case, we should skip them as we cannot calculate an accurate handover date for them.