### PR TITLE
MO-628 sort by pom_responsibility

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -23,6 +23,12 @@ private
 
     if field == :cell_location
       cell_location_sort(allocations, direction)
+    elsif field == :pom_responsibility
+      if direction == :asc
+        allocations.sort_by { |a| view_context.pom_responsibility_label(a) }
+      else
+        allocations.sort { |a, b| view_context.pom_responsibility_label(b) <=> view_context.pom_responsibility_label(a) }
+      end
     else
       sort_with_public_send allocations, field, direction
     end

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -12,7 +12,7 @@ module OffenderHelper
     elsif offender.pom_supporting?
       'Supporting'
     else
-      'Unknown'
+      'Co-Working'
     end
   end
 

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -5,7 +5,7 @@
 # e.g. when fetching allocations
 #
 class AllocatedOffender
-  delegate :last_name, :full_name, :earliest_release_date, :approaching_handover?, :pom_responsible?, :pom_supporting?,
+  delegate :last_name, :full_name, :earliest_release_date, :approaching_handover?,
            :indeterminate_sentence?, :prison_id, :parole_review_date, :delius_matched?,
            :handover_start_date, :responsibility_handover_date, :allocated_com_name, :case_allocation,
            :complexity_level, :offender_no, :sentence_start_date, :tier, :cell_location, :latest_temp_movement_date, to: :@offender
@@ -35,7 +35,11 @@ class AllocatedOffender
     @allocation.new_case_for? @staff_id
   end
 
-  def for_staff_id? staff_id
-    [@allocation.primary_pom_nomis_id, @allocation.secondary_pom_nomis_id].include? staff_id
+  def pom_responsible?
+    @offender.pom_responsible? if @allocation.primary_pom_nomis_id == @staff_id
+  end
+
+  def pom_supporting?
+    @offender.pom_supporting? if @allocation.primary_pom_nomis_id == @staff_id
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -49,6 +49,12 @@ class Allocation < ApplicationRecord
 
   scope  :active_allocations_for_prison, lambda { |prison| where.not(primary_pom_nomis_id: nil).where(prison: prison) }
 
+  scope :for_pom, lambda { |nomis_staff_id|
+    secondaries = where(secondary_pom_nomis_id: nomis_staff_id)
+
+    where(primary_pom_nomis_id: nomis_staff_id).or(secondaries)
+  }
+
   validate do |av|
     if av.primary_pom_nomis_id.present? &&
       av.primary_pom_nomis_id == av.secondary_pom_nomis_id

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -73,11 +73,7 @@ private
           :outside_omic_policy
         end
       end
-      allocated = summary.fetch(:allocated, []).map do |o|
-        a = alloc_hash.fetch(o.offender_no)
-        AllocatedOffender.new(a.primary_pom_nomis_id, a, o)
-      end
-      Summary.new allocated: allocated,
+      Summary.new allocated: summary.fetch(:allocated, []),
                   unallocated: summary.fetch(:unallocated, []),
                   new_arrivals: summary.fetch(:new_arrival, []),
                   missing_info: summary.fetch(:missing_info, []),

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -47,7 +47,13 @@ class StaffMember
   end
 
   def allocations
-    @allocations ||= @prison.allocated.select { |a| a.for_staff_id? @staff_id }
+    @allocations ||= begin
+      alloc_hash = @prison.allocations.for_pom(@staff_id).index_by(&:nomis_offender_id)
+
+      @prison.allocated.select { |a| alloc_hash.key?(a.offender_no) }.map do |offender|
+        AllocatedOffender.new(@staff_id, alloc_hash.fetch(offender.offender_no), offender)
+      end
+    end
   end
 
 private

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe OffenderHelper do
       }
 
       it 'shows unknown' do
-        expect(helper.pom_responsibility_label(offender)).to eq('Unknown')
+        expect(helper.pom_responsibility_label(offender)).to eq('Co-Working')
       end
     end
   end


### PR DESCRIPTION
As a result of the previous PR for MO-628, it appears that sorting by pom_responsibility was broken. This PR puts that feature back, adding a test as well