### PR TITLE
Seed prison records in Heroku upon deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma_prod.rb
 worker: bundle exec sidekiq -C config/sidekiq.yml
-release: bundle exec rails db:migrate
+release: bundle exec rails db:migrate && bundle exec rake import:prison


### PR DESCRIPTION
Heroku was failing because prison records weren't being seeded.