### PR TITLE
Only accept well formed NOMIS Offender IDs

### DIFF
--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Offender < ApplicationRecord
-  validates_presence_of :nomis_offender_id
+  # NOMIS offender IDs must be of the form <letter><4 numbers><2 letters> (all uppercase)
+  validates :nomis_offender_id, format: { with: /\A[A-Z][0-9]{4}[A-Z]{2}\z/ }
 
   has_one :case_information, foreign_key: :nomis_offender_id, primary_key: :nomis_offender_id, inverse_of: :offender, dependent: :destroy
 end

--- a/spec/features/when_nomis_is_missing_information_spec.rb
+++ b/spec/features/when_nomis_is_missing_information_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 context 'when NOMIS is missing information' do
   let(:prison_code) { create(:prison).code }
-  let(:offender_no) { 'A1' }
+  let(:offender_no) { build(:offender).nomis_offender_id }
   let(:stub_keyworker_host) { Rails.configuration.keyworker_api_host }
   let(:staff_id) { 123456 }
 

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
     end
 
     context 'when processing a com name' do
-      let(:offender_id) { 'A1111A' }
+      let(:offender_id) { 'A1111AA' }
 
       before do
         stub_offender(build(:nomis_offender, offenderNo: offender_id))

--- a/spec/models/offender_spec.rb
+++ b/spec/models/offender_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Offender, type: :model do
+  describe '#nomis_offender_id' do
+    subject { build(:offender) }
+
+    # NOMIS offender IDs must be of the form <letter><4 numbers><2 letters>
+    let(:valid_ids) { %w[A0000AA Z5432HD A4567CD] }
+
+    let(:invalid_ids) {
+      [
+        'A 1234 AA', # no spaces allowed
+        'E123456', # this is a nDelius CRN, not a NOMIS ID
+        'A0000aA', # must be all uppercase
+        '', # cannot be empty
+        nil, # cannot be nil
+        '1234567',
+        'ABCDEFG',
+      ]
+    }
+
+    it 'requires a valid NOMIS offender ID' do
+      valid_ids.each do |id|
+        subject.nomis_offender_id = id
+        expect(subject).to be_valid
+      end
+
+      invalid_ids.each do |id|
+        subject.nomis_offender_id = id
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
When creating new Offender records in our database, enforce that they follow the expected format of NOMIS Offender IDs:

```
<letter><4 numbers><2 letters>
```