### PR TITLE
MO-628 Part III - fix staff/poms controller sorting by role/responsibility

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CaseloadController < PrisonStaffApplicationController
-  include Sorting
+  before_action :ensure_signed_in_pom_is_this_pom, :load_pom
 
   def index
     @new_cases_count = @pom.allocations.count(&:new_case?)
@@ -17,39 +17,6 @@ class CaseloadController < PrisonStaffApplicationController
   end
 
 private
-
-  def sort_allocations(allocations)
-    field, direction = sort_params(default_sort: :last_name)
-
-    if field == :cell_location
-      cell_location_sort(allocations, direction)
-    elsif field == :pom_responsibility
-      if direction == :asc
-        allocations.sort_by { |a| view_context.pom_responsibility_label(a) }
-      else
-        allocations.sort { |a, b| view_context.pom_responsibility_label(b) <=> view_context.pom_responsibility_label(a) }
-      end
-    else
-      sort_with_public_send allocations, field, direction
-    end
-  end
-
-  def cell_location_sort(allocations, direction)
-    allocations = allocations.sort do |a, b|
-      if a.latest_temp_movement_date.nil? && b.latest_temp_movement_date.nil?
-        compare_via_public_send :cell_location, :asc, a, b
-      elsif a.latest_temp_movement_date.nil? && b.latest_temp_movement_date.present?
-        1
-      elsif a.latest_temp_movement_date.present? && b.latest_temp_movement_date.nil?
-        -1
-      else
-        a.latest_temp_movement_date <=> b.latest_temp_movement_date
-      end
-    end
-
-    allocations.reverse! if direction == :desc
-    allocations
-  end
 
   def filter_allocations(allocations)
     if params['q'].present?

--- a/app/controllers/caseload_handovers_controller.rb
+++ b/app/controllers/caseload_handovers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CaseloadHandoversController < PrisonStaffApplicationController
-  include Sorting
+  before_action :ensure_signed_in_pom_is_this_pom, :load_pom
 
   def index
     collection = sort_collection(@pom.allocations.select(&:approaching_handover?), default_sort: :last_name)

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PomsController < PrisonsApplicationController
+class PomsController < PrisonStaffApplicationController
   before_action :ensure_spo_user
 
   before_action :load_pom_staff_member, only: [:show, :edit, :update]
@@ -17,21 +17,6 @@ class PomsController < PrisonsApplicationController
   # the user will probably mark this POM inactive
   def show_non_pom
     @nomis_staff_id = nomis_staff_id
-  end
-
-  def sort_allocations(allocations)
-    if params['sort'].present?
-      sort_field, sort_direction = params['sort'].split.map(&:to_sym)
-    else
-      sort_field = :last_name
-      sort_direction = :asc
-    end
-
-    # cope with nil values by sorting using to_s - only dates and strings in these fields
-    allocations = allocations.sort_by { |sentence| sentence.public_send(sort_field).to_s }
-    allocations.reverse! if sort_direction == :desc
-
-    allocations
   end
 
   def edit

--- a/app/controllers/prison_staff_application_controller.rb
+++ b/app/controllers/prison_staff_application_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PrisonStaffApplicationController < PrisonsApplicationController
-  before_action :ensure_signed_in_pom_is_this_pom, :load_pom
-
 private
 
   def load_pom
@@ -17,5 +15,38 @@ private
 
   def staff_id
     params.fetch(:staff_id).to_i
+  end
+
+  def sort_allocations(allocations)
+    field, direction = sort_params(default_sort: :last_name)
+
+    if field == :cell_location
+      cell_location_sort(allocations, direction)
+    elsif field == :pom_responsibility
+      if direction == :asc
+        allocations.sort_by { |a| view_context.pom_responsibility_label(a) }
+      else
+        allocations.sort { |a, b| view_context.pom_responsibility_label(b) <=> view_context.pom_responsibility_label(a) }
+      end
+    else
+      sort_with_public_send allocations, field, direction
+    end
+  end
+
+  def cell_location_sort(allocations, direction)
+    allocations = allocations.sort do |a, b|
+      if a.latest_temp_movement_date.nil? && b.latest_temp_movement_date.nil?
+        compare_via_public_send :cell_location, :asc, a, b
+      elsif a.latest_temp_movement_date.nil? && b.latest_temp_movement_date.present?
+        1
+      elsif a.latest_temp_movement_date.present? && b.latest_temp_movement_date.nil?
+        -1
+      else
+        a.latest_temp_movement_date <=> b.latest_temp_movement_date
+      end
+    end
+
+    allocations.reverse! if direction == :desc
+    allocations
   end
 end

--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -3,6 +3,8 @@
 # This class is inherited by all controllers under the /prisons route
 # so that they have @prison and active_prison_id available
 class PrisonsApplicationController < ApplicationController
+  include Sorting
+
   before_action :authenticate_user, :check_prison_access, :load_staff_member, :service_notifications, :load_roles
 
 protected

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -36,45 +36,56 @@ feature "get poms list" do
     expect(page).to have_content("Caseload")
   end
 
-  it "can sort offenders allocated to a POM", vcr: { cassette_name: 'prison_api/show_poms_feature_view_sorting' } do
-    [['G7806VO', 754_207], ['G2911GD', 1_175_317]].each do |offender_id, _booking|
-      create(:case_information, offender: build(:offender, nomis_offender_id: offender_id))
-      AllocationService.create_or_update(
-        nomis_offender_id: offender_id,
-        prison: 'LEI',
-        allocated_at_tier: 'A',
-        created_by_username: 'MOIC_POM',
-        primary_pom_nomis_id: 485_926,
-        primary_pom_allocated_at: DateTime.now.utc,
-        recommended_pom_type: 'prison',
-        event: Allocation::ALLOCATE_PRIMARY_POM,
-        event_trigger: Allocation::USER
-      )
+  describe 'sorting', vcr: { cassette_name: 'prison_api/show_poms_feature_view_sorting' } do
+    before do
+      ['G7806VO', 'G2911GD'].each do |offender_id|
+        create(:case_information, offender: build(:offender, nomis_offender_id: offender_id))
+        create(:allocation, prison: 'LEI', nomis_offender_id: offender_id, primary_pom_nomis_id: 485_926)
+      end
     end
 
-    visit "/prisons/LEI/poms/485926"
+    it 'can sort' do
+      visit "/prisons/LEI/poms/485926"
 
-    expect(page).to have_css(".govuk-button", count: 1)
-    expect(page).to have_content("Pom, Moic")
-    expect(page).to have_content("Caseload")
-    expect(page).to have_css('.sort-arrow', count: 1)
+      expect(page).to have_css(".govuk-button", count: 1)
+      expect(page).to have_content("Pom, Moic")
+      expect(page).to have_content("Caseload")
+      expect(page).to have_css('.sort-arrow', count: 1)
 
-    check_for_order = lambda { |names|
-      row0 = page.find(:css, '.pom_cases_row_0')
-      row1 = page.find(:css, '.pom_cases_row_1')
+      check_for_order = lambda { |names|
+        row0 = page.find(:css, '.pom_cases_row_0')
+        row1 = page.find(:css, '.pom_cases_row_1')
 
-      within row0 do
-        expect(page).to have_content(names[0])
+        within row0 do
+          expect(page).to have_content(names[0])
+        end
+
+        within row1 do
+          expect(page).to have_content(names[1])
+        end
+      }
+
+      check_for_order.call(['Abdoria, Ongmetain', 'Ahmonis, Imanjah'])
+      click_link('Prisoner name')
+      check_for_order.call(['Ahmonis, Imanjah', 'Abdoria, Ongmetain'])
+    end
+
+    describe 'sorting by role' do
+      before do
+        secondary = create :case_information, offender: build(:offender, nomis_offender_id: 'G4328GK')
+        create(:allocation, prison: 'LEI', nomis_offender_id: secondary.nomis_offender_id,
+               primary_pom_nomis_id: 123456, secondary_pom_nomis_id: 485_926)
+
+        visit "/prisons/LEI/poms/485926"
       end
 
-      within row1 do
-        expect(page).to have_content(names[1])
+      it 'can sort' do
+        click_link 'Role'
+        expect(all('td[aria-label=Role]').map(&:text).uniq).to eq(['Co-Working', 'Supporting'])
+        click_link 'Role'
+        expect(all('td[aria-label=Role]').map(&:text).uniq).to eq(['Supporting', 'Co-Working'])
       end
-    }
-
-    check_for_order.call(['Abdoria, Ongmetain', 'Ahmonis, Imanjah'])
-    click_link('Prisoner name')
-    check_for_order.call(['Ahmonis, Imanjah', 'Abdoria, Ongmetain'])
+    end
   end
 
   it "allows editing a POM", vcr: { cassette_name: 'prison_api/show_poms_feature_edit' } do


### PR DESCRIPTION
MO-628 fell foul of the duplication between the poms_controller and the caseload_controller (which do the same thing only slightly differently, one for HOMds and one for POMs). This PR fixes the bug by removing most of the duplication around sorting between those 2 controllers.