### PR TITLE
Fix broken VCR test

### DIFF
--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -5,7 +5,7 @@ feature 'Allocation' do
   let!(:prison_officer_nomis_staff_id) { 485_926 }
   let!(:nomis_offender_id) { 'G7266VD' }
   let(:offender_name) { 'Omistius Annole' }
-  let!(:never_allocated_offender) { 'G1670VU' }
+  let!(:never_allocated_offender) { 'G9403UP' }
 
   let!(:probation_officer_pom_detail) {
     PomDetail.create!(

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -47,7 +47,7 @@ feature 'Provide debugging information for our team to use' do
       movement_table_row = page.find(:css, 'tr.govuk-table__row#movement_date', text: 'Movement date')
 
       within movement_table_row do
-        expect(page).to have_content('Movement date 20/07/2018')
+        expect(page).to have_content('Movement date 07/06/2021')
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,7 +14,7 @@ require 'support/matchers/responsibility_matchers'
 require 'capybara/rspec'
 require 'webmock/rspec'
 
-Capybara.default_max_wait_time = 4
+Capybara.default_max_wait_time = 10
 Capybara.asset_host = 'http://localhost:3000'
 
 begin

--- a/spec/services/hmpps_api/prison_api/movement_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/movement_api_spec.rb
@@ -8,7 +8,7 @@ describe HmppsApi::PrisonApi::MovementApi do
 
       expect(movements).to be_kind_of(Array)
       expect(movements.length).to eq(2)
-      expect(movements.first).to be_kind_of(HmppsApi::Movement)
+      expect(movements).to all be_kind_of(HmppsApi::Movement)
     end
   end
 
@@ -19,7 +19,7 @@ describe HmppsApi::PrisonApi::MovementApi do
 
       expect(movements).to be_kind_of(Array)
       expect(movements.length).to eq(2)
-      expect(movements.first).to be_kind_of(HmppsApi::Movement)
+      expect(movements).to all be_kind_of(HmppsApi::Movement)
     end
 
     it 'sort movements (oldest first) for a specific_offender' do
@@ -40,8 +40,8 @@ describe HmppsApi::PrisonApi::MovementApi do
       movements = described_class.movements_for('G1670VU')
 
       expect(movements).to be_kind_of(Array)
-      expect(movements.length).to eq(5)
-      expect(movements.first).to be_kind_of(HmppsApi::Movement)
+      expect(movements.length).to eq(7)
+      expect(movements).to all be_kind_of(HmppsApi::Movement)
     end
   end
 end


### PR DESCRIPTION
The world changed, and our test suite needed changing to keep up.

The Movement API client spec tests integration with the Dev (T3) instance of NOMIS / Prison API using the VCR gem.

It was expecting 5 movements on a specific offender, but someone has recently moved them again meaning there are now 7 movements.