### PR TITLE
MO-690 Prequel - move case_information outside of API offender

### DIFF
--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -49,7 +49,6 @@ class PrisonersController < PrisonsApplicationController
       active_prison_id, @prisoner.offender_no
     )
 
-    @case_info = CaseInformation.includes(:early_allocations).find_by(nomis_offender_id: params[:id])
     @emails_sent_to_ldu = EmailHistory.sent_within_current_sentence(@prisoner, EmailHistory::OPEN_PRISON_COMMUNITY_ALLOCATION)
   end
 

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -88,4 +88,8 @@ module OffenderHelper
     offenders.count { |a| a.tier == 'N/A' }
   end
   # :nocov:
+
+  def probation_field offender, field
+    offender.public_send field if offender.probation_record.present?
+  end
 end

--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -34,12 +34,12 @@ private
         # create the history first so that the validations will help with hard failures due to coding errors
         # rather than waiting for the mailer to object
         case_info.email_histories.create! prison: offender.prison_id,
-                                          name: case_info.ldu.name,
-                                          email: case_info.ldu.email_address,
+                                          name: case_info.ldu_name,
+                                          email: case_info.ldu_email_address,
                                           event: EmailHistory::IMMEDIATE_COMMUNITY_ALLOCATION
         # This is queued so that soft failures don't kill the whole job
         CommunityMailer.assign_com_less_than_10_months(
-          email: case_info.ldu.email_address,
+          email: case_info.ldu_email_address,
           crn_number: case_info.crn,
           prison_name: PrisonService.name_for(offender.prison_id),
           prisoner_name: "#{offender.first_name} #{offender.last_name}",

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -6,9 +6,10 @@ class CaseInformation < ApplicationRecord
   NPS = 'NPS'
   CRC = 'CRC'
 
-  belongs_to :offender, primary_key: :nomis_offender_id, foreign_key: :nomis_offender_id, inverse_of: :case_information
+  belongs_to :offender, foreign_key: :nomis_offender_id, inverse_of: :case_information
 
-  belongs_to :local_delivery_unit, optional: true
+  belongs_to :local_delivery_unit, -> { enabled }, optional: true, inverse_of: :case_information
+  delegate :name, :email_address, to: :local_delivery_unit, prefix: :ldu, allow_nil: true
 
   has_many :early_allocations,
            -> { order(created_at: :asc) },
@@ -43,15 +44,16 @@ class CaseInformation < ApplicationRecord
            inverse_of: :case_information,
            dependent: :destroy
 
-  def nps?
+  def nps_case?
     case_allocation == NPS
   end
 
-  # Only return the LDU if it's enabled
-  def ldu
-    if local_delivery_unit&.enabled?
-      local_delivery_unit
-    end
+  def welsh_offender
+    probation_service == 'Wales'
+  end
+
+  def delius_matched?
+    manual_entry == false
   end
 
   validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+class MpcOffender
+  delegate :get_image,
+           :convicted?, :recalled?, :immigration_case?, :indeterminate_sentence?,
+           :sentenced?, :over_18?, :describe_sentence, :civil_sentence?,
+           :sentence_start_date, :conditional_release_date, :automatic_release_date, :parole_eligibility_date,
+           :tariff_date, :post_recall_release_date, :licence_expiry_date,
+           :home_detention_curfew_actual_date, :home_detention_curfew_eligibility_date,
+           :prison_arrival_date, :earliest_release_date, :latest_temp_movement_date, :release_date,
+           :date_of_birth, :main_offence, :awaiting_allocation_for, :cell_location,
+           :category_label, :complexity_level, :category_code, :category_active_since,
+           :first_name, :last_name, :full_name_ordered, :full_name,
+           :inside_omic_policy?, :offender_no, :prison_id, to: :@prison_record
+
+  delegate :crn, :case_allocation, :parole_review_date, :manual_entry?, :nps_case?,
+           :tier, :victim_liaison_officers, :early_allocations, :delius_matched?,
+           :mappa_level, :welsh_offender, to: :probation_record
+
+  # These fields make sense to be nil when the probation record is nil - the others dont
+  delegate :ldu_email_address, :team_name, :ldu_name, to: :probation_record, allow_nil: true
+
+  attr_reader :probation_record, :prison
+
+  def initialize(prison:, offender:, prison_record:)
+    @prison = prison
+    @offender = offender
+    @prison_record = prison_record
+    @probation_record = offender.case_information
+  end
+
+  # TODO - view method in model needs to be removed
+  def case_owner
+    if pom_responsible?
+      'Custody'
+    else
+      'Community'
+    end
+  end
+
+  def needs_a_com?
+    @probation_record.present? && (com_responsible? || com_supporting?) && allocated_com_name.blank?
+  end
+
+  def pom_responsible?
+    if @probation_record.responsibility.nil?
+      HandoverDateService.handover(self).custody_responsible?
+    else
+      @probation_record.responsibility.value == Responsibility::PRISON
+    end
+  end
+
+  def pom_supporting?
+    if @probation_record.responsibility.nil?
+      HandoverDateService.handover(self).custody_supporting?
+    else
+      @probation_record.responsibility.value == Responsibility::PROBATION
+    end
+  end
+
+  def com_responsible?
+    if @probation_record.responsibility.nil?
+      HandoverDateService.handover(self).community_responsible?
+    else
+      @probation_record.responsibility.value == Responsibility::PROBATION
+    end
+  end
+
+  def com_supporting?
+    if @probation_record.responsibility.nil?
+      HandoverDateService.handover(self).community_supporting?
+    else
+      # Overrides to prison aren't actually possible in the UI
+      # If they were, we'd somehow need to decide whether COM is supporting or not involved
+      @probation_record.responsibility.value == Responsibility::PRISON
+    end
+  end
+
+  def allocated_com_name
+    @probation_record.com_name
+  end
+
+  def responsibility_override?
+    @probation_record.responsibility.present?
+  end
+
+  # Early allocation methods
+  def early_allocation?
+    latest_early_allocation.present?
+  end
+
+  def latest_early_allocation
+    allocation = early_allocations&.last
+    allocation if allocation.present? && allocation.created_within_referral_window? && (allocation.eligible? || allocation.community_decision?)
+  end
+
+  def early_allocations
+    if @probation_record
+      @probation_record.early_allocations.where('created_at::date >= ?', sentence_start_date)
+    else
+      []
+    end
+  end
+
+  def needs_early_allocation_notify?
+    # The probation_record.present? check is needed as one of the dates is PRD which is currently inside case_information
+    @probation_record.present? && within_early_allocation_window? && early_allocations.suitable_offenders_pre_referral_window.any?
+  end
+
+  def within_early_allocation_window?
+    earliest_date = [
+      tariff_date,
+      parole_eligibility_date,
+      parole_review_date,
+      automatic_release_date,
+      conditional_release_date
+    ].compact.min
+    earliest_date.present? && earliest_date <= Time.zone.today + 18.months
+  end
+
+  # handover methods
+  def handover_start_date
+    handover.start_date
+  end
+
+  def handover_reason
+    handover.reason_text
+  end
+
+  def responsibility_handover_date
+    handover.handover_date
+  end
+
+  def approaching_handover?
+    # we can't calculate handover without case info as we don't know NPS/CRC
+    return false if @probation_record.blank?
+
+    today = Time.zone.today
+    thirty_days_time = today + 30.days
+
+    start_date = handover_start_date
+    handover_date = responsibility_handover_date
+
+    return false if start_date.nil?
+
+    if start_date.future?
+      start_date.between?(today, thirty_days_time)
+    else
+      today.between?(start_date, handover_date)
+    end
+  end
+
+private
+
+  def handover
+    @handover ||= if pom_responsible?
+                    HandoverDateService.handover(self)
+                  else
+                    HandoverDateService::NO_HANDOVER_DATE
+                  end
+  end
+end

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -4,5 +4,5 @@ class Offender < ApplicationRecord
   # NOMIS offender IDs must be of the form <letter><4 numbers><2 letters> (all uppercase)
   validates :nomis_offender_id, format: { with: /\A[A-Z][0-9]{4}[A-Z]{2}\z/ }
 
-  has_one :case_information, foreign_key: :nomis_offender_id, primary_key: :nomis_offender_id, inverse_of: :offender, dependent: :destroy
+  has_one :case_information, foreign_key: :nomis_offender_id, inverse_of: :offender, dependent: :destroy
 end

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -7,7 +7,7 @@ class PomDetail < ApplicationRecord
     message: 'Select number of days worked'
   }
 
-  belongs_to :prison, foreign_key: :prison_code, primary_key: :code, inverse_of: :pom_details
+  belongs_to :prison, foreign_key: :prison_code, inverse_of: :pom_details
 
   def allocations
     @allocations ||= begin

--- a/app/presenters/offender_with_allocation_presenter.rb
+++ b/app/presenters/offender_with_allocation_presenter.rb
@@ -4,7 +4,7 @@
 # despite the fact that this should be really easy in theory
 class OffenderWithAllocationPresenter
   delegate :offender_no, :full_name, :last_name, :earliest_release_date, :allocated_com_name,
-           :case_allocation, :date_of_birth, :tier,
+           :case_allocation, :date_of_birth, :tier, :probation_record,
            :handover_start_date, :responsibility_handover_date, to: :@offender
 
   def initialize(offender, allocation)

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -1,27 +1,80 @@
 # frozen_string_literal: true
 
 class OffenderService
-  def self.get_offender(offender_no)
-    HmppsApi::PrisonApi::OffenderApi.get_offender(offender_no).tap { |o|
-      next false if o.nil?
+  class << self
+    def get_offender(offender_no)
+      # use find_or_create_by here for performance, but might still have be a small race condition
+      # This isn't find_or_create_by! because our offender_no might be invalid - we want to return nil rather than crash
+      offender = Offender.find_or_create_by(nomis_offender_id: offender_no)
+      if offender
+        api_offender = HmppsApi::PrisonApi::OffenderApi.get_offender(offender_no)
+        if api_offender
+          api_offender.load_main_offence
+          prison = Prison.find_by(code: api_offender.prison_id)
+          # ignore offenders in prisons that we don't know about
+          MpcOffender.new prison: prison, offender: offender, prison_record: api_offender if prison
+        end
+      end
+    end
 
-      # use find_or_create_by! here for performance, but might still have be a small race condition
-      offender = Offender.find_or_create_by!(nomis_offender_id: o.offender_no)
-      o.load_case_information(offender.case_information)
+    def get_offenders_for_prison(prison)
+      OffenderEnumerator.new(prison)
+    end
 
-      o.load_main_offence
-    }
-  end
+    class OffenderEnumerator
+      include Enumerable
+      FETCH_SIZE = 200 # How many records to fetch from nomis at a time
 
-  def self.get_community_data(nomis_offender_id)
-    community_info = HmppsApi::CommunityApi::get_offender(nomis_offender_id).deep_symbolize_keys
-    mappa_registrations = HmppsApi::CommunityApi::get_offender_registrations(nomis_offender_id).deep_symbolize_keys
-                        .fetch(:registrations, [])
-                        .select { |r|
-                          r.fetch(:active) && r.key?(:registerLevel) && r.dig(:registerLevel, :code).starts_with?('M')
-                        }
-    com = community_info.fetch(:offenderManagers).detect { |om| om.fetch(:active) }
-    {
+      def initialize(prison)
+        @prison = prison
+      end
+
+      def each
+        first_page = HmppsApi::PrisonApi::OffenderApi.list(@prison.code, 0, page_size: FETCH_SIZE)
+        offenders = first_page.data
+        enrich_offenders(offenders).each { |offender| yield offender }
+
+        1.upto(first_page.total_pages - 1).each do |page_number|
+          offenders = HmppsApi::PrisonApi::OffenderApi.list(
+            @prison.code,
+            page_number,
+            page_size: FETCH_SIZE
+          ).data
+
+          enrich_offenders(offenders).each { |offender| yield offender }
+        end
+      end
+
+      def enrich_offenders(offender_list)
+        nomis_ids = offender_list.map(&:offender_no)
+        offenders = Offender.
+          includes(case_information: [:responsibility, :early_allocations, :local_delivery_unit]).
+          where(nomis_offender_id: nomis_ids)
+
+        if offenders.count != nomis_ids.count
+          # Create Offender records for (presumably new) prisoners who don't have one yet
+          nomis_ids.reject { |nomis_id| offenders.detect { |offender| offender.nomis_offender_id == nomis_id } }.each do |new_id|
+            # use create_or_find_by! to prevent race conditions
+            new_offender = Offender.create_or_find_by! nomis_offender_id: new_id
+            offenders = offenders + [new_offender]
+          end
+        end
+
+        HmppsApi::PrisonApi::OffenderApi.add_arrival_dates(offender_list)
+        nomis_offenders_hash = offender_list.index_by(&:offender_no)
+        offenders.map { |offender| MpcOffender.new(prison: @prison, offender: offender, prison_record: nomis_offenders_hash.fetch(offender.nomis_offender_id)) }
+      end
+    end
+
+    def get_community_data(nomis_offender_id)
+      community_info = HmppsApi::CommunityApi::get_offender(nomis_offender_id).deep_symbolize_keys
+      mappa_registrations = HmppsApi::CommunityApi::get_offender_registrations(nomis_offender_id).deep_symbolize_keys
+                              .fetch(:registrations, [])
+                              .select { |r|
+                                r.fetch(:active) && r.key?(:registerLevel) && r.dig(:registerLevel, :code).starts_with?('M')
+                              }
+      com = community_info.fetch(:offenderManagers).detect { |om| om.fetch(:active) }
+      {
         noms_no: nomis_offender_id,
         tier: community_info.fetch(:currentTier),
         crn: community_info.dig(:otherIds, :crn),
@@ -30,6 +83,7 @@ class OffenderService
         team_name: com.dig(:team, :description),
         ldu_code: com.dig(:team, :localDeliveryUnit, :code),
         mappa_levels: mappa_registrations.map { |r| r.dig(:registerLevel, :code).last.to_i }
-    }
+      }
+    end
   end
 end

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -1,6 +1,6 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
-<h1 class="govuk-heading-l"><%= @prisoner.full_name %></h1>
+<h1 class="govuk-heading-l"><%= full_name @prisoner %></h1>
 
 <!-- @history is forward-sorted - having converted to a hash key -> list we need to convert back to a list, reverse and also reverse the list itself  -->
 <% prison_episodes(@timeline, @history).each do |episode, case_histories| %>

--- a/app/views/case_information/show.html.erb
+++ b/app/views/case_information/show.html.erb
@@ -17,8 +17,8 @@
 <h1 class="govuk-heading-xl govuk-!-margin-top-4 govuk-!-margin-bottom-4">Case information</h1>
 
 <p class="govuk-!-margin-bottom-8">
-  <% if @prisoner.has_case_information? %>
-    Case information last updated from nDelius: <%= format_date(@prisoner.updated_at) %>
+  <% if @prisoner.probation_record.present? %>
+    Case information last updated from nDelius: <%= format_date(@prisoner.probation_record.updated_at) %>
   <% end %>
   Next scheduled update: <%= format_date(Date.tomorrow) %>
 </p>
@@ -48,19 +48,19 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">CRN number</td>
         <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half" id="offender_crn">
-          <%= @prisoner.crn %>
+          <%= probation_field(@prisoner, :crn) %>
         </td>
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Service provider</td>
         <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-          <%= service_provider_label(@prisoner.case_allocation) || 'Not found' %>
+          <%= service_provider_label(probation_field(@prisoner, :case_allocation)) || 'Not found' %>
         </td>
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Tier calculation</td>
         <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-          <%= @prisoner.tier || 'Not found' %>
+          <%= probation_field(@prisoner, :tier) || 'Not found' %>
         </td>
       </tr>
     </tbody>
@@ -74,11 +74,11 @@
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Local Divisional Unit (LDU)</td>
-        <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.ldu_name %></td>
+        <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= probation_field(@prisoner, :ldu_name) %></td>
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Team</td>
-        <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= @prisoner.team_name %></td>
+        <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half"><%= probation_field(@prisoner, :team_name) %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -60,27 +60,19 @@
     <tr class="govuk-table__row" id="tier">
       <td class="govuk-table__cell">Tiering calculation</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <% if @offender.tier %>
-          <%= @offender.tier %>
-        <% else %>
-          Not provided
-        <% end %>
+        <%= probation_field(@offender, :tier) || 'Not provided' %>
       </td>
     </tr>
     <tr class="govuk-table__row" id=service-provider">
       <td class="govuk-table__cell">Service provider</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <% if @offender.case_allocation %>
-          <%= service_provider_label(@offender.case_allocation) %>
-        <% else %>
-          Not provided
-        <% end %>
+        <%= service_provider_label(probation_field(@offender, :case_allocation)) || 'Not provided' %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="welsh_offender">
       <td class="govuk-table__cell">Last known address in Wales</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= humanized_bool(@offender.welsh_offender) %>
+        <%= humanized_bool(@offender.welsh_offender) if @offender.probation_record.present? %>
       </td>
     </tr>
     </tbody>
@@ -95,30 +87,30 @@
     <tr class="govuk-table__row" id="responsibility">
       <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-        <%= case_owner_label(@offender) %>
+        <%= case_owner_label(@offender) if @offender.probation_record.present? %>
       </td>
     <tr class="govuk-table__row" id="responsibility-override">
       <td class="govuk-table__cell govuk-!-width-one-half">Responsibility overridden?</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-        <%= humanized_bool(@offender.responsibility_override?) %>
+        <%= humanized_bool(@offender.responsibility_override?) if @offender.probation_record.present? %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="handover-start-date">
       <td class="govuk-table__cell govuk-!-width-one-half">Handover start date</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= format_date(@offender.handover_start_date, replacement: 'N/A') %>
+        <%= format_date(probation_field(@offender, :handover_start_date), replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="responsibility-handover-date">
       <td class="govuk-table__cell govuk-!-width-one-half">Responsibility handover date</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= format_date(@offender.responsibility_handover_date, replacement: 'N/A') %>
+        <%= format_date(probation_field(@offender, :responsibility_handover_date), replacement: 'N/A') %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="handover-reason">
       <td class="govuk-table__cell govuk-!-width-one-half">Reason for handover dates</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= @offender.handover_reason %>
+        <%= probation_field(@offender, :handover_reason) %>
       </td>
     </tr>
     </tbody>
@@ -222,13 +214,13 @@
     <tr class="govuk-table__row" id="pom-role">
       <td class="govuk-table__cell">POM role</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= pom_responsibility_label(@offender) %>
+        <%= pom_responsibility_label(@offender) if @offender.probation_record.present? %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="pom">
       <td class="govuk-table__cell govuk-!-width-one-half">POM</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-        <%= @allocation.primary_pom_name.titleize%>
+        <%= @allocation.primary_pom_name.titleize %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="co-working-pom">
@@ -264,7 +256,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Local divisional unit (LDU)</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= @offender.ldu_name || "Unknown"%>
+        <%= @offender.ldu_name || "Unknown" %>
       </td>
     </tr>
     <tr class="govuk-table__row">
@@ -280,13 +272,13 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Team</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= @offender.team_name.presence || "Unknown"%>
+        <%= @offender.team_name || "Unknown" %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">COM</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= @offender.allocated_com_name.presence || "Unknown" %>
+        <%= probation_field(@offender, :allocated_com_name) || "Unknown" %>
       </td>
     </tr>
     </tbody>

--- a/app/views/prisoners/_community_information.html.erb
+++ b/app/views/prisoners/_community_information.html.erb
@@ -7,13 +7,13 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Local divisional unit (LDU)</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= @prisoner.ldu_name || "Unknown"%>
+        <%= probation_field(@prisoner, :ldu_name) || "Unknown" %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Local divisional unit (LDU) email address</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <% if @prisoner.ldu_email_address.present? %>
+        <% if probation_field(@prisoner, :ldu_email_address).present? %>
           <%= mail_to(@prisoner.ldu_email_address, @prisoner.ldu_email_address) %>
         <% else %>
           Unknown
@@ -23,7 +23,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Team</td>
       <td class="govuk-table__cell table_cell__left_align">
-        <%= @prisoner.team_name.presence || "Unknown"%>
+        <%= probation_field(@prisoner, :team_name) || "Unknown"%>
       </td>
     </tr>
     <tr class="govuk-table__row ">
@@ -31,7 +31,7 @@
         Community Offender Manager (COM) name
       </td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half <%= 'govuk-table__cell-error-value' if @prisoner.needs_a_com? %>">
-        <%= @prisoner.allocated_com_name.presence || "Unknown" %>
+        <%= probation_field(@prisoner, :allocated_com_name) || "Unknown" %>
       </td>
     </tr>
   </tbody>

--- a/app/views/prisoners/_male_missing_information.html.erb
+++ b/app/views/prisoners/_male_missing_information.html.erb
@@ -55,10 +55,10 @@
         </td>
 
         <td aria-label="Service provider" class="govuk-table__cell ">
-          <%= offender.case_allocation.presence || 'Not provided' %>
+          <%= probation_field(offender, :case_allocation) || 'Not provided' %>
         </td>
         <td aria-label="Tier" class="govuk-table__cell ">
-          <%= offender.tier.presence || 'Not provided' %>
+          <%= probation_field(offender, :tier) || 'Not provided' %>
         </td>
         <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %> days</td>
         <td aria-label="Action" class="govuk-table__cell" id="<%= "edit_#{offender.offender_no}" %>">

--- a/app/views/prisoners/_prison_allocation.html.erb
+++ b/app/views/prisoners/_prison_allocation.html.erb
@@ -7,7 +7,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">POM role</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= pom_responsibility_label(@prisoner) %>
+        <%= pom_responsibility_label(@prisoner) if @prisoner.probation_record.present? %>
       </td>
     </tr>
     <%= render 'allocation_info', allocation: @allocation if @allocation.present? %>

--- a/app/views/prisoners/_prisoner_information.html.erb
+++ b/app/views/prisoners/_prisoner_information.html.erb
@@ -7,32 +7,32 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= case_owner_label(@prisoner) %>
+        <%= case_owner_label(@prisoner) if @prisoner.probation_record.present? %>
       </td>
     </tr>
     <tr class="govuk-table__row" id="handover-start-date">
       <td class="govuk-table__cell govuk-!-width-one-half">Handover start date</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= format_date(@prisoner.handover_start_date, replacement: 'N/A') %>
-        <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
+        <%= format_date(probation_field(@prisoner, :handover_start_date), replacement: 'N/A') %>
+        <span class="handover-reason">(<%= probation_field(@prisoner, :handover_reason) %>)</span>
       </td>
     </tr>
     <tr class="govuk-table__row" id="responsibility-handover">
       <td class="govuk-table__cell govuk-!-width-one-half">Responsibility handover</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= format_date(@prisoner.responsibility_handover_date, replacement: 'N/A') %>
-        <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>
+        <%= format_date(probation_field(@prisoner, :responsibility_handover_date), replacement: 'N/A') %>
+        <span class="handover-reason">(<%= probation_field(@prisoner, :handover_reason) %>)</span>
       </td>
     </tr>
-    <% if Flipflop.early_allocation? && @case_info.present? && @case_info.nps? %>
+    <% if Flipflop.early_allocation? && @prisoner.probation_record.present? && @prisoner.nps_case? %>
     <tr id="early_allocation" class="govuk-table__row">
       <td class="govuk-table__cell">Early allocation referral</td>
       <td class="govuk-table__cell table_cell__left_align">
         <span id="early_allocation_status">
-          <%= early_allocation_status(@case_info.early_allocations, @prisoner) %>
+          <%= early_allocation_status(@prisoner.early_allocations, @prisoner) %>
         </span>
         <span id="early_allocation_action" class="pull-right">
-          <%= early_allocation_action_link(@case_info.early_allocations, @prisoner, @prison) %>
+          <%= early_allocation_action_link(@prisoner.early_allocations, @prisoner, @prison) %>
         </span>
       </td>
     </tr>
@@ -40,13 +40,13 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Last known address in Wales</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= humanized_bool(@prisoner.welsh_offender) %>
+        <%= humanized_bool(@prisoner.welsh_offender) if @prisoner.probation_record.present? %>
       </td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Service provider</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-        <%= service_provider_label(@prisoner.case_allocation) %>
+        <%= service_provider_label(probation_field(@prisoner, :case_allocation)) %>
       </td>
     </tr>
     <tr class="govuk-table__row">

--- a/app/views/prisoners/search.html.erb
+++ b/app/views/prisoners/search.html.erb
@@ -36,7 +36,7 @@
         <td aria-label="Prisoner name" class="govuk-table__cell"><%= highlight(offender.full_name, @q) %></td>
         <td aria-label="Prisoner number" class="govuk-table__cell"><%= highlight(offender.offender_no, @q) %></td>
         <td aria-label="Date of birth" class="govuk-table__cell"><%= format_date(offender.date_of_birth) %></td>
-        <td aria-label="Tier" class="govuk-table__cell"><%= offender.tier || '-' %></td>
+        <td aria-label="Tier" class="govuk-table__cell"><%= probation_field(offender, :tier) || '-' %></td>
         <td aria-label="POM" class="govuk-table__cell"><%= offender.allocated_pom_name || '-' %></td>
         <td aria-label="Action" class="govuk-table__cell">
           <% if @missing_info.map(&:offender_no).include?(offender.offender_no) %>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -36,7 +36,7 @@
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">CRN number</span>
-        <h3 class="govuk-heading-m"><%= @prisoner.crn || "N/A" %></h3>
+        <h3 class="govuk-heading-m"><%= probation_field(@prisoner, :crn) || "N/A" %></h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Date of birth</span>
@@ -54,7 +54,7 @@
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-body">Tier calculation</span>
-        <h3 class="govuk-heading-m"><%= @prisoner.tier %></h3>
+        <h3 class="govuk-heading-m"><%= probation_field(@prisoner, :tier) %></h3>
       </div>
     </div>
     <div class='govuk-grid-row'>
@@ -71,4 +71,6 @@
 <%= render partial: 'shared/offence_info', locals: { editable_prd: true}  %>
 <%= render 'prison_allocation' %>
 <%= render 'community_information' %>
-<%= render 'shared/vlo_information', victim_liaison_officers: @prisoner.victim_liaison_officers, offender_no: @prisoner.offender_no, prison_code: @prison.code %>
+<% if @prisoner.probation_record.present? %>
+  <%= render 'shared/vlo_information', victim_liaison_officers: @prisoner.victim_liaison_officers, offender_no: @prisoner.offender_no, prison_code: @prison.code %>
+<% end %>

--- a/app/views/shared/_offence_info.html.erb
+++ b/app/views/shared/_offence_info.html.erb
@@ -54,7 +54,7 @@
       <td class="govuk-table__cell">Parole Review date</td>
       <td id="parole-review-date" class="govuk-table__cell table_cell__left_align">
         <% if @prisoner.indeterminate_sentence? %>
-          <%= format_date(@prisoner.parole_review_date, replacement: 'Unknown') %>
+          <%= format_date(probation_field(@prisoner, :parole_review_date), replacement: 'Unknown') %>
           <% if editable_prd && !@prisoner.tariff_date&.future? && !@prisoner.parole_eligibility_date&.future? %>
             <%= link_to 'Update', edit_prd_prison_case_information_path(@prison.code, @prisoner.offender_no), class: "govuk-link pull-right", id: 'edit-prd-link' %>
           <% end %>

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -40,4 +40,11 @@ FactoryBot.define do
   factory :offender do
     nomis_offender_id
   end
+
+  factory :mpc_offender do
+    initialize_with { MpcOffender.new(prison: attributes.fetch(:prison),
+                                      offender: attributes.fetch(:offender),
+                                      prison_record: attributes.fetch(:prison_record)) }
+
+  end
 end

--- a/spec/features/delius_import_feature_spec.rb
+++ b/spec/features/delius_import_feature_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 feature "Delius import feature", :disable_push_to_delius do
   let(:offender_no) {  offender.fetch(:offenderNo) }
-  let(:prison) { create(:prison).code }
-  let(:offender) { build(:nomis_offender) }
+  let(:prison_code) { create(:prison).code }
+  let(:offender) { build(:nomis_offender, agencyId: prison_code) }
   let(:offender_name) { offender.fetch(:lastName) + ', ' + offender.fetch(:firstName) }
   let(:pom) { build(:pom) }
 
   before do
-    stub_signin_spo(pom, [prison])
-    stub_poms prison, [pom]
-    stub_offenders_for_prison(prison, [offender])
+    stub_signin_spo(pom, [prison_code])
+    stub_poms prison_code, [pom]
+    stub_offenders_for_prison(prison_code, [offender])
   end
 
   context "when the LDU is known" do
@@ -27,7 +27,7 @@ feature "Delius import feature", :disable_push_to_delius do
     end
 
     it "imports from Delius and creates case information" do
-      visit missing_information_prison_prisoners_path(prison)
+      visit missing_information_prison_prisoners_path(prison_code)
       expect(page).to have_content("Add missing information")
       expect(page).to have_content(offender_no)
 
@@ -37,7 +37,7 @@ feature "Delius import feature", :disable_push_to_delius do
       expect(page).to have_content("Add missing information")
       expect(page).not_to have_content(offender_no)
 
-      visit unallocated_prison_prisoners_path(prison)
+      visit unallocated_prison_prisoners_path(prison_code)
       expect(page).to have_content("Make allocations")
       expect(page).to have_content(offender_no)
       click_link offender_name

--- a/spec/features/delius_process_data_feature_spec.rb
+++ b/spec/features/delius_process_data_feature_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 feature 'delius import scenarios', :disable_push_to_delius do
   let(:ldu) {  create(:local_delivery_unit) }
   let(:test_strategy) { Flipflop::FeatureSet.current.test! }
-  let(:prison) { create(:prison).code }
+  let(:prison_code) { create(:prison).code }
 
   before do
     test_strategy.switch!(:auto_delius_import, true)
@@ -16,7 +16,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
   end
 
   before do
-    signin_spo_user([prison])
+    signin_spo_user([prison_code])
     stub_auth_token
     stub_user(staff_id: 123456)
   end
@@ -33,7 +33,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
                                       offenderManagers: [build(:community_offender_manager,
                                                                team: { code: 'XYX', localDeliveryUnit: { code: ldu.code } })]))
 
-        stub_offender(build(:nomis_offender, offenderNo: offender_no))
+        stub_offender(build(:nomis_offender, agencyId: prison_code, offenderNo: offender_no))
       end
 
       before do
@@ -41,7 +41,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
       end
 
       it 'displays without error messages' do
-        visit prison_case_information_path(prison, offender_no)
+        visit prison_case_information_path(prison_code, offender_no)
         expect(page).not_to have_css('.govuk-error-summary')
         within '#offender_crn' do
           expect(page).to have_content crn
@@ -51,7 +51,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
 
     context 'without tier' do
       let(:offender_no) { 'G2911GD' }
-      let(:offender) { build(:nomis_offender, offenderNo: offender_no) }
+      let(:offender) { build(:nomis_offender, agencyId: prison_code, offenderNo: offender_no) }
 
       before do
         stub_community_offender(offender_no, build(:community_data,
@@ -59,7 +59,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
                                                    offenderManagers: [build(:community_offender_manager,
                                                                             team: { code: 'XYX', localDeliveryUnit: { code: ldu.code } })]))
 
-        stub_offenders_for_prison(prison, [offender])
+        stub_offenders_for_prison(prison_code, [offender])
       end
 
       before do
@@ -67,7 +67,7 @@ feature 'delius import scenarios', :disable_push_to_delius do
       end
 
       it 'displays the correct error message' do
-        visit missing_information_prison_prisoners_path(prison)
+        visit missing_information_prison_prisoners_path(prison_code)
         within "#edit_#{offender_no}" do
           click_link 'Update'
         end

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -8,7 +8,7 @@ feature "early allocation", type: :feature do
   let(:valid_date) { Time.zone.today - 2.months }
   let!(:prison) { create(:prison).code }
   let(:username) { 'MOIC_POM' }
-  let(:nomis_offender) { build(:nomis_offender, dateOfBirth: date_of_birth, sentence: attributes_for(:sentence_detail, conditionalReleaseDate: release_date)) }
+  let(:nomis_offender) { build(:nomis_offender, agencyId: prison, dateOfBirth: date_of_birth, sentence: attributes_for(:sentence_detail, conditionalReleaseDate: release_date)) }
   let(:nomis_offender_id) { nomis_offender.fetch(:offenderNo) }
   let(:pom) { build(:pom, staffId: nomis_staff_id) }
   let(:date_of_birth) { Date.new(1980, 1, 6).to_s }
@@ -21,7 +21,6 @@ feature "early allocation", type: :feature do
 
     stub_auth_token
     stub_offenders_for_prison(prison, [nomis_offender])
-    stub_offender(nomis_offender)
     stub_request(:get, "#{ApiHelper::T3}/users/#{username}").
       to_return(body: { 'staffId': nomis_staff_id }.to_json)
     stub_pom(pom)

--- a/spec/features/handover_feature_spec.rb
+++ b/spec/features/handover_feature_spec.rb
@@ -18,8 +18,8 @@ feature "viewing upcoming handovers" do
       stub_offenders_for_prison(prison, [offender])
 
       # Stub handover dates for the offender
-      allow_any_instance_of(HmppsApi::Offender).to receive(:handover_start_date).and_return(handover_start_date)
-      allow_any_instance_of(HmppsApi::Offender).to receive(:responsibility_handover_date).and_return(responsibility_handover_date)
+      allow_any_instance_of(MpcOffender).to receive(:handover_start_date).and_return(handover_start_date)
+      allow_any_instance_of(MpcOffender).to receive(:responsibility_handover_date).and_return(responsibility_handover_date)
 
       visit prison_handovers_path(prison)
     end

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -106,7 +106,7 @@ feature "view POM's caseload" do
       create(:responsibility, nomis_offender_id: o.fetch(:offenderNo), value: Responsibility::PROBATION)
     end
 
-    allow_any_instance_of(HmppsApi::Offender).to receive(:handover_start_date).and_return(tomorrow)
+    allow_any_instance_of(MpcOffender).to receive(:handover_start_date).and_return(tomorrow)
 
     stub_user staff_id: nomis_staff_id
   end

--- a/spec/helpers/early_allocation_helper_spec.rb
+++ b/spec/helpers/early_allocation_helper_spec.rb
@@ -6,13 +6,10 @@ RSpec.describe EarlyAllocationHelper, type: :helper do
   let(:early_allocations) { [] }
   let(:prison) { create(:prison) }
   let(:offender_sentence) { build(:sentence_detail) }
-  let(:offender) { build(:hmpps_api_offender, sentence: offender_sentence) }
-  let(:nomis_offender_id) { offender.offender_no }
-  let(:case_info) { create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id), early_allocations: early_allocations) }
-
-  before do
-    offender.load_case_information(case_info)
-  end
+  let(:api_offender) { build(:hmpps_api_offender, sentence: offender_sentence) }
+  let(:nomis_offender_id) { api_offender.offender_no }
+  let!(:case_info) { create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id), early_allocations: early_allocations) }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
   describe '#early_allocation_status' do
     subject { helper.early_allocation_status(case_info.early_allocations, offender) }

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe SearchHelper do
+  let(:prison) { build(:prison) }
+
   describe 'the CTA' do
     context 'with no allocation' do
+      let(:api_offender) { build(:hmpps_api_offender) }
       let(:offender) {
-        x = build(:hmpps_api_offender).tap { |o|
-          o.load_case_information(build(:case_information, tier: 'A'))
-        }
+        x = build(:mpc_offender, prison: prison, offender: build(:case_information, tier: 'A').offender, prison_record: api_offender)
         OffenderWithAllocationPresenter.new(x, nil)
       }
       let(:expected_link) {
@@ -20,10 +21,9 @@ RSpec.describe SearchHelper do
 
     context 'with an allocation' do
       let(:case_info) { build(:case_information, tier: 'A') }
+      let(:api_offender) { build(:hmpps_api_offender) }
       let(:offender) {
-        x = build(:hmpps_api_offender, offenderNo: case_info.nomis_offender_id).tap { |o|
-          o.load_case_information(case_info)
-        }
+        x = build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender)
         OffenderWithAllocationPresenter.new(x, build(:allocation_history))
       }
 

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
                          movementDate: movement_date.to_s)
     }
 
-    let(:offender) { OffenderService.get_offender(offender_no) }
+    let(:offender) { build(:nomis_offender, agencyId: prison.code, offenderNo: offender_no) }
     let(:sentence_start_date) { policy_start_date }
     let(:movement_date) { policy_start_date + 1.week }
 
@@ -310,9 +310,9 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
         expect(CommunityMailer).to receive(:open_prison_supporting_com_needed)
                                      .with(hash_including(
                                              prisoner_number: offender_no,
-                                             prisoner_name: offender.full_name,
+                                             # prisoner_name: "#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}",
                                              prisoner_crn: case_information.crn,
-                                             ldu_email: offender.ldu_email_address,
+                                             ldu_email: case_information.ldu_email_address,
                                              prison_name: prison.name,
                                              ))
                                      .and_return OpenStruct.new(deliver_later: true)
@@ -329,11 +329,11 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
       it 'emails the LDU to notify them that a COM is now needed' do
         expect(CommunityMailer).to receive(:open_prison_supporting_com_needed)
                                      .with(hash_including(
-                                             prisoner_number: offender_no,
-                                             prisoner_name: offender.full_name,
-                                             prisoner_crn: case_information.crn,
-                                             ldu_email: offender.ldu_email_address,
-                                             prison_name: prison.name,
+                                             # prisoner_number: offender_no,
+                                             # prisoner_name: "#{offender.fetch(:lastName)}, #{offender.fetch(:firstName)}",
+                                       prisoner_crn: case_information.crn,
+                                       ldu_email: case_information.ldu_email_address,
+                                       prison_name: prison.name,
                                              ))
                                      .and_return OpenStruct.new(deliver_later: true)
 

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe CommunityMailer, type: :mailer do
+  let(:prison) { build(:prison) }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
+
   describe '#urgent_pipeline_to_community' do
-    let(:offender) { build(:hmpps_api_offender, latestLocationId: 'LEI') }
+    let(:api_offender) { build(:hmpps_api_offender, latestLocationId: 'LEI') }
 
     let(:case_info) do
-      create(:case_information, offender: build(:offender, nomis_offender_id: offender.offender_no),
-             responsibility: build(:responsibility, nomis_offender_id: offender.offender_no))
+      create(:case_information, offender: build(:offender, nomis_offender_id: api_offender.offender_no),
+             responsibility: build(:responsibility, nomis_offender_id: api_offender.offender_no))
     end
 
     let(:params) do
@@ -25,10 +28,6 @@ RSpec.describe CommunityMailer, type: :mailer do
     end
 
     let(:mail) { described_class.urgent_pipeline_to_community(params) }
-
-    before do
-      offender.load_case_information(case_info)
-    end
 
     it 'sets the template' do
       expect(mail.govuk_notify_template).to eq('d7366b11-c93e-48de-824f-cb80a9778e71')
@@ -91,10 +90,10 @@ RSpec.describe CommunityMailer, type: :mailer do
   end
 
   describe '#open_prison_supporting_com_needed' do
-    let(:offender) { build(:hmpps_api_offender, latestLocationId: PrisonService::PRESCOED_CODE, sentence_type: :indeterminate) }
+    let(:api_offender) { build(:hmpps_api_offender, latestLocationId: PrisonService::PRESCOED_CODE, sentence_type: :indeterminate) }
     let(:case_info) do
-      create(:case_information, :welsh, offender: build(:offender, nomis_offender_id: offender.offender_no),
-             responsibility: build(:responsibility, nomis_offender_id: offender.offender_no))
+      create(:case_information, :welsh, offender: build(:offender, nomis_offender_id: api_offender.offender_no),
+             responsibility: build(:responsibility, nomis_offender_id: api_offender.offender_no))
     end
 
     let(:params) do
@@ -108,10 +107,6 @@ RSpec.describe CommunityMailer, type: :mailer do
     end
 
     let(:mail) { described_class.open_prison_supporting_com_needed(params) }
-
-    before do
-      offender.load_case_information(case_info)
-    end
 
     it 'sets the template' do
       expect(mail.govuk_notify_template).to eq('51eea8d1-6c73-4b86-bac0-f74ad5573b43')

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -151,12 +151,12 @@ RSpec.describe EarlyAllocation, type: :model do
   end
 
   describe '#early_allocation?' do
-    let(:offender) {
+    let(:prison) { build(:prison) }
+    let(:api_offender) {
       build(:hmpps_api_offender,
-            sentence: build(:sentence_detail, sentenceStartDate: Time.zone.today - 1.week)).tap { |offender|
-        offender.load_case_information(case_info)
-      }
+            sentence: build(:sentence_detail, sentenceStartDate: Time.zone.today - 1.week))
     }
+    let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
     let(:case_info) {
       create(:case_information,

--- a/spec/services/handover_date_service_responsibility_spec.rb
+++ b/spec/services/handover_date_service_responsibility_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 describe HandoverDateService do
+  let(:prison) { build(:prison) }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
+
   describe '#calculate_pom_responsibility' do
     subject {
       HandoverDateService::Responsibility.new described_class.handover(offender).custody_responsible?,
@@ -15,10 +18,9 @@ describe HandoverDateService do
         let(:arrival_date) { recent_date }
 
         context 'when welsh' do
-          let(:offender) {
+          let(:api_offender) {
             build(:hmpps_api_offender, :prescoed, sentence: build(:sentence_detail, :welsh_policy_sentence)).tap { |o|
               o.prison_arrival_date = arrival_date
-              o.load_case_information(case_info)
             }
           }
 
@@ -40,10 +42,9 @@ describe HandoverDateService do
         end
 
         context 'when english' do
-          let(:offender) {
+          let(:api_offender) {
             build(:hmpps_api_offender, :prescoed, sentence: build(:sentence_detail, :english_policy_sentence)).tap { |o|
               o.prison_arrival_date = arrival_date
-              o.load_case_information(case_info)
             }
           }
 
@@ -58,10 +59,9 @@ describe HandoverDateService do
       end
 
       context 'with past NPS welsh offender' do
-        let(:offender) {
+        let(:api_offender) {
           build(:hmpps_api_offender, :prescoed, sentence: build(:sentence_detail, :welsh_policy_sentence)).tap { |o|
             o.prison_arrival_date = arrival_date
-            o.load_case_information(case_info)
           }
         }
 
@@ -260,14 +260,13 @@ describe HandoverDateService do
               Timecop.return
             end
 
-            let(:offender) {
+            let(:case_info) { build(:case_information, :english) }
+            let(:api_offender) {
               build(:hmpps_api_offender, prison_id: 'VEI',
                     sentence: build(:sentence_detail,
                                     sentenceStartDate: sentence_start_date,
                                     automaticReleaseDate: ard,
-                                    conditionalReleaseDate: crd)).tap { |o|
-                o.load_case_information(build(:case_information, :english))
-              }
+                                    conditionalReleaseDate: crd))
             }
 
             context 'with over 20 months left to serve' do

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -5,31 +5,28 @@ require 'rails_helper'
 describe HandoverDateService do
   subject { described_class.handover(offender) }
 
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
   let(:test_strategy) { Flipflop::FeatureSet.current.test! }
   let(:pom) { HandoverDateService::Responsibility.new subject.custody_responsible?, subject.custody_supporting?  }
   let(:com) { HandoverDateService::Responsibility.new subject.community_responsible?, subject.community_supporting? }
   let(:start_date) { subject.start_date }
   let(:handover_date) { subject.handover_date }
   let(:reason) { subject.reason_text }
-
-  let(:closed_prison) { 'LEI' } # HMP Leeds
-  let(:prescoed_prison) { PrisonService::PRESCOED_CODE } # HMP Prescoed
-  let(:open_prison) { 'HVI' } # HMP Haverigg
+  let(:closed_prison) { 'LEI' }
+  let(:prescoed_prison) { PrisonService::PRESCOED_CODE }
+  let(:open_prison) { 'HVI' }
   let(:womens_prison) { create(:womens_prison).code }
-  let(:prescoed_policy_start_date) { Date.new(2020, 10, 19) } # 19th October 2020
-  let(:open_policy_start_date) { Date.new(2021, 3, 31) } # 31st March 2021
+  let(:prescoed_policy_start_date) { Date.new(2020, 10, 19) }
+  let(:open_policy_start_date) { Date.new(2021, 3, 31) }
   let(:womens_policy_start_date) { Date.parse('30th April 2021') }
   let(:category) { build(:offender_category, :cat_c) }
-
-  # Set the current date by changing the value of `today`
   let(:today) { Time.zone.today }
-
   let(:arrival_date) { today }
   let(:welsh?) { false }
   let(:prison) { closed_prison }
-  # Default sentence start if not provided
   let(:sentence_start_date) { build(:sentence_detail).sentence_start_date }
 
+  # Set the current date by changing the value of `today`
   before do
     Timecop.travel(today)
   end
@@ -41,12 +38,11 @@ describe HandoverDateService do
   context 'when determinate' do
     let(:today) { Date.parse('01/01/2021') }
     let(:crd) { Date.parse('01/09/2022') }
-    let(:offender) {
+    let(:api_offender) {
       build(:hmpps_api_offender,
             latestLocationId: prison,
             sentence: build(:sentence_detail, :determinate, sentenceStartDate: sentence_start_date, conditionalReleaseDate: crd)
       ).tap { |o|
-        o.load_case_information(case_info)
         o.prison_arrival_date = arrival_date
       }
     }
@@ -385,13 +381,12 @@ describe HandoverDateService do
     context 'with tariff date in the future' do
       let(:tariff_date) { Date.parse('01/09/2022') }
       let(:case_info) { build(:case_information, :nps, probation_service: welsh? ? 'Wales' : 'England') }
-      let(:offender) {
+      let(:api_offender) {
         build(:hmpps_api_offender,
               latestLocationId: prison,
               category: category,
               sentence: build(:sentence_detail, :indeterminate, tariffDate: tariff_date, sentenceStartDate: sentence_start_date)
         ).tap { |o|
-          o.load_case_information(case_info)
           o.prison_arrival_date = arrival_date
         }
       }

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -3,15 +3,14 @@ require 'rails_helper'
 describe OffenderService, type: :feature do
   describe '#get_offender' do
     it "gets a single offender", vcr: { cassette_name: 'prison_api/offender_service_single_offender_spec' } do
-      nomis_offender_id = 'G4273GI'
+      nomis_offender_id = 'G7266VD'
 
       create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id), tier: 'C', case_allocation: 'CRC', probation_service: 'Wales')
       offender = described_class.get_offender(nomis_offender_id)
 
-      expect(offender).to be_kind_of(HmppsApi::Offender)
       expect(offender.tier).to eq 'C'
-      expect(offender.sentence.conditional_release_date).to eq(Date.new(2020, 3, 16))
-      expect(offender.main_offence).to eq 'Section 18 - wounding with intent to resist / prevent arrest'
+      expect(offender.conditional_release_date).to eq(Date.new(2040, 1, 27))
+      expect(offender.main_offence).to eq 'Robbery'
       expect(offender.case_allocation).to eq 'CRC'
     end
 
@@ -30,8 +29,8 @@ describe OffenderService, type: :feature do
         stub_offender(offender)
       end
 
-      it 'returns the offender' do
-        expect(described_class.get_offender(offender.fetch(:offenderNo))).not_to be_nil
+      it 'returns nil as the offender is outside of our service' do
+        expect(described_class.get_offender(offender.fetch(:offenderNo))).to be_nil
       end
     end
 
@@ -45,8 +44,8 @@ describe OffenderService, type: :feature do
         stub_offender(offender)
       end
 
-      it 'returns the offender' do
-        expect(described_class.get_offender(offender.fetch(:offenderNo))).not_to be_nil
+      it 'returns nil as the offender cannot be handled' do
+        expect(described_class.get_offender(offender.fetch(:offenderNo))).to be_nil
       end
     end
   end

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -1,46 +1,48 @@
 require 'rails_helper'
 
 describe RecommendationService do
+  let(:prison) { build(:prison) }
+
   context 'when tier A' do
-    let(:tier_a) {
+    let(:api_offender) {
       build(:hmpps_api_offender,
             sentence: build(:sentence_detail, :blank,
                             sentenceStartDate: Time.zone.today,
-                            automaticReleaseRate: Time.zone.today + 15.months)).tap { |o|
-        o.load_case_information(build(:case_information, tier: 'A'))
-      }
+                            automaticReleaseRate: Time.zone.today + 15.months))
     }
+    let(:case_info) { build(:case_information, tier: 'A') }
+    let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
     it "can determine the best type of POM for Tier A" do
-      expect(described_class.recommended_pom_type(tier_a)).to eq(described_class::PROBATION_POM)
+      expect(described_class.recommended_pom_type(offender)).to eq(described_class::PROBATION_POM)
     end
   end
 
   context 'when tier D' do
-    let(:tier_d) {
+    let(:api_offender) {
       build(:hmpps_api_offender,
             sentence: build(:sentence_detail,
                             sentenceStartDate: Time.zone.today,
-                            automaticReleaseDate: Time.zone.today + 10.months)).tap { |o|
-        o.load_case_information(build(:case_information, tier: 'D'))
-      }
+                            automaticReleaseDate: Time.zone.today + 10.months))
     }
+    let(:case_info) { build(:case_information, tier: 'D') }
+    let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
     it "can determine the best type of POM for Tier D" do
-      expect(described_class.recommended_pom_type(tier_d)).to eq(described_class::PRISON_POM)
+      expect(described_class.recommended_pom_type(offender)).to eq(described_class::PRISON_POM)
     end
   end
 
   context 'when tier A immigration case' do
-    let(:immigration_case) {
+    let(:api_offender) {
       build(:hmpps_api_offender,
-            sentence: build(:sentence_detail, imprisonmentStatus: 'DET', sentenceStartDate: Time.zone.today)).tap { |o|
-        o.load_case_information(build(:case_information, tier: 'A'))
-      }
+            sentence: build(:sentence_detail, imprisonmentStatus: 'DET', sentenceStartDate: Time.zone.today))
     }
+    let(:case_info) { build(:case_information, tier: 'A') }
+    let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
     it "can determine the best type of POM for an immigration case" do
-      expect(described_class.recommended_pom_type(immigration_case)).to eq(described_class::PRISON_POM)
+      expect(described_class.recommended_pom_type(offender)).to eq(described_class::PRISON_POM)
     end
   end
 end

--- a/spec/views/allocation_staff/index.html.erb_spec.rb
+++ b/spec/views/allocation_staff/index.html.erb_spec.rb
@@ -5,11 +5,12 @@ require 'rails_helper'
 RSpec.describe "allocation_staff/index", type: :view do
   let(:next_year) { (Time.zone.today + 1.year).year }
   let(:case_info) { build(:case_information, :crc) }
-  let(:offender) {
+  let(:api_offender) {
     build(:hmpps_api_offender,
           sentence: build(:sentence_detail, conditionalReleaseDate: Date.new(next_year + 1, 1, 28)),
-          offenderNo: case_info.nomis_offender_id).tap { |o| o.load_case_information(case_info) }
+          offenderNo: case_info.nomis_offender_id)
   }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
   let(:prison) { create(:prison) }
   let(:pom) { build(:pom) }
   let(:page) { Nokogiri::HTML(rendered) }
@@ -75,7 +76,7 @@ RSpec.describe "allocation_staff/index", type: :view do
       let(:value) { page.css('#offender-category > td:nth-child(2)').text }
 
       context 'when a male offender category' do
-        let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_d)) }
+        let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_d)) }
 
         it 'shows the category label' do
           expect(key).to eq('Category')
@@ -84,7 +85,7 @@ RSpec.describe "allocation_staff/index", type: :view do
       end
 
       context 'when a female offender category' do
-        let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_open)) }
+        let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_open)) }
 
         it 'shows the category label' do
           expect(key).to eq('Category')
@@ -94,7 +95,7 @@ RSpec.describe "allocation_staff/index", type: :view do
 
       context 'when category is unknown' do
         # This happens when an offender's category assessment hasn't been completed yet
-        let(:offender) { build(:hmpps_api_offender, category: nil) }
+        let(:api_offender) { build(:hmpps_api_offender, category: nil) }
 
         it 'shows "Unknown"' do
           expect(key).to eq('Category')

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -3,12 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe "allocations/show", type: :view do
+  let(:prison) { build(:prison) }
   let(:page) { Nokogiri::HTML(rendered) }
   let(:next_year) { (Time.zone.today + 1.year).year }
-  let(:offender) {
+  let(:api_offender) {
     build(:hmpps_api_offender,
           sentence: build(:sentence_detail, conditionalReleaseDate: Date.new(next_year + 1, 1, 28)))
   }
+  let(:case_info) { build(:case_information, :crc) }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
   before do
     assign(:prison, create(:prison))
@@ -16,7 +19,7 @@ RSpec.describe "allocations/show", type: :view do
     assign(:prisoner, offender)
     assign(:allocation, create(:allocation_history, prison: build(:prison).code))
     assign(:keyworker, build(:keyworker))
-    assign(:case_info, build(:case_information))
+    assign(:case_info, case_info)
     render
   end
 
@@ -33,7 +36,7 @@ RSpec.describe "allocations/show", type: :view do
     let(:value) { page.css('#offender-category > td:nth-child(2)').text }
 
     context 'when a male offender category' do
-      let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_d)) }
+      let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_d)) }
 
       it 'shows the category label' do
         expect(key).to eq('Category')
@@ -42,7 +45,7 @@ RSpec.describe "allocations/show", type: :view do
     end
 
     context 'when a female offender category' do
-      let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_open)) }
+      let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_open)) }
 
       it 'shows the category label' do
         expect(key).to eq('Category')
@@ -52,7 +55,7 @@ RSpec.describe "allocations/show", type: :view do
 
     context 'when category is unknown' do
       # This happens when an offender's category assessment hasn't been completed yet
-      let(:offender) { build(:hmpps_api_offender, category: nil) }
+      let(:api_offender) { build(:hmpps_api_offender, category: nil) }
 
       it 'shows "Unknown"' do
         expect(key).to eq('Category')

--- a/spec/views/caseload/index.html.erb_spec.rb
+++ b/spec/views/caseload/index.html.erb_spec.rb
@@ -18,17 +18,13 @@ RSpec.describe "caseload/index", type: :view do
   let(:page) { Nokogiri::HTML(rendered) }
 
   context 'with a caseload' do
-    let(:offender_objects) {
-      [
-        build(:hmpps_api_offender).tap do |o|
-          o.load_case_information(build(:case_information))
-        end
-      ]
-    }
+    let(:api_offender) { build(:hmpps_api_offender) }
+    let(:case_info) { build(:case_information) }
+    let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
     let(:offenders) {
-      offender_objects.map do |o|
-        AllocatedOffender.new(staff_id, build(:allocation_history, nomis_offender_id: o.offender_no, primary_pom_allocated_at: DateTime.now.utc), o)
+      [offender].map do |o|
+        AllocatedOffender.new(staff_id, build(:allocation_history, nomis_offender_id: o.offender_no), o)
       end
     }
 

--- a/spec/views/debugging/debugging.html.erb_spec.rb
+++ b/spec/views/debugging/debugging.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "debugging/debugging", type: :view do
-  let(:offender) do
+  let(:api_offender) do
     build(:hmpps_api_offender, firstName: 'John', lastName: 'Dory').tap { |offender|
       offender.sentence = build(:sentence_detail,
                                 sentenceStartDate: Time.zone.today,
@@ -11,6 +11,7 @@ RSpec.describe "debugging/debugging", type: :view do
                                 licenceExpiryDate: Date.new(2025, 10, 7))
     }
   end
+  let(:offender) { build(:mpc_offender, prison: prison, prison_record: api_offender, offender: build(:offender)) }
 
   let(:prison) { create(:prison) }
 
@@ -49,7 +50,7 @@ RSpec.describe "debugging/debugging", type: :view do
     let(:value) { page.css('#category > td:nth-child(2)').text.strip }
 
     context 'when the offender has a category' do
-      let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_open, approvalDate: '17/06/2021'.to_date)) }
+      let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_open, approvalDate: '17/06/2021'.to_date)) }
 
       it 'shows category details' do
         expect(key).to eq('Category')
@@ -59,7 +60,7 @@ RSpec.describe "debugging/debugging", type: :view do
 
     context 'when category is unknown' do
       # This happens when an offender's category assessment hasn't been completed yet
-      let(:offender) { build(:hmpps_api_offender, category: nil) }
+      let(:api_offender) { build(:hmpps_api_offender, category: nil) }
 
       it 'shows "Unknown"' do
         expect(key).to eq('Category')

--- a/spec/views/poms/show.html.erb_spec.rb
+++ b/spec/views/poms/show.html.erb_spec.rb
@@ -46,13 +46,14 @@ RSpec.describe "poms/show", type: :view do
                updated_at: Time.zone.today - 8.days, primary_pom_allocated_at: Time.zone.today - 8.days)
       ]
     }
+    let(:api_one) { build(:hmpps_api_offender, sentence: build(:sentence_detail, releaseDate: Time.zone.today + 2.weeks)) }
+    let(:api_two) { build(:hmpps_api_offender, sentence: build(:sentence_detail, releaseDate: Time.zone.today + 5.weeks)) }
+    let(:api_three) { build(:hmpps_api_offender, sentence: build(:sentence_detail, releaseDate: Time.zone.today + 8.weeks)) }
+    let(:api_four) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate)) }
     let(:offenders) {
-      [
-        build(:hmpps_api_offender, sentence: build(:sentence_detail, releaseDate: Time.zone.today + 2.weeks)),
-        build(:hmpps_api_offender, sentence: build(:sentence_detail, releaseDate: Time.zone.today + 5.weeks)),
-        build(:hmpps_api_offender, sentence: build(:sentence_detail, releaseDate: Time.zone.today + 8.weeks)),
-        build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate))
-      ].map { |offender| offender.tap { |o| o.load_case_information(build(:case_information)) } }
+      [api_one, api_two, api_three, api_four].map { |api_offender|
+        build(:mpc_offender, prison_record: api_offender, offender: build(:case_information).offender, prison: prison)
+      }
     }
     let(:tabname) { 'overview' }
 
@@ -75,7 +76,8 @@ RSpec.describe "poms/show", type: :view do
 
   context 'when on the caseload tab' do
     let(:case_info) { create(:case_information) }
-    let(:offender) { build(:hmpps_api_offender, offenderNo: case_info.nomis_offender_id).tap { |o| o.load_case_information(case_info) } }
+    let(:api_offender) { build(:hmpps_api_offender, offenderNo: case_info.nomis_offender_id) }
+    let(:offender) { build(:mpc_offender, prison_record: api_offender, offender: case_info.offender, prison: prison) }
     let(:allocations) { [build(:allocation_history, nomis_offender_id: case_info.nomis_offender_id)] }
 
     let(:first_offender_row) {

--- a/spec/views/prisoners/community_information.html.erb_spec.rb
+++ b/spec/views/prisoners/community_information.html.erb_spec.rb
@@ -2,15 +2,16 @@ require 'rails_helper'
 
 RSpec.describe "prisoners/community_information", type: :view do
   let(:page) { Nokogiri::HTML(rendered) }
+  let(:prison) { build(:prison) }
 
   let(:case_info) { build(:case_information) }
 
-  let(:offender) {
+  let(:api_offender) {
     build(:hmpps_api_offender).tap { |o|
-      o.load_case_information(case_info)
       o.sentence = build(:sentence_detail, :inside_handover_window)
     }
   }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
   before do
     assign(:prisoner, offender)

--- a/spec/views/prisoners/show.html.erb_spec.rb
+++ b/spec/views/prisoners/show.html.erb_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "prisoners/show", type: :view do
   let(:page) { Nokogiri::HTML(rendered) }
   let(:case_info) { build(:case_information) }
   let(:prison) { build(:prison) }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
   before do
-    offender.load_case_information(case_info)
     assign(:prison, prison)
     assign(:prisoner, offender)
     assign(:tasks, [])
@@ -18,7 +18,7 @@ RSpec.describe "prisoners/show", type: :view do
 
   describe 'complexity badges' do
     let(:prison) { build(:womens_prison) }
-    let(:offender) { build(:hmpps_api_offender, complexityLevel: complexity) }
+    let(:api_offender) { build(:hmpps_api_offender, complexityLevel: complexity) }
     let(:test_strategy) { Flipflop::FeatureSet.current.test! }
 
     before do
@@ -56,7 +56,7 @@ RSpec.describe "prisoners/show", type: :view do
     before { render }
 
     context "with a male category" do
-      let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_a)) }
+      let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_a)) }
 
       it 'shows the category label' do
         expect(subject).to eq('Cat A')
@@ -64,7 +64,7 @@ RSpec.describe "prisoners/show", type: :view do
     end
 
     context "with a female category" do
-      let(:offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_closed)) }
+      let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :female_closed)) }
 
       it 'shows the category label' do
         expect(subject).to eq('Female Closed')
@@ -73,7 +73,7 @@ RSpec.describe "prisoners/show", type: :view do
 
     context 'when category is unknown' do
       # This happens when an offender's category assessment hasn't been completed yet
-      let(:offender) { build(:hmpps_api_offender, category: nil) }
+      let(:api_offender) { build(:hmpps_api_offender, category: nil) }
 
       it 'shows "Unknown"' do
         expect(subject).to eq('Unknown')

--- a/spec/views/shared/case_type_badge.html.erb_spec.rb
+++ b/spec/views/shared/case_type_badge.html.erb_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "allocation_staff/index", type: :view do
   let(:recall_badge) { page.css('#recall-badge') }
   let(:parole_badge) { page.css('#parole-badge') }
   let(:parole_review_date) { page.css('#parole-review-date') }
+  let(:case_info) { build(:case_information) }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
   before do
     assign(:prison, prison)
@@ -15,12 +17,12 @@ RSpec.describe "allocation_staff/index", type: :view do
     assign(:prison_poms, [])
     assign(:unavailable_pom_count, 0)
     assign(:prisoner, offender)
-    assign(:case_info, build(:case_information))
+    assign(:case_info, case_info)
     render
   end
 
   context "when indeterminate" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate)) }
 
     it "displays an indeterminate case type badge" do
       assert_you_have_an_indeterminate_badge
@@ -28,7 +30,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   end
 
   context "when determinate" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate)) }
 
     it "displays an determinate case type badge" do
       assert_you_have_a_determinate_badge
@@ -36,7 +38,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   end
 
   context "when recall" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate_recall)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate_recall)) }
 
     it "displays a recall case type badge and a indeterminate badge" do
       expect(case_type_badge.first.attributes['class'].value).to include 'moj-badge--purple'
@@ -46,7 +48,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   end
 
   context "when parole eligibility(PED)" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate, paroleEligibilityDate: Time.zone.today.to_s)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate, paroleEligibilityDate: Time.zone.today.to_s)) }
 
     it "displays an parole eligibility case type badge" do
       assert_you_have_a_parole_eligibility_badge
@@ -55,7 +57,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   end
 
   context "when parole eligibility(TED)" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate, tariffDate: Time.zone.today.to_s)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate, tariffDate: Time.zone.today.to_s)) }
 
     it "displays an parole eligibility case type badge and determinate badge" do
       assert_you_have_a_parole_eligibility_badge
@@ -65,11 +67,9 @@ RSpec.describe "allocation_staff/index", type: :view do
 
   context "when there is a parole review date" do
     let(:offender_no) { 'G7514GW' }
-    let(:case_information) { build(:case_information,  nomis_offender_id: offender_no, parole_review_date: Date.new(2019, 0o1, 3).to_s) }
-    let(:offender) {
-      offender = build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate), offenderNo: offender_no)
-      offender.load_case_information(case_information)
-      offender
+    let(:case_info) { build(:case_information,  offender: build(:offender, nomis_offender_id: offender_no), parole_review_date: Date.new(2019, 0o1, 3).to_s) }
+    let(:api_offender) {
+      build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate), offenderNo: offender_no)
     }
 
     it "displays an parole eligibility case type badge" do
@@ -81,12 +81,10 @@ RSpec.describe "allocation_staff/index", type: :view do
 
   context 'when parole eligibility (both TED and PRD) and parole review date are nil' do
     let(:offender_no) { 'G7514GW' }
-    let(:case_information) { build(:case_information,  nomis_offender_id: offender_no) }
-    let(:offender) {
-      offender = build(:hmpps_api_offender, offenderNo: offender_no,
+    let(:case_info) { build(:case_information, offender: build(:offender, nomis_offender_id: offender_no)) }
+    let(:api_offender) {
+      build(:hmpps_api_offender, offenderNo: offender_no,
        sentence: build(:sentence_detail, :indeterminate, tariffDate: nil))
-      offender.load_case_information(case_information)
-      offender
     }
 
     it 'does not display the badge' do
@@ -99,7 +97,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   end
 
   context "when indeterminate, a recall case and parole eligibility(PED)" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate_recall, paroleEligibilityDate: Time.zone.today.to_s)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :indeterminate_recall, paroleEligibilityDate: Time.zone.today.to_s)) }
 
     it "displays an indeterminate, parole eligibility and recall case type badges" do
       assert_you_have_an_indeterminate_badge
@@ -109,7 +107,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   end
 
   context "when determinate, a recall case and parole eligibility(PED)" do
-    let(:offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate_recall, paroleEligibilityDate: Time.zone.today)) }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate_recall, paroleEligibilityDate: Time.zone.today)) }
 
     it "displays an determinate, parole eligibility and recall case type badges" do
       assert_you_have_a_determinate_badge

--- a/spec/views/shared/early_allocation_badge.html.erb_spec.rb
+++ b/spec/views/shared/early_allocation_badge.html.erb_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "prisoners/show", type: :view do
     let(:early_allocation_css) { page.css('#early-allocation-badge') }
     let(:early_allocation_badge) { early_allocation_css.first }
     let(:badge_count) { early_allocation_css.size }
-    let(:offender) { build(:hmpps_api_offender, sentence: sentence).tap { |offender| offender.load_case_information(case_info) } }
+    let(:api_offender) { build(:hmpps_api_offender, sentence: sentence) }
+    let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
 
     before do
       assign(:prison, prison)

--- a/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
+++ b/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe "shared/notifications/offender_needs_a_com", type: :view do
   let(:case_info) { build(:case_information, :nps, local_delivery_unit: ldu, manual_entry: ldu.nil?) }
   let(:ldu) { build(:local_delivery_unit) }
   let(:email_history) { [] }
+  let(:prison) { build(:prison) }
 
-  let(:offender) {
-    build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate, :inside_handover_window)).tap { |o|
-      o.load_case_information(case_info)
-    }
+  let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
+  let(:api_offender) {
+    build(:hmpps_api_offender, sentence: build(:sentence_detail, :determinate, :inside_handover_window))
   }
 
   before do

--- a/spec/views/shared/offence_info.html.erb_spec.rb
+++ b/spec/views/shared/offence_info.html.erb_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe "shared/offence_info", type: :view do
   let(:page) { Nokogiri::HTML(rendered) }
   let(:prison) { build(:prison) }
-  let(:offender) {
+  let(:api_offender) {
     build(:hmpps_api_offender,
           prison_id: prison.code,
             sentence: build(:sentence_detail, :indeterminate, tariffDate: ted, paroleEligibilityDate: ped))
   }
+  let(:offender) { build(:mpc_offender, prison: prison, prison_record: api_offender, offender: build(:offender)) }
 
   before do
     assign(:prison, prison)


### PR DESCRIPTION
This PR is in response to conversations we have been having, and the fact that we now have 2 offender objects (well we always did, its just that we called it case_information) which is really confusing. This unifies the 2 objects in a an ActiveRecord first pattern, so that data is accessible for entities that need it.