### PR TITLE
MO-690 Fallout - fix up tests that create allocations w/o case information

### DIFF
--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -52,7 +52,7 @@ describe 'Allocation API', vcr: { cassette_name: 'prison_api/allocation_api' } d
                },
                required: %w[primary_pom secondary_pom]
 
-        let(:offender_no) { 'G4273GI' }
+        let(:offender_no) { 'G7266VD' }
         let!(:allocation) {
           create(:allocation_history, nomis_offender_id: offender_no, primary_pom_name: 'OLD_NAME, MOIC')
         }

--- a/spec/controllers/coworking_controller_spec.rb
+++ b/spec/controllers/coworking_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe CoworkingController, :allocation, type: :controller do
         to_return(body: { 'firstName' => 'bill' }.to_json)
       stub_pom_emails(user.staffId, [])
 
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
       create(:allocation_history, prison: prison,
              nomis_offender_id: offender_no,
              primary_pom_nomis_id: primary_pom.staffId,

--- a/spec/controllers/handovers_controller_spec.rb
+++ b/spec/controllers/handovers_controller_spec.rb
@@ -45,25 +45,32 @@ RSpec.describe HandoversController, type: :controller do
         stub_movements
       end
 
-      describe 'sorting', :allocation do
+      describe 'with sorting' do
         before do
           create(:case_information, :with_com, case_allocation: 'CRC', offender: build(:offender, nomis_offender_id: 'G1234VV'))
-          create(:allocation_history, nomis_offender_id: 'G1234VV', primary_pom_nomis_id: pom.staffId)
+          create(:allocation_history, prison: prison, nomis_offender_id: 'G1234VV', primary_pom_nomis_id: pom.staffId)
           stub_pom(pom)
+
+          get :index, params: { prison_id: prison, sort: sort }
+          expect(response).to be_successful
         end
 
         let(:pom) { build(:pom) }
 
-        it 'sorts by COM' do
-          get :index, params: { prison_id: prison, sort: 'allocated_com_name asc' }
-          expect(response).to be_successful
-          expect(assigns(:offenders).map(&:offender_no)).to eq(["G4234GG", 'G1234VV'])
+        context 'when sorting by COM' do
+          let(:sort) { 'allocated_com_name asc' }
+
+          it 'sorts' do
+            expect(assigns(:offenders).map(&:offender_no)).to eq(["G4234GG", 'G1234VV'])
+          end
         end
 
-        it 'sorts by POM' do
-          get :index, params: { prison_id: prison, sort: 'allocated_pom_name asc' }
-          expect(response).to be_successful
-          expect(assigns(:offenders).map(&:offender_no)).to eq(['G1234VV', "G4234GG"])
+        context 'when sorting by POM' do
+          let(:sort) { 'allocated_pom_name desc' }
+
+          it 'sorts' do
+            expect(assigns(:offenders).map(&:offender_no)).to eq(['G1234VV', "G4234GG"])
+          end
         end
       end
 

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -18,6 +18,7 @@ describe AllocationService do
     let(:message) { 'Additional text' }
 
     let!(:allocation) {
+      create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id))
       create(:allocation_history,
              nomis_offender_id: nomis_offender_id,
              primary_pom_nomis_id: primary_pom_id,
@@ -103,6 +104,7 @@ describe AllocationService do
 
     context 'when one already exists' do
       before do
+        create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id))
         create(:allocation_history, nomis_offender_id: nomis_offender_id)
       end
 


### PR DESCRIPTION
During the implementation of MO-690, several invalid test scenarios were found. This PR fixes these up so that they don't add to the noise of the big MO-690 refactor work