### PR TITLE
Refactor how factories generate NOMIS Offender IDs

### DIFF
--- a/spec/factories/allocation_history.rb
+++ b/spec/factories/allocation_history.rb
@@ -20,9 +20,7 @@ FactoryBot.define do
       AllocationHistory::USER
     end
 
-    nomis_offender_id do
-      Faker::Alphanumeric.alpha(number: 10)
-    end
+    nomis_offender_id
 
     primary_pom_nomis_id do
       485_926

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -83,15 +83,15 @@ FactoryBot.define do
   end
 
   factory :early_allocation_eligible_form do
-    nomis_offender_id { 'T9999FC' }
+    nomis_offender_id
   end
 
   factory :early_allocation_date_form do
-    nomis_offender_id { 'T9999FC' }
+    nomis_offender_id
   end
 
   factory :early_allocation_discretionary_form do
-    nomis_offender_id { 'T9999FC' }
+    nomis_offender_id
 
     oasys_risk_assessment_date { Time.zone.today - 2.months }
     convicted_under_terrorisom_act_2000 { false }

--- a/spec/factories/email_history.rb
+++ b/spec/factories/email_history.rb
@@ -6,12 +6,7 @@ FactoryBot.define do
       'LEI'
     end
 
-    sequence(:nomis_offender_id) do |seq|
-      number = seq / 26 + 1000
-      letter = ('A'..'Z').to_a[seq % 26]
-      # This and the offender should produce different values to avoid clashes
-      "T#{number}C#{letter}"
-    end
+    nomis_offender_id
 
     name do
       # The last name is titleized after it's received from the API, e.g. "McDonald" becomes "Mcdonald"

--- a/spec/factories/hmpps_api/offenders.rb
+++ b/spec/factories/hmpps_api/offenders.rb
@@ -26,14 +26,7 @@ FactoryBot.define do
       "#{block}-#{num}-#{numbers}"
     }
 
-    # offender numbers are of the form <letter><4 numbers><2 letters>
-    sequence(:offenderNo) do |seq|
-      number = seq / 26 + 1000
-      letter = ('A'..'Z').to_a[seq % 26]
-      # This and case_information should produce different values to avoid clashes
-      "T#{number}O#{letter}"
-    end
-
+    offenderNo { generate :nomis_offender_id }
     sequence(:bookingId) { |x| x + 700_000 }
     convictedStatus { 'Convicted' }
     dateOfBirth { Date.new(1990, 12, 6).to_s }

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -16,13 +16,7 @@ FactoryBot.define do
       "#{block}-#{num}-#{numbers}"
     }
 
-    # offender numbers are of the form <letter><4 numbers><2 letters>
-    sequence(:offenderNo) do |seq|
-      number = seq / 26 + 1000
-      letter = ('A'..'Z').to_a[seq % 26]
-      # This and case_information should produce different values to avoid clashes
-      "T#{number}O#{letter}"
-    end
+    offenderNo { generate :nomis_offender_id }
     convictedStatus { 'Convicted' }
     dateOfBirth { Date.new(1990, 12, 6).to_s }
     firstName { Faker::Name.first_name }
@@ -44,12 +38,6 @@ FactoryBot.define do
   end
 
   factory :offender do
-    # offender numbers are of the form <letter><4 numbers><2 letters>
-    sequence(:nomis_offender_id) do |seq|
-      number = seq / 26 + 1000
-      letter = ('A'..'Z').to_a[seq % 26]
-      # This and the offender should produce different values to avoid clashes
-      "P#{number}P#{letter}"
-    end
+    nomis_offender_id
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -123,3 +123,17 @@ end
 # The en-GB locale gives us UK counties (used by the LocalDeliveryUnit factory)
 # See all the things we gain here: https://github.com/faker-ruby/faker/blob/master/lib/locales/en-GB.yml
 Faker::Config.locale = 'en-GB'
+
+# Define a global sequence for generating NOMIS Offender IDs
+# NOMIS offender IDs follow the format: <letter><4 numbers><2 letters> (all uppercase)
+FactoryBot.define do
+  sequence :nomis_offender_id do |seq|
+    index = seq - 1 # because seq starts at 1, not 0
+    number = "%04d" % (index / 26) # zero-pad to 4 digits, e.g. 0001
+    letter = ('A'..'Z').to_a[index % 26]
+
+    # Start with "T" to indicate that this is a "test" offender ID
+    # In the real world, offender IDs don't begin with "T"
+    "T#{number}A#{letter}"
+  end
+end


### PR DESCRIPTION
Several FactoryBot factories need to generate NOMIS Offender IDs.

Rather than generating them all as independent sequences, each with slightly different letters to avoid clashes, this commit refactors them to use one single global sequence which can be used in any factory.

That way, the logic for generating a realistic NOMIS Offender ID only exists in one place.

### Using it in factories

Most factories shouldn't need to generate a NOMIS Offender ID now that we have Offender records.

However, if you do need one, you have a couple of options.

1. If the field name is `nomis_offender_id`, then you can do something like this:
    
    ```ruby
    FactoryBot.define do
      factory :example do
        nomis_offender_id
      end
    end
    ```
    
    This will create an object where the `nomis_offender_id` attribute will be set.

2. If the field name is different (e.g. `offenderNo`), then you can use the `generate` method:
    
    ```ruby
    FactoryBot.define do
      factory :example do
        offenderNo { generate :nomis_offender_id }
      end
    end
    ```

You can [learn more about global sequences in the FactoryBot documentation](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#global-sequences).