### PR TITLE
Ignore the early allocations that are before the current sentence start date

### DIFF
--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -23,17 +23,13 @@ module BadgeHelper
     offender.indeterminate_sentence? && offender.parole_review_date.present?
   end
 
-  def early_allocation_notes?(offender, early_allocations)
-    if early_allocations.any?
-      !offender.within_early_allocation_window? || early_allocations.last.community_decision == false
+  def early_allocation_notes?(early_allocations)
+    if early_allocations.present?
+      !early_allocations.last.created_within_referral_window? || early_allocations.last.community_decision == false
     end
   end
 
   def early_allocation_active?(early_allocations)
-    early_allocations.any? && early_allocations.last.awaiting_community_decision?
-  end
-
-  def early_allocation_approved?(early_allocations)
-    early_allocations.any? && early_allocations.last.created_within_referral_window? && early_allocations.last.community_decision_eligible_or_automatically_eligible?
+    early_allocations.present? && early_allocations.last.awaiting_community_decision?
   end
 end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -54,11 +54,6 @@ class CaseInformation < ApplicationRecord
     end
   end
 
-  # We only normally show/edit the most recent early allocation
-  def latest_early_allocation
-    early_allocations.last
-  end
-
   validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }
   validates :nomis_offender_id, presence: true, uniqueness: true
 

--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -108,7 +108,7 @@ module HmppsApi
     def early_allocation?
       return false if @case_information.blank?
 
-      early_allocation.present?
+      latest_early_allocation.present?
     end
 
     def needs_early_allocation_notify?
@@ -257,6 +257,15 @@ module HmppsApi
         criminal_sentence? && convicted?
     end
 
+    def latest_early_allocation
+      allocation = early_allocations&.last
+      allocation if allocation.present? && allocation.created_within_referral_window? && (allocation.eligible? || allocation.community_decision?)
+    end
+
+    def early_allocations
+      @case_information.early_allocations.where('created_at::date >= ?', sentence_start_date) unless @case_information.nil?
+    end
+
   private
 
     def age
@@ -289,11 +298,6 @@ module HmppsApi
                     else
                       HandoverDateService::NO_HANDOVER_DATE
                     end
-    end
-
-    def early_allocation
-      allocation = @case_information&.latest_early_allocation
-      allocation if allocation.present? && (allocation.created_within_referral_window? && allocation.eligible? || allocation.community_decision?)
     end
   end
 end

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="case-type-badge">
-      <%= render 'shared/badges', offender: @prisoner, early_allocations: @case_info.nil? ? [] : @case_info.early_allocations %>
+      <%= render 'shared/badges', offender: @prisoner %>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">

--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -1,11 +1,13 @@
 <span id="prisoner-case-type" class="moj-badge moj-badge--<%=badge_colour(offender) %>"><%=badge_text(offender)%></span>
 <%= render('shared/badges/recall_badge') if offender.recalled? %>
 <%= render('shared/badges/parole_badge') if badge_for_parole?(offender) %>
-<% if early_allocation_approved?(early_allocations) %>
+
+<% if offender.early_allocation? %>
   <%=  render('shared/badges/early_allocation_approved_badge') %>
-<% else %>
-  <%= render('shared/badges/early_allocation_notes_badge') if early_allocation_notes?(offender, early_allocations)%>
-  <%= render('shared/badges/early_allocation_active_badge') if early_allocation_active?(early_allocations) %>
+<% elsif early_allocation_active?(offender.early_allocations) %>
+  <%= render('shared/badges/early_allocation_active_badge') %>
+<% elsif early_allocation_notes?(offender.early_allocations) %>
+  <%= render('shared/badges/early_allocation_notes_badge')%>
 <% end %>
 <% if @prison.womens? %>
   <% if offender.complexity_level == 'high' %>

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe EarlyAllocationsController, :allocation, type: :controller do
     ]
   }
 
-  let(:offender) { build(:nomis_offender, agencyId: prison, sentence: attributes_for(:sentence_detail, conditionalReleaseDate: release_date)) }
+  let(:offender) { build(:nomis_offender, agencyId: prison, sentence: attributes_for(:sentence_detail, sentenceStartDate: Time.zone.today - 9.months,  conditionalReleaseDate: release_date)) }
 
   let(:nomis_offender_id) { offender.fetch(:offenderNo) }
 

--- a/spec/factories/early_allocations.rb
+++ b/spec/factories/early_allocations.rb
@@ -61,11 +61,7 @@ FactoryBot.define do
       other_reason { false }
     end
 
-    trait :unsent do
-      created_within_referral_window { false }
-    end
-
-    trait :unsent do
+    trait :pre_window do
       created_within_referral_window { false }
     end
 
@@ -75,10 +71,6 @@ FactoryBot.define do
       mappa_level_2 do false end
       pathfinder_process do false end
       other_reason { false }
-    end
-
-    trait :unsent do
-      created_within_referral_window { false }
     end
   end
 

--- a/spec/features/early_allocation_badge_feature_spec.rb
+++ b/spec/features/early_allocation_badge_feature_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'early allocation badges' do
+  let(:prison) { create(:prison) }
+  let(:nomis_offender) {
+    build(:nomis_offender, agencyId: prison.code,
+                               sentence: attributes_for(:sentence_detail,
+                                                        conditionalReleaseDate: release_date,
+                                                        sentenceStartDate: sentence_start))
+  }
+  let(:offender_no) { nomis_offender.fetch(:offenderNo) }
+  let(:notes_badge) { 'EARLY ALLOCATION NOTES' }
+  let(:active_badge) { 'EARLY ALLOCATION ACTIVE' }
+  let(:approved_badge) { 'EARLY ALLOCATION APPROVED' }
+
+  before do
+    signin_spo_user([prison.code])
+
+    stub_auth_token
+    stub_user(staff_id: 1234)
+    stub_keyworker(prison.code, offender_no, build(:keyworker))
+    stub_offender nomis_offender
+
+    create(:case_information,
+           offender: build(:offender, nomis_offender_id: offender_no),
+           early_allocations: [early_allocation])
+    visit prison_prisoner_path(prison.code, offender_no)
+  end
+
+  context 'when pre-window' do
+    let(:release_date) { Time.zone.today + 19.months }
+
+    context 'with a current sentence' do
+      let(:sentence_start) { Time.zone.today - 1.week }
+      let(:allocation_date) { Time.zone.today }
+
+      context 'when in flight (not really)' do
+        let(:early_allocation) { build(:early_allocation, :pre_window, :discretionary, created_at: allocation_date) }
+
+        it 'shows the right badge' do
+          expect(page).to have_content notes_badge
+        end
+      end
+
+      context 'when automatic' do
+        let(:early_allocation) { build(:early_allocation, :pre_window, :eligible, created_at: allocation_date) }
+
+        it 'shows the right badge' do
+          expect(page).to have_content notes_badge
+        end
+      end
+    end
+
+    context 'with a previous sentence' do
+      let(:sentence_start) { Time.zone.today - 1.week }
+      let(:allocation_date) { Time.zone.today - 2.weeks }
+
+      context 'when in flight (not really)' do
+        let(:early_allocation) { build(:early_allocation, :pre_window, :discretionary, created_at: allocation_date) }
+
+        it 'doesnt show a badge' do
+          expect(page).not_to have_content notes_badge
+        end
+      end
+
+      context 'when automatic' do
+        let(:early_allocation) { build(:early_allocation, :pre_window, :eligible, created_at: allocation_date) }
+
+        it 'doesnt show a badge' do
+          expect(page).not_to have_content notes_badge
+        end
+      end
+    end
+  end
+
+  context 'when within window' do
+    let(:release_date) { Time.zone.today + 17.months }
+
+    context 'with current sentence' do
+      #sentence start date come before the allocation date
+      let(:sentence_start) { Time.zone.today - 1.week }
+      let(:allocation_date) { Time.zone.today }
+
+      context 'when declined' do
+        let(:early_allocation) { build(:early_allocation, :discretionary_declined, created_at: allocation_date) }
+
+        it 'shows notes' do
+          expect(page).to have_content notes_badge
+        end
+      end
+
+      context 'when in flight' do
+        let(:early_allocation) { build(:early_allocation, :discretionary, created_at: allocation_date) }
+
+        it 'shows active' do
+          expect(page).to have_content active_badge
+        end
+      end
+
+      context 'when approved' do
+        let(:early_allocation) { build(:early_allocation, :discretionary_accepted, created_at: allocation_date) }
+
+        it 'shows approved' do
+          expect(page).to have_content approved_badge
+        end
+      end
+
+      context 'when automatic' do
+        let(:early_allocation) { build(:early_allocation, :eligible, created_at: allocation_date) }
+
+        it 'shows approved' do
+          expect(page).to have_content approved_badge
+        end
+      end
+    end
+
+    context 'with a previous sentence' do
+      # sentence start date comes after the allocation date
+      let(:sentence_start) { Time.zone.today - 1.week }
+      let(:allocation_date) { Time.zone.today - 2.weeks }
+
+      context 'when declined' do
+        let(:early_allocation) { build(:early_allocation, :discretionary_declined, created_at: allocation_date) }
+
+        it 'doesnt display a badge' do
+          expect(page).not_to have_content notes_badge
+        end
+      end
+
+      context 'when in flight' do
+        let(:early_allocation) { build(:early_allocation, :discretionary, created_at: allocation_date) }
+
+        it 'doesnt display a badge' do
+          expect(page).not_to have_content active_badge
+        end
+      end
+
+      context 'when approved' do
+        let(:early_allocation) { build(:early_allocation, :discretionary_accepted, created_at: allocation_date) }
+
+        it 'doesnt display a badge' do
+          expect(page).not_to have_content approved_badge
+        end
+      end
+
+      context 'when automatic' do
+        let(:early_allocation) { build(:early_allocation, :eligible, created_at: allocation_date) }
+
+        it 'doesnt display a badge' do
+          expect(page).not_to have_content notes_badge
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/early_allocation_helper_spec.rb
+++ b/spec/helpers/early_allocation_helper_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe EarlyAllocationHelper, type: :helper do
 
   describe '#early_allocation_long_outcome' do
     context 'when eligible and unsent' do
-      let(:early_allocation) { build(:early_allocation, :eligible, :unsent) }
+      let(:early_allocation) { build(:early_allocation, :eligible, :pre_window) }
 
       it 'works' do
         expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Eligible - assessment not sent to the community probation team')
@@ -325,7 +325,7 @@ RSpec.describe EarlyAllocationHelper, type: :helper do
     end
 
     context 'when discretionary - not sent' do
-      let(:early_allocation) { build(:early_allocation, :discretionary, :unsent) }
+      let(:early_allocation) { build(:early_allocation, :discretionary, :pre_window) }
 
       it 'works' do
         expect(helper.early_allocation_long_outcome(early_allocation)).to eq('Discretionary - assessment not sent to the community probation team')

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -149,4 +149,35 @@ RSpec.describe EarlyAllocation, type: :model do
                                                                                      eligible_outside_referral])
     end
   end
+
+  describe '#early_allocation?' do
+    let(:offender) {
+      build(:hmpps_api_offender,
+            sentence: build(:sentence_detail, sentenceStartDate: Time.zone.today - 1.week)).tap { |offender|
+        offender.load_case_information(case_info)
+      }
+    }
+
+    let(:case_info) {
+      create(:case_information,
+             early_allocations: [build(:early_allocation, :eligible, created_at: assessment_date)])
+    }
+
+
+    context 'when early allocations comes before the current sentence start date' do
+      let(:assessment_date) { Time.zone.today - 2.weeks }
+
+      it 'ignores them' do
+        expect(offender.early_allocation?).to eq(false)
+      end
+    end
+
+    context 'when early allocations come after the current sentence start date' do
+      let(:assessment_date) { Time.zone.today }
+
+      it 'doesnt ignores them' do
+        expect(offender.early_allocation?).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/services/handover_date_service_old_spec.rb
+++ b/spec/services/handover_date_service_old_spec.rb
@@ -123,7 +123,7 @@ describe HandoverDateService do
             o.load_case_information(case_info)
           }
         }
-        let(:case_info) { build(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: false)]) }
+        let(:case_info) { create(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: false)]) }
         let(:ard) { nil }
 
         it 'will be unaffected' do
@@ -143,7 +143,7 @@ describe HandoverDateService do
             o.load_case_information(case_info)
           }
         }
-        let(:case_info) { build(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: true)]) }
+        let(:case_info) { create(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: true)]) }
 
         context 'without PED' do
           let(:ped) { nil }
@@ -173,7 +173,7 @@ describe HandoverDateService do
         }
 
         context 'when inside referral window' do
-          let(:case_info) { build(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: true)]) }
+          let(:case_info) { create(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: true)]) }
 
           context 'without ARD' do
             let(:ard) { nil }
@@ -193,7 +193,7 @@ describe HandoverDateService do
         end
 
         context 'when outside referral window' do
-          let(:case_info) { build(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: false)]) }
+          let(:case_info) { create(:case_information, early_allocations: [build(:early_allocation, created_within_referral_window: false)]) }
           let(:ard) { nil }
 
           it 'will be unaffected' do

--- a/spec/views/allocations/allocation_history.html.erb_spec.rb
+++ b/spec/views/allocations/allocation_history.html.erb_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "allocations/history", type: :view do
     end
 
     context 'with an eligible unsent early alloc' do
-      let(:ea) { create(:early_allocation, :unsent, created_at: DateTime.new(2019, 11, 19, 11, 28, 0)) }
+      let(:ea) { create(:early_allocation, :pre_window, created_at: DateTime.new(2019, 11, 19, 11, 28, 0)) }
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
@@ -68,7 +68,7 @@ RSpec.describe "allocations/history", type: :view do
     end
 
     context 'with an ineligible unsent early alloc' do
-      let(:ea) { create(:early_allocation, :unsent, :ineligible, created_at: DateTime.new(2019, 11, 19, 11, 28, 0)) }
+      let(:ea) { create(:early_allocation, :pre_window, :ineligible, created_at: DateTime.new(2019, 11, 19, 11, 28, 0)) }
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
@@ -83,7 +83,7 @@ RSpec.describe "allocations/history", type: :view do
     end
 
     context 'with a discretionary unsent early alloc' do
-      let(:ea) { create(:early_allocation, :unsent, :discretionary, created_at: DateTime.new(2019, 11, 19, 11, 28, 0)) }
+      let(:ea) { create(:early_allocation, :pre_window, :discretionary, created_at: DateTime.new(2019, 11, 19, 11, 28, 0)) }
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do

--- a/spec/views/early_allocations/show.html.erb_spec.rb
+++ b/spec/views/early_allocations/show.html.erb_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "early_allocations/show", type: :view do
   end
 
   context 'when eligible and unsent' do
-    let(:early_allocation) { create(:early_allocation, :eligible, :unsent) }
+    let(:early_allocation) { create(:early_allocation, :eligible, :pre_window) }
 
     it 'shows the outcome' do
       expect(page).to have_text('Eligible - assessment not sent to the community probation team')
@@ -71,7 +71,7 @@ RSpec.describe "early_allocations/show", type: :view do
   end
 
   context 'when discretionary - not sent' do
-    let(:early_allocation) { create(:early_allocation, :discretionary, :unsent) }
+    let(:early_allocation) { create(:early_allocation, :discretionary, :pre_window) }
 
     it 'shows the outcome' do
       expect(page).to have_text('Discretionary - assessment not sent to the community probation team')

--- a/spec/views/shared/early_allocation_badge.html.erb_spec.rb
+++ b/spec/views/shared/early_allocation_badge.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "prisoners/show", type: :view do
       let(:case_info) { create(:case_information, early_allocations: [early_allocation]) }
 
       context 'when unsent' do
-        let(:early_allocation) { build(:early_allocation, :unsent) }
+        let(:early_allocation) { build(:early_allocation, :pre_window) }
         let(:sentence) { build(:sentence_detail, :outside_early_allocation_window) }
 
         it 'displays a badge text EARLY ALLOCATION NOTES' do


### PR DESCRIPTION
Early allocations are not held onto by the offender but are attached to a specific sentence, so an offender returning on a new sentence should not have their previous early allocation surfaced. 

This PR fixes that.