### PR TITLE
MO 510 remove the action column 

### DIFF
--- a/app/views/prisoners/unallocated.html.erb
+++ b/app/views/prisoners/unallocated.html.erb
@@ -40,7 +40,7 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('last_name') %>">
-          Prisoner
+          Case
         </a>
         <%= sort_arrow('last_name') %>
       </th>
@@ -58,18 +58,17 @@
       </th>
       <th class="govuk-table__header sorter-false" scope="col">
         <a href="<%= sort_link('awaiting_allocation_for') %>">
-          Waiting
+          Days waiting for allocation
         </a>
         <%= sort_arrow('awaiting_allocation_for') %>
       </th>
-      <th class="govuk-table__header sorter-false" scope="col">Action</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     <% @offenders.each_with_index do |offender, i| %>
       <tr class="govuk-table__row offender_row_<%= i %>">
         <td aria-label="Prisoner name" class="govuk-table__cell ">
-          <%= offender.full_name %>
+          <%= link_to offender.full_name, prison_prisoner_staff_index_path(@prison.code, offender.offender_no) %>
           <br/>
           <span class='govuk-hint govuk-!-margin-bottom-0'>
             <%= offender.offender_no %>
@@ -84,9 +83,6 @@
         </td>
         <td aria-label="Awaiting allocation for" class="govuk-table__cell">
           <%= offender.awaiting_allocation_for %> days
-        </td>
-        <td aria-label="Action" class="govuk-table__cell ">
-          <%= link_to 'Allocate', prison_prisoner_staff_index_path(@prison.code, offender.offender_no) %>
         </td>
       </tr>
     <% end %>

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -6,6 +6,7 @@ feature 'Allocation' do
   let!(:nomis_offender_id) { 'G7266VD' }
   let(:offender_name) { 'Omistius Annole' }
   let!(:never_allocated_offender) { 'G9403UP' }
+  let!(:unallocated_offender_name) { 'Albina, Obinins' }
 
   let!(:probation_officer_pom_detail) {
     PomDetail.create!(
@@ -185,11 +186,10 @@ feature 'Allocation' do
 
     scenario 'removing a community override', vcr: { cassette_name: 'prison_api/allocation_remove_community_override' } do
       visit prison_dashboard_index_path('LEI')
-
       click_link 'Make new allocations'
       find '.offender_row_0'
       within '.offender_row_0' do
-        click_link 'Allocate'
+        click_link unallocated_offender_name
       end
 
       find '.responsibility_change'

--- a/spec/features/delius_import_feature_spec.rb
+++ b/spec/features/delius_import_feature_spec.rb
@@ -6,6 +6,7 @@ feature "Delius import feature", :disable_push_to_delius do
   let(:offender_no) {  offender.fetch(:offenderNo) }
   let(:prison) { create(:prison).code }
   let(:offender) { build(:nomis_offender) }
+  let(:offender_name) { offender.fetch(:lastName) + ', ' + offender.fetch(:firstName) }
   let(:pom) { build(:pom) }
 
   before do
@@ -39,7 +40,7 @@ feature "Delius import feature", :disable_push_to_delius do
       visit unallocated_prison_prisoners_path(prison)
       expect(page).to have_content("Make allocations")
       expect(page).to have_content(offender_no)
-      click_link 'Allocate'
+      click_link offender_name
       expect(page.find(:css, '#welsh-offender-row')).not_to have_content('Change')
       expect(page.find(:css, '#service-provider-row')).not_to have_content('Change')
       expect(page.find(:css, '#tier-row')).not_to have_content('Change')

--- a/spec/features/female_allocation_journey_feature_spec.rb
+++ b/spec/features/female_allocation_journey_feature_spec.rb
@@ -6,6 +6,7 @@ feature "womens allocation journey" do
   let(:prison) { create(:womens_prison) }
   let(:offenders) { build_list(:nomis_offender, 5, agencyId: prison.code, complexityLevel: 'high') }
   let(:offender) { build(:nomis_offender, sentence: attributes_for(:sentence_detail, :determinate_release_in_three_years), agencyId: prison.code) }
+  let(:offender_name) { offender.fetch(:lastName) + ', ' + offender.fetch(:firstName) }
   let(:nomis_offender_id) { offender.fetch(:offenderNo) }
   let(:user) { build(:pom) }
   let(:probation_pom) { build(:pom, :probation_officer, lastName: 'Jones') }
@@ -41,7 +42,7 @@ feature "womens allocation journey" do
       end
 
       visit unallocated_prison_prisoners_path prison.code
-      click_link 'Allocate'
+      click_link offender_name
     end
 
     scenario 'accepting recommendation' do

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -98,15 +98,17 @@ feature 'Navigation' do
 
       describe 'allocations section' do
         let(:index) { 1 }
+        let!(:offender_id) { 'G9403UP' }
+        let(:offender_name) { 'Albina, Obinins' }
 
         before do
-          create(:case_information, offender: build(:offender, nomis_offender_id: 'G8668GF'))
+          create(:case_information, offender: build(:offender, nomis_offender_id: offender_id))
         end
 
         it 'highlights the section' do
           click_menu_and_wait(link_css, index, delay: 10)
-          click_link_and_wait 'Allocate'
-          wait_for(80) { page.has_content? 'Burglary dwelling - with intent to steal' }
+          click_link_and_wait offender_name
+          wait_for(80) { page.has_content? 'Conspire to do an act to facilitate the commission of a breach of UK immigration law by a non EU person' }
           new_link = all(link_css)[index]
           expect(new_link['aria-current']).to eq('page')
         end


### PR DESCRIPTION
This PR removes the 'action' column and make case name link to allocation journey. 

It then fixes the broken feature tests