### PR TITLE
MO-765 crash on encountering an old allocation due to missing a release event

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -7,7 +7,7 @@ class AllocationStaffController < PrisonsApplicationController
 
   def index
     @case_info = Offender.find_by!(nomis_offender_id: prisoner_id_from_url).case_information
-    @allocation = AllocationHistory.find_by nomis_offender_id: prisoner_id_from_url
+    @allocation = AllocationHistory.find_by prison: @prison.code, nomis_offender_id: prisoner_id_from_url
     previous_pom_ids = if @allocation
                          @allocation.previously_allocated_poms
                        else
@@ -15,7 +15,7 @@ class AllocationStaffController < PrisonsApplicationController
                        end
     poms = @prison.get_list_of_poms.index_by(&:staff_id)
     @previous_poms = previous_pom_ids.map { |staff_id| poms[staff_id] }.compact
-    @current_pom = @prison.get_single_pom(@allocation.primary_pom_nomis_id) if @allocation&.primary_pom_nomis_id
+    @current_pom = poms[@allocation.primary_pom_nomis_id] if @allocation&.primary_pom_nomis_id
   end
 
 private

--- a/spec/controllers/allocation_staff_controller_spec.rb
+++ b/spec/controllers/allocation_staff_controller_spec.rb
@@ -28,9 +28,22 @@ RSpec.describe AllocationStaffController, type: :controller do
     end
 
     describe '#index' do
-      context 'with previous allocations for this POM' do
-        let(:alice) { poms.first }
+      let(:alice) { poms.first }
 
+      context 'with an allocation from a previous prison' do
+        before do
+          create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+          create(:allocation_history, prison: build(:prison).code, nomis_offender_id: offender_no)
+        end
+
+        it 'makes a nil current POM' do
+          get :index, params: { prison_id: prison_code, prisoner_id: offender_no }
+          expect(response).to be_successful
+          expect(assigns(:current_pom)).to be_nil
+        end
+      end
+
+      context 'with previous allocations for this POM' do
         before do
           { a: 5, b: 4, c: 3, d: 2 }.each do |tier, quantity|
             0.upto(quantity - 1) do


### PR DESCRIPTION
prevent crash when encountering an allocation from a previous prison or one from a POM who is no longer in the POMs list for the prison