### PR TITLE
Fix Preprod target so it depends on test and rubocop and can't deploy without

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,8 @@ workflows:
               only: main
       - deploy_preprod:
           requires:
+            - rubocop
+            - test
             - build_and_push_docker_image
           filters:
             branches:


### PR DESCRIPTION
I found a tiny bug in the preproduction target - it wasn't dependent on the other bits of the pipeline (now it is async)