### PR TITLE
Mo 507 rename reorder items in the HOMD allocations

### DIFF
--- a/app/views/prisoners/_male_missing_information.html.erb
+++ b/app/views/prisoners/_male_missing_information.html.erb
@@ -14,7 +14,8 @@
                                                             :new_arrivals_count => @new_arrivals.count
 }) %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Add missing information</h1>
+<h1 class="govuk-heading-l govuk-!-margin-bottom-4">Add missing details</h1>
+<p>You need to add missing details to <%=@missing_info.count %> cases so they can be allocated to a POM.</p>
 
 <section id="awaiting-information">
   <%= render(
@@ -28,15 +29,13 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('last_name') %>">
-          Prisoner
+          Case
         </a>
         <%= sort_arrow('last_name') %>
       </th>
-      <th class="govuk-table__header" scope="col">Service provider</th>
-      <th class="govuk-table__header" scope="col">Tier</th>
       <th class="govuk-table__header" scope="col">
         <a href="<%= sort_link('awaiting_allocation_for') %>">
-          Waiting
+          Days waiting for allocation
         </a>
         <%= sort_arrow('awaiting_allocation_for') %>
       </th>
@@ -53,19 +52,12 @@
             <%= offender.offender_no %>
           </span>
         </td>
-
-        <td aria-label="Service provider" class="govuk-table__cell ">
-          <%= probation_field(offender, :case_allocation) || 'Not provided' %>
-        </td>
-        <td aria-label="Tier" class="govuk-table__cell ">
-          <%= probation_field(offender, :tier) || 'Not provided' %>
-        </td>
-        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %> days</td>
+        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %></td>
         <td aria-label="Action" class="govuk-table__cell" id="<%= "edit_#{offender.offender_no}" %>">
           <% if auto_delius_import_enabled?(@prison.code) %>
-            <%= link_to "Update", prison_case_information_path(@prison.code, offender.offender_no) %>
+            <%= link_to "Update missing details", prison_case_information_path(@prison.code, offender.offender_no) %>
           <% else %>
-            <%= link_to "Edit", new_prison_case_information_path(@prison.code, offender.offender_no, sort: params[:sort], page: params[:page] || 1) %>
+            <%= link_to "Add missing details", new_prison_case_information_path(@prison.code, offender.offender_no, sort: params[:sort], page: params[:page] || 1) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/shared/_summary_subnav.html.erb
+++ b/app/views/shared/_summary_subnav.html.erb
@@ -1,30 +1,30 @@
 <nav class="moj-sub-navigation govuk-!-margin-top-0" aria-label="Sub navigation">
   <ul class="moj-sub-navigation__list">
     <li class="moj-sub-navigation__item">
-      <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :allocated %>
-      href="<%= allocated_prison_prisoners_path(@prison.code) %>">
-        See allocations (<%= allocated_count %>)
-      </a>
-    </li>
-
-    <li class="moj-sub-navigation__item">
       <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :unallocated %>
-      href="<%= unallocated_prison_prisoners_path(@prison.code) %>">
-        Make allocations (<%= unallocated_count %>)
+         href="<%= unallocated_prison_prisoners_path(@prison.code) %>">
+        Make new allocations (<%= unallocated_count %>)
       </a>
     </li>
 
     <li class="moj-sub-navigation__item">
       <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :missing_information %>
-      href="<%= missing_information_prison_prisoners_path(@prison.code) %>">
-        Add missing information (<%= missing_info_count %>)
+         href="<%= missing_information_prison_prisoners_path(@prison.code) %>">
+        Add missing details (<%= missing_info_count %>)
       </a>
     </li>
 
     <li class="moj-sub-navigation__item">
       <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :new_arrivals %>
-      href="<%= new_arrivals_prison_prisoners_path(@prison.code) %>">
+         href="<%= new_arrivals_prison_prisoners_path(@prison.code) %>">
         Newly arrived (<%= new_arrivals_count %>)
+      </a>
+    </li>
+
+    <li class="moj-sub-navigation__item">
+      <a class="moj-sub-navigation__link" <%= 'aria-current=page' if active == :allocated %>
+      href="<%= allocated_prison_prisoners_path(@prison.code) %>">
+        See allocations (<%= allocated_count %>)
       </a>
     </li>
   </ul>

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -14,7 +14,7 @@ feature 'summary summary feature' do
       visit missing_information_prison_prisoners_path(prison)
 
       expect(page).to have_css('.moj-sub-navigation__item')
-      expect(page).to have_content('Add missing information')
+      expect(page).to have_content('Add missing details')
       expect(page).to have_css('.pagination ul.links li', count: 16)
     end
 
@@ -22,7 +22,7 @@ feature 'summary summary feature' do
       visit unallocated_prison_prisoners_path(prison)
 
       expect(page).to have_css('.moj-sub-navigation__item')
-      expect(page).to have_content('Add missing information')
+      expect(page).to have_content('Add missing details')
     end
 
     context 'with allocations' do

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -15,7 +15,7 @@ feature 'case information feature' do
       stub_poms(prison.code, [spo])
     end
 
-    context 'when add missing information the first time (create journey)' do
+    context 'when add missing details the first time (create journey)' do
       before do
         visit new_prison_case_information_path(prison.code, offender.fetch(:offenderNo))
         find('label[for=case-information-probation-service-england-field]').click
@@ -60,9 +60,9 @@ feature 'case information feature' do
 
       visit missing_information_prison_prisoners_path('LEI')
 
-      expect(page).to have_content('Add missing information')
+      expect(page).to have_content('Add missing details')
       within "#edit_#{nomis_offender_id}" do
-        click_link 'Edit'
+        click_link 'Add missing details'
       end
 
       find('label[for=case-information-probation-service-england-field]').click
@@ -81,14 +81,13 @@ feature 'case information feature' do
     it "clicking back link after viewing prisoner's case information, returns back the same paginated page",
        vcr: { cassette_name: 'prison_api/case_information_back_link' }, js: true do
       visit missing_information_prison_prisoners_path('LEI', page: 3)
-
-      within ".govuk-table tr:first-child td:nth-child(5)" do
-        click_link 'Edit'
+      within ".govuk-table tr:first-child td:nth-child(3)" do
+        click_link 'Add missing details'
       end
       expect(page).to have_selector('h1', text: 'Case information')
       click_link 'Back'
       find('#awaiting-information')
-      expect(page).to have_selector('h1', text: 'Add missing information')
+      expect(page).to have_selector('h1', text: 'Add missing details')
     end
 
     it 'complains if allocation data is missing', vcr: { cassette_name: 'prison_api/case_information_missing_case_feature' } do
@@ -162,8 +161,8 @@ feature 'case information feature' do
        vcr: { cassette_name: 'prison_api/case_information_return_to_previously_paginated_page' } do
       visit missing_information_prison_prisoners_path('LEI', sort: "last_name desc", page: 3)
 
-      within ".govuk-table tr:first-child td:nth-child(5)" do
-        click_link 'Edit'
+      within ".govuk-table tr:first-child td:nth-child(3)" do
+        click_link 'Add missing details'
       end
       expect(page).to have_selector('h1', text: 'Case information')
 

--- a/spec/features/delius_import_feature_spec.rb
+++ b/spec/features/delius_import_feature_spec.rb
@@ -28,17 +28,17 @@ feature "Delius import feature", :disable_push_to_delius do
 
     it "imports from Delius and creates case information" do
       visit missing_information_prison_prisoners_path(prison_code)
-      expect(page).to have_content("Add missing information")
+      expect(page).to have_content("Add missing details")
       expect(page).to have_content(offender_no)
 
       ProcessDeliusDataJob.perform_now offender_no
 
       reload_page
-      expect(page).to have_content("Add missing information")
+      expect(page).to have_content("Add missing details")
       expect(page).not_to have_content(offender_no)
 
       visit unallocated_prison_prisoners_path(prison_code)
-      expect(page).to have_content("Make allocations")
+      expect(page).to have_content("Make new allocations")
       expect(page).to have_content(offender_no)
       click_link offender_name
       expect(page.find(:css, '#welsh-offender-row')).not_to have_content('Change')

--- a/spec/features/female_prison_index_page_feature_spec.rb
+++ b/spec/features/female_prison_index_page_feature_spec.rb
@@ -40,14 +40,14 @@ feature "female prison index page" do
     ]
   }
 
-  describe 'missing information page' do
+  describe 'missing details page' do
     before do
       visit missing_information_prison_prisoners_path(prison.code)
     end
 
     it 'displays offenders with missing details' do
       expect(page).to have_css('.moj-sub-navigation__item')
-      expect(page).to have_content('Add missing information')
+      expect(page).to have_content('Add missing details')
       expect(page).to have_text("You need to add missing details to 3 cases so they can be allocated to a POM")
     end
 
@@ -83,7 +83,7 @@ feature "female prison index page" do
     end
 
     it 'shows unallocated offenders' do
-      click_link('Make allocations (1)')
+      click_link('Make new allocations (1)')
       expect(page).to have_css("h1", text: "Make new allocations")
       expect(page).to have_css("p", text: "There are currently 1 cases waiting to be allocated to a POM.")
     end
@@ -94,7 +94,7 @@ feature "female prison index page" do
     end
 
     it 'shows offenders with missing information' do
-      click_link('Add missing information (3)')
+      click_link('Add missing details (3)')
       expect(page).to have_css("h1", text: "Add missing details")
     end
   end

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -72,7 +72,7 @@ feature 'Search for offenders' do
     it 'Can search from the Awaiting Allocation summary page', vcr: { cassette_name: 'prison_api/waiting_allocation_search_feature' } do
       visit unallocated_prison_prisoners_path(prison_code)
 
-      expect(page).to have_text('Make allocations')
+      expect(page).to have_text('Make new allocations')
       fill_in 'q', with: 'Tre'
       click_on('search-button')
 
@@ -83,7 +83,7 @@ feature 'Search for offenders' do
     it 'Can search from the Missing Information summary page', vcr: { cassette_name: 'prison_api/missing_info_search_feature' } do
       visit  missing_information_prison_prisoners_path(prison_code)
 
-      expect(page).to have_text('Make allocations')
+      expect(page).to have_text('Make new allocations')
       fill_in 'q', with: 'Ste'
       click_on('search-button')
 

--- a/spec/features/summary_feature_spec.rb
+++ b/spec/features/summary_feature_spec.rb
@@ -49,17 +49,17 @@ feature 'male prisoners summary navigation tabs' do
     visit allocated_prison_prisoners_path(prison.code)
     expect(active_tab).to eq('See allocations (2)')
     expect(page).to have_content('See allocations (2)')
-    expect(page).to have_content('Make allocations (1)')
-    expect(page).to have_content('Add missing information (3)')
+    expect(page).to have_content('Make new allocations (1)')
+    expect(page).to have_content('Add missing details (3)')
     expect(page).to have_content('Newly arrived (1)')
   end
 
   it 'shows unallocated offenders' do
     visit unallocated_prison_prisoners_path(prison.code)
-    expect(active_tab).to eq('Make allocations (1)')
+    expect(active_tab).to eq('Make new allocations (1)')
     expect(page).to have_content('See allocations (2)')
-    expect(page).to have_content('Make allocations (1)')
-    expect(page).to have_content('Add missing information (3)')
+    expect(page).to have_content('Make new allocations (1)')
+    expect(page).to have_content('Add missing details (3)')
     expect(page).to have_content('Newly arrived (1)')
   end
 
@@ -67,17 +67,17 @@ feature 'male prisoners summary navigation tabs' do
     visit new_arrivals_prison_prisoners_path(prison.code)
     expect(active_tab).to eq('Newly arrived (1)')
     expect(page).to have_content('See allocations (2)')
-    expect(page).to have_content('Make allocations (1)')
-    expect(page).to have_content('Add missing information (3)')
+    expect(page).to have_content('Make new allocations (1)')
+    expect(page).to have_content('Add missing details (3)')
     expect(page).to have_content('Newly arrived (1)')
   end
 
   it 'shows offenders with missing information' do
     visit missing_information_prison_prisoners_path(prison.code)
-    expect(active_tab).to eq('Add missing information (3)')
+    expect(active_tab).to eq('Add missing details (3)')
     expect(page).to have_content('See allocations (2)')
-    expect(page).to have_content('Make allocations (1)')
-    expect(page).to have_content('Add missing information (3)')
+    expect(page).to have_content('Make new allocations (1)')
+    expect(page).to have_content('Add missing details (3)')
     expect(page).to have_content('Newly arrived (1)')
   end
 end


### PR DESCRIPTION
[link to designs](https://hmpps-moic-staging.herokuapp.com/womens/homd_second_round/missing-info-list)

This PR 
Adds the 'Add missing details' title in H1 for the HOMD view - actually it was already H1 so I made it a govuk-heading-l instead of xl, as it did look very big. So I should probably check that with Steph.

Add paragraph text below the h1 title

Add the column headers (remove the ‘silly’ missing columns from men’s)

Re order the sub nav headings and rename some of them. 
