### PR TITLE
MO-733: Make the back button return to the previous page it has visited

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -22,6 +22,7 @@ class PomsController < PrisonStaffApplicationController
 
   def edit
     @errors = {}
+    @referrer = referrer_or_root
   end
 
   def update

--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -65,6 +65,10 @@ private
     session[:referrer] || request.referer || root_path
   end
 
+  def referrer_or_root
+    request.referer || root_path
+  end
+
   def store_referrer_in_session
     session[:referrer] = request.referer
   end

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -85,7 +85,7 @@
 
     <div class="govuk-form-group">
       <button type="submit" class="govuk-button">Save</button>
-      <a href="<%= prison_poms_path(@prison.code, nomis_staff_id: @pom.staff_id) %>" class="govuk-link">Cancel</a>
+     <%=link_to 'Cancel', @referrer,  class: "govuk-link" %>
     </div>
 
     </form>

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -3,119 +3,144 @@
 require "rails_helper"
 
 feature "edit a POM's details" do
-  let(:nomis_staff_id) { 485_637 }
-  let(:fulltime_pom_id) { 485_833 }
-  let(:nomis_offender_id) { 'G4273GI' }
-  let(:pom) { build(:pom) }
+  let!(:prison) { create(:prison) }
 
-  before do
-    create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id))
-
-    create(:pom_detail, prison_code: 'LEI', nomis_staff_id: fulltime_pom_id, working_pattern: 1)
-
-    signin_spo_user
-  end
-
-  it "setting unavailable shows selected on re-edit", vcr: { cassette_name: 'prison_api/edit_poms_unavailable_check' } do
-    visit edit_prison_pom_path('LEI', nomis_staff_id)
-    expect(page).to have_css('h1', text: 'Edit profile')
-
-    choose('working_pattern-2')
-    choose('Active but unavailable for new cases')
-    click_on('Save')
-
-    visit edit_prison_pom_path('LEI', nomis_staff_id)
-    expect(page).to have_css('h1', text: 'Edit profile')
-
-    expect(page).to have_field('status-conditional-unavailable', checked: true)
-  end
-
-  it "validates a POM when missing data", vcr: { cassette_name: 'prison_api/edit_poms_missing_check' } do
-    visit edit_prison_pom_path('LEI', fulltime_pom_id)
-    expect(page).to have_css('h1', text: 'Edit profile')
-
-    expect(page.find('#working_pattern-ft')).to be_checked
-
-    # The only way to trigger (and therefore cover) the validation is for a full-time POM
-    # to be edited to part time but not choose a working pattern.
-    choose('part-time-conditional-1')
-    click_on('Save')
-
-    expect(page).to have_css('h1', text: 'Edit profile')
-    expect(page).to have_content('Select number of days worked')
-  end
-
-  describe "making an inactive POM active", :js, vcr: { cassette_name: 'prison_api/edit_poms_activate_pom_feature' } do
-    let(:prison) { Prison.find('LEI') }
-    let(:other_prison) { create(:prison) }
-    let(:moic_integration_tests_staff_id) { 485_758 }
+  context 'with VCR' do
+    let(:nomis_staff_id) { 485_637 }
+    let(:fulltime_pom_id) { 485_833 }
+    let(:nomis_offender_id) { 'G4273GI' }
+    let(:pom) { build(:pom) }
 
     before do
-      # create 2 inactive POM details records (to make POM inactive) - there was a bug that found the first(and wrong) one
-      create(:pom_detail, :inactive, prison: other_prison, nomis_staff_id: moic_integration_tests_staff_id)
-      create(:pom_detail, :inactive, prison: prison, nomis_staff_id: moic_integration_tests_staff_id)
+      create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id))
+
+      create(:pom_detail, prison_code: 'LEI', nomis_staff_id: fulltime_pom_id, working_pattern: 1)
+
+      signin_spo_user
     end
 
-    it 'makes the pom have a status of active' do
-      visit "/prisons/LEI/poms"
-      click_link "Inactive staff (1)"
-      click_link 'Moic Integration-Tests'
-
-      within first('.govuk-summary-list__row') do
-        click_link "Change"
-      end
-
+    it "setting unavailable shows selected on re-edit", vcr: { cassette_name: 'prison_api/edit_poms_unavailable_check' } do
+      visit edit_prison_pom_path('LEI', nomis_staff_id)
       expect(page).to have_css('h1', text: 'Edit profile')
 
-      find('label[for=status-active]').click
-      find('label[for=part-time-conditional-1]').click
-      find('label[for=working_pattern-5]').click
+      choose('working_pattern-2')
+      choose('Active but unavailable for new cases')
+      click_on('Save')
 
-      click_button('Save')
+      visit edit_prison_pom_path('LEI', nomis_staff_id)
+      expect(page).to have_css('h1', text: 'Edit profile')
 
-      expect(prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('active')
-      expect(other_prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('inactive')
+      expect(page).to have_field('status-conditional-unavailable', checked: true)
+    end
 
-      expect(page).to have_content('0.5')
-      expect(page).to have_content('Active')
+    it "validates a POM when missing data", vcr: { cassette_name: 'prison_api/edit_poms_missing_check' } do
+      visit edit_prison_pom_path('LEI', fulltime_pom_id)
+      expect(page).to have_css('h1', text: 'Edit profile')
+
+      expect(page.find('#working_pattern-ft')).to be_checked
+
+      # The only way to trigger (and therefore cover) the validation is for a full-time POM
+      # to be edited to part time but not choose a working pattern.
+      choose('part-time-conditional-1')
+      click_on('Save')
+
+      expect(page).to have_css('h1', text: 'Edit profile')
+      expect(page).to have_content('Select number of days worked')
+    end
+
+    describe "making an inactive POM active", :js, vcr: { cassette_name: 'prison_api/edit_poms_activate_pom_feature' } do
+      let(:prison) { Prison.find('LEI') }
+      let(:other_prison) { create(:prison) }
+      let(:moic_integration_tests_staff_id) { 485_758 }
+
+      before do
+        # create 2 inactive POM details records (to make POM inactive) - there was a bug that found the first(and wrong) one
+        create(:pom_detail, :inactive, prison: other_prison, nomis_staff_id: moic_integration_tests_staff_id)
+        create(:pom_detail, :inactive, prison: prison, nomis_staff_id: moic_integration_tests_staff_id)
+      end
+
+      it 'makes the pom have a status of active' do
+        visit "/prisons/LEI/poms"
+        click_link "Inactive staff (1)"
+        click_link 'Moic Integration-Tests'
+
+        within first('.govuk-summary-list__row') do
+          click_link "Change"
+        end
+
+        expect(page).to have_css('h1', text: 'Edit profile')
+
+        find('label[for=status-active]').click
+        find('label[for=part-time-conditional-1]').click
+        find('label[for=working_pattern-5]').click
+
+        click_button('Save')
+
+        expect(prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('active')
+        expect(other_prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('inactive')
+
+        expect(page).to have_content('0.5')
+        expect(page).to have_content('Active')
+      end
+    end
+
+    context 'when a POM is made inactive' do
+      before do
+        # create an allocation with the POM as the primary POM
+        create(
+          :allocation_history,
+          nomis_offender_id: 'G7806VO',
+          primary_pom_nomis_id: 485_926,
+          prison: 'LEI'
+        )
+
+        # create an allocation with the POM as the co-working POM
+        create(
+          :allocation_history,
+          nomis_offender_id: 'G1670VU',
+          primary_pom_nomis_id: 485_833,
+          secondary_pom_nomis_id: 485_926,
+          prison: 'LEI'
+        )
+      end
+
+      it "de-allocates all a POM's cases", vcr: { cassette_name: 'prison_api/edit_poms_deactivate_pom_feature' } do
+        visit "/prisons/LEI/poms/485926"
+        within first('.govuk-summary-list__row') do
+          click_link "Change"
+        end
+
+        expect(page).to have_content("Moic Pom")
+        expect(AllocationHistory.count).to eq 2
+
+        choose('working_pattern-2')
+        choose('Inactive')
+        click_button('Save')
+
+        expect(page).to have_content("Moic Pom")
+        expect(page).to have_css('.offender_row_0', count: 0)
+      end
     end
   end
 
-  context 'when a POM is made inactive' do
-    before do
-      # create an allocation with the POM as the primary POM
-      create(
-        :allocation_history,
-        nomis_offender_id: 'G7806VO',
-        primary_pom_nomis_id: 485_926,
-        prison: 'LEI'
-      )
+  context 'without VCR' do
+    let!(:pom_detail) { create(:pom_detail, prison: prison) }
 
-      # create an allocation with the POM as the co-working POM
-      create(
-        :allocation_history,
-        nomis_offender_id: 'G1670VU',
-        primary_pom_nomis_id: 485_833,
-        secondary_pom_nomis_id: 485_926,
-        prison: 'LEI'
-          )
+    before do
+      stub_auth_token
+      stub_offenders_for_prison(prison.code, [])
+      stub_poms(prison.code, [build(:pom, staffId: pom_detail.nomis_staff_id)])
+
+      signin_spo_user([prison.code])
     end
 
-    it "de-allocates all a POM's cases", vcr: { cassette_name: 'prison_api/edit_poms_deactivate_pom_feature' } do
-      visit "/prisons/LEI/poms/485926"
+    it 'returns you to to the pom work load page' do
+      visit prison_pom_path(prison.code, pom_detail.nomis_staff_id)
       within first('.govuk-summary-list__row') do
         click_link "Change"
       end
-
-      expect(page).to have_content("Moic Pom")
-      expect(AllocationHistory.count).to eq 2
-
-      choose('working_pattern-2')
-      choose('Inactive')
-      click_button('Save')
-
-      expect(page).to have_content("Moic Pom")
-      expect(page).to have_css('.offender_row_0', count: 0)
+      click_link "Cancel"
+      expect(page).to have_current_path(prison_pom_path(prison.code, pom_detail.nomis_staff_id))
     end
   end
 end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 module FeaturesHelper
-  def signin_spo_user(prisons = ['LEI'])
-    mock_sso_response('MOIC_POM', [SsoIdentity::SPO_ROLE], prisons)
+  def signin_spo_user(prisons = nil)
+    if prisons.nil?
+      mock_sso_response('MOIC_POM', [SsoIdentity::SPO_ROLE], Prison.all.pluck(:code))
+    else
+      mock_sso_response('MOIC_POM', [SsoIdentity::SPO_ROLE], prisons)
+    end
+    stub_user(staff_id: 1)
   end
+
+  # def signin_spo_user(prisons = %w[LEI RSI], name = 'MOIC_POM')
+  #   mock_sso_response(name, [SsoIdentity::SPO_ROLE], prisons)
+  #   stub_user(staff_id: 1)
+  # end
 
   def stub_signin_spo(pom, prisons = ['LEI'])
     stub_auth_token
@@ -20,6 +30,7 @@ module FeaturesHelper
 
   def signin_spo_pom_user(prisons = %w[LEI RSI], name = 'MOIC_POM')
     mock_sso_response(name, [SsoIdentity::SPO_ROLE, SsoIdentity::POM_ROLE], prisons)
+    stub_user(staff_id: 1)
   end
 
   def signin_global_admin_user


### PR DESCRIPTION
This PR makes sure the 'Change POM availability' screen (the edit page) returns the user to the previous POM screen they visited, as opposed to hard coding it to return to the list of Poms. If for some reason, they landed directly on the 'Change POM availability' screen, so there is no previous page, then pressing the back button will return them to the home page. 

**The POM edit page**
<img width="769" alt="Screenshot 2021-07-14 at 09 12 35" src="https://user-images.githubusercontent.com/12900007/125588004-970bd984-6a03-4da8-8707-9b36e026df44.png">


**The POM show page**
<img width="999" alt="Screenshot 2021-07-14 at 09 12 16" src="https://user-images.githubusercontent.com/12900007/125587639-f7434341-5735-4396-8529-3e639cd32438.png">
