### PR TITLE
MO-735-The case information edit journey now returns to the previous page 

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -5,7 +5,7 @@ class CaseInformationController < PrisonsApplicationController
   before_action :set_case_info, only: [:edit, :show]
 
   before_action :set_referrer
-  before_action :store_referrer_in_session, only: [:edit_prd]
+  before_action :store_referrer_in_session, only: [:edit_prd, :edit]
 
   def new
     @case_info = Offender.find_by!(nomis_offender_id: nomis_offender_id_from_url).build_case_information
@@ -64,7 +64,7 @@ class CaseInformationController < PrisonsApplicationController
     @prisoner = prisoner(case_information_params[:nomis_offender_id])
     # Nothing here can fail due to radio buttons being unselectable
     @case_info.update!(case_information_params.merge(manual_entry: true))
-    redirect_to prison_prisoner_staff_index_path(active_prison_id, @case_info.nomis_offender_id)
+    redirect_to referrer
   end
 
 private

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -55,7 +55,7 @@
   </tr>
   <tr class="govuk-table__row" id="tier-row">
     <td class="govuk-table__cell">Tiering calculation</td>
-    <td class="govuk-table__cell table_cell__left_align">
+    <td id="tier" class="govuk-table__cell table_cell__left_align">
     Tier <%= @prisoner.tier %>
       <%= link_to 'Change', edit_prison_case_information_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' if @prisoner.manual_entry? %>
     </td>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -33,7 +33,7 @@
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">Tiering calculation</td>
-      <td class="govuk-table__cell table_cell__left_align">
+      <td id="tier" class="govuk-table__cell table_cell__left_align">
         Tier <%= @prisoner.tier %>
         <% unless auto_delius_import_enabled?(@prison.code) %>
           <a class="govuk-link pull-right" href="<%= edit_prison_case_information_path(@prison.code, @prisoner.offender_no) %>">Change</a>

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -50,6 +50,9 @@ feature 'case information feature' do
   end
 
   context 'with vcr' do
+    let(:staff_id) { 485_833 }
+    let(:poms) { [build(:pom, staffId: staff_id)] }
+
     before do
       signin_spo_user
     end
@@ -129,32 +132,6 @@ feature 'case information feature' do
 
       expect(CaseInformation.count).to eq(0)
       expect(page).to have_content("Select the prisoner’s tier")
-    end
-
-    it 'allows editing case information for a prisoner', vcr: { cassette_name: 'prison_api/case_information_editing_feature' } do
-      nomis_offender_id = 'G1821VA'
-
-      visit new_prison_case_information_path('LEI', nomis_offender_id)
-      find('label[for=case-information-probation-service-england-field]').click
-      find('label[for=case-information-case-allocation-nps-field]').click
-      find('label[for=case-information-tier-a-field]').click
-      click_button 'Save'
-
-      visit edit_prison_case_information_path('LEI', nomis_offender_id)
-
-      expect(page).to have_content('Case information')
-      expect(page).to have_content('G1821VA')
-      find('label[for=case-information-probation-service-england-field]').click
-      find('label[for=case-information-case-allocation-crc-field]').click
-      click_button 'Update'
-
-      expect(CaseInformation.count).to eq(1)
-      expect(CaseInformation.first.nomis_offender_id).to eq(nomis_offender_id)
-      expect(CaseInformation.first.tier).to eq('A')
-      expect(CaseInformation.first.case_allocation).to eq('CRC')
-
-      expect(page).to have_current_path prison_prisoner_staff_index_path('LEI', nomis_offender_id)
-      expect(page).to have_content('CRC')
     end
 
     it 'returns to previously paginated page after saving',

--- a/spec/features/complexity_level_feature_spec.rb
+++ b/spec/features/complexity_level_feature_spec.rb
@@ -6,7 +6,6 @@ feature 'complexity level feature' do
   let(:offenders) { [offender] }
   let(:pom) { build(:pom) }
   let(:spo) { build(:pom) }
-  let(:test_strategy) { Flipflop::FeatureSet.current.test! }
   let(:offender_no) { offender.fetch(:offenderNo) }
 
 
@@ -20,7 +19,7 @@ feature 'complexity level feature' do
     stub_keyworker(womens_prison.code, offender.fetch(:offenderNo), build(:keyworker))
   end
 
-  context 'when on prisoner profile page' do
+  context 'when on allocation information page' do
     it 'can update the complexity level journey' do
       expect(HmppsApi::ComplexityApi).to receive(:save).with(offender.fetch(:offenderNo), level: 'low', username: "MOIC_POM", reason: 'bla bla bla')
 

--- a/spec/features/update_case_information_spec.rb
+++ b/spec/features/update_case_information_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.feature "Update case information", type: :feature do
+  let(:offender) { build(:nomis_offender, complexityLevel: 'high', agencyId: prison.code) }
+  let(:offenders) { [offender] }
+  let(:pom) { build(:pom) }
+  let(:spo) { build(:pom) }
+  let(:prison) { create(:prison) }
+  let(:offender_no) { offender.fetch(:offenderNo) }
+
+  before do
+    stub_offenders_for_prison(prison.code, offenders)
+    stub_signin_spo(spo, [prison.code])
+    stub_poms(prison.code, [pom, spo])
+    stub_keyworker(prison.code, offender.fetch(:offenderNo), build(:keyworker))
+  end
+
+  context 'when there is a new allocation' do
+    before do
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+    end
+
+    it 'returns to the Allocate a POM page' do
+      visit prison_prisoner_staff_index_path(prison_id: prison.code, prisoner_id: offender_no)
+
+      # This takes you to the change case information edit page
+      within(:css, "td#tier") do
+        click_link('Change')
+      end
+
+      # This returns you back from where you came (Allocation information page)
+      click_on('Update')
+
+      expect(page).to have_current_path(prison_prisoner_staff_index_path(prison_id: prison.code, prisoner_id: offender_no))
+    end
+  end
+
+  context 'when there is an existing allocation' do
+    before do
+      create(:allocation_history, nomis_offender_id: offender_no, primary_pom_nomis_id: pom.staff_id,  prison: prison.code)
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+    end
+
+    it 'returns to the prisoner Allocation information page' do
+      visit prison_prisoner_allocation_path(prison_id: prison.code, prisoner_id: offender_no)
+
+      # This takes you to the change case information edit page
+      within(:css, "td#tier") do
+        click_link('Change')
+      end
+
+      # This returns you back from where you came (Allocation information page)
+      click_on('Update')
+
+      expect(page).to have_current_path(prison_prisoner_allocation_path(prison_id: prison.code, prisoner_id: offender_no))
+    end
+  end
+
+  context 'when reallocating a POM on an existing allocation' do
+    before do
+      create(:allocation_history, nomis_offender_id: offender_no, primary_pom_nomis_id: pom.staff_id,  prison: prison.code)
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+    end
+
+    it 'returns to the Reallocate POM page' do
+      visit prison_prisoner_allocation_path(prison_id: prison.code, prisoner_id: offender_no)
+
+      # To reallocate the pom page
+      click_link('Reallocate')
+
+      # To take you to the change case information edit page
+      within(:css, "td#tier") do
+        click_link('Change')
+      end
+
+      # This returns you back from where you came (Reallocate Pom page)
+      click_on('Update')
+
+      expect(page).to have_current_path(prison_prisoner_staff_index_path(prison_id: prison.code, prisoner_id: offender_no))
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the update button on the case information edit page, which used to return the user to the `Reallocate a POM` page. It now uses the referrer to return the user to the last page they were on. In this feature test it is checking it can return to the `Allocation information` page. 

<img width="992" alt="Screenshot 2021-07-15 at 12 40 22" src="https://user-images.githubusercontent.com/12900007/125782557-66909201-0c81-4e2a-9e71-a9cc55626f66.png">
<img width="533" alt="Screenshot 2021-07-15 at 12 40 38" src="https://user-images.githubusercontent.com/12900007/125782563-b767c23b-39d8-4434-9362-1c0f5f1977f5.png">
