### PR TITLE
Use Postgres 10 in Heroku deployments

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "9.6"
+        "version": "10"
       }
     },
     "heroku-redis"


### PR DESCRIPTION
Heroku review apps were failing to build because they were dependent on a now-unsupported version of Postgres.

This commit updates the Heroku config to use the same major version of Postgres that we use in our Cloud Platform hosted environments (staging, preprod and production).

Postgres 10 will reach End Of Life (EOL) in November 2022. Before then, the Cloud Platform and Heroku versions of Postgres should be upgraded to use the current major version.