### PR TITLE
MO-647 – fixup a couple of bugs

### DIFF
--- a/app/jobs/early_allocation_event_job.rb
+++ b/app/jobs/early_allocation_event_job.rb
@@ -3,6 +3,6 @@ class EarlyAllocationEventJob < ApplicationJob
 
   def perform offender_id
     offender = OffenderService.get_offender(offender_id)
-    offender.trigger_early_allocation_event
+    offender.trigger_early_allocation_event unless offender.nil?
   end
 end

--- a/deploy/preprod/cron-community-api-import.yaml
+++ b/deploy/preprod/cron-community-api-import.yaml
@@ -49,5 +49,20 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure
 

--- a/deploy/preprod/cron-early-allocation-events.yaml
+++ b/deploy/preprod/cron-early-allocation-events.yaml
@@ -47,7 +47,22 @@ spec:
                 - name: REDIS_URL
                   valueFrom:
                     secretKeyRef:
-                      name: elasticache-offender-management-allocation-manager-token-cache-production
+                      name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure
 

--- a/deploy/preprod/cron-process-movements.yaml
+++ b/deploy/preprod/cron-process-movements.yaml
@@ -50,4 +50,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/deploy/production/cron-community-api-import.yaml
+++ b/deploy/production/cron-community-api-import.yaml
@@ -49,5 +49,20 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure
 

--- a/deploy/production/cron-early-allocation-events.yaml
+++ b/deploy/production/cron-early-allocation-events.yaml
@@ -49,5 +49,20 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure
 

--- a/deploy/production/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/production/cron-early-allocation-suitability-email-job.yaml
@@ -50,4 +50,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/deploy/production/cron-handover-chase-email-job.yaml
+++ b/deploy/production/cron-handover-chase-email-job.yaml
@@ -50,4 +50,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/deploy/production/cron-handover-email-job.yaml
+++ b/deploy/production/cron-handover-email-job.yaml
@@ -50,4 +50,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/deploy/production/cron-recalculate-handover-dates.yaml
+++ b/deploy/production/cron-recalculate-handover-dates.yaml
@@ -50,4 +50,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/deploy/staging/cron-early-allocation-events.yaml
+++ b/deploy/staging/cron-early-allocation-events.yaml
@@ -47,7 +47,22 @@ spec:
                 - name: REDIS_URL
                   valueFrom:
                     secretKeyRef:
-                      name: elasticache-offender-management-allocation-manager-token-cache-production
+                      name: elasticache-offender-management-allocation-manager-token-cache-staging
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure
 

--- a/deploy/staging/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/staging/cron-early-allocation-suitability-email-job.yaml
@@ -49,4 +49,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-staging
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/deploy/staging/cron-integration-test-cleanup.yaml
+++ b/deploy/staging/cron-integration-test-cleanup.yaml
@@ -50,4 +50,19 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-staging
                       key: url
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: access_key_id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: secret_access_key
+                - name: DOMAIN_EVENTS_TOPIC_ARN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-domain-events-topic
+                      key: topic_arn
           restartPolicy: OnFailure

--- a/spec/jobs/early_allocation_event_job_spec.rb
+++ b/spec/jobs/early_allocation_event_job_spec.rb
@@ -4,12 +4,25 @@ RSpec.describe EarlyAllocationEventJob, type: :job do
   let(:prison) { create(:prison) }
   let(:offender) { build(:offender) }
 
-  before do
-    stub_offender(build(:nomis_offender, offenderNo: offender.nomis_offender_id, agencyId: prison.code))
-    expect(EarlyAllocationEventService).to receive(:send_early_allocation)
+  context 'when the offender exists in NOMIS' do
+    before do
+      stub_offender(build(:nomis_offender, offenderNo: offender.nomis_offender_id, agencyId: prison.code))
+      expect(EarlyAllocationEventService).to receive(:send_early_allocation)
+    end
+
+    it 'sends the event via the job' do
+      described_class.perform_now offender.nomis_offender_id
+    end
   end
 
-  it 'sends the event via the job' do
-    described_class.perform_now offender.nomis_offender_id
+  context 'when that offender ID no longer exists in NOMIS' do
+    before do
+      stub_non_existent_offender(offender.nomis_offender_id)
+      expect(EarlyAllocationEventService).not_to receive(:send_early_allocation)
+    end
+
+    it 'does not send the event' do
+      described_class.perform_now offender.nomis_offender_id
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a couple of bugs that were introduced with MO-647.

1. Fix [an error reported in Sentry](https://sentry.io/organizations/ministryofjustice/issues/2529184654/?environment=production&project=5584139) which resulted in us attempting to run methods against a `nil` offender object.
2. Make the environment variables consistent between Deployments and Cron Jobs.