### PR TITLE
Mo 789 change back link behaviour and improve cancel button positioning

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -4,6 +4,8 @@ class PomsController < PrisonStaffApplicationController
   before_action :ensure_spo_user
 
   before_action :load_pom_staff_member, only: [:show, :edit, :update]
+  before_action :store_referrer_in_session, only: [:edit]
+  before_action :set_referrer
 
   def index
     @poms = @prison.get_list_of_poms.sort_by(&:last_name)

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => "/shared/backlink", :locals => {:page => prison_poms_path(@prison.code, id: @pom.staff_id)} %>
+<%= render :partial => "/shared/backlink", :locals => {:page => @referrer} %>
 
 <div>
   <%= form_tag prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), method: :put, id: "edit_pom_form" do %>
@@ -85,7 +85,7 @@
 
     <div class="govuk-form-group">
       <button type="submit" class="govuk-button">Save</button>
-      <a class="govuk-link cancel-button" href="<%= prison_poms_path(@prison.code, nomis_staff_id: @pom.staff_id) %>">Cancel</a>
+      <%= link_to 'Cancel', @referrer, class: 'govuk-link cancel-button' %>
     </div>
 
     </form>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -85,7 +85,7 @@
 
     <div class="govuk-form-group">
       <button type="submit" class="govuk-button">Save</button>
-      <a href="<%= prison_poms_path(@prison.code, nomis_staff_id: @pom.staff_id) %>" class="govuk-link">Cancel</a>
+      <a class="govuk-link cancel-button" href="<%= prison_poms_path(@prison.code, nomis_staff_id: @pom.staff_id) %>">Cancel</a>
     </div>
 
     </form>

--- a/spec/features/edit_a_pom_spec.rb
+++ b/spec/features/edit_a_pom_spec.rb
@@ -3,119 +3,162 @@
 require "rails_helper"
 
 feature "edit a POM's details" do
-  let(:nomis_staff_id) { 485_637 }
-  let(:fulltime_pom_id) { 485_833 }
-  let(:nomis_offender_id) { 'G4273GI' }
-  let(:pom) { build(:pom) }
-
-  before do
-    create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id))
-
-    create(:pom_detail, prison_code: 'LEI', nomis_staff_id: fulltime_pom_id, working_pattern: 1)
-
-    signin_spo_user
-  end
-
-  it "setting unavailable shows selected on re-edit", vcr: { cassette_name: 'prison_api/edit_poms_unavailable_check' } do
-    visit edit_prison_pom_path('LEI', nomis_staff_id)
-    expect(page).to have_css('h1', text: 'Edit profile')
-
-    choose('working_pattern-2')
-    choose('Active but unavailable for new cases')
-    click_on('Save')
-
-    visit edit_prison_pom_path('LEI', nomis_staff_id)
-    expect(page).to have_css('h1', text: 'Edit profile')
-
-    expect(page).to have_field('status-conditional-unavailable', checked: true)
-  end
-
-  it "validates a POM when missing data", vcr: { cassette_name: 'prison_api/edit_poms_missing_check' } do
-    visit edit_prison_pom_path('LEI', fulltime_pom_id)
-    expect(page).to have_css('h1', text: 'Edit profile')
-
-    expect(page.find('#working_pattern-ft')).to be_checked
-
-    # The only way to trigger (and therefore cover) the validation is for a full-time POM
-    # to be edited to part time but not choose a working pattern.
-    choose('part-time-conditional-1')
-    click_on('Save')
-
-    expect(page).to have_css('h1', text: 'Edit profile')
-    expect(page).to have_content('Select number of days worked')
-  end
-
-  describe "making an inactive POM active", :js, vcr: { cassette_name: 'prison_api/edit_poms_activate_pom_feature' } do
-    let(:prison) { Prison.find('LEI') }
-    let(:other_prison) { create(:prison) }
-    let(:moic_integration_tests_staff_id) { 485_758 }
+  context 'when not VCR tests' do
+    let(:spo) { build(:pom) }
+    let!(:prison) { create(:prison) }
+    let(:probation_poms) {
+      [
+        build(:pom, :probation_officer),
+        build(:pom, :probation_officer)
+      ]
+    }
+    let(:offenders) { build_list(:nomis_offender, 2, agencyId: prison.code) }
 
     before do
-      # create 2 inactive POM details records (to make POM inactive) - there was a bug that found the first(and wrong) one
-      create(:pom_detail, :inactive, prison: other_prison, nomis_staff_id: moic_integration_tests_staff_id)
-      create(:pom_detail, :inactive, prison: prison, nomis_staff_id: moic_integration_tests_staff_id)
-    end
+      stub_pom(spo)
+      stub_signin_spo(spo, [prison.code])
+      stub_offenders_for_prison(prison.code, offenders)
+      stub_poms(prison.code, probation_poms)
 
-    it 'makes the pom have a status of active' do
-      visit "/prisons/LEI/poms"
-      click_link "Inactive staff (1)"
-      click_link 'Moic Integration-Tests'
+      # Goes to the POM workload page
+      visit prison_pom_path(prison_id: prison.code, nomis_staff_id: spo.staffId)
 
+      # Goes to the Edit profile page where the SPO can change the working pattern or the status
       within first('.govuk-summary-list__row') do
         click_link "Change"
       end
+    end
 
+    context 'when the back button is clicked'do
+      it 'returns to the "view a POM screen"' do
+        click_link 'Back'
+        expect(page).to have_current_path(prison_pom_path(prison_id: prison.code, nomis_staff_id: spo.staffId))
+      end
+    end
+
+    context 'when the cancel button is clicked'do
+      it 'returns to the "view a POM screen"' do
+        click_link 'Cancel'
+        expect(page).to have_current_path(prison_pom_path(prison_id: prison.code, nomis_staff_id: spo.staffId))
+      end
+    end
+  end
+
+  context 'with VCR tests' do
+    let(:nomis_staff_id) { 485_637 }
+    let(:fulltime_pom_id) { 485_833 }
+    let(:nomis_offender_id) { 'G4273GI' }
+    let(:pom) { build(:pom) }
+
+    before do
+      signin_spo_user
+
+      create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id))
+
+      create(:pom_detail, prison_code: 'LEI', nomis_staff_id: fulltime_pom_id, working_pattern: 1)
+    end
+
+    it "setting unavailable shows selected on re-edit", vcr: { cassette_name: 'prison_api/edit_poms_unavailable_check' } do
+      visit edit_prison_pom_path('LEI', nomis_staff_id)
       expect(page).to have_css('h1', text: 'Edit profile')
 
-      find('label[for=status-active]').click
-      find('label[for=part-time-conditional-1]').click
-      find('label[for=working_pattern-5]').click
+      choose('working_pattern-2')
+      choose('Active but unavailable for new cases')
+      click_on('Save')
 
-      click_button('Save')
+      visit edit_prison_pom_path('LEI', nomis_staff_id)
+      expect(page).to have_css('h1', text: 'Edit profile')
 
-      expect(prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('active')
-      expect(other_prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('inactive')
-
-      expect(page).to have_content('0.5')
-      expect(page).to have_content('Active')
-    end
-  end
-
-  context 'when a POM is made inactive' do
-    before do
-      # create an allocation with the POM as the primary POM
-      create(
-        :allocation_history,
-        nomis_offender_id: 'G7806VO',
-        primary_pom_nomis_id: 485_926,
-        prison: 'LEI'
-      )
-
-      # create an allocation with the POM as the co-working POM
-      create(
-        :allocation_history,
-        nomis_offender_id: 'G1670VU',
-        primary_pom_nomis_id: 485_833,
-        secondary_pom_nomis_id: 485_926,
-        prison: 'LEI'
-          )
+      expect(page).to have_field('status-conditional-unavailable', checked: true)
     end
 
-    it "de-allocates all a POM's cases", vcr: { cassette_name: 'prison_api/edit_poms_deactivate_pom_feature' } do
-      visit "/prisons/LEI/poms/485926"
-      within first('.govuk-summary-list__row') do
-        click_link "Change"
+    it "validates a POM when missing data", vcr: { cassette_name: 'prison_api/edit_poms_missing_check' } do
+      visit edit_prison_pom_path('LEI', fulltime_pom_id)
+      expect(page).to have_css('h1', text: 'Edit profile')
+
+      expect(page.find('#working_pattern-ft')).to be_checked
+
+      # The only way to trigger (and therefore cover) the validation is for a full-time POM
+      # to be edited to part time but not choose a working pattern.
+      choose('part-time-conditional-1')
+      click_on('Save')
+
+      expect(page).to have_css('h1', text: 'Edit profile')
+      expect(page).to have_content('Select number of days worked')
+    end
+
+    describe "making an inactive POM active", vcr: { cassette_name: 'prison_api/edit_poms_activate_pom_feature' } do
+      let(:prison) { Prison.find('LEI') }
+      let(:other_prison) { create(:prison) }
+      let(:moic_integration_tests_staff_id) { 485_758 }
+
+      before do
+        # create 2 inactive POM details records (to make POM inactive) - there was a bug that found the first(and wrong) one
+        create(:pom_detail, :inactive, prison: other_prison, nomis_staff_id: moic_integration_tests_staff_id)
+        create(:pom_detail, :inactive, prison: prison, nomis_staff_id: moic_integration_tests_staff_id)
       end
 
-      expect(page).to have_content("Moic Pom")
-      expect(AllocationHistory.count).to eq 2
+      it 'makes the pom have a status of active' do
+        visit "/prisons/LEI/poms"
+        click_link "Inactive staff (1)"
+        click_link 'Moic Integration-Tests'
 
-      choose('working_pattern-2')
-      choose('Inactive')
-      click_button('Save')
+        within first('.govuk-summary-list__row') do
+          click_link "Change"
+        end
 
-      expect(page).to have_content("Moic Pom")
-      expect(page).to have_css('.offender_row_0', count: 0)
+        expect(page).to have_css('h1', text: 'Edit profile')
+
+        find('label[for=status-active]').click
+        find('label[for=part-time-conditional-1]').click
+        find('label[for=working_pattern-5]').click
+
+        click_button('Save')
+
+        expect(prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('active')
+        expect(other_prison.pom_details.find_by(nomis_staff_id: moic_integration_tests_staff_id).status).to eq('inactive')
+
+        expect(page).to have_content('0.5')
+        expect(page).to have_content('Active')
+      end
+    end
+
+    context 'when a POM is made inactive' do
+      before do
+        # create an allocation with the POM as the primary POM
+        create(
+          :allocation_history,
+          nomis_offender_id: 'G7806VO',
+          primary_pom_nomis_id: 485_926,
+          prison: 'LEI'
+        )
+
+        # create an allocation with the POM as the co-working POM
+        create(
+          :allocation_history,
+          nomis_offender_id: 'G1670VU',
+          primary_pom_nomis_id: 485_833,
+          secondary_pom_nomis_id: 485_926,
+          prison: 'LEI'
+        )
+      end
+
+      it "de-allocates all a POM's cases", vcr: { cassette_name: 'prison_api/edit_poms_deactivate_pom_feature' } do
+        visit "/prisons/LEI/poms/485926"
+        within first('.govuk-summary-list__row') do
+          click_link "Change"
+        end
+
+        expect(page).to have_content("Moic Pom")
+        expect(AllocationHistory.count).to eq 2
+
+        choose('working_pattern-2')
+        choose('Inactive')
+        click_button('Save')
+
+        expect(page).to have_content("Moic Pom")
+        expect(page).to have_css('.offender_row_0', count: 0)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR:

1. Adjusts the position of the 'cancel’ link by adding a missing cancel-button class
2. When you click ‘Back’ or 'Cancel' from the ‘editing working pattern’ screen, it takes you back the previous page (view a POM screen)