### PR TITLE
Fix a broken VCR feature test

### DIFF
--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -32,9 +32,8 @@ feature 'Allocation' do
     expect(page).to have_content('Determinate')
 
     within '#recommended_poms' do
-      # 6th POM in the list is Moic Integration-Tests
-      within 'tbody > tr:nth-child(6)' do
-        expect(all('td[aria-label="POM name"]').map(&:text).first).to eq('Moic Integration-Tests')
+      # Allocate to the POM called "Moic Integration-Tests"
+      within page.find(:css, 'tr', text: 'Moic Integration-Tests') do
         click_link 'Allocate'
       end
     end


### PR DESCRIPTION
The allocation feature test broke due to a change in the POM list on T3 NOMIS (Prison API dev).

This commit fixes the test by making it more resilient to change. Rather than expecting the "Moic Integration-Tests" POM to be in a particular position in the POM list, it simply searches for that name.