### PR TITLE
MO-785 - Bugfix for missing allocation history

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -7,7 +7,7 @@ class AllocationStaffController < PrisonsApplicationController
 
   def index
     @case_info = Offender.find_by!(nomis_offender_id: prisoner_id_from_url).case_information
-    @allocation = AllocationHistory.find_by prison: @prison.code, nomis_offender_id: prisoner_id_from_url
+    @allocation = AllocationHistory.find_by nomis_offender_id: prisoner_id_from_url
     previous_pom_ids = if @allocation
                          @allocation.previously_allocated_poms
                        else


### PR DESCRIPTION
Fix a bug which was causing the 'new allocation' screen to incorrectly show offenders as having 'no allocation history' under certain conditions.

If the offender's most recent allocation was in a different prison, their allocation history was incorrectly ignored and the page would show "no history". It would only show a link to the case history page if the most recent allocation had been in the current prison.

This commit adds a test to cover this specific scenario to avoid the chance of future regressions.