### PR TITLE
MO-803: Allocate more CPU & memory to cron jobs

### DIFF
--- a/deploy/preprod/cron-community-api-import.yaml
+++ b/deploy/preprod/cron-community-api-import.yaml
@@ -16,6 +16,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake community_api:import"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "50m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/preprod/cron-early-allocation-events.yaml
+++ b/deploy/preprod/cron-early-allocation-events.yaml
@@ -16,6 +16,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake trigger:early_allocation_events"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "50m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/preprod/cron-process-movements.yaml
+++ b/deploy/preprod/cron-process-movements.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake movements:process"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "50m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -99,6 +99,13 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
           command: ['sh', '-c', "bundle exec sidekiq -C config/sidekiq.yml"]
+          resources:
+            limits:
+              memory: "1500Mi"
+              cpu: "1000m"
+            requests:
+              memory: "500Mi"
+              cpu: "50m"
           envFrom:
             - configMapRef:
                 name: shared-environment
@@ -153,6 +160,13 @@ spec:
           command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           ports:
             - containerPort: 9394
+          resources:
+            limits:
+              memory: "200Mi"
+              cpu: "50m"
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
           livenessProbe:
             httpGet:
               path: /metrics

--- a/deploy/production/cron-community-api-import.yaml
+++ b/deploy/production/cron-community-api-import.yaml
@@ -16,6 +16,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake community_api:import"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/cron-early-allocation-events.yaml
+++ b/deploy/production/cron-early-allocation-events.yaml
@@ -16,6 +16,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake trigger:early_allocation_events"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/production/cron-early-allocation-suitability-email-job.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake early_allocation_suitability_email:process"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/cron-handover-chase-email-job.yaml
+++ b/deploy/production/cron-handover-chase-email-job.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake handover_chase_emails:process"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/cron-handover-email-job.yaml
+++ b/deploy/production/cron-handover-email-job.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake cronjob:handover_email"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/cron-process-movements.yaml
+++ b/deploy/production/cron-process-movements.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake movements:process"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/cron-recalculate-handover-dates.yaml
+++ b/deploy/production/cron-recalculate-handover-dates.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake recalculate_handover_dates"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "100m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -99,18 +99,18 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
           command: ['sh', '-c', "bundle exec sidekiq -C config/sidekiq.yml"]
+          resources:
+            limits:
+              memory: "1500Mi"
+              cpu: "1000m"
+            requests:
+              memory: "500Mi"
+              cpu: "100m"
           envFrom:
-            - configMapRef:
+              - configMapRef:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
-          resources:
-            limits:
-              memory: "500Mi"
-              cpu: "100m"
-            requests:
-              memory: "250Mi"
-              cpu: "50m"
           env:
             - name: RAILS_LOG_TO_STDOUT
               value: "on"

--- a/deploy/staging/cron-early-allocation-events.yaml
+++ b/deploy/staging/cron-early-allocation-events.yaml
@@ -16,6 +16,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake trigger:early_allocation_events"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "50m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/staging/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/staging/cron-early-allocation-suitability-email-job.yaml
@@ -16,6 +16,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake early_allocation_suitability_email:process"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "50m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/staging/cron-integration-test-cleanup.yaml
+++ b/deploy/staging/cron-integration-test-cleanup.yaml
@@ -17,6 +17,13 @@ spec:
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
               imagePullPolicy: Always
               command: ['sh', '-c', "bundle exec rake integration_tests:clean_up"]
+              resources:
+                limits:
+                  memory: "1500Mi"
+                  cpu: "1000m"
+                requests:
+                  memory: "500Mi"
+                  cpu: "50m"
               envFrom:
                 - configMapRef:
                     name: shared-environment

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -99,6 +99,13 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always
           command: ['sh', '-c', "bundle exec sidekiq -C config/sidekiq.yml"]
+          resources:
+            limits:
+              memory: "1500Mi"
+              cpu: "1000m"
+            requests:
+              memory: "500Mi"
+              cpu: "50m"
           envFrom:
             - configMapRef:
                 name: shared-environment
@@ -153,6 +160,13 @@ spec:
           command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           ports:
             - containerPort: 9394
+          resources:
+            limits:
+              memory: "200Mi"
+              cpu: "50m"
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
           livenessProbe:
             httpGet:
               path: /metrics


### PR DESCRIPTION
We've been experiencing some overnight cron jobs failing to complete successfully. Strangely, they've ended up hanging with little explanation as to why (no log output, and not killed due to OOM).

While investigating potential causes, I realised that cron jobs defined in the service's namespace on the MOJ Cloud Platform didn't have explicitly defined CPU & memory resource limits. Instead, they were implicitly inheriting the default resource limits for the Kubernetes namespace (which are quite low for a Rails app).

Having watched the Community API import job run, I can see that it was being CPU throttled, causing the job to take longer than expected to complete.

I've therefore bumped up the resource limits to see how this affects the successful completion rate of cron jobs.

I also noticed that the Sidekiq containers running in production were using slightly more memory than requested. Given the number of jobs we tend to queue overnight nowadays (which has steadily increased over time), it made sense to slightly bump up the requested resources to give it some more breathing room.