### PR TITLE
MO-803: Fix invalid Kubernetes config file

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               memory: "500Mi"
               cpu: "100m"
           envFrom:
-              - configMapRef:
+            - configMapRef:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets


### PR DESCRIPTION
The previous commit managed to break the Kubernetes config file by introducing some unwanted whitespace, resulting in invalid YAML.

In the future, it'd be a good idea to introduce [kubeval][1] to the CI pipeline to catch invalid Kubernetes config before it can be merged into the `main` branch.

[1]: https://www.kubeval.com