### PR TITLE
MO-811: Fix a bug where PRDs couldn't be updated

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -21,9 +21,8 @@ class CaseInformationController < PrisonsApplicationController
   def update_prd
     @parole_form = ParoleReviewDateForm.new parole_review_date_params
     if @parole_form.valid?
-      ParoleRecord.find_or_create_by!(nomis_offender_id: nomis_offender_id_from_url) do |parole|
-        parole.update(parole_review_date: @parole_form.parole_review_date)
-      end
+      ParoleRecord.find_or_initialize_by(nomis_offender_id: nomis_offender_id_from_url)
+                  .update!(parole_review_date: @parole_form.parole_review_date)
       redirect_to referrer
     else
       render 'edit_prd'

--- a/app/forms/parole_review_date_form.rb
+++ b/app/forms/parole_review_date_form.rb
@@ -7,5 +7,7 @@ class ParoleReviewDateForm
 
   attribute :parole_review_date, :date
 
-  validates :parole_review_date, date: { after: proc { Date.yesterday }, allow_nil: true }
+  validates :parole_review_date,
+            date: { after: proc { Date.yesterday }, allow_blank: true },
+            presence: true
 end

--- a/app/views/case_information/edit_prd.html.erb
+++ b/app/views/case_information/edit_prd.html.erb
@@ -1,19 +1,29 @@
-<%= render :partial => "/shared/backlink", :locals => { :page => prison_prisoner_staff_index_path(@prison.code, @prisoner.offender_no) } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<h2 class="govuk-heading-m"><%= @prisoner.full_name %> - <%= @prisoner.offender_no %></h2>
+    <%= back_link %>
 
-<%= form_for(@parole_form,
-             url: update_prd_prison_case_information_path(@prison.code, @prisoner.offender_no),
-             method: :put,
-             builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-             id: "case_info_form") do |f| %>
-  <%= f.govuk_error_summary %>
+    <%= form_for(@parole_form,
+                 url: update_prd_prison_case_information_path(@prison.code, @prisoner.offender_no),
+                 method: :put,
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                 id: "case_info_form") do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <div class="govuk-form-group">
-    <!-- Change text in en.yml -->
-    <%= f.govuk_date_field :parole_review_date %>
+      <div class="govuk-form-group">
+        <%=
+          f.govuk_date_field :parole_review_date,
+                             legend: { text: "Enter a new parole review date (PRD) for #{ @prisoner.full_name_ordered } (#{ @prisoner.offender_no })", tag: 'h1', size: 'l' },
+                             hint: -> do %>
+          <p class="govuk-hint">You can find this on the outcome letter from the Parole Board or by asking a case admin to
+            look it up in the Public Protection Unit Database (PPUD).</p>
+          <p class="govuk-hint">For example, 4 6 2022.</p>
+        <% end %>
+      </div>
+
+      <%= submit_tag "Update", role: "button", draggable: "false", class: "govuk-button govuk govuk-!-margin-top-4" %>
+
+    <% end %>
+
   </div>
-
-  <%= submit_tag "Update", role: "button", draggable: "false", class: "govuk-button govuk govuk-!-margin-top-4" %>
-
-<% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,8 @@ en:
           format: "%{message}"
           attributes:
             parole_review_date:
-              after: "Parole review date must be after %{date}"
+              after: The new parole review date must be in the future
+              blank: Enter a new parole review date
         complexity_form:
           format: "%{message}"
           attributes:

--- a/spec/features/service_notification_feature_spec.rb
+++ b/spec/features/service_notification_feature_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
 feature 'Service Notification' do
-  let!(:prison) { create(:prison) }
+  let(:prison) { create(:prison) }
+  let(:user) { build(:pom) }
 
   before do
-    signin_spo_user([prison.code])
+    stub_signin_spo(user, [prison.code])
+    stub_offenders_for_prison(prison.code, [])
   end
 
-  it 'does not display service notification if none exist',
-     vcr: { cassette_name: 'prison_api/service_notifications_none_exist' } do
+  it 'does not display service notification if none exist' do
     allow(ServiceNotificationsService).to receive(:notifications).and_return([])
 
     visit root_path
@@ -31,15 +32,13 @@ feature 'Service Notification' do
       allow(ServiceNotificationsService).to receive(:notifications).and_return(messages)
     end
 
-    it 'does not display service notifications on static pages',
-       vcr: { cassette_name: 'prison_api/service_notifications_static_pages' } do
+    it 'does not display service notifications on static pages' do
       visit "/404"
 
       expect(page).not_to have_css('.service_banner')
     end
 
-    it 'displays service notifications on dynamic pages',
-       vcr: { cassette_name: 'prison_api/service_notifications_dynamic_pages' } do
+    it 'displays service notifications on dynamic pages' do
       visit root_path
 
       expect(page).to have_css('.service_banner')
@@ -47,8 +46,7 @@ feature 'Service Notification' do
     end
 
     context 'when user clicks on close button', js: true do
-      it 'permanently hides the notification',
-         vcr: { cassette_name: 'prison_api/service_notifications_close_button' } do
+      it 'permanently hides the notification' do
         visit root_path
 
         expect(page).to have_css('.service_banner')

--- a/spec/forms/parole_review_date_form_spec.rb
+++ b/spec/forms/parole_review_date_form_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ParoleReviewDateForm, type: :model do
+  describe 'validation rules' do
+    context 'when the date is missing' do
+      it { is_expected.to validate_presence_of(:parole_review_date).with_message('Enter a new parole review date') }
+    end
+
+    context 'when the date is in the past' do
+      subject { described_class.new(parole_review_date: 2.days.ago) }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:parole_review_date]).to eq ['The new parole review date must be in the future']
+      end
+    end
+
+    context 'when the date is today or in the future' do
+      let(:future_dates) {
+        [
+          Time.zone.today,
+          Time.zone.tomorrow,
+          Time.zone.today + 1.year
+        ]
+      }
+
+      it { is_expected.to allow_values(*future_dates).for(:parole_review_date) }
+    end
+  end
+end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -63,4 +63,28 @@ module FeaturesHelper
 
     new_tab.close
   end
+
+  # Helpers for key/value tables
+  # (e.g. those used on prisoner profile pages)
+  #
+  # For example, with a table like this:
+  #   | Offender number | A1234BC    |
+  #   | Tier            | B [Change] |
+  #
+  # You can update the tier using:
+  #   td_for_row('Tier').click_link('Change')
+  # Or expect it to have a link using:
+  #   expect(td_for_row('Tier')).to have_link('Change')
+  #
+  # You can get the offender number using:
+  #   value_for_row('Offender number')
+  # Or expect a value using:
+  #   expect(value_for_row('Offender number')).to eq('A1234BC')
+  def td_for_row(label)
+    page.find('td', text: label).sibling('td')
+  end
+
+  def value_for_row(row_label)
+    td_for_row(row_label).text
+  end
 end


### PR DESCRIPTION
Jira ticket: MO-811

---

This commit fixes a bug where users weren't able to update Parole Review Dates (PRDs) for offenders.

I took the opportunity to re-write the feature test for updating PRDs, since it needed some love: it didn't test the 'update' journey (so didn't cover this bug), and it was dependent on VCR (which we're trying to move away from in favour of stubbed API calls).

The new feature test covers a few journeys:

1. The PRD cannot be updated if the TED is in the future
2. A new PRD can be entered (first time entry)
3. An existing PRD can be updated

This behaviour is accessible to both HOMDs and POMs, so the feature test covers both types of user.

I've also introduced a couple of helper methods for feature tests – they make it easier to find and assert values in the key/value tables on prisoner profile pages.