### PR TITLE
MO-734 user is re-directed after completing allocation 

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -4,6 +4,8 @@ class AllocationStaffController < PrisonsApplicationController
   before_action :ensure_spo_user
   before_action :load_pom_types
   before_action :load_prisoner_via_prisoner_id
+  before_action :store_referrer_in_session, only: [:index]
+  before_action :set_referrer
 
   def index
     @case_info = Offender.find_by!(nomis_offender_id: prisoner_id_from_url).case_information

--- a/app/controllers/build_allocations_controller.rb
+++ b/app/controllers/build_allocations_controller.rb
@@ -3,6 +3,7 @@
 class BuildAllocationsController < PrisonsApplicationController
   before_action :ensure_spo_user
   before_action :load_prisoner
+  before_action :set_referrer
 
   include Wicked::Wizard
 
@@ -70,7 +71,7 @@ class BuildAllocationsController < PrisonsApplicationController
       flash[:notice] =
         "#{@prisoner.full_name_ordered} has been allocated to #{view_context.full_name_ordered(pom)} (#{view_context.grade(pom)})"
 
-      redirect_to unallocated_prison_prisoners_path(active_prison_id)
+      redirect_to @referrer
     end
   end
 

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -5,8 +5,9 @@ feature 'Allocation' do
   let!(:prison_officer_nomis_staff_id) { 485_926 }
   let!(:nomis_offender_id) { 'G7266VD' }
   let(:offender_name) { 'Omistius Annole' }
-  let!(:never_allocated_offender) { 'G9403UP' }
+  let!(:never_allocated_offender_id) { 'G9403UP' }
   let!(:unallocated_offender_name) { 'Albina, Obinins' }
+  let(:recently_allocated_offender_name) { 'Obinins Albina' }
 
   let!(:probation_officer_pom_detail) {
     PomDetail.create!(
@@ -19,55 +20,64 @@ feature 'Allocation' do
 
   let!(:case_information) {
     create(:case_information, offender: build(:offender, nomis_offender_id: nomis_offender_id), tier: 'A', case_allocation: 'NPS', probation_service: 'England')
-    create(:case_information, offender: build(:offender, nomis_offender_id: never_allocated_offender))
+    create(:case_information, offender: build(:offender, nomis_offender_id: never_allocated_offender_id))
   }
 
   before do
     signin_spo_user
   end
 
-  scenario 'accepting the recommended POM type', vcr: { cassette_name: 'prison_api/create_new_allocation_feature' } do
-    visit prison_prisoner_staff_index_path('LEI', nomis_offender_id)
+  context 'when a journey begins on the "Make new allocations" page' do
+    let(:start_page) { unallocated_prison_prisoners_path('LEI') }
 
-    expect(page).to have_content('Determinate')
-
-    # Allocate to the Probation POM called "Moic Integration-Tests"
-    within '#recommended_poms' do
-      within row_containing 'Moic Integration-Tests' do
-        click_link 'Allocate'
-      end
+    before do
+      visit start_page
+      click_link unallocated_offender_name
+      # Takes you to the Review case and allocate page where users review case details and scroll down to select from a list of POMs
+      expect(page).to have_current_path(prison_prisoner_staff_index_path('LEI', never_allocated_offender_id))
     end
 
-    expect(page).to have_css('h1', text: 'Confirm allocation')
-    expect(page).to have_css('p', text: "You are allocating #{offender_name} to Moic Integration-Tests")
+    scenario 'accepting the recommended POM type', vcr: { cassette_name: 'prison_api/create_new_allocation_feature' } do
+      expect(page).to have_content('Determinate')
 
-    click_button 'Complete allocation'
-
-    expect(current_url).to have_content(unallocated_prison_prisoners_path('LEI'))
-    expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Moic Integration-Tests (Probation POM)")
-  end
-
-  scenario 'overriding the recommended POM type', vcr: { cassette_name: 'prison_api/override_allocation_feature_ok' } do
-    visit prison_prisoner_staff_index_path('LEI', nomis_offender_id)
-    find('#non-recommended-accordion-section-heading').click
-
-    # Allocate to the Prison POM called "Moic Pom"
-    within '#non-recommended-accordion-section' do
-      within row_containing 'Moic Pom' do
-        click_link 'Allocate'
+      # Allocate to the Prison POM called "Moic Pom"
+      within '#recommended_poms' do
+        within row_containing 'Moic Pom' do
+          click_link 'Allocate'
+        end
       end
+
+      expect(page).to have_css('h1', text: 'Confirm allocation')
+
+      click_button 'Complete allocation'
+
+      expect(page).to have_current_path(start_page)
+      expect(page).to have_css('.notification', text: "#{recently_allocated_offender_name} has been allocated to Moic Pom (Prison POM)")
     end
 
-    expect(page).to have_css('h1', text: 'Why are you allocating a prison officer POM?')
+    scenario 'overriding the recommended POM type', vcr: { cassette_name: 'prison_api/override_allocation_feature_ok' } do
+      find('#non-recommended-accordion-section-heading').click
 
-    find('label[for=override-form-override-reasons-no-staff-field]').click
-    find('label[for=override-form-override-reasons-continuity-field]').click
+      # Allocate to the Probation POM called "Moic Integration-Tests"
+      within '#non-recommended-accordion-section' do
+        within row_containing 'Moic Integration-Tests' do
+          click_link 'Allocate'
+        end
+      end
 
-    click_button('Continue')
+      expect(page).to have_css('h1', text: 'Why are you allocating a probation officer POM?')
 
-    click_button 'Complete allocation'
-    expect(current_url).to have_content(unallocated_prison_prisoners_path('LEI'))
-    expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Moic Pom (Prison POM)")
+      find('label[for=override-form-override-reasons-no-staff-field]').click
+      find('label[for=override-form-override-reasons-continuity-field]').click
+
+      click_button('Continue')
+
+      click_button 'Complete allocation'
+      # Returns to the "Make new allocation" page
+
+      expect(current_url).to have_content(unallocated_prison_prisoners_path('LEI'))
+      expect(page).to have_css('.notification', text: "#{recently_allocated_offender_name} has been allocated to Moic Integration-Tests (Probation POM)")
+    end
   end
 
   scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: 'prison_api/override_allocation_feature_validate_reasons' } do
@@ -151,17 +161,21 @@ feature 'Allocation' do
       primary_pom_nomis_id: 485_735,
       recommended_pom_type: 'probation'
     )
-
+    # Goes to 'allocations' page
     visit allocated_prison_prisoners_path('LEI')
     within('.allocated_offender_row_0') do
       click_link 'View'
     end
+
+    # Takes you to the 'View a case' page (Allocation information)
     expect(current_url).to have_content(prison_prisoner_allocation_path('LEI', nomis_offender_id))
     expect(page).to have_link(nil, href: "/prisons/LEI/poms/485735")
     expect(page).to have_css('.table_cell__left_align', text: 'Jara Duncan, Laura')
     expect(page).to have_css('.table_cell__left_align', text: 'Responsible')
 
     click_link 'Reallocate'
+    # Takes you to the 'Review case and reallocate' page (‘Reallocate a POM)
+    expect(page).to have_current_path(prison_prisoner_staff_index_path(prison_id: 'LEI', prisoner_id: nomis_offender_id))
 
     expect(page).to have_css('.current_pom_full_name', text: 'Jara Duncan, Laura')
     expect(page).to have_css('.current_pom_grade', text: 'Probation POM')
@@ -174,12 +188,14 @@ feature 'Allocation' do
 
     click_button 'Complete allocation'
 
+    # Returns to the 'View a case' page (Allocation information)
+    expect(page).to have_current_path(prison_prisoner_allocation_path(prison_id: 'LEI', prisoner_id: nomis_offender_id), ignore_query: true)
     expect(AllocationHistory.find_by(nomis_offender_id: nomis_offender_id).event).to eq("reallocate_primary_pom")
   end
 
   context 'with a community override' do
     before do
-      create(:responsibility, nomis_offender_id: never_allocated_offender)
+      create(:responsibility, nomis_offender_id: never_allocated_offender_id)
     end
 
     scenario 'removing a community override', vcr: { cassette_name: 'prison_api/allocation_remove_community_override' } do
@@ -200,7 +216,7 @@ feature 'Allocation' do
       fill_in('responsibility[reason_text]', with: Faker::Lorem.sentence)
       click_button 'Confirm'
 
-      expect(page).to have_current_path(prison_prisoner_staff_index_path('LEI', never_allocated_offender), ignore_query: true)
+      expect(page).to have_current_path(prison_prisoner_staff_index_path('LEI', never_allocated_offender_id), ignore_query: true)
     end
   end
 end


### PR DESCRIPTION
<img width="1254" alt="Screenshot 2021-08-11 at 13 28 47" src="https://user-images.githubusercontent.com/12900007/129028662-f6f1a8b5-91d4-4559-b63b-0b4e25b2d0dc.png">

1. This has already been fixed else where it seems. 
2. This has been revised and now redirects the user to ‘3.2 View a case’, and not ‘1.8 See allocations list’ after they have allocated a previously unallocated offender. Previously it redirected to the 'make new allocations' list - which was a bug. 

As part of the journey, the user will click the 'Complete allocations' button once the allocation has been made. This redirect happens inside the 'update' action in the BuildAllocationsController. This button is shared by 2 journeys. One where a user wants to allocate for the first time and one where a user wants to reallocate. Previously it was hardcoded to always return to the unallocated list used by the former, which is why the bug existed. 

There for a @refferer has been used to send the user back to the relevant page however I found it quite tricky as the journey goes through several controllers: PrisonersController, AllocationStaffController and BuildAllocationsController. I had to put the store_referrer_in_session in the AllocationsStaffController to capture any visited pages prior to the index but it still kept on displaying a page within the BuildAllocatonsController.  I ended up putting an 'except:[:override] inside the AllocationsStaffController, which felt a bit strange as override is not part of that controller. But it worked. However rubocop errored and told me that I had to put an empty `override' action inside AllocationsStaffController for it to be valid. 

I had to fix a few broken tests - which I am still confused by. 

**The two tests that confused me were:**
1. scenario 'accepting the recommended POM type'
2. scenario 'overriding the recommended POM type

This could be because of my gaps in domain knowledge. But when I got visibility over them it looked like they were doing the opposite of what the set out to do. Test 1. was displaying the override POMs, and so `Moic Integration-Tests` was not available in the list and Test 2. was displaying the recommended POMs, so `Moic Pom' was not available. 

So I have edited them. But I am not confident I fully understand them. 
