### PR TITLE
Make a feature test more resilient to change

### DIFF
--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -26,14 +26,14 @@ feature 'Allocation' do
     signin_spo_user
   end
 
-  scenario 'accepting a recommended allocation', vcr: { cassette_name: 'prison_api/create_new_allocation_feature' } do
+  scenario 'accepting the recommended POM type', vcr: { cassette_name: 'prison_api/create_new_allocation_feature' } do
     visit prison_prisoner_staff_index_path('LEI', nomis_offender_id)
 
     expect(page).to have_content('Determinate')
 
+    # Allocate to the Probation POM called "Moic Integration-Tests"
     within '#recommended_poms' do
-      # Allocate to the POM called "Moic Integration-Tests"
-      within page.find(:css, 'tr', text: 'Moic Integration-Tests') do
+      within row_containing 'Moic Integration-Tests' do
         click_link 'Allocate'
       end
     end
@@ -47,13 +47,13 @@ feature 'Allocation' do
     expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Moic Integration-Tests (Probation POM)")
   end
 
-  scenario 'overriding an allocation', vcr: { cassette_name: 'prison_api/override_allocation_feature_ok' } do
+  scenario 'overriding the recommended POM type', vcr: { cassette_name: 'prison_api/override_allocation_feature_ok' } do
     visit prison_prisoner_staff_index_path('LEI', nomis_offender_id)
     find('#non-recommended-accordion-section-heading').click
 
-    # Amit is 6th on the non-recommended list
+    # Allocate to the Prison POM called "Moic Pom"
     within '#non-recommended-accordion-section' do
-      within 'tbody > tr:nth-child(6)' do
+      within row_containing 'Moic Pom' do
         click_link 'Allocate'
       end
     end
@@ -67,7 +67,7 @@ feature 'Allocation' do
 
     click_button 'Complete allocation'
     expect(current_url).to have_content(unallocated_prison_prisoners_path('LEI'))
-    expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Amit Muthu (Prison POM)")
+    expect(page).to have_css('.notification', text: "#{offender_name} has been allocated to Moic Pom (Prison POM)")
   end
 
   scenario 'overriding an allocation can validate missing reasons', vcr: { cassette_name: 'prison_api/override_allocation_feature_validate_reasons' } do
@@ -92,7 +92,6 @@ feature 'Allocation' do
 
     find('#non-recommended-accordion-section-heading').click
 
-    # Amit is 6th on the non-recommended list
     within '#non-recommended-accordion-section' do
       within 'tbody > tr:nth-child(1)' do
         click_link 'Allocate'

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -84,6 +84,7 @@ feature 'case information feature' do
     it "clicking back link after viewing prisoner's case information, returns back the same paginated page",
        vcr: { cassette_name: 'prison_api/case_information_back_link' }, js: true do
       visit missing_information_prison_prisoners_path('LEI', page: 3)
+      expect(current_page_number).to eq(3)
       within ".govuk-table tr:first-child td:nth-child(3)" do
         click_link 'Add missing details'
       end
@@ -91,6 +92,7 @@ feature 'case information feature' do
       click_link 'Back'
       find('#awaiting-information')
       expect(page).to have_selector('h1', text: 'Add missing details')
+      expect(current_page_number).to eq(3)
     end
 
     it 'complains if allocation data is missing', vcr: { cassette_name: 'prison_api/case_information_missing_case_feature' } do
@@ -137,6 +139,7 @@ feature 'case information feature' do
     it 'returns to previously paginated page after saving',
        vcr: { cassette_name: 'prison_api/case_information_return_to_previously_paginated_page' } do
       visit missing_information_prison_prisoners_path('LEI', sort: "last_name desc", page: 3)
+      expect(current_page_number).to eq(3)
 
       within ".govuk-table tr:first-child td:nth-child(3)" do
         click_link 'Add missing details'
@@ -149,6 +152,7 @@ feature 'case information feature' do
       click_button 'Save'
 
       expect(current_url).to have_content(missing_information_prison_prisoners_path('LEI') + "?page=3&sort=last_name+desc")
+      expect(current_page_number).to eq(3)
     end
 
     it 'does not show update link on view only case info',

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -87,4 +87,17 @@ module FeaturesHelper
   def value_for_row(row_label)
     td_for_row(row_label).text
   end
+
+  # Get the <tr> containing the specified text
+  # Useful when used with "within" to scope subsequent actions:
+  #   within row_containing 'Name of a POM' do
+  #     click_link 'Allocate'
+  #   end
+  def row_containing(text)
+    page.find('tr', text: text)
+  end
+
+  def current_page_number
+    page.find('.pagination .current.page', match: :first).text.to_i
+  end
 end


### PR DESCRIPTION
The feature test `spec/features/show_poms_feature_spec.rb` runs against data held in NOMIS dev (T3). It was previously quite brittle due to expecting the POM "Moic Pom" to appear 8th in the list of POMs. It's inevitable that this will change as team members come and go, and the list of available POMs changes accordingly.

To make the test more resilient to such external change, I've introduced a new helper method `row_containing`. Now rather than expecting the "Moic Pom" to always be in 8th position in the table, we can simply find the table row which contains that POM's name.