### PR TITLE
MO-826: Deallocate offenders upon release from prison

### DIFF
--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -143,7 +143,12 @@ private
 
   def deallocate_offender event:, event_trigger:
     primary_pom = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(primary_pom_nomis_id)
-    offender = OffenderService.get_offender(nomis_offender_id)
+
+    # If the offender has been released from prison, OffenderService.get_offender will return nil (due to "OUT" being an unrecognised Prison)
+    # So instead we'll call the Prison API directly to get just the Prison record of the offender. We don't need a full MpcOffender object.
+    # We only need the offender's name, so this is enough for us.
+    offender = HmppsApi::PrisonApi::OffenderApi.get_offender(nomis_offender_id)
+
     mail_params = {
         email: primary_pom.email_address,
         pom_name: primary_pom.first_name.titleize,

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -1,38 +1,76 @@
 require 'rails_helper'
 
 RSpec.describe MovementsOnDateJob, type: :job do
-  let!(:prison) { create(:prison, code: 'MDI') }
-  let(:nomis_offender_id) { 'G3462VT' }
-  let!(:alloc) { create(:allocation_history, nomis_offender_id: nomis_offender_id, secondary_pom_nomis_id: 123_435, prison: 'MDI') }
+  let(:nomis_offender_id) { nomis_offender.fetch(:offenderNo) }
+  let(:nomis_offender) { build(:nomis_offender, agencyId: to_prison_code) }
+  let(:case_info) { create(:case_information) }
+  let!(:offender_record) { create(:offender, nomis_offender_id: nomis_offender_id, case_information: case_info) }
+  let(:today) { Time.zone.today }
+  let(:yesterday) { today - 1.day }
+  let(:pom) { build(:pom) }
+  let!(:allocation) { create(:allocation_history, nomis_offender_id: nomis_offender_id, primary_pom_nomis_id: pom.staff_id, prison: from_prison_code) }
+  let(:mail_params) {
+    {
+      email: pom.email_address,
+      pom_name: pom.first_name.titleize,
+      offender_name: "#{nomis_offender.fetch(:lastName)}, #{nomis_offender.fetch(:firstName)}".titleize,
+      nomis_offender_id: nomis_offender_id,
+      prison_name: Prison.find(from_prison_code).name,
+      url: "http://localhost:3000/prisons/#{from_prison_code}/staff/#{pom.staff_id}/caseload"
+    }
+  }
 
   before do
-    stub_auth_token
+    stub_offender(nomis_offender)
+    stub_poms(from_prison_code, [pom])
+
+    # Stub offender movements from yesterday
+    stub_request(:get, "#{ApiHelper::T3}/movements?fromDateTime=#{yesterday - 1.year}T00:00&movementDate=#{yesterday}").
+      to_return(body: [movement].to_json)
+
+    # Expect POM to be emailed about the deallocation
+    expect(PomMailer).to receive(:offender_deallocated).with(mail_params).and_return(double(deliver_later: nil))
   end
 
-  it 'deallocates' do
-    allow(OffenderService).to receive(:get_offender).and_return(build(:hmpps_api_offender))
+  context 'when the offender has been released from prison' do
+    let(:from_prison_code) { create(:prison).code }
+    let(:to_prison_code) { 'OUT' } # "OUT" is the prison code NOMIS uses to mean "not in prison"
 
-    stub_request(:get, "#{ApiHelper::T3}/movements?fromDateTime=2018-06-30T00:00&movementDate=2019-06-30").
-      to_return(body: [attributes_for(:movement,
-                                      offenderNo: nomis_offender_id,
-         fromAgency: "MDI",
-         toAgency: "WEI",
-         movementType: "ADM",
-         directionCode: "IN")].to_json)
+    let(:movement) {
+      attributes_for(:movement,
+                     offenderNo: nomis_offender_id,
+                     movementType: 'REL',
+                     directionCode: 'OUT',
+                     fromAgency: from_prison_code,
+                     toAgency: to_prison_code)
+    }
 
-    pom = build(:pom, staffId: 485926)
-    stub_poms('MDI', [pom])
-    stub_pom pom
-    stub_offenders_for_prison('MDI', [])
+    it 'deallocates and emails the POM' do
+      expect(allocation).to be_active
+      described_class.perform_now(today.to_s)
+      allocation.reload
+      expect(allocation).not_to be_active
+    end
+  end
 
-    expect(alloc.primary_pom_nomis_id).not_to be_nil
-    expect(alloc.secondary_pom_nomis_id).not_to be_nil
+  context 'when the offender has transferred to a different prison' do
+    let(:from_prison_code) { create(:prison).code }
+    let(:to_prison_code) { create(:prison).code }
 
-    described_class.perform_now(Date.new(2019, 7, 1).to_s)
+    let(:movement) {
+      attributes_for(:movement,
+                     offenderNo: nomis_offender_id,
+                     movementType: 'ADM',
+                     directionCode: 'IN',
+                     fromAgency: from_prison_code,
+                     toAgency: to_prison_code)
+    }
 
-    alloc.reload
-
-    expect(alloc.primary_pom_nomis_id).to be_nil
-    expect(alloc.secondary_pom_nomis_id).to be_nil
+    it 'deallocates and emails the POM' do
+      expect(allocation).to be_active
+      described_class.perform_now(today.to_s)
+      allocation.reload
+      expect(allocation).not_to be_active
+    end
   end
 end


### PR DESCRIPTION
Jira ticket: MO-826

This PR fixes a bug which has become apparent due to offenders not having been automatically deallocated upon release from prison.

### Background

We process offender movements overnight – and if we see that an offender has been released from prison, we automatically deallocate their POM. However due to recent changes in the behaviour of the `OffenderService.get_offender` method, it meant that we could no longer process offenders who aren't in a recognised Prison.

### Old behaviour

Prior to PR #1767, the offender service would happily return a `HmppsApi::Offender` object even if the offender's prison code wasn't recognised within our local list of prisons.

And since in this case we only need the offender's name, we could still call `offender.full_name` without any problems.

### New behaviour

After #1767, the offender service no longer returns a `HmppsApi::Offender` object. Instead, it returns an `MpcOffender` wrapper object which contains a `HmppsApi::Offender`, but also a `Prison` and other records. This new & improved wrapper data model gives us a very clear way to combine offender data from different sources, while still recognising that they come from separate places.

But the knock-on effect of that is: an `MpcOffender` object cannot be returned from the offender service unless they're in a recognised `Prison` (i.e. one which we have a record for in our local database).

Instead, we want this piece of code to continue using a `HmppsApi::Offender` object, since all we need is the offender's name. We don't care which prison they're in, nor do we care about anything else on the offender object – we only need their name.