### PR TITLE
MO-843: default to NPS if resourcing not assessed

### DIFF
--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -73,19 +73,20 @@ class OffenderService
                               .select { |r|
                                 r.fetch(:active) && r.key?(:registerLevel) && r.dig(:registerLevel, :code).starts_with?('M')
                               }
-      resourcing = begin
-                   HmppsApi::CommunityApi.get_latest_resourcing(nomis_offender_id).deep_symbolize_keys
-                   rescue Faraday::ResourceNotFound
-                     { enhancedResourcing: true } # assume NPS when not found
-                 end
+
+      is_nps = begin
+                 HmppsApi::CommunityApi.get_latest_resourcing(nomis_offender_id)
+                                       .fetch('enhancedResourcing')
+               rescue Faraday::ResourceNotFound, KeyError
+                 true # default to NPS if 404 Not Found or no enhancedResourcing field present in the response
+               end
 
       com = community_info.fetch(:offenderManagers).detect { |om| om.fetch(:active) }
       {
           noms_no: nomis_offender_id,
           tier: community_info.fetch(:currentTier),
           crn: community_info.dig(:otherIds, :crn),
-
-          service_provider: resourcing.fetch(:enhancedResourcing) ? 'NPS' : 'CRC',
+          service_provider: is_nps ? 'NPS' : 'CRC',
           offender_manager: com.dig(:staff, :unallocated) ? nil : "#{com.dig(:staff, :surname)}, #{com.dig(:staff, :forenames)}",
           team_name: com.dig(:team, :description),
           ldu_code: com.dig(:team, :localDeliveryUnit, :code),

--- a/spec/factories/community_data.rb
+++ b/spec/factories/community_data.rb
@@ -10,8 +10,6 @@ FactoryBot.define do
 
     offenderManagers { [ build(:community_offender_manager) ] }
 
-    enhancedResourcing { true }
-
     trait :crc do
       enhancedResourcing { false }
     end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -222,7 +222,7 @@ module ApiHelper
     stub_request(:get, "#{COMMUNITY_HOST}/offenders/nomsNumber/#{nomis_offender_id}/registrations").
         to_return(body: { registrations: registrations }.to_json)
     stub_request(:get, "#{COMMUNITY_HOST}/offenders/nomsNumber/#{nomis_offender_id}/risk/resourcing/latest").
-        to_return(body: { enhancedResourcing: community_data.fetch(:enhancedResourcing) }.to_json)
+        to_return(body: community_data.slice(:enhancedResourcing).to_json)
   end
 
   def stub_resourcing_404 nomis_offender_id


### PR DESCRIPTION
Jira ticket: MO-843

This commit changes the behaviour of `OffenderService.get_community_data` to gracefully handle resourcing responses from the Community API which are missing the `enhancedResourcing` field.

If the `enhancedResourcing` field is missing, we handle it the same as if we received a 404 Not Found response – i.e. we default the service provider to NPS.

Only if the `enhancedResourcing` field is present and `false` will we designate an offender as being under CRC rules.