### PR TITLE
MO-844 Fix bug

### DIFF
--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -27,8 +27,6 @@ FactoryBot.define do
 
     trait :welsh_policy_sentence do
       sentenceStartDate { '2019-02-05' }
-      conditionalReleaseDate { "2022-01-28" }
-      automaticReleaseDate { "2022-01-28" }
     end
 
     trait :welsh_open_policy do


### PR DESCRIPTION
This PR removes a hardcoded sentence date (part of the `sentence_details` factory) that results in a static handover date causing the test `spec/services/handover_date_service_responsibility_spec.rb:30` to fail, as it expects the POM to be responsible.