### PR TITLE
Use `jq` instead of `yq` in database sync script

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,11 +9,14 @@
 # required by Rails Active Record
 brew 'postgres'
 
-# required by gem 'undercover'
+# required to install gem 'undercover'
 brew 'cmake'
 
-# required by Capybara to drive tests in Firefox
+# required by Capybara to drive feature tests in Firefox
 brew 'geckodriver'
 
 # required by gem 'mimemagic' v0.3.9
 brew 'shared-mime-info'
+
+# required by bin/copy-prod-db-to-preprod.sh
+brew 'jq'


### PR DESCRIPTION
The script `bin/copy-prod-db-to-preprod.sh` originally used a package called `yq` to parse data from `kubectl` which was output in YAML format.

However, there were breaking changes between `yq@3` and `yq@4` which meant that this script wouldn't run if you'd installed the latest version of `yq`.

Rather than upgrade the script to work with the latest version of `yq`, it made sense to switch over to `jq` which is significantly more popular tool in the world of devops. It also seems to have a more long-lived and stable API, meaning it's less likely to have breaking changes any time soon.