### PR TITLE
Allow Google Tag Manager to track error pages

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -6,3 +6,8 @@
     we're working hard to get things up and running again.
   </div>
 </div>
+
+<script>
+  // Make error details available to Google Tag Manager
+  dataLayer.push({ "event": "error_page", "error_page_type": "500 Internal Server Error" });
+</script>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -7,3 +7,8 @@
     <p>You can go <a href="/">back to the dashboard</a></p>
   </div>
 </div>
+
+<script>
+  // Make error details available to Google Tag Manager
+  dataLayer.push({ "event": "error_page", "error_page_type": "404 Not Found" });
+</script>

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -40,3 +40,8 @@
     </div>
   </div>
 </div>
+
+<script>
+  // Make error details available to Google Tag Manager
+  dataLayer.push({ "event": "error_page", "error_page_type": "401 Unauthorized" });
+</script>


### PR DESCRIPTION
This commit adds a JavaScript snippet to each of the error page views which pushes details of the error to into the `dataLayer` object – which is used by Google Analytics to receive custom events from the page.

This makes it possible to begin tracking when and how often these pages are displayed to end users.