### PR TITLE
MO-615_remove unused feature flags for Early_Allocation

### DIFF
--- a/app/views/prisoners/_prisoner_information.html.erb
+++ b/app/views/prisoners/_prisoner_information.html.erb
@@ -24,7 +24,7 @@
         <span class="handover-reason">(<%= probation_field(@prisoner, :handover_reason) %>)</span>
       </td>
     </tr>
-    <% if Flipflop.early_allocation? && @prisoner.probation_record.present? && @prisoner.nps_case? %>
+    <% if @prisoner.probation_record.present? && @prisoner.nps_case? %>
     <tr id="early_allocation" class="govuk-table__row">
       <td class="govuk-table__cell">Early allocation referral</td>
       <td class="govuk-table__cell table_cell__left_align">

--- a/config/features.rb
+++ b/config/features.rb
@@ -5,7 +5,4 @@ Flipflop.configure do
   feature :auto_delius_import,
           default: false,
           description: 'Load case information via nDelius, disable manual editing'
-  feature :early_allocation,
-          default: true,
-          description: 'Early Allocation to probation team'
 end

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -36,25 +36,6 @@ feature "early allocation", :disable_early_allocation_event, type: :feature do
     expect(page).to have_content("Showing 1 - 1 of 1 results")
   end
 
-  context 'with switch set false' do
-    let(:test_strategy) { Flipflop::FeatureSet.current.test! }
-    let(:release_date) { Time.zone.today }
-
-    before do
-      test_strategy.switch!(:early_allocation, false)
-    end
-
-    after do
-      test_strategy.switch!(:early_allocation, true)
-    end
-
-    it 'does not show the section' do
-      click_link offender_name
-      expect(page).not_to have_content 'Early allocation eligibility'
-    end
-  end
-
-  # switch is on by default
   context 'with switch' do
     context 'when CRC' do
       let(:case_alloc) { CaseInformation::CRC }


### PR DESCRIPTION
This PR removes any unused feature flags from early allocation.