### PR TITLE
MO-454 This displays the date of the last OASys report

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -18,6 +18,7 @@ class AllocationStaffController < PrisonsApplicationController
     poms = @prison.get_list_of_poms.index_by(&:staff_id)
     @previous_poms = previous_pom_ids.map { |staff_id| poms[staff_id] }.compact
     @current_pom = poms[@allocation.primary_pom_nomis_id] if @allocation&.primary_pom_nomis_id
+    @oasys_assessment = HmppsApi::AssessmentApi.get_latest_oasys_date(@prisoner.offender_no)
   end
 
 private

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -7,6 +7,7 @@ class AllocationsController < PrisonsApplicationController
   def show
     allocation = AllocationHistory.find_by!(nomis_offender_id: @prisoner.offender_no)
     @allocation = CaseHistory.new(allocation.get_old_versions.last, allocation, allocation.versions.last)
+    @oasys_assessment = HmppsApi::AssessmentApi.get_latest_oasys_date(@prisoner.offender_no)
 
     @pom = StaffMember.new(@prison, @allocation.primary_pom_nomis_id)
     redirect_to prison_pom_non_pom_path(@prison.code, @pom.staff_id) unless @pom.has_pom_role?

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -38,6 +38,7 @@ class PrisonersController < PrisonsApplicationController
 
     @tasks = PomTasks.new.for_offender(@prisoner)
     @allocation = AllocationHistory.find_by(nomis_offender_id: @prisoner.offender_no)
+    @oasys_assessment = HmppsApi::AssessmentApi.get_latest_oasys_date(@prisoner.offender_no)
 
     if @allocation.present?
       @primary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.primary_pom_nomis_id).

--- a/app/views/allocations/_case_information.html.erb
+++ b/app/views/allocations/_case_information.html.erb
@@ -21,6 +21,12 @@
       <%= pom_responsibility_label(@prisoner) %>
     </td>
   </tr>
+  <tr id="oasys-date" class="govuk-table__row">
+    <td class="govuk-table__cell">Last OASys completed</td>
+    <td class="govuk-table__cell table_cell__left_align">
+      <%= format_date(@oasys_assessment, replacement: 'This prisoner has not had an OASys assessment.') %>
+    </td>
+  </tr>
   <tr class="govuk-table__row" id="handover-start-date-row">
     <td class="govuk-table__cell govuk-!-width-one-half">Handover start date</td>
     <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -63,6 +63,12 @@
         <%= service_provider_label(@prisoner.case_allocation) %>
       </td>
     </tr>
+    <tr id="oasys-date" class="govuk-table__row">
+      <td class="govuk-table__cell">Last OASys completed</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= format_date(@oasys_assessment, replacement: 'This prisoner has not had an OASys assessment.') %>
+      </td>
+    </tr>
     </tbody>
   </table>
 

--- a/app/views/prisoners/_prisoner_information.html.erb
+++ b/app/views/prisoners/_prisoner_information.html.erb
@@ -55,5 +55,11 @@
         <%= prisoner_location(@prisoner) %>
       </td>
     </tr>
+    <tr id="oasys-date" class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Last OASys completed</td>
+      <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
+        <%= format_date(@oasys_assessment, replacement: 'This prisoner has not had an OASys assessment') %>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/deploy/preprod/shared-environment.yaml
+++ b/deploy/preprod/shared-environment.yaml
@@ -17,3 +17,5 @@ data:
   ZENDESK_USERNAME: "moic+zendesk@digital.justice.gov.uk"
   ZENDESK_URL: "https://ministryofjustice.zendesk.com/api/v2"
   LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+  ASSESSMENT_API_HOST: "https://offender-prprod.aks-live-1.studio-hosting.service.justice.gov.uk"
+

--- a/deploy/production/shared-environment.yaml
+++ b/deploy/production/shared-environment.yaml
@@ -17,5 +17,6 @@ data:
   ZENDESK_USERNAME: "moic+zendesk@digital.justice.gov.uk"
   ZENDESK_URL: "https://ministryofjustice.zendesk.com/api/v2"
   LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+  ASSESSMENT_API_HOST: "https://offender-prod.aks-live-1.studio-hosting.service.justice.gov.uk"
 
 

--- a/deploy/staging/shared-environment.yaml
+++ b/deploy/staging/shared-environment.yaml
@@ -17,4 +17,5 @@ data:
   ZENDESK_USERNAME: "moic+zendesk@digital.justice.gov.uk"
   ZENDESK_URL: "https://ministryofjustice.zendesk.com/api/v2"
   LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+  ASSESSMENT_API_HOST: "https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,6 +99,11 @@ RSpec.configure do |config|
   # in VCR mode, allow HTTP connections to T3, but then
   # reset back to default afterwards
   config.around(:each, :vcr) do |example|
+    # Stub out the Assessments API because it's IP restricted
+    api_host = Rails.configuration.assessment_api_host
+    WebMock.stub_request(:get, ->(uri) { uri.to_s.start_with?(api_host) }).
+      to_return(status: 200, body: [].to_json)
+
     # VCR tests expect Leeds (HMP) prison to exist
     unless Prison.where(code: 'LEI').exists?
       create(:prison, code:'LEI')

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -56,6 +56,8 @@ module ApiHelper
 
     stub_request(:get, "#{Rails.configuration.complexity_api_host}/v1/complexity-of-need/offender-no/#{offender_no}").
       to_return(body: { level: offender.fetch(:complexityLevel) }.to_json)
+
+    stub_oasys_assessments(offender_no)
   end
 
   def stub_movements(movements = [])
@@ -176,6 +178,11 @@ module ApiHelper
     )
 
     offenders.each { |o| stub_offender(o) }
+  end
+
+  def stub_oasys_assessments(offender_no)
+    stub_request(:get, "#{ASSESSMENT_API_HOST}/offenders/nomisId/#{offender_no}/assessments/summary?assessmentStatus=COMPLETE&assessmentType=LAYER_3").
+    to_return(body: [].to_json)
   end
 
   def stub_multiple_offenders(offenders, bookings)


### PR DESCRIPTION
This PR displays the the date of the last completed OASys report on all the various prisoner profile pages. 

It does feel like I have created a lot of duplication! 

I added in the final expectation on each test, which uses match to look for a chunk of html as opposed to discrete dates or lines of content because initially I was testing 'N/A', which was already present in numerous places, and therefore passed before I had implemented the code, therefore I felt I needed something a bit more robust to test it properly. But now I have replaced N/A with more specific content perhaps I don't need it??