### PR TITLE
refs #MO-876

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "10"
+        "version": "11"
       }
     },
     "heroku-redis"

--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -34,5 +34,6 @@ private
 
   def load_prisoner_via_prisoner_id
     @prisoner = OffenderService.get_offender(prisoner_id_from_url)
+    redirect_to('/404') if @prisoner.nil?
   end
 end

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -8,7 +8,10 @@ class CaseInformationController < PrisonsApplicationController
   before_action :store_referrer_in_session, only: [:edit_prd, :edit]
 
   def new
-    @case_info = Offender.find_by!(nomis_offender_id: nomis_offender_id_from_url).build_case_information
+    offender = Offender.find_by(nomis_offender_id: nomis_offender_id_from_url)
+    return redirect_to('/404') if offender.nil?
+
+    @case_info = offender.build_case_information
   end
 
   def edit; end

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -34,6 +34,8 @@ class PrisonersController < PrisonsApplicationController
   def show
     @prisoner = OffenderService.get_offender(params[:id])
 
+    return redirect_to '/404' if @prisoner.nil?
+
     return render 'show_outside_omic_policy' unless @prisoner.inside_omic_policy?
 
     @tasks = PomTasks.new.for_offender(@prisoner)

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -5,7 +5,7 @@
     <p>If you used a bookmark or a saved web address, this may need updating.</p>
     <p>If you pasted the web address, check you copied the entire address.</p>
     <p>If you typed the web address, check it is correct.</p>
-    <p><a href="/">Go to the service's dashboard</a></p>
+    <p><a href="/">Go to the allocation service's dashboard</a></p>
   </div>
 </div>
 

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -2,9 +2,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-body-l">
-    <p>If you entered a web address please check it was correct.</p>
-
-    <p>You can go <a href="/">back to the dashboard</a></p>
+    <p>If you used a bookmark or a saved web address, this may need updating.</p>
+    <p>If you pasted the web address, check you copied the entire address.</p>
+    <p>If you typed the web address, check it is correct.</p>
+    <p><a href="/">Go to the service's dashboard</a></p>
   </div>
 </div>
 

--- a/app/views/pages/help_step1.html.erb
+++ b/app/views/pages/help_step1.html.erb
@@ -23,10 +23,6 @@
 
     <p><%=image_tag("spreadsheet_image.png") %></p>
 
-    <h2>Send the information to the allocations team</h2>
-
-    <p>Send the names, roles and email addresses to: <%= mail_to("moic@digital.justice.gov.uk")%></p>
-
     <h2>Share the information with the Local System Administrator (LSA)</h2>
 
     <p>You need to send the same list of names, roles and, (for POMs only),

--- a/app/views/pages/help_step2.html.erb
+++ b/app/views/pages/help_step2.html.erb
@@ -40,10 +40,8 @@
         <div><%=image_tag("help_step2/user_roles.png", width: 552, height: 396) %></div><br>
       </li>
       <li>
-        <div>Select the relevant checkboxes before clicking confirm.</div><br>
-        <div><%=image_tag("help_step2/select_roles.png", width: 328, height: 625) %></div><br>
-        <p>HOMDs and Case Admins need to have the ‘Allocation manager’ role added.</p>
-        <p>Prison Offender Managers need to have the ‘Allocation case manager’ role added.</p>
+        <div>Select the Allocations – POM role for POMs. HOMDs and case admins need the Allocations – HOMD role. Choose confirm.
+        </div><br>
       </li>
     </ul>
 

--- a/app/views/pages/help_step3.html.erb
+++ b/app/views/pages/help_step3.html.erb
@@ -18,8 +18,9 @@
 
     <h2>a) Make sure POMs have the right ‘roles’ assigned in NOMIS</h2>
 
-    <p>All POMs need to have a new staff role added in NOMIS.</p>
-    <p>This will add them to the list of POMs in the new service.</p>
+    <p>All POMs need to have a new staff role added in NOMIS. This will add them to the list of POMs in the service.</p>
+
+    <p>It can take about an hour for POMs to appear in the service after they have been added to NOMIS.</p>
 
     <p><%=image_tag("caseload2_image.png") %></p>
 

--- a/spec/features/help_feature_spec.rb
+++ b/spec/features/help_feature_spec.rb
@@ -82,7 +82,6 @@ feature 'Help' do
       expect(page).to have_css('.govuk-inset-text', text: inset_text[:SPO_HoOMU])
       expect(page).to have_link('spreadsheet template')
       expect(page).to have_xpath("//img[contains(@src,'assets/spreadsheet_image')]")
-      expect(page).to have_link('moic@digital.justice.gov.uk')
       expect(page).to have_link('Task 2: Set up access in Digital Prison Services', href: 'help_step2')
     end
 


### PR DESCRIPTION
Catch incorrect offender Id values and navigate to 404 page, rather than cause an unhandled exception to display the 500 error page.