### PR TITLE
Mo 809 restricted patient movement changes

### DIFF
--- a/app/services/hmpps_api/prison_api/agencies_api.rb
+++ b/app/services/hmpps_api/prison_api/agencies_api.rb
@@ -2,18 +2,17 @@ module HmppsApi
   module PrisonApi
     class AgenciesApi
       extend PrisonApiClient
+      BASE_PATH = '/agencies/type'.freeze
       HOSPITAL_AGENCY_TYPE = 'HSHOSP'.freeze
       def self.agencies_by_type(type)
-        route = "/agencies/type/#{type}"
-        data = client.get(route, cache: true)
+        data = client.get("#{BASE_PATH}/#{type}", cache: true)
         data.map { |agency|
-          { agency_type: agency['agencyId'], description: agency['description'], active: (!!agency['active']) }
+          { agency_type: agency['agencyId'], description: agency['description'], active: agency['active'] }
         }
       end
 
       def self.agency_ids_by_type(type)
-        route = "/agencies/type/#{type}"
-        data = client.get(route, cache: true)
+        data = client.get("#{BASE_PATH}/#{type}", cache: true)
         data.map { |agency| agency['agencyId'] }
       end
     end

--- a/app/services/hmpps_api/prison_api/agencies_api.rb
+++ b/app/services/hmpps_api/prison_api/agencies_api.rb
@@ -1,0 +1,21 @@
+module HmppsApi
+  module PrisonApi
+    class AgenciesApi
+      extend PrisonApiClient
+      HOSPITAL_AGENCY_TYPE = 'HSHOSP'.freeze
+      def self.agencies_by_type(type)
+        route = "/agencies/type/#{type}"
+        data = client.get(route)
+        data.map { |agency|
+          { agency_type: agency['agencyId'], description: agency['description'], active: (!!agency['active']) }
+        }
+      end
+
+      def self.agency_ids_by_type(type)
+        route = "/agencies/type/#{type}"
+        data = client.get(route)
+        data.map { |agency| agency['agencyId'] }
+      end
+    end
+  end
+end

--- a/app/services/hmpps_api/prison_api/agencies_api.rb
+++ b/app/services/hmpps_api/prison_api/agencies_api.rb
@@ -5,7 +5,7 @@ module HmppsApi
       HOSPITAL_AGENCY_TYPE = 'HSHOSP'.freeze
       def self.agencies_by_type(type)
         route = "/agencies/type/#{type}"
-        data = client.get(route)
+        data = client.get(route, cache: true)
         data.map { |agency|
           { agency_type: agency['agencyId'], description: agency['description'], active: (!!agency['active']) }
         }
@@ -13,7 +13,7 @@ module HmppsApi
 
       def self.agency_ids_by_type(type)
         route = "/agencies/type/#{type}"
-        data = client.get(route)
+        data = client.get(route, cache: true)
         data.map { |agency| agency['agencyId'] }
       end
     end

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -94,7 +94,11 @@ private
       return true
     end
 
-    return false unless release.from_prison?
+    hospital_agencies = HmppsApi::PrisonApi::AgenciesApi.agency_ids_by_type(
+      HmppsApi::PrisonApi::AgenciesApi::HOSPITAL_AGENCY_TYPE
+    )
+
+    return false unless release.from_prison? || hospital_agencies.include?(release.from_agency)
 
     release_offender(release.offender_no)
     true

--- a/spec/features/case_history_spec.rb
+++ b/spec/features/case_history_spec.rb
@@ -92,6 +92,8 @@ feature 'Case History' do
 
       stub_pom build(:pom, staffId: prison_pom.fetch(:primary_pom_nomis_id))
       stub_pom_emails(prison_pom.fetch(:primary_pom_nomis_id), [prison_pom.fetch(:email)])
+
+      stub_agencies(HmppsApi::PrisonApi::AgenciesApi::HOSPITAL_AGENCY_TYPE)
     }
 
     context 'when on the allocation history page' do

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe MovementsOnDateJob, type: :job do
 
     # Expect POM to be emailed about the deallocation
     expect(PomMailer).to receive(:offender_deallocated).with(mail_params).and_return(double(deliver_later: nil))
+
+    # Stub hospital agencies
+    stub_agencies(HmppsApi::PrisonApi::AgenciesApi::HOSPITAL_AGENCY_TYPE)
   end
 
   context 'when the offender has been released from prison' do

--- a/spec/services/hmpps_api/prison_api/agencies_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/agencies_api_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe HmppsApi::PrisonApi::AgenciesApi do
+  describe '#agencies_by_type' do
+    it "returns array of agencies", vcr: { cassette_name: 'prison_api/agencies_api' } do
+      response = described_class.agencies_by_type(described_class::HOSPITAL_AGENCY_TYPE)
+
+      expect(response).not_to be_nil
+      expect(response).to be_instance_of(Array)
+      expect(response).to include(include(agency_type: a_kind_of(String), description: a_kind_of(String), active: be_truthy))
+    end
+  end
+
+  describe '#agency_ids_by_type' do
+    it "returns array of agency IDs", vcr: { cassette_name: 'prison_api/agencies_api' } do
+      response = described_class.agency_ids_by_type(described_class::HOSPITAL_AGENCY_TYPE)
+
+      expect(response).not_to be_nil
+      expect(response).to be_instance_of(Array)
+      expect(response).to include(a_kind_of(String))
+    end
+  end
+end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -164,6 +164,11 @@ module ApiHelper
       to_return(status: 404)
   end
 
+  def stub_agencies(type)
+    stub_request(:get, "https://api-dev.prison.service.justice.gov.uk/api/agencies/type/#{type}").
+      to_return(body: [{ 'agencyId' => 'HOS1', 'description' => 'Hospital One', 'active' => 1 }].to_json)
+  end
+
 private
 
   def search_api_response(offender)


### PR DESCRIPTION
Ensure a Probation office is deallocated when released from Hospital back to the community. Cross reference the fromAgency code with current list of Hospital Agencies on a release movement record.