### PR TITLE
Mo 908 use supporting prison id and allocation api fix

### DIFF
--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -9,7 +9,7 @@ module Api
 
       if offender.nil? || !allocation.active? || !offender.inside_omic_policy?
         return render_404('Not allocated')
-       end
+      end
 
       render json: allocation_as_json
     end

--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -6,7 +6,10 @@ module Api
       render_404('Not ready for allocation') && return if allocation.nil?
 
       offender = OffenderService.get_offender(offender_number)
-      render_404('Not allocated') && return unless allocation.active? && offender.inside_omic_policy?
+
+      if offender.nil? || !allocation.active? || !offender.inside_omic_policy?
+        return render_404('Not allocated')
+       end
 
       render json: allocation_as_json
     end

--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -35,7 +35,7 @@ module HmppsApi
       @category = category
       @sentence = HmppsApi::SentenceDetail.new(offender)
       @booking_id = offender.fetch('bookingId').to_i
-      @prison_id = offender.fetch('prisonId')
+      @prison_id = restricted_patient ? offender.fetch('supportingPrisonId') : offender.fetch('prisonId')
       @restricted_patient = restricted_patient
     end
 

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -146,7 +146,7 @@ module HmppsApi
 
       def self.get_search_api_offenders(offender_nos)
         search_route = '/prisoner-search/prisoner-numbers'
-        search_client.post(search_route,{ prisonerNumbers: offender_nos }, queryparams: { 'include-restricted-patients': true }, cache: true)
+        search_client.post(search_route, { prisonerNumbers: offender_nos }, queryparams: { 'include-restricted-patients': true }, cache: true)
       end
 
       def self.default_image

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -62,11 +62,10 @@ module HmppsApi
           (ALLOWED_LEGAL_STATUSES.include?(offender['legalStatus']) || ignore_legal_status)
 
         offender_no = offender.fetch('prisonerNumber')
-        prison_id = offender['prisonId']
 
         # Get additional data from other APIs
         offender_categories = get_offender_categories([offender_no])
-        complexity_level = if Prison.womens.exists?(prison_id)
+        complexity_level = if Prison.womens.exists?(offender['prisonId'])
                              HmppsApi::ComplexityApi.get_complexity(offender_no)
                            end
         temp_movement = if temp_out_of_prison?(offender)
@@ -141,13 +140,13 @@ module HmppsApi
         # So here we bypass pagination by asking for 10,000 results per page.
         # There are only ever up to ~2000 offenders per prison, and this API seems happy to return them all at once.
         # This endpoint also requires a "Content-Type: application/json" header even though it's a GET request with no body.
-        search_client.get(route, queryparams: { page: 0, size: 10_000 }, extra_headers: { 'Content-Type': 'application/json' })
+        search_client.get(route, queryparams: { page: 0, size: 10_000, 'include-restricted-patients': true }, extra_headers: { 'Content-Type': 'application/json' })
                      .fetch('content')
       end
 
       def self.get_search_api_offenders(offender_nos)
         search_route = '/prisoner-search/prisoner-numbers'
-        search_client.post(search_route, { prisonerNumbers: offender_nos }, cache: true)
+        search_client.post(search_route,{ prisonerNumbers: offender_nos }, queryparams: { 'include-restricted-patients': true }, cache: true)
       end
 
       def self.default_image

--- a/spec/controllers/api/allocation_api_controller_spec.rb
+++ b/spec/controllers/api/allocation_api_controller_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe Api::AllocationApiController, :allocation, type: :controller do
           expect(JSON.parse(response.body)).to eq("message" => "Not allocated", "status" => "error")
         end
       end
+
+      context 'when an offender is no longer returned from prison API but has case information' do
+        # if an offender has case information but is not being returned from the prison API as a valid
+        # inmate, return the expected 404 status code
+        let(:offender) { build(:nomis_offender, prisonId: prison.code,  sentence: attributes_for(:sentence_detail)) }
+
+        it 'does not return a poms allocation details' do
+          stub_offender(nil)
+          get :show, params: { prison_id: prison.code, offender_no: offender.fetch(:prisonerNumber) }
+
+          expect(response).to have_http_status(404)
+          expect(JSON.parse(response.body)).to eq("message" => "Not allocated", "status" => "error")
+        end
+      end
     end
   end
 

--- a/spec/controllers/api/allocation_api_controller_spec.rb
+++ b/spec/controllers/api/allocation_api_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::AllocationApiController, :allocation, type: :controller do
         let(:offender) { build(:nomis_offender, prisonId: prison.code,  sentence: attributes_for(:sentence_detail)) }
 
         it 'does not return a poms allocation details' do
-          stub_offender(nil)
+          stub_nil_offender
           get :show, params: { prison_id: prison.code, offender_no: offender.fetch(:prisonerNumber) }
 
           expect(response).to have_http_status(404)

--- a/spec/factories/hmpps_api/offenders.rb
+++ b/spec/factories/hmpps_api/offenders.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
                              complexity_level: attributes.fetch(:complexityLevel))
     end
 
+    prisonId { 'LEI' }
+
     trait :prescoed do
       prisonId { PrisonService::PRESCOED_CODE }
     end

--- a/spec/factories/hmpps_api/offenders.rb
+++ b/spec/factories/hmpps_api/offenders.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
       # run attributes through JSON for a more realistic payload
       values_hash = JSON.parse(attributes.to_json)
 
+      unless values_hash.member?(:prisonId)
+        values_hash['prisonId'] = 'LEI'
+      end
+
       # merge SentenceDetails into the main Offender object (Prison Search API returns it all in one)
       sentence = values_hash.extract!('sentence').fetch('sentence')
       values_hash.merge!(sentence)
@@ -13,8 +17,6 @@ FactoryBot.define do
                              latest_temp_movement: nil,
                              complexity_level: attributes.fetch(:complexityLevel))
     end
-
-    prisonId { 'LEI' }
 
     trait :prescoed do
       prisonId { PrisonService::PRESCOED_CODE }

--- a/spec/factories/hmpps_api/offenders.rb
+++ b/spec/factories/hmpps_api/offenders.rb
@@ -4,10 +4,6 @@ FactoryBot.define do
       # run attributes through JSON for a more realistic payload
       values_hash = JSON.parse(attributes.to_json)
 
-      unless values_hash.member?(:prisonId)
-        values_hash['prisonId'] = 'LEI'
-      end
-
       # merge SentenceDetails into the main Offender object (Prison Search API returns it all in one)
       sentence = values_hash.extract!('sentence').fetch('sentence')
       values_hash.merge!(sentence)

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -309,7 +309,7 @@ describe HmppsApi::Offender do
       let(:offender_location) { 'Hazelwood Hospital' }
       let(:offender) {
         build(
-          :hmpps_api_offender, restrictedPatient: true, dischargedHospitalDescription: offender_location,
+          :hmpps_api_offender, prisonId: 'OUT', supportingPrisonId: 'LEI', restrictedPatient: true, dischargedHospitalDescription: offender_location,
           cellLocation: nil, imprisonmentStatus: immigration_detainee, dateOfBirth: over_18, legalStatus: 'IMMIGRATION_DETAINEE',
           sentence: attributes_for(:sentence_detail, sentenceStartDate: '2019-02-05')
         )
@@ -321,6 +321,10 @@ describe HmppsApi::Offender do
 
       it "returns hospital location" do
         expect(offender.location).to eq(offender_location)
+      end
+
+      it "returns correct prison code using " do
+        expect(offender.prison_id).to eq('LEI')
       end
     end
 

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -11,16 +11,15 @@ module ApiHelper
   ASSESSMENT_API_HOST = Rails.configuration.assessment_api_host
 
   def stub_offender(offender)
-
     if offender.nil?
-      return stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers?include-restricted-patients=true").to_return(body: [].to_json)
+      # return stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers").to_return(body: [].to_json).with(query: { 'include-restricted-patients': true })
     end
 
     offender_no = offender.fetch(:prisonerNumber)
 
     # Prison Search API
-    stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers?include-restricted-patients=true")
-      .with(body: { prisonerNumbers: [offender_no] }.to_json)
+    stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers")
+      .with(body: { prisonerNumbers: [offender_no] }.to_json, query: { 'include-restricted-patients': true })
       .to_return(body: [search_api_response(offender)].to_json)
 
     # This endpoint is only used by HmppsApi::PrisonApi::OffenderApi.get_image
@@ -100,7 +99,7 @@ module ApiHelper
     offenders.each { |offender| offender[:prisonId] = prison }
 
     # Prison Search API
-    stub_request(:get, "#{T3_SEARCH}/prisoner-search/prison/#{prison}").with(query: hash_including(:page, :size))
+    stub_request(:get, "#{T3_SEARCH}/prisoner-search/prison/#{prison}").with(query: hash_including(:page, :size, 'include-restricted-patients'))
       .to_return(body: {
         content: offenders.map { |o| search_api_response(o) }
       }.to_json)
@@ -146,7 +145,7 @@ module ApiHelper
   # Stub an 'empty' response from the Prison Search API, indicating that the offender does not exist in NOMIS
   def stub_non_existent_offender(offender_no)
     stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers")
-      .with(body: { prisonerNumbers: [offender_no] }.to_json)
+      .with(body: { prisonerNumbers: [offender_no] }.to_json, query: { 'include-restricted-patients': true })
       .to_return(body: [].to_json)
   end
 

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -15,7 +15,6 @@ module ApiHelper
   end
 
   def stub_offender(offender)
-
     offender_no = offender.fetch(:prisonerNumber)
 
     # Prison Search API

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -10,10 +10,11 @@ module ApiHelper
   T3_BOOKINGS_URL = "#{T3}/offender-sentences/bookings"
   ASSESSMENT_API_HOST = Rails.configuration.assessment_api_host
 
+  def stub_nil_offender
+    stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers").to_return(body: [].to_json).with(query: { 'include-restricted-patients': true })
+  end
+
   def stub_offender(offender)
-    if offender.nil?
-      # return stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers").to_return(body: [].to_json).with(query: { 'include-restricted-patients': true })
-    end
 
     offender_no = offender.fetch(:prisonerNumber)
 

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -11,10 +11,15 @@ module ApiHelper
   ASSESSMENT_API_HOST = Rails.configuration.assessment_api_host
 
   def stub_offender(offender)
+
+    if offender.nil?
+      return stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers?include-restricted-patients=true").to_return(body: [].to_json)
+    end
+
     offender_no = offender.fetch(:prisonerNumber)
 
     # Prison Search API
-    stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers")
+    stub_request(:post, "#{T3_SEARCH}/prisoner-search/prisoner-numbers?include-restricted-patients=true")
       .with(body: { prisonerNumbers: [offender_no] }.to_json)
       .to_return(body: [search_api_response(offender)].to_json)
 


### PR DESCRIPTION
Include GET param for all offender related requests to return restricted patient records.
Fix allocation API bug where the offender object is not checked for nil before accessing an object property.