### PR TITLE
refs MO-960 Move production cron jobs to live cluster. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,8 +403,38 @@ jobs:
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/deployment.yaml
             kubectl annotate deployments/allocation-manager kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
             kubectl apply --record=false -f ./deploy/production
-            kubectl apply --record=false -f ./deploy/production/cron
             kubectl apply --record=false -f ./deploy/production/ingress/ingress-live-1.yaml
+          environment:
+            <<: *github_team_name_slug
+
+  deploy_production_live_cluster:
+    <<: *deploy_container_config
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Kubectl deployment live cluster production setup
+          command: |
+            echo -n ${CLUSTER_CERT_LIVE} | base64 -d > ./live_ca.crt
+            kubectl config set-cluster ${CLUSTER_NAME_LIVE} --certificate-authority=./live_ca.crt --server=https://${CLUSTER_NAME_LIVE}
+            kubectl config set-credentials circleci --token=${TOKEN_LIVE_PRODUCTION}
+            kubectl config set-context ${CLUSTER_NAME_LIVE} --cluster=${CLUSTER_NAME_LIVE} --user=circleci --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE}
+            kubectl config use-context ${CLUSTER_NAME_LIVE}
+            kubectl config current-context
+            kubectl --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} get pods
+      - *install_gpg
+      - *configure_gpg
+      - *decrypt_secrets
+      - deploy:
+          name: Deploy to live cluster production
+          command: |
+            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/cron/cron-*.yaml
+            sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/production/deployment.yaml
+            kubectl annotate deployments/allocation-manager kubernetes.io/change-cause="$CIRCLE_BUILD_URL"
+            kubectl apply --record=false -f ./deploy/production
+            kubectl apply --record=false -f ./deploy/production/cron
+            kubectl apply --record=false -f ./deploy/production/ingress/ingress.yaml
           environment:
             <<: *github_team_name_slug
 
@@ -459,6 +489,12 @@ workflows:
             branches:
               only: main
       - deploy_production:
+          requires:
+            - deploy_production_approval
+          filters:
+            branches:
+              only: main
+      - deploy_production_live_cluster:
           requires:
             - deploy_production_approval
           filters:

--- a/deploy/preprod/cron/cron-community-api-import.yaml
+++ b/deploy/preprod/cron/cron-community-api-import.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:

--- a/deploy/preprod/cron/cron-early-allocation-events.yaml
+++ b/deploy/preprod/cron/cron-early-allocation-events.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:

--- a/deploy/production/cron/cron-community-api-import.yaml
+++ b/deploy/production/cron/cron-community-api-import.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:

--- a/deploy/production/cron/cron-early-allocation-events.yaml
+++ b/deploy/production/cron/cron-early-allocation-events.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       template:
         spec:
+          ttlSecondsAfterFinished: 3600
           containers:
             - name: early-allocation-events
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/staging/cron-early-allocation-events.yaml
+++ b/deploy/staging/cron-early-allocation-events.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           containers:


### PR DESCRIPTION
Add missing TTL values in manifest files where not present, in order to enable cleanup of completed tasks.