### PR TITLE
Preventing the page view from jumping to the top of the page

### DIFF
--- a/app/views/early_allocations/index.html.erb
+++ b/app/views/early_allocations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Early allocation assessment – Digital Prison Services" %>
 
-<%= back_link %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/victim_liaison_officers/delete.html.erb
+++ b/app/views/victim_liaison_officers/delete.html.erb
@@ -16,7 +16,7 @@ Contact details for the VLO <%= @vlo.full_name %> will be removed from the priso
              builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
 
   <%= f.submit "Confirm", role: "button", draggable: "false", class: "govuk-button" %>
-  <%= link_to 'Cancel', @referrer, class: 'govuk-link cancel-button' %>
+  <%= link_to 'Cancel', 'javascript:history.back()', class: 'govuk-link cancel-button' %>
 
 <% end %>
 

--- a/app/views/victim_liaison_officers/edit.html.erb
+++ b/app/views/victim_liaison_officers/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render '/layouts/prison_switcher' %>
 <% end %>
 
-<%= render 'shared/backlink', page: @referrer %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <h2 class="govuk-heading-l">Edit Victim Liaison Officer (VLO) contact details</h2>
 

--- a/app/views/victim_liaison_officers/new.html.erb
+++ b/app/views/victim_liaison_officers/new.html.erb
@@ -4,7 +4,7 @@
   <%= render '/layouts/prison_switcher' %>
 <% end %>
 
-<%= render 'shared/backlink', page: @referrer %>
+<%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <h2 class="govuk-heading-l">Add Victim Liaison Officer (VLO) contact details</h2>
 


### PR DESCRIPTION
Some pages (after having viewed either VLO-related or EA-related pages) were jumping back to the top of the page when clicking the `back` link. 
The scroll position should now be retained.