### PR TITLE
Updating dashboard tile content

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -21,12 +21,18 @@
   <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
   <div class="govuk-grid-row card-group">
     <%= render 'dashboard_partition',
-               title: "Make new allocations",
+               title: "Make allocations",
                link:  unallocated_prison_prisoners_path(@prison.code),
                content: display_content(@unallocated_cases_count,
                  no_cases: "You don’t have any cases to allocate currently.",
-                 one_case: "You have 1 case to allocate to a POM.",
-                 multiple_cases: "You have #{@unallocated_cases_count} cases to allocate to POMs.")
+                 one_case: "You have 1 case to allocate.",
+                 multiple_cases: "You have #{@unallocated_cases_count} cases to allocate.")
+    %>
+
+    <%= render 'dashboard_partition',
+               title: "All allocated cases",
+               link: allocated_prison_prisoners_path(@prison.code),
+               content: "Everyone who has been allocated to POMs in this prison."
     %>
 
     <%= render 'dashboard_partition',
@@ -34,28 +40,22 @@
                link: missing_information_prison_prisoners_path(@prison.code),
                content: display_content(@missing_details_cases_count,
                  no_cases: "None of your cases are missing information right now.",
-                 one_case: "You need to add missing details to 1 case before it can be allocated to a POM.",
-                 multiple_cases: "You need to add missing details to #{@missing_details_cases_count} cases before they can be allocated to POMs.")
-    %>
-
-    <%= render 'dashboard_partition',
-               title: "Newly arrived",
-               link: new_arrivals_prison_prisoners_path(@prison.code),
-               content: "Cases that have not yet been matched with NDelius records."
+                 one_case: "Missing details need to be added to 1 case before it can be allocated to a POM.",
+                 multiple_cases: "Missing details need to be added to #{@missing_details_cases_count} cases before they can be allocated to POMs.")
     %>
   </div>
 
   <div class="govuk-grid-row card-group">
     <%= render 'dashboard_partition',
-               title: "See all allocated prisoners",
-               link: allocated_prison_prisoners_path(@prison.code),
-               content: "All prisoners who have been allocated to POMs."
+               title: "All handover cases",
+               link: prison_handovers_path(@prison.code),
+               content: "All cases coming up for handover in the next 30 days."
     %>
 
     <%= render 'dashboard_partition',
-               title: "See case handover status",
-               link: prison_handovers_path(@prison.code),
-               content: "Cases where responsibility is being handed over or is within 30 days of handover to the community probation team."
+               title: "Newly arrived cases",
+               link: new_arrivals_prison_prisoners_path(@prison.code),
+               content: "Cases waiting to be matched with NDelius records before they can be allocated."
     %>
   </div>
 <% end  %>
@@ -65,21 +65,21 @@
   <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
   <div class="govuk-grid-row card-group">
     <%= render 'dashboard_partition',
-               title: "See your caseload",
+               title: "Your cases",
                link: prison_staff_caseload_path(@prison.code, @staff_id),
-               content: "All prisoners allocated to you."
+               content: "All cases allocated to you."
     %>
 
     <%= render 'dashboard_partition',
-               title: "See new allocations",
+               title: "New allocations",
                link: prison_staff_new_cases_path(@prison.code, @staff_id),
-               content: "Prisoners allocated to you in the last 7 days."
+               content: "Cases allocated to you in the last 7 days."
     %>
 
     <%= render 'dashboard_partition',
-               title: "See cases close to handover",
+               title: "Cases close to handover",
                link: prison_staff_caseload_handovers_path(@prison.code, @staff_id),
-               content: "All cases coming up for handover to the community in the next 30 days."
+               content: "Your cases that need handing over in the next 30 days."
     %>
   </div>
 
@@ -87,9 +87,14 @@
     <%= render 'dashboard_partition',
                title: "Case updates needed",
                link: prison_tasks_path(@prison.code),
-               content: "Update information so handover dates and community probation details are correct."
+               content: "Enter some information to ensure responsibility for these cases is correct."
     %>
 
+    <%= render 'dashboard_partition',
+               title: "All allocations in this prison",
+               link: allocated_prison_prisoners_path(@prison.code),
+               content: "Cases allocated to all POMs."
+    %>
   </div>
 <% end %>
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe DashboardController, type: :controller do
         expect(response.body).not_to have_content('Case updates needed')
         expect(response.body).not_to have_content('All allocations in this prison')
 
-
         expect(response.body).to have_content('All allocated cases')
         expect(response.body).to have_content('Make allocations')
         expect(response.body).to have_content('Add missing details')

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -35,17 +35,18 @@ RSpec.describe DashboardController, type: :controller do
         expect(assigns(:is_pom)).to be true
         expect(assigns(:is_spo)).to be false
 
-        expect(response.body).to have_content('See your caseload')
-        expect(response.body).to have_content('See new allocations')
-        expect(response.body).to have_content('See cases close to handover')
+        expect(response.body).to have_content('Your cases')
+        expect(response.body).to have_content('New allocations')
+        expect(response.body).to have_content('Cases close to handover')
         expect(response.body).to have_content('Case updates needed')
+        expect(response.body).to have_content('All allocations in this prison')
 
-        expect(response.body).not_to have_content('See all allocated prisoners')
-        expect(response.body).not_to have_content('Make new allocations')
-        expect(response.body).not_to have_content('Update case information')
-        expect(response.body).not_to have_content('Newly arrived')
+        expect(response.body).not_to have_content('All allocated cases')
+        expect(response.body).not_to have_content('Make allocations')
+        expect(response.body).not_to have_content('Add missing details')
+        expect(response.body).not_to have_content('Newly arrived cases')
         expect(response.body).not_to have_content('View all offender managers')
-        expect(response.body).not_to have_content('See case handover status')
+        expect(response.body).not_to have_content('All handover cases')
       end
     end
 
@@ -65,17 +66,19 @@ RSpec.describe DashboardController, type: :controller do
         expect(assigns(:is_pom)).to be false
         expect(assigns(:is_spo)).to be true
 
-        expect(response.body).not_to have_content('See your caseload')
-        expect(response.body).not_to have_content('See new allocations')
-        expect(response.body).not_to have_content('See cases close to handover')
+        expect(response.body).not_to have_content('Your cases')
+        expect(response.body).not_to have_content('New allocations')
+        expect(response.body).not_to have_content('Cases close to handover')
         expect(response.body).not_to have_content('Case updates needed')
+        expect(response.body).not_to have_content('All allocations in this prison')
 
-        expect(response.body).to have_content('See all allocated prisoners')
-        expect(response.body).to have_content('Make new allocations')
+
+        expect(response.body).to have_content('All allocated cases')
+        expect(response.body).to have_content('Make allocations')
         expect(response.body).to have_content('Add missing details')
-        expect(response.body).to have_content('Newly arrived')
+        expect(response.body).to have_content('Newly arrived cases')
         expect(response.body).to have_content('View all offender managers')
-        expect(response.body).to have_content('See case handover status')
+        expect(response.body).to have_content('All handover cases')
       end
 
       describe 'Make new allocations tab' do
@@ -96,7 +99,7 @@ RSpec.describe DashboardController, type: :controller do
             render_views
             it 'displays the number of cases that need to be allocated' do
               get :index, params: { prison_id: prison }
-              expect(response.body).to include 'You have 3 cases to allocate to POMs.'
+              expect(response.body).to include 'You have 3 cases to allocate.'
             end
           end
         end
@@ -134,7 +137,7 @@ RSpec.describe DashboardController, type: :controller do
             render_views
             it 'displays the number of cases that need to be allocated' do
               get :index, params: { prison_id: prison }
-              expect(response.body).to include 'You have 1 case to allocate to a POM.'
+              expect(response.body).to include 'You have 1 case to allocate.'
             end
           end
         end
@@ -153,7 +156,7 @@ RSpec.describe DashboardController, type: :controller do
             render_views
             it 'displays the number of cases that having missing details' do
               get :index, params: { prison_id: prison }
-              expect(response.body).to include 'You need to add missing details to 3 cases before they can be allocated to POMs.'
+              expect(response.body).to include 'Missing details need to be added to 3 cases before they can be allocated to POMs.'
             end
           end
         end
@@ -190,7 +193,7 @@ RSpec.describe DashboardController, type: :controller do
               render_views
               it 'displays the number of cases that having missing details' do
                 get :index, params: { prison_id: prison }
-                expect(response.body).to include 'You need to add missing details to 1 case before it can be allocated to a POM.'
+                expect(response.body).to include 'Missing details need to be added to 1 case before it can be allocated to a POM.'
               end
             end
           end

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -200,7 +200,7 @@ feature 'Allocation' do
 
     scenario 'removing a community override', vcr: { cassette_name: 'prison_api/allocation_remove_community_override' } do
       visit prison_dashboard_index_path('LEI')
-      click_link 'Make new allocations'
+      click_link 'Make allocations'
       find '.offender_row_0'
       within '.offender_row_0' do
         click_link unallocated_offender_name

--- a/spec/features/change_parole_review_date_spec.rb
+++ b/spec/features/change_parole_review_date_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature "ChangeParoleReviewDates", type: :feature do
 
       # Navigate to the "Allocate a POM" page
       visit prison_dashboard_index_path(prison.code)
-      click_link 'Make new allocations'
+      click_link 'Make allocations'
       page.find('[aria-label="Prisoner name"] a').click
     end
 
@@ -143,7 +143,7 @@ RSpec.feature "ChangeParoleReviewDates", type: :feature do
 
       # Navigate to the prisoner profile page
       visit prison_dashboard_index_path(prison.code)
-      click_link 'See your caseload'
+      click_link 'Your cases'
       click_link 'Your cases (1)'
       page.find('#all-cases [aria-label="Prisoner name"] a').click
     end


### PR DESCRIPTION
Refs MO-907

Updating dashboard tile content and adding a new tile for POMs to see all allocations within the prison.