### PR TITLE
Declare language of html pages and emails as accessibility improvement

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="govuk-template js flexbox">
+<html lang="en" class="govuk-template js flexbox">
   <head>
     <%= render 'layouts/google_tag_manager_head' %>
     <title><%= yield(:title).blank? ? "Manage Offenders in Custody" : yield(:title).to_s%></title>

--- a/app/views/layouts/errors_and_contact.html.erb
+++ b/app/views/layouts/errors_and_contact.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="govuk-template js flexbox">
+<html lang="en" class="govuk-template js flexbox">
   <head>
     <title><%= yield(:title).blank? ? "Manage Offenders in Custody" : yield(:title).to_s%></title>
     <%= csrf_meta_tags %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>

--- a/public/422.html
+++ b/public/422.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The change you wanted was rejected (422)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
Refs: MO-1095

All \<html\> tags now have a lang="en" attribute.
