### PR TITLE
Show restricted patients on the Debug page

### DIFF
--- a/app/controllers/debugging_controller.rb
+++ b/app/controllers/debugging_controller.rb
@@ -4,9 +4,9 @@ class DebuggingController < PrisonsApplicationController
   before_action :ensure_admin_user
 
   def debugging
-    nomis_offender_id = id
+    return unless id
 
-    prisoner = OffenderService.get_offender(nomis_offender_id) if nomis_offender_id.present?
+    prisoner = OffenderService.get_offender(id, ignore_legal_status: true)
 
     if prisoner.present?
       @offender = prisoner

--- a/app/views/debugging/debugging.html.erb
+++ b/app/views/debugging/debugging.html.erb
@@ -86,6 +86,11 @@
         <% end %>
       </td>
     </tr>
+    <tr class="govuk-table__row" id="restricted-patient">
+      <td class="govuk-table__cell">Restricted Patient Service</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= humanized_bool(@offender.restricted_patient?) %>
+    </tr>
     </tbody>
   </table>
 

--- a/spec/features/debugging_feature_spec.rb
+++ b/spec/features/debugging_feature_spec.rb
@@ -16,7 +16,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 41)
+      expect(page).to have_css('tbody tr', count: 42)
       expect(page).to have_content("Not currently allocated")
     end
 
@@ -32,7 +32,7 @@ feature 'Provide debugging information for our team to use' do
       fill_in 'offender_no', with: nomis_offender_id
       click_on('search-button')
 
-      expect(page).to have_css('tbody tr', count: 46)
+      expect(page).to have_css('tbody tr', count: 47)
 
       pom_table_row = page.find(:css, 'tr.govuk-table__row#pom', text: 'POM')
 

--- a/spec/services/offender_service_spec.rb
+++ b/spec/services/offender_service_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 describe OffenderService, type: :feature do
+  describe '#get_offender (mocked API calls)' do
+    let(:offender_no) { "FAKENUMBER" }
+    let(:offender) { double :offender }
+    let(:api_offender) { double :api_offender, prison_id: "FAKE" }
+    let(:prison) { instance_double Prison, :prison }
+
+    before do
+      allow(Offender).to receive(:find_or_create_by)
+      allow(HmppsApi::PrisonApi::OffenderApi).to receive(:get_offender)
+      allow(Prison).to receive(:find_by)
+      allow(MpcOffender).to receive(:new)
+    end
+
+    it 'can ignore legal status when getting MOIC offender' do
+      allow(Offender).to receive(:find_or_create_by).and_return(offender)
+      described_class.get_offender(offender_no, ignore_legal_status: true)
+
+      expect(HmppsApi::PrisonApi::OffenderApi).to have_received(:get_offender).with(offender_no,
+                                                                                    ignore_legal_status: true)
+    end
+  end
+
   describe '#get_offender' do
     it "gets a single offender", vcr: { cassette_name: 'prison_api/offender_service_single_offender_spec' } do
       nomis_offender_id = 'G7266VD'


### PR DESCRIPTION
Due to an API change, the Offender API was not returning restricted patients before. It does now.

The page also shows whether a prisoner is a restricted patient when they are shown.

Closes MO-1072 and MO-1088