### PR TITLE
Flaky tests can now be marked and skipped when testing in CircleCI. 'Responsibility override' feature spec is the first to get this treatment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           name: Run tests
           command: |
             cc-test-reporter before-build
-            bundle exec rspec spec
+            bundle exec rspec spec -t ~flaky
             cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
             ALLOCATION_MANAGER_HOST: https://dev.moic.service.justice.gov.uk

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Responsibility override' do
+feature 'Responsibility override', :flaky do
   include ActiveJob::TestHelper
 
   before do


### PR DESCRIPTION
To disable more spec in CircleCI, mark them with the `flaky` tag.

See https://relishapp.com/rspec/rspec-core/v/3-11/docs/command-line/tag-option#exclude-examples-with-a-simple-tag
