### PR TITLE
MO-957 - Adding new parole rules

### DIFF
--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -20,6 +20,8 @@ class CalculatedHandoverDate < ApplicationRecord
     nps_determinate_mappa_2_3: 'NPS Determinate Mappa 2/3',
     less_than_10_months_left_to_serve: 'Less than 10 months left to serve',
     pre_omic_rules: 'Pre-OMIC rules',
+    thd_within_12_months_of_hearing_outcome: 'Next parole hearing more than 12 months away',
+    thd_more_than_12_months_from_hearing_outcome: 'Next parole hearing under 12 months away',
   }.stringify_keys.freeze
 
   belongs_to :offender,

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -19,6 +19,7 @@ class CalculatedHandoverDate < ApplicationRecord
     nps_determinate_mappa_1_n: 'NPS Determinate Mappa 1/N',
     nps_determinate_mappa_2_3: 'NPS Determinate Mappa 2/3',
     less_than_10_months_left_to_serve: 'Less than 10 months left to serve',
+    parole_mappa_2_3: 'Unsuccessful parole and Mappa 2/3',
     pre_omic_rules: 'Pre-OMIC rules',
     thd_within_12_months_of_hearing_outcome: 'Next parole hearing more than 12 months away',
     thd_more_than_12_months_from_hearing_outcome: 'Next parole hearing under 12 months away',

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -18,7 +18,7 @@ class MpcOffender
            :mappa_level, :welsh_offender, to: :probation_record
 
   delegate :victim_liaison_officers, :current_parole_record, :previous_parole_records,
-           :build_parole_record_sections, to: :@offender
+           :most_recent_parole_record, :build_parole_record_sections, to: :@offender
 
   # These fields make sense to be nil when the probation record is nil - the others dont
   delegate :ldu_email_address, :team_name, :ldu_name, to: :probation_record, allow_nil: true
@@ -156,12 +156,14 @@ class MpcOffender
   end
 
   def target_hearing_date
-    @offender.current_parole_record.target_hearing_date if @offender.current_parole_record.present?
+    @offender.most_recent_parole_record&.target_hearing_date
+  end
+
+  def hearing_outcome_received
+    @offender.most_recent_parole_record&.hearing_outcome_received
   end
 
   def approaching_parole?
-    return false if @offender.current_parole_record.blank?
-
     earliest_date = next_parole_date
     earliest_date.present? && earliest_date <= Time.zone.today + 10.months
   end

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -45,6 +45,10 @@ class Offender < ApplicationRecord
     parole_records.max_by(&:custody_report_due)
   end
 
+  def most_recent_parole_record
+    parole_records.sort_by(&:custody_report_due).reverse.first
+  end
+
   def build_parole_record_sections
     @current_parole_record = nil
     @previous_parole_records = []

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -45,10 +45,6 @@ class Offender < ApplicationRecord
     parole_records.max_by(&:custody_report_due)
   end
 
-  def most_recent_parole_record
-    parole_records.sort_by(&:custody_report_due).reverse.first
-  end
-
   def build_parole_record_sections
     @current_parole_record = nil
     @previous_parole_records = []

--- a/app/models/parole_record.rb
+++ b/app/models/parole_record.rb
@@ -24,7 +24,7 @@ class ParoleRecord < ApplicationRecord
   # outcome having been received. There should always be a value in the hearing_outcome field, and not having a nil check allows
   # this method to be used to determine the date that the hearing outcome was given.
   def no_hearing_outcome?
-    hearing_outcome == 'Not Applicable' || hearing_outcome == 'Not Specified'
+    hearing_outcome == 'Not Applicable' || hearing_outcome == 'Not Specified' || hearing_outcome.blank?
   end
 
   def active?

--- a/app/models/pom_tasks.rb
+++ b/app/models/pom_tasks.rb
@@ -17,27 +17,13 @@ class PomTasks
       early_allocations = get_early_allocations([offender.offender_no])
     end
 
-    tasks = [
-      target_hearing_date_task(offender)
-    ].compact
+    tasks = []
 
     if early_allocations.include?(offender.offender_no)
       tasks << early_allocation_update_task(offender)
     end
 
     tasks
-  end
-
-  def target_hearing_date_task(offender)
-    # Offender is indeterminate and their THD is old or missing and their TED has expired
-    if offender.indeterminate_sentence? &&
-      (offender.tariff_date.blank? || offender.tariff_date < Time.zone.today) &&
-      (offender.target_hearing_date.blank? || offender.target_hearing_date < Time.zone.today)
-      PomTaskPresenter.new offender_name: offender.full_name,
-                           offender_number: offender.offender_no,
-                           action_label: 'Target hearing date',
-                           long_label: 'Target hearing date must be updated so handover dates can be calculated.'
-    end
   end
 
   def early_allocation_update_task(offender)

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -24,10 +24,16 @@ class HandoverDateService
 
     # Should only trigger on offenders who have not been released as a part of their parole review, ie not on their first allocation
     if eligible_unsuccessful_parole_applicant(offender)
-      if offender.target_hearing_date < offender.hearing_outcome_received + 12.months
+      if offender.mappa_level.in? [2, 3]
+        CalculatedHandoverDate.new responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+                                   start_date: nil, handover_date: nil,
+                                   reason: :parole_mappa_2_3
+
+      elsif offender.target_hearing_date < offender.hearing_outcome_received + 12.months
         CalculatedHandoverDate.new responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
                                    start_date: nil, handover_date: nil,
                                    reason: :thd_within_12_months_of_hearing_outcome
+
       else
         handover_date = indeterminate_responsibility_date(offender)
         CalculatedHandoverDate.new responsibility: responsibility(handover_date, handover_date),

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -22,7 +22,19 @@ class HandoverDateService
 
     offender = OffenderWrapper.new(raw_offender)
 
-    if offender.recalled?
+    # Should only trigger on offenders who have not been released as a part of their parole review, ie not on their first allocation
+    if eligible_unsuccessful_parole_applicant(offender)
+      if offender.target_hearing_date < offender.hearing_outcome_received + 12.months
+        CalculatedHandoverDate.new responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+                                   start_date: nil, handover_date: nil,
+                                   reason: :thd_within_12_months_of_hearing_outcome
+      else
+        handover_date = indeterminate_responsibility_date(offender)
+        CalculatedHandoverDate.new responsibility: responsibility(handover_date, handover_date),
+                                   start_date: handover_date, handover_date: handover_date,
+                                   reason: :thd_more_than_12_months_from_hearing_outcome
+      end
+    elsif offender.recalled?
       CalculatedHandoverDate.new responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
                                  start_date: nil, handover_date: nil,
                                  reason: :recall_case
@@ -165,6 +177,14 @@ private
     end
   end
 
+  def self.eligible_unsuccessful_parole_applicant(offender)
+    return false if offender.most_recent_parole_record.blank?
+    return false if offender.most_recent_parole_record.hearing_outcome_received.blank?
+    return false if offender.most_recent_parole_record.current_hearing_outcome == 'Release'
+
+    offender.indeterminate_sentence? && offender.tariff_date&.past?
+  end
+
   WELSH_POLICY_START_DATE = Time.zone.local(2019, 2, 4).utc.to_date.freeze
   WELSH_CUTOFF_DATE = '4 May 2020'.to_date.freeze
 
@@ -179,6 +199,7 @@ private
              :early_allocation?, :mappa_level, :prison_arrival_date, :category_active_since,
              :parole_eligibility_date, :conditional_release_date, :automatic_release_date,
              :home_detention_curfew_eligibility_date, :home_detention_curfew_actual_date,
+             :tariff_date, :target_hearing_date, :hearing_outcome_received, :most_recent_parole_record,
              to: :@offender
 
     def initialize(offender)

--- a/deploy/production/cron-parole-data-import-job.yaml
+++ b/deploy/production/cron-parole-data-import-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: import-parole-records-job
 spec:
-  schedule: "0 4 * * *"
+  schedule: "0 3 * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/deploy/production/cron-recalculate-handover-dates.yaml
+++ b/deploy/production/cron-recalculate-handover-dates.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: recalculate-handover-dates
 spec:
-  schedule: "0 3 * * *"
+  schedule: "0 4 * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe TasksController, :allocation, type: :controller do
   let(:tariff_end_date) { Time.zone.today - 3.days }
   let(:offenders) do
     [
-     build(:nomis_offender, prisonerNumber: 'G1234VV', firstName: "Bob", lastName: "Bibby"),
-     build(:nomis_offender, prisonerNumber: 'G1234AB', firstName: "Carole", lastName: "Caroleson"),
-     build(:nomis_offender, prisonerNumber: 'G1234GG', firstName: "David", lastName: "Davidson")
+      build(:nomis_offender, prisonerNumber: 'G1234VV', firstName: "Bob", lastName: "Bibby"),
+      build(:nomis_offender, prisonerNumber: 'G1234AB', firstName: "Carole", lastName: "Caroleson"),
+      build(:nomis_offender, prisonerNumber: 'G1234GG', firstName: "David", lastName: "Davidson")
     ]
   end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe TasksController, :allocation, type: :controller do
   let(:next_week) { Time.zone.today + 7.days }
   let(:tariff_end_date) { Time.zone.today - 3.days }
   let(:offenders) do
-    [build(:nomis_offender, prisonerNumber: 'G7514GW', firstName: "Alice", lastName: "Aliceson",
-                            sentence: attributes_for(:sentence_detail, :indeterminate, tariffDate: tariff_end_date)),
+    [
      build(:nomis_offender, prisonerNumber: 'G1234VV', firstName: "Bob", lastName: "Bibby"),
      build(:nomis_offender, prisonerNumber: 'G1234AB', firstName: "Carole", lastName: "Caroleson"),
      build(:nomis_offender, prisonerNumber: 'G1234GG', firstName: "David", lastName: "Davidson")
@@ -41,45 +40,8 @@ RSpec.describe TasksController, :allocation, type: :controller do
     end
   end
 
-  describe 'showing target hearing date pom tasks' do
-    let(:offender_no) { 'G7514GW' }
-    let(:pomtasks) { assigns(:pomtasks) }
-
-    before do
-      # Allocate all of the offenders to this POM
-      # Make sure that we don't generate missing nDelius data by mistake
-      offenders.each do |offender|
-        create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)), tier: 'A')
-        create(:allocation_history, nomis_offender_id: offender.fetch(:prisonerNumber), primary_pom_nomis_id: staff_id, prison: prison)
-      end
-      get :index, params: { prison_id: prison }
-
-      expect(response).to be_successful
-    end
-
-    context 'with a TED in the past' do
-      let(:tariff_end_date) { Time.zone.today - 3.days }
-
-      it 'can show offenders needing target hearing date updates' do
-        # We expect only one of these to have a target hearing date task
-        expect(pomtasks).to eq([PomTaskPresenter.new(offender_number: offender_no,
-                                                     action_label: 'Target hearing date',
-                                                     offender_name: 'Aliceson, Alice',
-                                                     long_label: 'Target hearing date must be updated so handover dates can be calculated.')])
-      end
-    end
-
-    context 'with a TED in the future' do
-      let(:tariff_end_date) { Time.zone.today + 3.days }
-
-      it 'does not show THD task' do
-        expect(pomtasks).to eq([])
-      end
-    end
-  end
-
   context 'when showing early allocation decisions required' do
-    let(:offender_nos) { %w[G1234AB G1234GG G7514GW G1234VV] }
+    let(:offender_nos) { %w[G1234AB G1234GG G1234VV] }
     let(:test_offender_no) { 'G1234AB' }
 
     it 'can show offenders needing early allocation decision updates' do
@@ -101,7 +63,7 @@ RSpec.describe TasksController, :allocation, type: :controller do
   end
 
   context 'when showing tasks' do
-    let(:offender_nos) { %w[G1234AB G1234GG G7514GW G1234VV] }
+    let(:offender_nos) { %w[G1234AB G1234GG G1234VV] }
     let(:test_offender_no) { 'G1234AB' }
 
     before do
@@ -113,39 +75,22 @@ RSpec.describe TasksController, :allocation, type: :controller do
       create(:case_information, tier: 'A', mappa_level: 1,
                                 offender: build(:offender, nomis_offender_id: 'G1234GG', parole_records: [build(:parole_record, target_hearing_date: next_week)]))
       create(:allocation_history, nomis_offender_id: 'G1234GG', primary_pom_nomis_id: staff_id, prison: prison)
-
-      create(:case_information, offender: build(:offender, nomis_offender_id: 'G7514GW'), tier: 'A', mappa_level: 1)
-      create(:allocation_history, nomis_offender_id: 'G7514GW', primary_pom_nomis_id: staff_id, prison: prison)
-    end
-
-    it 'can show multiple types at once' do
-      # One offender should have a pending early allocation
-      create(:early_allocation, :discretionary, nomis_offender_id: test_offender_no)
-
-      get :index, params: { prison_id: prison }
-
-      expect(response).to be_successful
-
-      pomtasks = assigns(:pomtasks)
-      expect(pomtasks.count).to eq(2)
     end
 
     it 'can sort the results' do
       # Two offenders should have a pending early allocation
       create(:early_allocation, :discretionary, nomis_offender_id: 'G1234AB')
       create(:early_allocation, :discretionary, nomis_offender_id: 'G1234GG')
-      # This 'task' doesn't show up as it was created before the referral window of <18 months before release
-      create(:early_allocation, :discretionary, created_within_referral_window: false, nomis_offender_id: 'G7514GW')
 
       get :index, params: { prison_id: prison, sort: 'offender_name asc' }
       expect(response).to be_successful
       pomtasks = assigns(:pomtasks)
-      expect(pomtasks.map(&:offender_name)).to eq(['Aliceson, Alice', "Caroleson, Carole", 'Davidson, David'])
+      expect(pomtasks.map(&:offender_name)).to eq(["Caroleson, Carole", 'Davidson, David'])
 
       get :index, params: { prison_id: prison, sort: 'offender_name desc' }
       expect(response).to be_successful
       pomtasks = assigns(:pomtasks)
-      expect(pomtasks.map(&:offender_name)).to eq(['Davidson, David', "Caroleson, Carole", 'Aliceson, Alice'])
+      expect(pomtasks.map(&:offender_name)).to eq(['Davidson, David', "Caroleson, Carole"])
     end
   end
 end

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -23,7 +23,10 @@ feature 'View a prisoner profile page' do
     before do
       create(:case_information,
              offender: build(:offender, nomis_offender_id: 'G7266VD',
-                                        parole_records: [build(:parole_record, target_hearing_date: Time.zone.today + 1.year)],
+                                        parole_records: [build(:parole_record,
+                                                               target_hearing_date: Time.zone.today,
+                                                               custody_report_due: Time.zone.today,
+                                                               hearing_outcome: 'Not Specified')],
                                         early_allocations: [build(:early_allocation, created_within_referral_window: within_window)]))
       visit prison_prisoner_path(prison.code, 'G7266VD')
     end

--- a/spec/features/responsibility_override_feature_spec.rb
+++ b/spec/features/responsibility_override_feature_spec.rb
@@ -7,7 +7,10 @@ feature 'Responsibility override', :flaky do
     signin_spo_user
   end
 
-  let(:offender_id) { 'G8060UF' }
+  # This WILL break again, most likely when the Earliest Release Date for the offender below comes within 10 months.
+  # This will cause the case responsiblity to swap to COM, which will cause the 'Change' link to disappear.
+  # When this happens, replace the offender_id with one for an offender with a more distant ERD.
+  let(:offender_id) { 'G7281UH' }
   let(:pom_id) { 485_926 }
 
   context 'when overriding responsibility', vcr: { cassette_name: 'prison_api/override_responsibility' } do

--- a/spec/models/hmpps_api/offender_summary_spec.rb
+++ b/spec/models/hmpps_api/offender_summary_spec.rb
@@ -73,7 +73,13 @@ describe HmppsApi::Offender do
     context 'when THD < 18 months' do
       let(:case_info) do
         build(:case_information, offender: build(:offender,
-                                                 parole_records: [build(:parole_record, target_hearing_date: Time.zone.today + 17.months)]))
+                                                 parole_records: [build(:parole_record,
+                                                                        target_hearing_date: Time.zone.today + 17.months,
+                                                                        review_status: 'Active',
+                                                                        hearing_outcome: 'Not Specified'
+                                                                       )
+                                                 ]
+                                                ))
       end
       let(:api_offender) do
         build(:hmpps_api_offender,

--- a/spec/services/handover_date_service_responsibility_spec.rb
+++ b/spec/services/handover_date_service_responsibility_spec.rb
@@ -125,19 +125,6 @@ describe HandoverDateService do
       end
     end
 
-    context 'when indeterminate with dates in the past' do
-      let(:offender) do
-        OpenStruct.new indeterminate_sentence?: true,
-                       recalled?: false,
-                       tariff_date: Time.zone.today - 1.year,
-                       inside_omic_policy?: true
-      end
-
-      it 'is responsible' do
-        expect(pom).to be_responsible
-      end
-    end
-
     context 'when indeterminate with no tariff date' do
       let(:offender) do
         OpenStruct.new immigration_case?: false,

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -663,6 +663,15 @@ describe HandoverDateService do
           described_class.handover(offender)
         end
       end
+
+      context 'when an offender is mappa level 2 or 3' do
+        let(:target_hearing_date) { Time.zone.today + 2.years }
+        let(:case_info) { build(:case_information, :nps, probation_service: 'England', offender: case_info_offender, mappa_level: 3) }
+
+        it 'assigns to COM responsible, regardless of THD' do
+          expect(com).to be_responsible
+        end
+      end
     end
   end
 

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -380,7 +380,7 @@ describe HandoverDateService do
 
   context 'when indeterminate' do
     context 'with tariff date in the future' do
-      let(:tariff_date) { Date.parse('01/09/2022') }
+      let(:tariff_date) { 1.year.from_now.to_date }
       let(:case_info) { build(:case_information, :nps, probation_service: welsh? ? 'Wales' : 'England') }
       let(:api_offender) do
         build(:hmpps_api_offender,
@@ -606,6 +606,61 @@ describe HandoverDateService do
               expect(com).to be_responsible
             end
           end
+        end
+      end
+    end
+
+    context 'with a tariff date in the past' do
+      let(:tariff_date) { Date.parse('1/1/2020') }
+      let(:case_info) { build(:case_information, :nps, probation_service: 'England', offender: case_info_offender) }
+      let(:case_info_offender) { build(:offender, parole_records: [parole_record]) }
+      let(:parole_record) { build(:parole_record, target_hearing_date: target_hearing_date, hearing_outcome_received: Time.zone.today) }
+      let(:api_offender) do
+        build(:hmpps_api_offender,
+              prisonId: prison,
+              category: category,
+              sentence: attributes_for(:sentence_detail, :indeterminate, tariffDate: tariff_date, sentenceStartDate: '1/1/2018')
+             ).tap do |o|
+          o.prison_arrival_date = arrival_date
+        end
+      end
+
+      context 'with a target hearing date within a year of the hearing outcome' do
+        let(:target_hearing_date) { Time.zone.today + 6.months }
+
+        it 'COM is responsible' do
+          expect(com).to be_responsible
+        end
+      end
+
+      context 'with a target hearing date over a year away from the hearing outcome' do
+        context 'with a target hearing date more than 8 months in the future' do
+          let(:target_hearing_date) { Time.zone.today + 2.years }
+
+          it 'POM is responsibe' do
+            expect(pom).to be_responsible
+          end
+        end
+
+        context 'with a target hearing date less than 8 months in the future' do
+          let(:target_hearing_date) { Time.zone.today + 6.months }
+          let(:parole_record) { build(:parole_record, target_hearing_date: target_hearing_date, hearing_outcome_received: Time.zone.today - 18.months) }
+
+          it 'COM is responsible' do
+            expect(com).to be_responsible
+          end
+        end
+      end
+
+      context 'with a hearing outcome of "Release [*]"' do
+        let(:target_hearing_date) { Time.zone.today + 2.years }
+        let(:parole_record) { build(:parole_record, target_hearing_date: target_hearing_date, hearing_outcome_received: Time.zone.today - 1.week, hearing_outcome: 'Release [*]') }
+
+        it 'follows non-parole allocation rules' do
+          expect_any_instance_of(MpcOffender).not_to receive(:hearing_outcome_received)
+          expect_any_instance_of(MpcOffender).to receive(:recalled?)
+          
+          described_class.handover(offender)
         end
       end
     end

--- a/spec/services/handover_date_service_spec.rb
+++ b/spec/services/handover_date_service_spec.rb
@@ -659,7 +659,7 @@ describe HandoverDateService do
         it 'follows non-parole allocation rules' do
           expect_any_instance_of(MpcOffender).not_to receive(:hearing_outcome_received)
           expect_any_instance_of(MpcOffender).to receive(:recalled?)
-          
+
           described_class.handover(offender)
         end
       end


### PR DESCRIPTION
Refs MO-957

Adds new handover rules for parole cases and the ability to fetch the most recent parole record for an offender, regardless of the activity status of the parole application.
Also removes Target Hearing Date from PomTasks, to prevent a prompt to enter information to a now un-editable field.