### PR TITLE
Adding job to push all handover dates to nDelius

### DIFF
--- a/app/jobs/repush_all_handover_dates_to_delius_job.rb
+++ b/app/jobs/repush_all_handover_dates_to_delius_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Sometimes the PushToDeliusDataJob during the ReallocateHandoverDateJob fails.
+# This is a job to push the handover dates of all offenders, to attempt to bring Delius fully up-to-date.
+# This job is not the solution to the problem, and should only be used as a temporary stop-gap until a solution can be found.
+class RepushAllHandoverDatesToDeliusJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Prison.all.each do |prison|
+      prison.offenders.each do |offender|
+        handover_date = Offender.find(offender.offender_no).calculated_handover_date
+        begin
+          PushHandoverDatesToDeliusJob.perform_now(handover_date)
+          rescue StandardError => e
+          p e.message
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/repush_all_handover_dates_to_delius_job.rb
+++ b/app/jobs/repush_all_handover_dates_to_delius_job.rb
@@ -12,8 +12,8 @@ class RepushAllHandoverDatesToDeliusJob < ApplicationJob
         handover_date = Offender.find(offender.offender_no).calculated_handover_date
         begin
           PushHandoverDatesToDeliusJob.perform_now(handover_date)
-          rescue StandardError => e
-          p e.message
+        rescue StandardError => e
+          Rails.logger.error e.message
         end
       end
     end


### PR DESCRIPTION
The automatic nDelius push after a new handover is calculated occasionally fails, and due to the method that we use to push dates, it is never retried.
As such, the added code is occasionally run to push all handover dates to nDelius, with the intention of ensuring data consistency.

Currently, this code is run manually via the console, but it makes more sense to have a documented job that can be directly invoked rather than manual code execution. This is not a permanent fix, and should not be treated as one, hence the lack of a cronjob. This is a temporary stop-gap until a more suitable solution is created.