### PR TITLE
Renaming parole_controller to parole_case_controller to distinguish from parole_records_controller

### DIFF
--- a/app/controllers/parole_cases_controller.rb
+++ b/app/controllers/parole_cases_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-class ParoleController < PrisonsApplicationController
+# Used to display all parole cases within a prison to the HOMD
+class ParoleCasesController < PrisonsApplicationController
   include Sorting
 
   before_action :ensure_spo_user

--- a/app/controllers/parole_records_controller.rb
+++ b/app/controllers/parole_records_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Used to view and edit individual parole applications (records) for individual offenders
 class ParoleRecordsController < PrisonsApplicationController
   before_action :load_offender
 

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -177,6 +177,19 @@ class MpcOffender
     ].compact.min
   end
 
+  # Separate from next_parole_date as parole case index view sorts by next_parole_date, so it seemed sensible to avoid changing default rails behaviour
+  # for the sake of saving a couple of simple, albeit slightly inefficient, comparisons.
+  def next_parole_date_type
+    case next_parole_date
+    when tariff_date
+      'TED'
+    when parole_eligibility_date
+      'PED'
+    when target_hearing_date
+      'Target hearing date'
+    end
+  end
+
   def early_allocation_state
     if early_allocation?
       :eligible

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -39,8 +39,6 @@ class Offender < ApplicationRecord
 
   has_many :victim_liaison_officers, foreign_key: :nomis_offender_id, inverse_of: :offender, dependent: :destroy
 
-  delegate :parsed_hearing_outcome, to: :parole_record
-
   def most_recent_parole_record
     parole_records.max_by(&:custody_report_due)
   end

--- a/app/presenters/offender_with_allocation_presenter.rb
+++ b/app/presenters/offender_with_allocation_presenter.rb
@@ -5,7 +5,8 @@
 class OffenderWithAllocationPresenter
   delegate :offender_no, :full_name, :last_name, :earliest_release_date, :earliest_release, :latest_temp_movement_date, :allocated_com_name,
            :case_allocation, :complexity_level, :date_of_birth, :tier, :probation_record, :handover_start_date, :restricted_patient?,
-           :location, :responsibility_handover_date, :pom_responsible?, :pom_supporting?, :coworking?, :next_parole_date, :allocated_pom_role, to: :@offender
+           :location, :responsibility_handover_date, :pom_responsible?, :pom_supporting?, :coworking?, :next_parole_date, :next_parole_date_type,
+           :allocated_pom_role, to: :@offender
 
   def initialize(offender, allocation)
     @offender = offender

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -54,7 +54,7 @@
 
     <%= render 'dashboard_partition',
                title: "Parole cases",
-               link: prison_parole_index_path(@prison.code),
+               link: prison_parole_cases_path(@prison.code),
                content: "All cases in the prison with a target hearing date, PED or TED in the next 10 months."
     %>
     

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -18,7 +18,7 @@
                        controllers: {caseload: [], tasks: [], prisoners: [:show], allocations: [:show]} %>
           <% end %>
           <% if @is_spo %>
-            <%= render 'layouts/controller_nav_link', text: 'Parole', path: prison_parole_index_path(@prison.code), controllers: {parole: []} %>
+            <%= render 'layouts/controller_nav_link', text: 'Parole', path: prison_parole_cases_path(@prison.code), controllers: {} %>
             <%= render 'layouts/controller_nav_link', text: 'Handover', path: prison_handovers_path(@prison.code), controllers: {handovers: [], caseload_handovers: []} %>
             <%= render 'layouts/controller_nav_link', text: 'Staff', path: prison_poms_path(@prison.code), controllers: {poms: []} %>
           <% else %>

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -61,7 +61,11 @@
               <%= offender.allocated_pom_role %>
             </td>
             <td aria-label="Next parole date" class="govuk-table__cell">
-              <%= offender.next_parole_date %>
+              <span class='govuk-!-margin-bottom-0'>
+                <%= offender.next_parole_date_type %>:
+              </span>
+              <br/>
+              <%= format_date(offender.next_parole_date) %>
             </td>
           </tr>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     resources :prisons, only: :index
 
     resources :dashboard, only: :index
-    resources :parole, only: :index
+    resources :parole_cases, only: :index
     resources :handovers, only: :index
     resources :staff do
       resources :caseload_handovers, only: %i[index]
@@ -82,11 +82,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :parole_records, only: [:edit, :update] do
-        member do
-          get '/enter_parole_hearing_outcome_confirmed', to: 'parole_records#edit'
-        end
-      end
+      resources :parole_records, only: [:edit, :update]
 
       resources :staff, only: %i[index], controller: 'allocation_staff' do
         resources :build_allocations, only: %i[new show update], controller: 'build_allocations'

--- a/spec/controllers/parole_cases_controller_spec.rb
+++ b/spec/controllers/parole_cases_controller_spec.rb
@@ -98,9 +98,8 @@ RSpec.describe ParoleCasesController, type: :controller do
         end
 
         context 'when sorting by pom role' do
-          # This works a touch counter intuitively, it sorts based on 'true' or 'false', not what is on the screen of 'Responsible' or 'Supporting
           it 'sorts' do
-            get :index, params: { prison_id: prison, sort: 'pom_responsible? asc' }
+            get :index, params: { prison_id: prison, sort: 'allocated_pom_role desc' }
             expect(assigns(:offenders).map(&:offender_no)).to eq(['G7514GW', 'G1234QQ', 'G1234VV'])
           end
         end


### PR DESCRIPTION
Also removing redundant code and fixing minor display issue with dates in parole cases index view.

No particular ticket reference, just improvements to be made to the parole work that was noticed between the main dev effort and before QA.