### PR TITLE
Changing next_parole_date to prioritise Target Hearing Date

### DIFF
--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -170,10 +170,11 @@ class MpcOffender
   end
 
   def next_parole_date
+    return target_hearing_date if target_hearing_date.present?
+
     [
       tariff_date,
-      parole_eligibility_date,
-      target_hearing_date
+      parole_eligibility_date
     ].compact.min
   end
 

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe MpcOffender, type: :model do
+  let(:case_information) { build(:case_information) }
+  let(:prison) { build(:prison) }
+  let(:db_offender) { build(:offender, nomis_offender_id: 'G1234GY', parole_records: [build(:parole_record, target_hearing_date: target_hearing_date)]) }
+  let(:tariff_date) { Time.zone.today + 1.year }
+  let(:parole_eligibility_date) { Time.zone.today + 2.years }
+  let(:target_hearing_date) { nil }
+  let(:prison_record) do
+    build(:hmpps_api_offender,
+          prisonerNumber: 'G1234GY',
+          sentence: sentence)
+  end
+  let(:sentence) do
+    attributes_for(:sentence_detail,
+                   releaseDate: Time.zone.today + 10.years,
+                   sentenceStartDate: Time.zone.today - 5.years,
+                   tariffDate: tariff_date,
+                   paroleEligibilityDate: parole_eligibility_date
+                  )
+  end
+  let(:mpc_offender) do
+    described_class.new(prison: prison,
+                        offender: db_offender,
+                        prison_record: prison_record)
+  end
+
+  describe '#next_parole_date' do
+    context 'when target_hearing_date is unavailable' do
+      context 'when tariff_date is earlier than parole_eligibility_date' do
+        it 'returns tariff_date' do
+          expect(mpc_offender.next_parole_date).to eq tariff_date
+        end
+      end
+
+      context 'when parole_eligibility_date is earlier thhan tariff_date' do
+        let(:parole_eligibility_date) { Time.zone.today - 1.year }
+
+        it 'returns parole_eligibility_date' do
+          expect(mpc_offender.next_parole_date).to eq parole_eligibility_date
+        end
+      end
+    end
+
+    context 'when target_hearing_date is available' do
+      let(:target_hearing_date) { Time.zone.today + 5.years }
+
+      it 'returns the target_hearing_date regardless of whether it is the earliest date' do
+        expect(mpc_offender.next_parole_date).to eq target_hearing_date
+      end
+    end
+  end
+
+  describe '#next_parole_date_type' do
+    context 'when next_parole_date is tariff_date' do
+      it 'returns "TED"' do
+        allow(mpc_offender).to receive(:next_parole_date).and_return(tariff_date)
+
+        expect(mpc_offender.next_parole_date_type).to eq 'TED'
+      end
+    end
+
+    context 'when next_parole_date is parole_eligibility_date' do
+      it 'returns "TED"' do
+        allow(mpc_offender).to receive(:next_parole_date).and_return(parole_eligibility_date)
+
+        expect(mpc_offender.next_parole_date_type).to eq 'PED'
+      end
+    end
+
+    context 'when next_parole_date is target_hearing_date' do
+      it 'returns "TED"' do
+        allow(mpc_offender).to receive(:next_parole_date).and_return(target_hearing_date)
+
+        expect(mpc_offender.next_parole_date_type).to eq 'Target hearing date'
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was no 'lower bound' to the date shown for the next parole date, it took the earliest date out of PED, TED and THD. This is somewhat correct, but it lead to situations where a second or third parole application (after previous unsuccessful applications) would show the original PED/TED for a sentence, rather than the more relevant most-recent Target Hearing Date.

As such, the next_parole_date method now returns the target hearing date if there is one, and only if there isn't will it return the PED or TED, as THD should always be given after PED/TED and therefore be a more accurate date.