### PR TITLE
Changing parole cases table in POM caseload from generic caseload table to parole-specific table

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -9,7 +9,7 @@ class AllocatedOffender
            :indeterminate_sentence?, :prison_id, :target_hearing_date, :approaching_parole?,
            :handover_start_date, :responsibility_handover_date, :allocated_com_name, :case_allocation,
            :complexity_level, :offender_no, :sentence_start_date, :tier, :location, :latest_temp_movement_date, :restricted_patient?,
-           :most_recent_parole_record, :pom_tasks, to: :@offender
+           :most_recent_parole_record, :pom_tasks, :allocated_pom_role, :next_parole_date, :next_parole_date_type, to: :@offender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id,
            to: :@allocation
 

--- a/app/views/caseload/parole_cases.html.erb
+++ b/app/views/caseload/parole_cases.html.erb
@@ -8,5 +8,51 @@
 <% if @pom.blank? || @parole_cases.empty? %>
   <h2 class="govuk-heading-l">No cases approaching parole </h2>
 <% else %>
-  <%= render 'shared/caseload_table', header_partial: 'shared/caseload_headers', collection_partial: 'shared/caseload', collection: @parole_cases %>
+  <table class="govuk-table responsive tablesorter">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">
+          <a href="<%= sort_link('last_name') %>">
+            Case
+          </a>
+          <%= sort_arrow('last_name') %>
+        </th>
+        <th class="govuk-table__header sorter-false" xscope="col">
+          <a href="<%= sort_link('allocated_pom_role') %>">
+            Role
+          </a>
+          <%= sort_arrow('allocated_pom_role') %>
+        </th>
+        <th class="govuk-table__header sorter-false" xscope="col">
+          <a href="<%= sort_link('next_parole_date') %>">
+            Next parole date
+          </a>
+          <%= sort_arrow('next_parole_date') %>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @parole_cases.each_with_index do |offender, i| %>
+        <tr class="govuk-table__row offender_row_<%= i %>">
+          <td aria-label="Prisoner name" class="govuk-table__cell ">
+            <a href="<%= prison_prisoner_path(@prison.code, offender.offender_no) %>"><%= offender.full_name %></a>
+            <br/>
+            <span class='govuk-hint govuk-!-margin-bottom-0'>
+              <%= offender.offender_no %>
+            </span>
+          </td>
+          <td aria-label="POM Role" class="govuk-table__cell">
+            <%= offender.allocated_pom_role %>
+          </td>
+          <td aria-label="Next parole date" class="govuk-table__cell">
+            <span class='govuk-!-margin-bottom-0'>
+              <%= offender.next_parole_date_type %>:
+            </span>
+            <br/>
+            <%= format_date(offender.next_parole_date) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 <% end %>


### PR DESCRIPTION
Previously, a generic table partial was used to display the parole cases in a POM's caseload. This contained a lot of superfluous data, and displayed the earliest release date rather than the next parole date.

A custom table definition has now been added, which is similar to the prison-wide parole cases table (without the Assigned POM column)