### PR TITLE
Add exception and backtrace to JSON errors for live deployments

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,6 +1,17 @@
 Rails.application.configure do
   stdout_logger = ActiveSupport::Logger.new($stdout)
   config.lograge.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
+  config.lograge.custom_options = lambda do |event|
+    ex = event.payload[:exception_object]
+    if ex
+      {
+        exception: event.payload[:exception],
+        backtrace: event.payload[:exception_object].backtrace,
+      }
+    else
+      {}
+    end
+  end
 end
 
 # Disable logging from typhoeus (ETHON) because it's too noisy.


### PR DESCRIPTION
We were not seeing the context for errors that were occurring before; now we add the backtrace for any exceptions that are caught. They're not pretty, but at least they are there.

e.g.:

```json
{
  "_index": "live_kubernetes_cluster-2022.07.26",
  "_type": "_doc",
  "_id": "59f75095-aa29-7fab-a94f-8d226488843c",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2022-07-26T14:58:42.666Z",
    "log": "{\"method\":\"GET\",\"path\":\"/prisons/LEI/handovers\",\"format\":\"html\",\"controller\":\"HandoversController\",\"action\":\"index\",\"status\":500,\"error\":\"NoMethodError: undefined method `parole_review_date' for #\\u003cParoleRecord:0x00007f62d45e39e8\\u003e\",\"duration\":816.75,\"view\":0.0,\"db\":94.9,\"exception\":[\"NoMethodError\",\"undefined method `parole_review_date' for #\\u003cParoleRecord:0x00007f62d45e39e8\\u003e\"],\"backtrace\":[\"/usr/local/bundle/gems/activemodel-6.1.5.1/lib/active_model/attribute_methods.rb:469:in `method_missing'\",\"/app/app/models/mpc_offender.rb:153:in `parole_review_date'\",\"/app/app/services/handover_date_service.rb:223:in `release_date'\",\"/app/app/services/handover_date_service.rb:35:in `handover'\",\"/app/app/models/mpc_offender.rb:49:in `pom_responsible?'\",\"/app/app/models/mpc_offender.rb:194:in `handover'\",\"/app/app/models/mpc_offender.rb:123:in `handover_start_date'\",\"/app/app/models/mpc_offender.rb:140:in `approaching_handover?'\",\"/app/app/controllers/handovers_controller.rb:10:in `select'\",\"/app/app/controllers/handovers_controller.rb:10:in `index'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/abstract_controller/base.rb:228:in `process_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal/rendering.rb:30:in `process_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/abstract_controller/callbacks.rb:42:in `block in process_action'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/callbacks.rb:117:in `block in run_callbacks'\",\"/usr/local/bundle/gems/sentry-raven-3.1.2/lib/raven/integrations/rails/controller_transaction.rb:7:in `block in included'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/callbacks.rb:126:in `instance_exec'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/callbacks.rb:126:in `block in run_callbacks'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/callbacks.rb:137:in `run_callbacks'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/abstract_controller/callbacks.rb:41:in `process_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal/rescue.rb:22:in `process_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/notifications.rb:203:in `block in instrument'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/notifications.rb:203:in `instrument'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal/instrumentation.rb:33:in `process_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal/params_wrapper.rb:249:in `process_action'\",\"/usr/local/bundle/gems/activerecord-6.1.5.1/lib/active_record/railties/controller_runtime.rb:27:in `process_action'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/abstract_controller/base.rb:165:in `process'\",\"/usr/local/bundle/gems/actionview-6.1.5.1/lib/action_view/rendering.rb:39:in `process'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal.rb:190:in `dispatch'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_controller/metal.rb:254:in `dispatch'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/routing/route_set.rb:33:in `serve'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/journey/router.rb:50:in `block in serve'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/journey/router.rb:32:in `each'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/journey/router.rb:32:in `serve'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/routing/route_set.rb:842:in `call'\",\"/usr/local/bundle/gems/turnout-2.5.0/lib/rack/turnout.rb:25:in `call'\",\"/app/app/middleware/robots_tag.rb:12:in `call'\",\"/usr/local/bundle/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'\",\"/usr/local/bundle/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'\",\"/usr/local/bundle/gems/omniauth-1.9.1/lib/omniauth/builder.rb:45:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/tempfile_reaper.rb:15:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/etag.rb:27:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/conditional_get.rb:27:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/head.rb:12:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/http/permissions_policy.rb:22:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/http/content_security_policy.rb:19:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/session/abstract/id.rb:266:in `context'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/session/abstract/id.rb:260:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/cookies.rb:689:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/callbacks.rb:98:in `run_callbacks'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/callbacks.rb:26:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/debug_exceptions.rb:29:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'\",\"/usr/local/bundle/gems/lograge-0.11.2/lib/lograge/rails_ext/rack/logger.rb:15:in `call_app'\",\"/usr/local/bundle/gems/railties-6.1.5.1/lib/rails/rack/logger.rb:26:in `block in call'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/tagged_logging.rb:99:in `block in tagged'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/tagged_logging.rb:37:in `tagged'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/tagged_logging.rb:99:in `tagged'\",\"/usr/local/bundle/gems/railties-6.1.5.1/lib/rails/rack/logger.rb:26:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'\",\"/usr/local/bundle/gems/request_store-1.5.1/lib/request_store/middleware.rb:19:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/request_id.rb:26:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/method_override.rb:24:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/runtime.rb:22:in `call'\",\"/usr/local/bundle/gems/activesupport-6.1.5.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/executor.rb:14:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/static.rb:24:in `call'\",\"/usr/local/bundle/gems/rack-2.2.3.1/lib/rack/sendfile.rb:110:in `call'\",\"/usr/local/bundle/gems/actionpack-6.1.5.1/lib/action_dispatch/middleware/host_authorization.rb:142:in `call'\",\"/usr/local/bundle/gems/sentry-raven-3.1.2/lib/raven/integrations/rack.rb:51:in `call'\",\"/usr/local/bundle/gems/prometheus_exporter-2.0.2/lib/prometheus_exporter/middleware.rb:34:in `call'\",\"/usr/local/bundle/gems/railties-6.1.5.1/lib/rails/engine.rb:539:in `call'\",\"/usr/local/bundle/gems/puma-5.6.4/lib/puma/configuration.rb:252:in `call'\",\"/usr/local/bundle/gems/puma-5.6.4/lib/puma/request.rb:77:in `block in handle_request'\",\"/usr/local/bundle/gems/puma-5.6.4/lib/puma/thread_pool.rb:340:in `with_force_shutdown'\",\"/usr/local/bundle/gems/puma-5.6.4/lib/puma/request.rb:76:in `handle_request'\",\"/usr/local/bundle/gems/puma-5.6.4/lib/puma/server.rb:441:in `process_client'\",\"/usr/local/bundle/gems/puma-5.6.4/lib/puma/thread_pool.rb:147:in `block in spawn_thread'\"],\"@timestamp\":\"2022-07-26T14:58:42.665Z\",\"@version\":\"1\",\"message\":\"[500] GET /prisons/LEI/handovers (HandoversController#index)\"}\n",
    "stream": "stdout",
    "time": "2022-07-26T14:58:42.666963761Z",
    "kubernetes": {
      "pod_name": "allocation-manager-7d869695bf-xmtfp",
      "namespace_name": "offender-management-test",
      "pod_id": "f6cf3a70-c9ff-4ad0-ad1e-5696f05ffa7b",
      "labels": {
        "app": "allocation-manager",
        "pod-template-hash": "7d869695bf"
      },
      "annotations": {
        "kubectl_kubernetes_io/restartedAt": "2022-07-14T10:22:40+01:00",
        "kubernetes_io/psp": "restricted",
        "seccomp_security_alpha_kubernetes_io/pod": "runtime/default"
      },
      "host": "ip-172-20-32-168.eu-west-2.compute.internal",
      "container_name": "allocation-manager",
      "docker_id": "1ca38f574ce76987c3c9af09398be9f96b6eba4568fc35e78e4317955bc5fece",
      "container_hash": "754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager@sha256:d819a16f0d5de40c9e33e2c3642885d1ed10825174701b4520ae125d1030e612",
      "container_image": "754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:482f9da96c3c1fb3d06c36aabe54744ed584434d"
    }
  },
  "fields": {
    "@timestamp": [
      "2022-07-26T14:58:42.666Z"
    ],
    "time": [
      "2022-07-26T14:58:42.666Z"
    ],
    "kubernetes.annotations.kubectl_kubernetes_io/restartedAt": [
      "2022-07-14T09:22:40.000Z"
    ]
  },
  "highlight": {
    "kubernetes.namespace_name": [
      "@kibana-highlighted-field@offender@/kibana-highlighted-field@-@kibana-highlighted-field@management@/kibana-highlighted-field@-@kibana-highlighted-field@test@/kibana-highlighted-field@"
    ]
  },
  "sort": [
    1658847522666
  ]
}
```