### PR TITLE
CircleCI now runs test in parallel and enables headless Firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           name: Run tests
           command: |
             cc-test-reporter before-build
-            bundle exec rspec spec -t ~flaky
+            MOZ_HEADLESS=1 bundle exec parallel_test -t rspec -- -t ~flaky -fd -- spec
             cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
             ALLOCATION_MANAGER_HOST: https://dev.moic.service.justice.gov.uk


### PR DESCRIPTION
Cuts down testing speed to about 1/3 of the original time.

Branches are now tested in about 1/3 of the time.

Merging to main/deploy to staging now has about 10 minutes cut off the process.
