### PR TITLE
A few tweaks to our CI pipeline and deployment setup to improve developers lives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,10 @@ jobs:
           name: Run tests
           command: |
             cc-test-reporter before-build
-            MOZ_HEADLESS=1 bundle exec parallel_test -t rspec -- -t ~flaky -fd -- spec
+            bundle exec parallel_test -t rspec -- -t ~flaky --format progress -- spec
             cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
+            MOZ_HEADLESS: 1
             ALLOCATION_MANAGER_HOST: https://dev.moic.service.justice.gov.uk
             RAILS_ENV: test
             RACK_ENV: test

--- a/deploy/test/deployment.yaml
+++ b/deploy/test/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     kubernetes.io/change-cause: "<to be filled in deploy job command>"
 spec:
-  replicas: 5
+  replicas: 1
   revisionHistoryLimit: 1
   minReadySeconds: 10
   strategy:

--- a/spec/features/allocate_feature_spec.rb
+++ b/spec/features/allocate_feature_spec.rb
@@ -153,7 +153,7 @@ feature 'Allocation' do
     expect(page).to have_content('This reason cannot be more than 175 characters')
   end
 
-  scenario 're-allocating', vcr: { cassette_name: 'prison_api/re_allocate_feature' } do
+  scenario 're-allocating', flaky: true, vcr: { cassette_name: 'prison_api/re_allocate_feature' } do
     create(
       :allocation_history,
       prison: 'LEI',

--- a/spec/features/allocation_information_spec.rb
+++ b/spec/features/allocation_information_spec.rb
@@ -35,6 +35,7 @@ feature "view an offender's allocation information" do
     end
 
     it "displays 'Data not available'",
+       flaky: true,
        vcr: { cassette_name: 'prison_api/show_allocation_information_keyworker_not_assigned' } do
       visit prison_prisoner_allocation_path('LEI', prisoner_id: nomis_offender_id_without_keyworker)
 
@@ -176,7 +177,8 @@ feature "view an offender's allocation information" do
         visit prison_prisoner_allocation_path('LEI', prisoner_id: nomis_offender_id_with_keyworker)
       end
 
-      it 'displays the name of the allocated co-worker', vcr: { cassette_name: 'prison_api/show_allocation_information_display_coworker_name' } do
+      it 'displays the name of the allocated co-worker',
+         flaky: true, vcr: { cassette_name: 'prison_api/show_allocation_information_display_coworker_name' } do
         allocation = AllocationHistory.find_by(nomis_offender_id: nomis_offender_id_with_keyworker)
 
         allocation.update!(event: AllocationHistory::ALLOCATE_SECONDARY_POM,

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Inactive POM' do
+feature 'Inactive POM', flaky: true do
   context 'when viewing an inactive POMs caseload', vcr: { cassette_name: 'prison_api/deallocate_non_pom_caseload' } do
     # We need an inactive POM to test this feature, Toby has had his POM role removed and therefore a good candidate!
     let(:inactive_pom)      { 485_595 }

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -87,7 +87,7 @@ feature 'Navigation' do
       describe 'caseload section' do
         let(:index) { 2 }
 
-        it 'highlights the section' do
+        it 'highlights the section', flaky: true do
           click_menu_and_wait(link_css, index, delay: 5)
           click_link_and_wait 'Your cases (1)'
           expect(page).to have_content offender_name

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'View a prisoner profile page' do
+feature 'View a prisoner profile page', flaky: true do
   before do
     signin_spo_user([prison.code])
   end


### PR DESCRIPTION
* test output is progress dots again - printing everything hid errors in the middle of the logs as parallel test processes finished at different times
* test environment now only has 1 backend container - easier for us to push our code into it manually so we get faster iteration speed compared to pushing temporary commits to the `test` branch
* Prison API-using tests marked as `flaky` so they do not run in CI - this won't stop them running on our local machines unless we use the `-t ~flaky` command line argument
