### PR TITLE
Renaming env vars and adding ability for env vars to be read from kubernetes envs

### DIFF
--- a/app/jobs/parole_data_import_job.rb
+++ b/app/jobs/parole_data_import_job.rb
@@ -19,7 +19,7 @@ private
   # It was confirmed by the PPUD team that in the case of duplicate emails, we should take the most recently-received one.
   # For this reason, the email with the highest ID is taken, as the IDs appear to be sequential.
   def fetch_email(imap)
-    imap.login(ENV['GMAIL_USERNAME'], ENV['GMAIL_PASSWORD'])
+    imap.login(ENV['EMAIL_USERNAME'], ENV['EMAIL_PASSWORD'])
     imap.select('INBOX')
     email_id = imap.search(['FROM', 'moic-data@digital.justice.gov.uk', 'SUBJECT', 'POM Cases list', 'ON', @date.strftime('%d-%b-%Y').to_s]).max
     imap.fetch(email_id, 'RFC822')[0].attr['RFC822']

--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -105,6 +105,16 @@ spec:
                 secretKeyRef:
                   name: hmpps-auth-secrets
                   key: NOMIS_OAUTH_API_CLIENT_SECRET
+            - name: EMAIL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: parole-data-import
+                  key: email_username
+            - name: EMAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: parole-data-import
+                  key: email_password
         - name: allocation-manager-sidekiq
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -105,6 +105,16 @@ spec:
                 secretKeyRef:
                   name: hmpps-auth-secrets
                   key: NOMIS_OAUTH_API_CLIENT_SECRET
+            - name: EMAIL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: parole-data-import
+                  key: email_username
+            - name: EMAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: parole-data-import
+                  key: email_password
         - name: allocation-manager-sidekiq
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always

--- a/deploy/test/deployment.yaml
+++ b/deploy/test/deployment.yaml
@@ -105,6 +105,16 @@ spec:
                 secretKeyRef:
                   name: hmpps-auth-secrets
                   key: NOMIS_OAUTH_API_CLIENT_SECRET
+            - name: EMAIL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: parole-data-import
+                  key: email_username
+            - name: EMAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: parole-data-import
+                  key: email_password
         - name: allocation-manager-sidekiq
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest
           imagePullPolicy: Always


### PR DESCRIPTION
Env vars have already been added to staging, test, and preprod via kubectl.
This PR adds the ability for the app to read them from the environment.