### PR TITLE
MO-Parole - Testing round 1 changes

### DIFF
--- a/app/helpers/parole_info_helper.rb
+++ b/app/helpers/parole_info_helper.rb
@@ -1,0 +1,7 @@
+module ParoleInfoHelper
+  def display_hearing_outcome?(parole_record)
+    parole_record&.target_hearing_date.present? &&
+    parole_record.target_hearing_date <= Time.zone.today &&
+    parole_record&.hearing_outcome.present?
+  end
+end

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -233,6 +233,10 @@ class MpcOffender
     tariff_date.present? || parole_eligibility_date.present? || current_parole_record.present?
   end
 
+  def due_for_release?
+    most_recent_parole_record&.current_record_hearing_outcome == 'Release'
+  end
+
 private
 
   def early_allocation_notes?

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -164,9 +164,22 @@ class MpcOffender
     @offender.most_recent_parole_record&.hearing_outcome_received
   end
 
+  # If the parole application is set for a hearing within 10 months, or the outcome for a hearing was received in the last 14 days,
+  # the offender should be counted as approaching parole. If we do not know the date that the hearing outcome was received,
+  # continue to count the case as approaching parole until we know.
   def approaching_parole?
     earliest_date = next_parole_date
-    earliest_date.present? && earliest_date <= Time.zone.today + 10.months
+    return false unless earliest_date.present? 
+    return false unless earliest_date <= Time.zone.today + 10.months
+    
+    if earliest_date.past? && 
+      hearing_outcome_received.present? && 
+      hearing_outcome_received <= Time.zone.today - 14.days
+
+      return false
+    end
+    
+    true
   end
 
   def next_parole_date

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -166,19 +166,19 @@ class MpcOffender
 
   # If the parole application is set for a hearing within 10 months, or the outcome for a hearing was received in the last 14 days,
   # the offender should be counted as approaching parole. If we do not know the date that the hearing outcome was received,
-  # continue to count the case as approaching parole until we know.
+  # continue to count the case as approaching parole until we know.
   def approaching_parole?
     earliest_date = next_parole_date
-    return false unless earliest_date.present? 
+    return false if earliest_date.blank?
     return false unless earliest_date <= Time.zone.today + 10.months
-    
-    if earliest_date.past? && 
-      hearing_outcome_received.present? && 
+
+    if earliest_date.past? &&
+      hearing_outcome_received.present? &&
       hearing_outcome_received <= Time.zone.today - 14.days
 
       return false
     end
-    
+
     true
   end
 

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -229,6 +229,10 @@ class MpcOffender
     end
   end
 
+  def display_current_parole_info?
+    tariff_date.present? || parole_eligibility_date.present? || current_parole_record.present?
+  end
+
 private
 
   def early_allocation_notes?

--- a/app/models/parole_record.rb
+++ b/app/models/parole_record.rb
@@ -12,11 +12,13 @@ class ParoleRecord < ApplicationRecord
     'Active - Referred'
   ].freeze
 
-  def current_hearing_outcome
+  # Returns the hearing outcome formatted for upcoming hearing
+  def current_record_hearing_outcome
     no_hearing_outcome? ? 'No hearing outcome yet' : format_hearing_outcome
   end
 
-  def previous_hearing_outcome
+  # Returns the hearing outcome formatted for a past hearing
+  def previous_record_hearing_outcome
     no_hearing_outcome? ? 'No hearing outcome given' : format_hearing_outcome
   end
 

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -186,7 +186,7 @@ private
   def self.eligible_unsuccessful_parole_applicant(offender)
     return false if offender.most_recent_parole_record.blank?
     return false if offender.most_recent_parole_record.hearing_outcome_received.blank?
-    return false if offender.most_recent_parole_record.current_hearing_outcome == 'Release'
+    return false if offender.due_for_release?
 
     offender.indeterminate_sentence? && offender.tariff_date&.past?
   end
@@ -206,7 +206,7 @@ private
              :parole_eligibility_date, :conditional_release_date, :automatic_release_date,
              :home_detention_curfew_eligibility_date, :home_detention_curfew_actual_date,
              :tariff_date, :target_hearing_date, :hearing_outcome_received, :most_recent_parole_record,
-             to: :@offender
+             :due_for_release?, to: :@offender
 
     def initialize(offender)
       @offender = offender

--- a/app/views/allocation_staff/index.html.erb
+++ b/app/views/allocation_staff/index.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <%= render partial: 'shared/offence_info', locals: { editable_thd: true }  %>
-<% if @prisoner.tariff_date.present? || @prisoner.parole_eligibility_date.present? || @prisoner.current_parole_record.present? %>
+<% if @prisoner.display_current_parole_info? %>
   <%= render partial: 'shared/parole_info' %>
 <% end %>
 <% if @prisoner.previous_parole_records.any? %>

--- a/app/views/allocation_staff/index.html.erb
+++ b/app/views/allocation_staff/index.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <%= render partial: 'shared/offence_info', locals: { editable_thd: true }  %>
-<% if @prisoner.current_parole_record.present? %>
+<% if @prisoner.tariff_date.present? || @prisoner.parole_eligibility_date.present? || @prisoner.current_parole_record.present? %>
   <%= render partial: 'shared/parole_info' %>
 <% end %>
 <% if @prisoner.previous_parole_records.any? %>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -91,7 +91,7 @@
   </table>
 
   <%= render partial: 'shared/offence_info', locals: { editable_thd: true}  %>
-  <% if @prisoner.tariff_date.present? || @prisoner.parole_eligibility_date.present? || @prisoner.current_parole_record.present? %>
+  <% if @prisoner.display_current_parole_info? %>
     <%= render partial: 'shared/parole_info' %>
   <% end %>
   <% if @prisoner.previous_parole_records.any? %>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -91,6 +91,12 @@
   </table>
 
   <%= render partial: 'shared/offence_info', locals: { editable_thd: true}  %>
+  <% if @prisoner.tariff_date.present? || @prisoner.parole_eligibility_date.present? || @prisoner.current_parole_record.present? %>
+    <%= render partial: 'shared/parole_info' %>
+  <% end %>
+  <% if @prisoner.previous_parole_records.any? %>
+    <%= render partial: 'shared/historical_parole' %>
+  <% end%>
 
   <table class="govuk-table">
     <tbody class="govuk-table__body">

--- a/app/views/caseload/parole_cases.html.erb
+++ b/app/views/caseload/parole_cases.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: 'layouts/caseload' %>
 
 <h2 class="govuk-heading-l">Parole cases</h2>
-<p class="govuk-body">Cases with a target hearing date, PED or TED in the next 10 months.</p>
+<p class="govuk-body">Cases with a target hearing date, PED or TED in the next 10 months or that have had a hearing recently.</p>
 
 <% if @pom.blank? || @parole_cases.empty? %>
   <h2 class="govuk-heading-l">No cases approaching parole </h2>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -55,7 +55,7 @@
     <%= render 'dashboard_partition',
                title: "Parole cases",
                link: prison_parole_cases_path(@prison.code),
-               content: "All cases in the prison with a target hearing date, PED or TED in the next 10 months."
+               content: "All cases in the prison with a target hearing date, PED or TED in the next 10 months or that have had a hearing recently."
     %>
     
     <%= render 'dashboard_partition',
@@ -105,7 +105,7 @@
     <%= render 'dashboard_partition',
                title: 'Parole cases',
                link: prison_staff_caseload_parole_cases_path(@prison.code, @staff_id),
-               content: 'Cases with a target hearing date, PED or TED in the next 10 months.'
+               content: 'Cases with a target hearing date, PED or TED in the next 10 months or that have had a hearing recently.'
     %>
     
     <%= render 'dashboard_partition',

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -48,7 +48,7 @@
         <% @offenders.each_with_index do |offender, i| %>
           <tr class="govuk-table__row offender_row_<%= i %>">
             <td aria-label="Prisoner name" class="govuk-table__cell ">
-              <a href="<%= prison_prisoner_path(@prison.code, offender.offender_no) %>"><%= offender.full_name %></a>
+              <a href="<%= prison_prisoner_allocation_path(@prison.code, offender.offender_no) %>"><%= offender.full_name %></a>
               <br/>
               <span class='govuk-hint govuk-!-margin-bottom-0'>
                 <%= offender.offender_no %>

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Parole cases</h1>
-<p>All cases in this prison with a target hearing date, PED or TED in the next 10 months.</p>
+<p>All cases in this prison with a target hearing date, PED or TED in the next 10 months or that have had a hearing recently.</p>
 
 <section id="approaching-parole">
   <% if @offenders.empty? %>

--- a/app/views/poms/_parole_tab.html.erb
+++ b/app/views/poms/_parole_tab.html.erb
@@ -4,7 +4,7 @@
       <h2 class="govuk-tabs__title">
         Parole Cases
       </h2>
-      <p class="govuk-body">Cases with a target hearing date, PED or TED in the next 10 months.</p>
+      <p class="govuk-body">Cases with a target hearing date, PED or TED in the next 10 months or that have had a hearing recently.</p>
         <% if @parole_cases.empty? %>
           <h2 class="govuk-heading-l">No cases approaching parole </h2>
         <% else %>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -80,7 +80,7 @@
 
 <%= render 'prisoner_information' %>
 <%= render partial: 'shared/offence_info', locals: { editable_thd: true}  %>
-<% if @prisoner.tariff_date.present? || @prisoner.parole_eligibility_date.present? || @prisoner.current_parole_record.present? %>
+<% if @prisoner.display_current_parole_info? %>
   <%= render partial: 'shared/parole_info' %>
 <% end %>
 <% if @prisoner.previous_parole_records.any? %>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -80,7 +80,7 @@
 
 <%= render 'prisoner_information' %>
 <%= render partial: 'shared/offence_info', locals: { editable_thd: true}  %>
-<% if @prisoner.current_parole_record.present? %>
+<% if @prisoner.tariff_date.present? || @prisoner.parole_eligibility_date.present? || @prisoner.current_parole_record.present? %>
   <%= render partial: 'shared/parole_info' %>
 <% end %>
 <% if @prisoner.previous_parole_records.any? %>

--- a/app/views/shared/_historical_parole.html.erb
+++ b/app/views/shared/_historical_parole.html.erb
@@ -12,10 +12,10 @@
           <td class="govuk-table__cell govuk-!-width-one-half"></td>
         <% end %>
         <% if record.hearing_outcome_received.present? %>
-          <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= "#{record.hearing_outcome_received.strftime("%b %Y")} – #{record.previous_hearing_outcome}" %></td>
+          <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= "#{record.hearing_outcome_received.strftime("%b %Y")} – #{record.previous_record_hearing_outcome}" %></td>
         <% else %>
           <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-            <%= record.previous_hearing_outcome %>
+            <%= record.previous_record_hearing_outcome %>
             <br/>
             We do not have the date this outcome was confirmed
           </td>

--- a/app/views/shared/_parole_info.html.erb
+++ b/app/views/shared/_parole_info.html.erb
@@ -1,3 +1,4 @@
+<%= parole_record = @prisoner.current_parole_record%>
 <table class="govuk-table">
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
@@ -10,10 +11,10 @@
         <td id='tariff-expiriy-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.tariff_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.current_parole_record&.custody_report_due.present? %>
+    <% if parole_record&.custody_report_due.present? %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Custody report due</td>
-        <td id='custody-report-due' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.current_parole_record.custody_report_due) %></td>
+        <td id='custody-report-due' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(parole_record.custody_report_due) %></td>
       </tr>
     <% end %>
     <% if @prisoner.parole_eligibility_date.present? %>
@@ -22,16 +23,16 @@
         <td id='parole-eligibility-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.parole_eligibility_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.current_parole_record&.target_hearing_date.present? %>
+    <% if parole_record&.target_hearing_date.present? %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Target hearing date</td>
-        <td id='target-hearing-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.target_hearing_date) %></td>
+        <td id='target-hearing-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(parole_record.target_hearing_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.target_hearing_date.present? && @prisoner.target_hearing_date <= Time.zone.today && @prisoner.current_parole_record&.hearing_outcome.present?%>
+    <% if display_hearing_outcome?(parole_record)%>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Hearing outcome</td>
-        <td id='hearing-outcome' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.current_parole_record.current_hearing_outcome %></td>
+        <td id='hearing-outcome' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= parole_record.current_record_hearing_outcome %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/shared/_parole_info.html.erb
+++ b/app/views/shared/_parole_info.html.erb
@@ -1,4 +1,4 @@
-<%= parole_record = @prisoner.current_parole_record%>
+<% parole_record = @prisoner.current_parole_record%>
 <table class="govuk-table">
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">

--- a/app/views/shared/_parole_info.html.erb
+++ b/app/views/shared/_parole_info.html.erb
@@ -28,7 +28,7 @@
         <td id='target-hearing-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.target_hearing_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.target_hearing_date <= Time.zone.today && @prisoner.current_parole_record&.hearing_outcome.present?%>
+    <% if @prisoner.target_hearing_date.present? && @prisoner.target_hearing_date <= Time.zone.today && @prisoner.current_parole_record&.hearing_outcome.present?%>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Hearing outcome</td>
         <td id='hearing-outcome' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.current_parole_record.current_hearing_outcome %></td>

--- a/app/views/shared/_parole_info.html.erb
+++ b/app/views/shared/_parole_info.html.erb
@@ -10,7 +10,7 @@
         <td id='tariff-expiriy-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.tariff_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.current_parole_record.custody_report_due.present? %>
+    <% if @prisoner.current_parole_record&.custody_report_due.present? %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Custody report due</td>
         <td id='custody-report-due' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.current_parole_record.custody_report_due) %></td>
@@ -22,13 +22,13 @@
         <td id='parole-eligibility-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.parole_eligibility_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.target_hearing_date.present? %>
+    <% if @prisoner.current_parole_record&.target_hearing_date.present? %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Target hearing date</td>
         <td id='target-hearing-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.target_hearing_date) %></td>
       </tr>
     <% end %>
-    <% if @prisoner.current_parole_record.hearing_outcome.present? %>
+    <% if @prisoner.target_hearing_date <= Time.zone.today && @prisoner.current_parole_record&.hearing_outcome.present?%>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Hearing outcome</td>
         <td id='hearing-outcome' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= @prisoner.current_parole_record.current_hearing_outcome %></td>

--- a/spec/jobs/parole_data_import_job_spec.rb
+++ b/spec/jobs/parole_data_import_job_spec.rb
@@ -40,15 +40,15 @@ RSpec.describe ParoleDataImportJob, type: :job do
 
           parole_application_1 = ParoleRecord.find_by(review_id: '123456', nomis_offender_id: 'A1111AA')
           expect(parole_application_1.active?).to eq(true)
-          expect(parole_application_1.current_hearing_outcome).to eq('No hearing outcome yet')
+          expect(parole_application_1.current_record_hearing_outcome).to eq('No hearing outcome yet')
 
           parole_application_2 = ParoleRecord.find_by(review_id: '098765', nomis_offender_id: 'B2222BB')
           expect(parole_application_2.active?).to eq(true)
-          expect(parole_application_2.previous_hearing_outcome).to eq('No hearing outcome given')
+          expect(parole_application_2.previous_record_hearing_outcome).to eq('No hearing outcome given')
 
           parole_application_3 = ParoleRecord.find_by(review_id: '024680', nomis_offender_id: 'C3333CC')
           expect(parole_application_3.active?).to eq(false)
-          expect(parole_application_3.previous_hearing_outcome).to eq('No hearing outcome given')
+          expect(parole_application_3.previous_record_hearing_outcome).to eq('No hearing outcome given')
         end
       end
 
@@ -113,7 +113,7 @@ RSpec.describe ParoleDataImportJob, type: :job do
         # Ensure data is seeded correctly
         parole_application_1 = ParoleRecord.find_by(review_id: '123456', nomis_offender_id: 'A1111AA')
         expect(parole_application_1.active?).to eq(true)
-        expect(parole_application_1.current_hearing_outcome).to eq('No hearing outcome yet')
+        expect(parole_application_1.current_record_hearing_outcome).to eq('No hearing outcome yet')
 
         # Update seed data with new data
         allow(Mail).to receive(:new).and_return(double(attachments: [attachment_mock_3]))
@@ -121,15 +121,15 @@ RSpec.describe ParoleDataImportJob, type: :job do
 
         parole_application_1 = ParoleRecord.find_by(review_id: '123456', nomis_offender_id: 'A1111AA')
         expect(parole_application_1.active?).to eq(false)
-        expect(parole_application_1.current_hearing_outcome).to eq('Stay in closed')
+        expect(parole_application_1.current_record_hearing_outcome).to eq('Stay in closed')
 
         parole_application_2 = ParoleRecord.find_by(review_id: '098765', nomis_offender_id: 'B2222BB')
         expect(parole_application_2.active?).to eq(true)
-        expect(parole_application_2.previous_hearing_outcome).to eq('No hearing outcome given')
+        expect(parole_application_2.previous_record_hearing_outcome).to eq('No hearing outcome given')
 
         parole_application_3 = ParoleRecord.find_by(review_id: '024680', nomis_offender_id: 'C3333CC')
         expect(parole_application_3.active?).to eq(false)
-        expect(parole_application_3.previous_hearing_outcome).to eq('No hearing outcome given')
+        expect(parole_application_3.previous_record_hearing_outcome).to eq('No hearing outcome given')
       end
     end
   end


### PR DESCRIPTION
Changes #approaching_parole? to better reflect when a case would actually be counted as approaching parole
Shows parole section of prisoner profile if PED or TED are present
Adds parole section to allocation page for an offender
Hides hearing outcome field from parole section of prisoner profile if target hearing date has not yet passed
Updates text relating to #approaching_parole? to better describe what the tables will show.