### PR TITLE
MO-Parole - Fixing responsibility calculations and adding comments + specs

### DIFF
--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -18,7 +18,8 @@ class MpcOffender
            :mappa_level, :welsh_offender, to: :probation_record
 
   delegate :victim_liaison_officers, :current_parole_record, :previous_parole_records,
-           :most_recent_parole_record, :build_parole_record_sections, to: :@offender
+           :most_recent_parole_record, :build_parole_record_sections, :parole_record_awaiting_hearing,
+           :most_recent_completed_parole_record, to: :@offender
 
   # These fields make sense to be nil when the probation record is nil - the others dont
   delegate :ldu_email_address, :team_name, :ldu_name, to: :probation_record, allow_nil: true
@@ -157,11 +158,24 @@ class MpcOffender
   end
 
   def target_hearing_date
-    @offender.most_recent_parole_record&.target_hearing_date
+    most_recent_parole_record&.target_hearing_date
   end
 
+  # Returns the target hearing date for the offender's next active parole application, or nil if there isn't one.
+  # Used to exclude THDs of previous (completed/inactive) parole applications.
+  def next_thd
+    parole_record_awaiting_hearing&.target_hearing_date
+  end
+
+  # Returns the date that the most recent hearing outcome was received.
   def hearing_outcome_received
-    @offender.most_recent_parole_record&.hearing_outcome_received
+    most_recent_parole_record&.hearing_outcome_received
+  end
+
+  # Returns the date that the most recent COMPLETED hearing outcome was received.
+  # Used to exclude any active parole applications.
+  def last_hearing_outcome_received
+    most_recent_completed_parole_record&.hearing_outcome_received
   end
 
   # If the parole application is set for a hearing within 10 months, or the outcome for a hearing was received in the last 14 days,

--- a/app/services/handover_date_service.rb
+++ b/app/services/handover_date_service.rb
@@ -29,7 +29,7 @@ class HandoverDateService
                                    start_date: nil, handover_date: nil,
                                    reason: :parole_mappa_2_3
 
-      elsif offender.target_hearing_date < offender.hearing_outcome_received + 12.months
+      elsif offender.next_thd.present? && offender.next_thd < offender.last_hearing_outcome_received + 12.months
         CalculatedHandoverDate.new responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
                                    start_date: nil, handover_date: nil,
                                    reason: :thd_within_12_months_of_hearing_outcome
@@ -184,8 +184,8 @@ private
   end
 
   def self.eligible_unsuccessful_parole_applicant(offender)
-    return false if offender.most_recent_parole_record.blank?
-    return false if offender.most_recent_parole_record.hearing_outcome_received.blank?
+    return false if offender.most_recent_completed_parole_record.blank?
+    return false if offender.last_hearing_outcome_received.blank?
     return false if offender.due_for_release?
 
     offender.indeterminate_sentence? && offender.tariff_date&.past?
@@ -206,6 +206,7 @@ private
              :parole_eligibility_date, :conditional_release_date, :automatic_release_date,
              :home_detention_curfew_eligibility_date, :home_detention_curfew_actual_date,
              :tariff_date, :target_hearing_date, :hearing_outcome_received, :most_recent_parole_record,
+             :next_thd, :most_recent_completed_parole_record, :last_hearing_outcome_received,
              :due_for_release?, to: :@offender
 
     def initialize(offender)

--- a/app/views/shared/_historical_parole.html.erb
+++ b/app/views/shared/_historical_parole.html.erb
@@ -7,7 +7,7 @@
     <% @prisoner.previous_parole_records.first(3).each_with_index do |record, index| %>
       <tr class="govuk-table__row">
         <% if index == 0 %>
-          <td class="govuk-table__cell govuk-!-width-one-half">Hearing outcome</td>
+          <td class="govuk-table__cell govuk-!-width-one-half">Hearing outcomes (up to last 3)</td>
         <% else %>
           <td class="govuk-table__cell govuk-!-width-one-half"></td>
         <% end %>
@@ -15,9 +15,7 @@
           <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= "#{record.hearing_outcome_received.strftime("%b %Y")} – #{record.previous_record_hearing_outcome}" %></td>
         <% else %>
           <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-            <%= record.previous_record_hearing_outcome %>
-            <br/>
-            We do not have the date this outcome was confirmed
+            No date available - <%= record.previous_record_hearing_outcome %>
           </td>
         <% end %>
       </tr>


### PR DESCRIPTION
Fixes an issue where THD was being taken from the last parole application, rather than the next upcoming one

Also adds a handful of new methods to Offender and MpcOffender to get different parole records depends on state
Also adds comments to explain various methods, as parole can be quite complicated!