### PR TITLE
Undo renaming of parole_review_date to target_hearing_date for old table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -168,7 +168,7 @@ ActiveRecord::Schema.define(version: 2022_08_16_170141) do
   end
 
   create_table "parole_records", primary_key: "nomis_offender_id", id: :string, force: :cascade do |t|
-    t.date "target_hearing_date", null: false
+    t.date "parole_review_date", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Despite removing the migration responsible, the renaming of `parole_review_date` to `target_hearing_date` still crept its way into the schema.
The decision to _not_ rename the column for the `parole_records` table came from the fact that the table will be being replaced as a part of this work, and renaming it would make any rollbacks (if necessary) harder to perform.