### PR TITLE
Redirect /help to /help/dashboard so references to old help page work

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
   get '/help_step6', to: 'help#help_step6'
 
   get '/help/dashboard', to: 'help#dashboard'
+  get '/help', to: redirect('/help/dashboard')
   get '/help/missing_cases', to: 'help#missing_cases'
   get '/help/case_responsibility', to: 'help#case_responsibility'
 


### PR DESCRIPTION
Other orgs have hardcoded /help so we need that back

MO-1143