### PR TITLE
Changes from round 2 of parole work testing

### DIFF
--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -186,12 +186,13 @@ class MpcOffender
   end
 
   # If the parole application is set for a hearing within 10 months, or the outcome for a hearing was received in the last 14 days,
-  # the offender should be counted as approaching parole. If we do not know the date that the hearing outcome was received,
-  # continue to count the case as approaching parole until we know.
+  # return true. If the hearing has an outcome but we do not have the date that it was received, assume that it is no longer
+  # approaching parole (return false).
   def approaching_parole?
     earliest_date = next_parole_date
     return false if earliest_date.blank?
     return false unless earliest_date <= Time.zone.today + 10.months
+    return false if !most_recent_parole_record&.no_hearing_outcome? && hearing_outcome_received.blank?
 
     if earliest_date.past? &&
       hearing_outcome_received.present? &&

--- a/app/views/caseload/parole_cases.html.erb
+++ b/app/views/caseload/parole_cases.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Cases approaching parole – Digital Prison Services" %>
+<% content_for :title, "Parole cases – Digital Prison Services" %>
 
 <%= render partial: 'layouts/caseload' %>
 

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, 'All parole cases' %>
+
 <% content_for :switcher do %>
   <%= render '/layouts/prison_switcher' %>
 <% end %>

--- a/app/views/shared/_historical_parole.html.erb
+++ b/app/views/shared/_historical_parole.html.erb
@@ -15,7 +15,7 @@
           <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= "#{record.hearing_outcome_received.strftime("%b %Y")} – #{record.previous_record_hearing_outcome}" %></td>
         <% else %>
           <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
-            No date available - <%= record.previous_record_hearing_outcome %>
+            No date available – <%= record.previous_record_hearing_outcome %>
           </td>
         <% end %>
       </tr>

--- a/app/views/shared/_parole_info.html.erb
+++ b/app/views/shared/_parole_info.html.erb
@@ -11,7 +11,7 @@
         <td id='tariff-expiriy-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.tariff_date) %></td>
       </tr>
     <% end %>
-    <% if parole_record&.custody_report_due.present? %>
+    <% if parole_record&.custody_report_due.present? && !parole_record&.target_hearing_date&.past? %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">Custody report due</td>
         <td id='custody-report-due' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(parole_record.custody_report_due) %></td>
@@ -19,7 +19,7 @@
     <% end %>
     <% if @prisoner.parole_eligibility_date.present? %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-!-width-one-half">Parole Eligibility Date</td>
+        <td class="govuk-table__cell govuk-!-width-one-half">Parole eligibility date</td>
         <td id='parole-eligibility-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.parole_eligibility_date) %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
Parole records with a hearing outcome but with `#hearing_outcome_recieved` as null no longer return true from `#approaching_parole?`
Custody report due field on prisoner profile no longer appears if the target hearing date is in the past.

A handful of minor content tweaks