### PR TITLE
MO-1145 - Fixing parole dashboard error

### DIFF
--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -47,7 +47,7 @@ class Offender < ApplicationRecord
 
   # Returns the most recent parole record that has an outcome
   def most_recent_completed_parole_record
-    filtered_parole_records.reject{ |pr| pr.no_hearing_outcome? }.max_by(&:sortable_date)
+    filtered_parole_records.reject(&:no_hearing_outcome?).max_by(&:sortable_date)
   end
 
   # @current_parole_record is the most recent parole record and will either be currently active, or will have had its hearing outcome
@@ -74,10 +74,10 @@ class Offender < ApplicationRecord
     end
   end
 
-  private
+private
 
   # If neither the THD or custody_report_due date are defined, we have no method of determining when the parole hearing was, which is vital for MPC.
   def filtered_parole_records
-    parole_records.reject{|pr| pr.sortable_date.blank? }
+    parole_records.reject { |pr| pr.sortable_date.blank? }
   end
 end

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -37,7 +37,7 @@ class Offender < ApplicationRecord
 
   # Returns the most recent parole record (can be a future parole application), regardless of activity status and outcome.
   def most_recent_parole_record
-    parole_records.max_by(&:custody_report_due)
+    filtered_parole_records.max_by(&:sortable_date)
   end
 
   # Returns the most recent parole application if it has not yet had a hearing.
@@ -47,7 +47,7 @@ class Offender < ApplicationRecord
 
   # Returns the most recent parole record that has an outcome
   def most_recent_completed_parole_record
-    parole_records.where.not(hearing_outcome: ['Not Specified', 'Not Applicable']).max_by(&:custody_report_due)
+    filtered_parole_records.reject{ |pr| pr.no_hearing_outcome? }.max_by(&:sortable_date)
   end
 
   # @current_parole_record is the most recent parole record and will either be currently active, or will have had its hearing outcome
@@ -59,7 +59,7 @@ class Offender < ApplicationRecord
     @current_parole_record = nil
     @previous_parole_records = []
 
-    parole_records.sort_by(&:custody_report_due).reverse_each do |record|
+    filtered_parole_records.sort_by(&:sortable_date).reverse_each do |record|
       if record.no_hearing_outcome?
         if record.active?
           @current_parole_record = record
@@ -72,5 +72,12 @@ class Offender < ApplicationRecord
         @previous_parole_records << record
       end
     end
+  end
+
+  private
+
+  # If neither the THD or custody_report_due date are defined, we have no method of determining when the parole hearing was, which is vital for MPC.
+  def filtered_parole_records
+    parole_records.reject{|pr| pr.sortable_date.blank? }
   end
 end

--- a/app/models/parole_record.rb
+++ b/app/models/parole_record.rb
@@ -33,6 +33,10 @@ class ParoleRecord < ApplicationRecord
     ACTIVE_REVIEW_STATUS.include? review_status
   end
 
+  def sortable_date
+    target_hearing_date.present? ? target_hearing_date : custody_report_due
+  end
+
 private
 
   # While the parsing is gnarly, there is a wide set of criteria that needs to be met for the hearing outcome to be displayed.

--- a/app/models/parole_record.rb
+++ b/app/models/parole_record.rb
@@ -34,7 +34,7 @@ class ParoleRecord < ApplicationRecord
   end
 
   def sortable_date
-    target_hearing_date.present? ? target_hearing_date : custody_report_due
+    target_hearing_date.presence || custody_report_due
   end
 
 private

--- a/spec/factories/parole_records.rb
+++ b/spec/factories/parole_records.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     # Defaults a parole record to be the currently active record
     review_status {'Active'}
     hearing_outcome {'Not Specified'}
+    custody_report_due {Time.zone.today}
   end
 end


### PR DESCRIPTION
Filters out parole records that have neither a target hearing date or custody report due date, as we need at least one of the two to estimate when the parole application took place.

Also now sorts by THD if present and custody report due date if not.

Adds default custody report due date to parole record spec factory to prevent spec failures from the changes.