### PR TITLE
Revert "Bump redis from 4.6.0 to 5.0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'sentry-raven'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 gem 'typhoeus'
-gem 'redis'
+gem 'redis', '~> 4.6.0'
 gem 'fast_underscore', require: false
 gem 'hashdiff', ['>= 1.0.0.beta1', '< 2.0.0']
 gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,10 +376,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.0.2)
-      redis-client (~> 0.7)
-    redis-client (0.7.1)
-      connection_pool
+    redis (4.6.0)
     regexp_parser (2.5.0)
     request_store (1.5.1)
       rack (>= 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,7 +584,7 @@ DEPENDENCIES
   rails (~> 6.1.6)
   rails-controller-testing
   rails-i18n
-  redis
+  redis (~> 4.6.0)
   rspec-rails
   rswag-api
   rswag-specs


### PR DESCRIPTION
This reverts commit d3d4ddf15a6cbfa2bf9f87e396fec07391023f6e.