### PR TITLE
Hide handovers in progress tab on new handover pages

### DIFF
--- a/app/controllers/handovers_controller.rb
+++ b/app/controllers/handovers_controller.rb
@@ -22,6 +22,8 @@ class HandoversController < PrisonsApplicationController
 
   def upcoming; end
 
+  def in_progress; end
+
 private
 
   def new_handovers_ui?

--- a/app/views/layouts/handovers.html.erb
+++ b/app/views/layouts/handovers.html.erb
@@ -38,7 +38,6 @@
         <ul class='moj-sub-navigation__list'>
           <% [
                ['upcoming', "Upcoming handovers (#{@handover_cases.upcoming.count})", upcoming_prison_handovers_path(@prison_id)],
-               ['in_progress', "Handovers in progress (#{@handover_cases.in_progress.count})", in_progress_prison_handovers_path(@prison_id)],
                ['overdue_tasks', 'Overdue tasks (_)', '#'],
                ['com_allocation_overdue', 'COM allocation overdue (_)', '#'],
              ].each do |action, title, path|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
     resources :handovers, only: :index do
       collection do
         get :upcoming
-        get :in_progress
       end
     end
     resources :staff do

--- a/spec/features/handovers_feature_spec.rb
+++ b/spec/features/handovers_feature_spec.rb
@@ -51,27 +51,4 @@ RSpec.feature 'Handovers feature:' do
       end
     end
   end
-
-  describe 'in progress handovers' do
-    it 'works' do
-      allow_any_instance_of(StaffMember).to receive(:unreleased_allocations).and_return(
-        [
-          instance_double(AllocatedOffender, offender_attrs.merge(allocated_com_name: 'Mr COM',
-                                                                  allocated_com_email: 'mr-com@example.org'))
-        ]
-      )
-      date = FactoryBot.create :calculated_handover_date, :between_com_allocated_and_responsible_dates,
-                               offender: FactoryBot.create(:offender, nomis_offender_id: 'X1111XX')
-      allow(CalculatedHandoverDate).to receive(:by_handover_in_progress).and_return [date]
-
-      visit in_progress_prison_handovers_path(default_params)
-
-      aggregate_failures do
-        expect(page.status_code).to eq 200
-        expect(page).to have_text 'Handovers in progress'
-        expect(page).to have_text 'Surname1, Firstname1 X1111XX'
-        expect(page).to have_text 'Mr COM mr-com@example.org'
-      end
-    end
-  end
 end


### PR DESCRIPTION
No "Handovers In Progress" tab on new handover pages

Keeping the plumbing until new policy changes are released next year
in case they bring handover windows back
