### PR TITLE
Upcoming and in-progress handover policy changes

### DIFF
--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -77,7 +77,6 @@ class CalculatedHandoverDate < ApplicationRecord
     # case is considered to be in the upcoming handover window
     def in_upcoming_handover_window(upcoming_handover_window_duration: DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION,
                                     relative_to_date: Time.zone.now.to_date)
-      # TODO: start_date will be renamed to com_allocated_date when we update the schema
       where('"start_date" - :days_before <= :relative_to AND :relative_to < "start_date"',
             { days_before: upcoming_handover_window_duration, relative_to: relative_to_date })
     end

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -283,6 +283,10 @@ class MpcOffender
     active_codes.map { |c| labels[c] }.compact
   end
 
+  def model
+    @offender
+  end
+
 private
 
   def early_allocation_notes?

--- a/app/views/handovers/cells/_handover_dates.html.erb
+++ b/app/views/handovers/cells/_handover_dates.html.erb
@@ -1,13 +1,7 @@
-<% alloc_date, resp_date = calc_handover.com_allocated_date, calc_handover.com_responsible_date %>
-<td class="govuk-table__cell handover-dates" data-sort-value="<%= alloc_date.iso8601 %>">
-  <% unless alloc_date == resp_date %>
-    <p>
-      COM allocated: <br>
-      <%= format_date(alloc_date, replacement: "Unknown") %>
-    </p>
-  <% end %>
+<% handover_date = calc_handover.handover_date %>
+<td class="govuk-table__cell handover-dates" data-sort-value="<%= handover_date.iso8601 %>">
   <p>
     COM responsible: <br>
-    <%= format_date(resp_date, replacement: "Unknown") %>
+    <%= format_date(handover_date, replacement: "Unknown") %>
   </p>
 </td>

--- a/app/views/handovers/in_progress.html.erb
+++ b/app/views/handovers/in_progress.html.erb
@@ -23,7 +23,7 @@
 
       <% com_name = offender.allocated_com_name %>
       <td class="govuk-table__cell com-details" data-sort-value="<%= com_name || 'Unknown' %>">
-        <% if com_name.nil? and calc_handover.com_allocated_date > Time.zone.now.to_date - 2.days %>
+        <% if com_name.nil? and calc_handover.handover_date > Time.zone.now.to_date - 2.days %>
           Unknown
         <% elsif com_name.nil? %>
           <div class="highlight-primary highlight-alert">Unknown</div>

--- a/spec/factories/calculated_handover_date.rb
+++ b/spec/factories/calculated_handover_date.rb
@@ -4,9 +4,7 @@ FactoryBot.define do
   factory :calculated_handover_date do
     association :offender
 
-    com_allocated_date { Faker::Date.forward }
-
-    com_responsible_date { Faker::Date.forward }
+    start_date { handover_date }
 
     reason {
       # Randomly select a valid reason
@@ -22,18 +20,15 @@ FactoryBot.define do
       ].sample
     }
 
-    trait :before_com_allocated_date do
+    trait :before_handover do
       responsibility { CalculatedHandoverDate::CUSTODY_ONLY }
+      start_date { Faker::Date.forward }
+      handover_date { Faker::Date.forward }
     end
 
-    trait :between_com_allocated_and_responsible_dates do
-      com_allocated_date { Faker::Date.backward }
-      responsibility { CalculatedHandoverDate::CUSTODY_WITH_COM }
-    end
-
-    trait :after_com_responsible_date do
-      com_allocated_date { Faker::Date.backward }
-      com_responsible_date { Faker::Date.backward }
+    trait :after_handover do
+      start_date { Faker::Date.backward }
+      handover_date { Faker::Date.backward }
       responsibility { CalculatedHandoverDate::COMMUNITY_RESPONSIBLE }
     end
   end

--- a/spec/features/handovers_feature_spec.rb
+++ b/spec/features/handovers_feature_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Handovers feature:' do
           instance_double(AllocatedOffender, offender_attrs.merge(allocated_com_name: nil))
         ]
       )
-      date = FactoryBot.create :calculated_handover_date,
+      date = FactoryBot.create :calculated_handover_date, :before_handover,
                                offender: FactoryBot.create(:offender, nomis_offender_id: 'X1111XX')
       allow(CalculatedHandoverDate).to receive(:by_upcoming_handover).and_return [date]
 
@@ -57,7 +57,7 @@ RSpec.feature 'Handovers feature:' do
                                                                   allocated_com_email: 'mr-com@example.org'))
         ]
       )
-      date = FactoryBot.create :calculated_handover_date, :between_com_allocated_and_responsible_dates,
+      date = FactoryBot.create :calculated_handover_date, :after_handover,
                                offender: FactoryBot.create(:offender, nomis_offender_id: 'X1111XX')
       allow(CalculatedHandoverDate).to receive(:by_handover_in_progress).and_return [date]
 

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -61,12 +61,11 @@ RSpec.describe CalculatedHandoverDate do
   describe '::by_upcoming_handover scope' do
     let(:upcoming_handover_date_attributes) do
       {
-        com_allocated_date: Date.new(2022, 12, 1),
-        com_responsible_date: Date.new(2022, 12, 30)
+        handover_date: Date.new(2022, 12, 1),
       }
     end
     let!(:row) do # instantiate it immediately
-      FactoryBot.create :calculated_handover_date, :before_com_allocated_date,
+      FactoryBot.create :calculated_handover_date, :before_handover,
                         offender: FactoryBot.create(:offender, nomis_offender_id: 'X1111XX'),
                         **upcoming_handover_date_attributes
     end
@@ -121,7 +120,7 @@ RSpec.describe CalculatedHandoverDate do
 
   describe '::by_handover_in_progress scope' do
     let!(:row) do # instantiate it immediately
-      FactoryBot.create :calculated_handover_date, :between_com_allocated_and_responsible_dates,
+      FactoryBot.create :calculated_handover_date, :after_handover,
                         offender: FactoryBot.create(:offender, nomis_offender_id: 'X1111XX')
     end
 

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -2,11 +2,18 @@ require 'rails_helper'
 
 RSpec.describe MpcOffender, type: :model do
   subject(:offender) do
-    build(:mpc_offender, prison: prison, prison_record: api_offender, offender: build(:case_information).offender)
+    build(:mpc_offender, prison: prison, prison_record: api_offender, offender: offender_model)
   end
 
+  let(:nomis_offender_id) { FactoryBot.generate :nomis_offender_id }
+  let(:offender_model) do
+    instance_double(Offender,
+                    id: nomis_offender_id,
+                    nomis_offender_id: nomis_offender_id,
+                    case_information: instance_double(CaseInformation))
+  end
   let(:prison) { build(:prison) }
-  let(:api_offender) { double(:nomis_offender, offender_no: FactoryBot.generate(:nomis_offender_id)) }
+  let(:api_offender) { double(:nomis_offender, offender_no: nomis_offender_id) }
 
   describe '#additional_information' do
     let(:api_offender) { double(:nomis_offender, recalled?: recalled) }
@@ -174,6 +181,12 @@ RSpec.describe MpcOffender, type: :model do
 
     it 'returns nil if saved value does not exist' do
       expect(offender.com_responsible_date).to be_nil
+    end
+  end
+
+  describe '#model' do
+    it 'returns the Offender model instance' do
+      expect(offender.model).to eq offender_model
     end
   end
 end

--- a/spec/views/handovers/in_progress.html.erb_spec.rb
+++ b/spec/views/handovers/in_progress.html.erb_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe 'handovers/in_progress' do
   let(:cases) do
     [
       [
-        double(:calculated_dates1, com_allocated_date: Date.new(2022, 1, 5),
-                                   com_responsible_date: Date.new(2022, 1, 12)),
+        double(:calculated_dates1, handover_date: Date.new(2022, 1, 12)),
         instance_double(AllocatedOffender,
                         full_name: 'Surname1, Firstname1',
                         last_name: 'Surname1',
@@ -18,8 +17,7 @@ RSpec.describe 'handovers/in_progress' do
                         handover_progress_task_completion_data: all_false_hash),
       ],
       [
-        double(:calculated_dates2, com_allocated_date: Date.new(2022, 2, 5),
-                                   com_responsible_date: Date.new(2022, 2, 12)),
+        double(:calculated_dates2, handover_date: Date.new(2022, 2, 12)),
         instance_double(AllocatedOffender,
                         full_name: 'Surname2, Firstname2',
                         last_name: 'Surname2',
@@ -58,7 +56,7 @@ RSpec.describe 'handovers/in_progress' do
 
     it 'shows handover dates correctly' do
       aggregate_failures do
-        expect(first_row_text).to include 'COM allocated: 05 Jan 2022 COM responsible: 12 Jan 2022'
+        expect(first_row_text).to include 'COM responsible: 12 Jan 2022'
       end
     end
 
@@ -75,18 +73,7 @@ RSpec.describe 'handovers/in_progress' do
     end
   end
 
-  describe 'when com responsible date is the same as the com allocated date' do
-    it 'only shows com responsible date' do
-      allow(cases[0][0]).to receive(:com_allocated_date).and_return(Date.new(2022, 1, 12))
-      render
-      aggregate_failures do
-        expect(first_row_text).to include 'COM responsible: 12 Jan 2022'
-        expect(first_row_text).not_to include 'COM allocated: 12 Jan 2022'
-      end
-    end
-  end
-
-  describe 'when no COM is allocated and 2 days after COM allocated date' do
+  describe 'when no COM is allocated and 2 days after COM responsible date' do
     it 'shows a warning' do
       allow(cases[0][1]).to receive(:allocated_com_name).and_return nil
       render

--- a/spec/views/handovers/upcoming.html.erb_spec.rb
+++ b/spec/views/handovers/upcoming.html.erb_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe 'handovers/upcoming' do
   let(:upcoming_handover_cases) do
     [
       [
-        double(:handover_date1, com_allocated_date: Date.new(2022, 1, 5),
-                                com_responsible_date: Date.new(2022, 1, 12)),
+        double(:handover_date1, handover_date: Date.new(2022, 1, 12)),
         instance_double(AllocatedOffender,
                         full_name: 'Surname1, Firstname1',
                         last_name: 'Surname1',
@@ -16,8 +15,7 @@ RSpec.describe 'handovers/upcoming' do
                         handover_progress_task_completion_data: all_false_hash),
       ],
       [
-        double(:handover_date2, com_allocated_date: Date.new(2022, 2, 5),
-                                com_responsible_date: Date.new(2022, 2, 12)),
+        double(:handover_date2, handover_date: Date.new(2022, 2, 12)),
         instance_double(AllocatedOffender,
                         full_name: 'Surname2, Firstname2',
                         last_name: 'Surname2',
@@ -50,7 +48,7 @@ RSpec.describe 'handovers/upcoming' do
 
     it 'shows handover dates correctly' do
       aggregate_failures do
-        expect(first_row_text).to include 'COM allocated: 05 Jan 2022 COM responsible: 12 Jan 2022'
+        expect(first_row_text).to include 'COM responsible: 12 Jan 2022'
       end
     end
 
@@ -64,17 +62,6 @@ RSpec.describe 'handovers/upcoming' do
 
     it 'shows more than one case on the page' do
       expect(page).to have_css('.upcoming-handovers .allocated-offender', count: 2)
-    end
-  end
-
-  describe 'when com responsible date is the same as the com allocated date' do
-    it 'only shows com responsible date' do
-      allow(upcoming_handover_cases[0][0]).to receive(:com_allocated_date).and_return(Date.new(2022, 1, 12))
-      render
-      aggregate_failures do
-        expect(first_row_text).to include 'COM responsible: 12 Jan 2022'
-        expect(first_row_text).not_to include 'COM allocated: 12 Jan 2022'
-      end
     end
   end
 end


### PR DESCRIPTION
MO-1172

Upcoming handovers
Remove COM allocated date

Handovers in progress
Remove COM allocated date

How cases move through the tables
We should now only take COM responsibility date into account when determining when cases should appear on the different tables.

Cases appear on the Upcoming table 8 weeks before the COM responsible date

They move from Upcoming to In progress on the date the COM becomes responsible, even if a COM has not been allocated. If a COM is allocated early, the case should move to the In progress tab

If a case is missing COM details 48 hours after the COM responsible date, it should remain on the In progress table. However, it should also be displayed on the COM allocation overdue table. Once a case is allocated a COM, it should be removed from this table. The 48 hours condition reflects a stipulation in a service level agreement that states LDUs have this amount of time to allocate a COM.

A case should stay on the In progress table until the release date is reached.