### PR TITLE
Remove paper trail from some models

### DIFF
--- a/app/models/email_history.rb
+++ b/app/models/email_history.rb
@@ -7,8 +7,6 @@ class EmailHistory < ApplicationRecord
   OPEN_PRISON_COMMUNITY_ALLOCATION = 'open_prison_community_allocation'
   IMMEDIATE_COMMUNITY_ALLOCATION = 'immediate_community_allocation'
 
-  has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
-
   belongs_to :offender,
              primary_key: :nomis_offender_id,
              foreign_key: :nomis_offender_id,

--- a/app/models/local_delivery_unit.rb
+++ b/app/models/local_delivery_unit.rb
@@ -6,8 +6,6 @@ class LocalDeliveryUnit < ApplicationRecord
   VALID_COUNTRIES = ['England', 'Wales'].freeze
   CODE_REGEX = /\A[a-zA-Z0-9]+\z/.freeze
 
-  has_paper_trail
-
   auto_strip_attributes :code, :name, :email_address
 
   validates :country, inclusion: { in: VALID_COUNTRIES }


### PR DESCRIPTION
It was crashing LocalDeliveryUnit active_admin page. Also remove it from EmailHistory