### PR TITLE
Use Faraday's built-in HTTP basic authentication intead of rolling own

### DIFF
--- a/app/services/hmpps_api/oauth/client.rb
+++ b/app/services/hmpps_api/oauth/client.rb
@@ -16,6 +16,7 @@ module HmppsApi
 
           faraday.response :raise_error
         end
+        @connection.basic_auth(Rails.configuration.hmpps_api_client_id, Rails.configuration.hmpps_api_client_secret)
       end
 
       def post(route)
@@ -28,7 +29,6 @@ module HmppsApi
         response = @connection.send(method) do |req|
           url = URI.join(@host, route).to_s
           req.url(url)
-          req.headers['Authorization'] = api_authorisation
         end
 
         JSON.parse(response.body)

--- a/app/services/hmpps_api/oauth/client_helper.rb
+++ b/app/services/hmpps_api/oauth/client_helper.rb
@@ -6,12 +6,6 @@ require 'base64'
 module HmppsApi
   module Oauth
     module ClientHelper
-      def api_authorisation
-        "Basic #{Base64.urlsafe_encode64(
-          "#{Rails.configuration.hmpps_api_client_id}:#{Rails.configuration.hmpps_api_client_secret}"
-        )}"
-      end
-
       def user_login_authorisation
         "Basic #{Base64.urlsafe_encode64(
           "#{Rails.configuration.hmpps_oauth_client_id}:#{Rails.configuration.hmpps_oauth_client_secret}"


### PR DESCRIPTION
This fixes preprod credentials not being fudged properly into an Authorization header

MO-1180