### PR TITLE
Move hmpps OAUTH secrets to same K8s secret as the API secrets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,10 +39,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-
-  config.log_level = :info
+  config.log_level = ENV.fetch('LOG_LEVEL', 'info').to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,8 +10,7 @@ Rails.application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
-  # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = ENV['CONSIDER_ALL_REQUESTS_LOCAL'].present?
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]

--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: POSTGRES_HOST
               valueFrom:
@@ -121,6 +123,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: RAILS_LOG_TO_STDOUT
               value: "on"

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: POSTGRES_HOST
               valueFrom:
@@ -121,6 +123,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: RAILS_LOG_TO_STDOUT
               value: "on"

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: POSTGRES_HOST
               valueFrom:
@@ -121,6 +123,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: RAILS_LOG_TO_STDOUT
               value: "on"

--- a/deploy/test/deployment.yaml
+++ b/deploy/test/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: POSTGRES_HOST
               valueFrom:

--- a/deploy/test2/deployment.yaml
+++ b/deploy/test2/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: allocation-manager-secrets
+            - secretRef:
+                name: hmpps-auth-secrets
           env:
             - name: POSTGRES_HOST
               valueFrom:


### PR DESCRIPTION
This moves them into one the same K8s Secret as the API secrets, which makes them easier to rotate by the HAAR team

Also make some options more configurable
