### PR TITLE
Remove com_responsible_date from internal naming

### DIFF
--- a/app/assets/stylesheets/handovers.scss
+++ b/app/assets/stylesheets/handovers.scss
@@ -8,7 +8,7 @@
   }
 }
 
-.govuk-inset-text.govuk-inset-text--com-responsible-date {
+.govuk-inset-text.govuk-inset-text--handover-date {
   margin-bottom: 40px;
 }
 

--- a/app/helpers/handovers/handover_list_helper.rb
+++ b/app/helpers/handovers/handover_list_helper.rb
@@ -19,9 +19,8 @@ module Handovers
       (relative_to_date - offender.com_responsible_date).to_i
     end
 
-    def dps_sentence_and_release_link(offender_or_offender_no)
-      offender_or_offender_no = offender_or_offender_no.offender_no unless offender_or_offender_no.is_a?(String)
-      "#{ENV['DIGITAL_PRISON_SERVICE_HOST']}/prisoner/#{offender_or_offender_no}/sentence-and-release"
+    def dps_sentence_and_release_link(offender_no)
+      "#{ENV['DIGITAL_PRISON_SERVICE_HOST']}/prisoner/#{offender_no}/sentence-and-release"
     end
 
   private

--- a/app/helpers/handovers/handover_list_helper.rb
+++ b/app/helpers/handovers/handover_list_helper.rb
@@ -11,12 +11,12 @@ module Handovers
       end
     end
 
-    def com_allocation_overdue_days(offender, relative_to_date: Time.zone.now.to_date)
-      raise 'COM responsible date not set' unless offender.com_responsible_date
+    def com_allocation_overdue_days(mpc_offender, relative_to_date: Time.zone.now.to_date)
+      raise 'Handover date not set' unless mpc_offender.model.handover_date
 
-      raise 'COM responsible date is in the future' if offender.com_responsible_date > relative_to_date
+      raise 'Handover date is in the future' if mpc_offender.model.handover_date > relative_to_date
 
-      (relative_to_date - offender.com_responsible_date).to_i
+      (relative_to_date - mpc_offender.model.handover_date).to_i
     end
 
     def dps_sentence_and_release_link(offender_no)

--- a/app/lib/handover/handover_date_rules.rb
+++ b/app/lib/handover/handover_date_rules.rb
@@ -12,12 +12,11 @@ module Handover
             nomis_offender_id: nomis_offender_id)
         end
 
-        com_responsible_date = earliest_release_date - 7.months - 15.days
+        handover_date = earliest_release_date - 7.months - 15.days
 
-        com_responsible_date = sentence_start_date if com_responsible_date < sentence_start_date
+        handover_date = sentence_start_date if handover_date < sentence_start_date
 
-        HandoverDates.new(handover_date: com_responsible_date,
-                          com_responsible_date: com_responsible_date,
+        HandoverDates.new(handover_date: handover_date,
                           reason: :nps_determinate)
       end
     end

--- a/app/lib/handover/handover_dates.rb
+++ b/app/lib/handover/handover_dates.rb
@@ -1,6 +1,5 @@
 module Handover
   HandoverDates = Struct.new(:handover_date,
-                             :com_responsible_date,
                              :reason,
                              keyword_init: true)
 end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -11,7 +11,7 @@ class AllocatedOffender
            :handover_start_date, :responsibility_handover_date, :allocated_com_name, :case_allocation,
            :complexity_level, :offender_no, :sentence_start_date, :tier, :location, :latest_temp_movement_date,
            :restricted_patient?, :handover_progress_task_completion_data, :handover_progress_complete?,
-           :com_responsible_date, :ldu_name, :ldu_email_address, to: :@offender
+           :ldu_name, :ldu_email_address, :model, to: :@offender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id,
            to: :@allocation
 

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -35,7 +35,6 @@ class CalculatedHandoverDate < ApplicationRecord
   validates :responsibility, inclusion: { in: [CUSTODY_ONLY, CUSTODY_WITH_COM, COMMUNITY_RESPONSIBLE], nil: false }
   validates :reason, inclusion: { in: REASONS.keys, nil: false }
 
-  alias_attribute :com_allocated_date, :start_date
   alias_attribute :com_responsible_date, :handover_date
 
   def custody_responsible?

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -35,8 +35,6 @@ class CalculatedHandoverDate < ApplicationRecord
   validates :responsibility, inclusion: { in: [CUSTODY_ONLY, CUSTODY_WITH_COM, COMMUNITY_RESPONSIBLE], nil: false }
   validates :reason, inclusion: { in: REASONS.keys, nil: false }
 
-  alias_attribute :com_responsible_date, :handover_date
-
   def custody_responsible?
     responsibility.in? [CUSTODY_WITH_COM, CUSTODY_ONLY]
   end

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -155,10 +155,6 @@ class MpcOffender
     end
   end
 
-  def com_responsible_date
-    CalculatedHandoverDate.find_by(nomis_offender_id: offender_no)&.com_responsible_date
-  end
-
   # early allocation methods
 
   def parole_review_date

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -41,6 +41,8 @@ class Offender < ApplicationRecord
 
   delegate :handover_progress_complete?, to: :handover_progress_checklist, allow_nil: true
 
+  delegate :handover_date, to: :calculated_handover_date, allow_nil: true
+
   def handover_progress_task_completion_data
     (handover_progress_checklist || build_handover_progress_checklist).task_completion_data
   end

--- a/app/services/hmpps_api/community_api.rb
+++ b/app/services/hmpps_api/community_api.rb
@@ -5,8 +5,6 @@ module HmppsApi
     class KeyDate
       # These are `{typeCode}` values for 'key dates' in the Community API
       #
-      # TODO: Rename HANDOVER_START_DATE to COM_ALLOCATED_DATE and RESPONSIBILITY_HANDOVER_DATE to COM_RESPONSIBLE_DATE
-      #  to match confirmed domain language
       HANDOVER_START_DATE = 'POM1'
       RESPONSIBILITY_HANDOVER_DATE = 'POM2'
     end

--- a/app/views/handover_progress_checklists/edit.html.erb
+++ b/app/views/handover_progress_checklists/edit.html.erb
@@ -25,8 +25,8 @@
       tasks.
     </p>
 
-    <div class="govuk-inset-text govuk-inset-text--com-responsible-date">
-      COM responsible from <%= format_date(@offender.com_responsible_date, replacement: 'Unknown') %>
+    <div class="govuk-inset-text govuk-inset-text--handover-date">
+      COM responsible from <%= format_date(@offender.model.handover_date, replacement: 'Unknown') %>
     </div>
 
     <%= form_for(@handover_progress_checklist,

--- a/app/views/handovers/com_allocation_overdue.html.erb
+++ b/app/views/handovers/com_allocation_overdue.html.erb
@@ -41,7 +41,7 @@
         <% if offender.ldu_name.nil? && offender.ldu_email_address.nil? %>
           We don’t have this information.
           <%= link_to 'Check DPS to find where this person was sentenced',
-                      dps_sentence_and_release_link(offender),
+                      dps_sentence_and_release_link(offender.offender_no),
                       class: %w[govuk-link govuk-link--no-visited-state],
                       target: '_blank'
           %>

--- a/features/step_definitions/handover_date_rules.rb
+++ b/features/step_definitions/handover_date_rules.rb
@@ -21,13 +21,11 @@ end
 Then(/^handover date is (\d+) months (\d+) days before CRD$/) do |num_months, num_days|
   expected_handover = @conditional_release_date - num_months.months - num_days.days
   expect(@community_dates.handover_date).to eq(expected_handover)
-  expect(@community_dates.com_responsible_date).to eq(expected_handover)
 end
 
 Then(/^handover date is (\d+) months (\d+) days before ARD$/) do |num_months, num_days|
   expected_handover = @automatic_release_date - num_months.months - num_days.days
   expect(@community_dates.handover_date).to eq(expected_handover)
-  expect(@community_dates.com_responsible_date).to eq(expected_handover)
 end
 
 Then(/^reason is ([a-z_]+)$/) do |expected_reason|

--- a/spec/features/handovers_feature_spec.rb
+++ b/spec/features/handovers_feature_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Handovers feature:' do
       handover_progress_task_completion_data: {},
       allocated_com_email: nil,
       allocated_com_name: nil,
-      com_responsible_date: Faker::Date.backward,
+      model: double(:model, handover_date: Faker::Date.backward),
       ldu_name: nil,
       ldu_email_address: nil,
       handover_progress_complete?: false,

--- a/spec/helpers/handovers/handover_list_helper_spec.rb
+++ b/spec/helpers/handovers/handover_list_helper_spec.rb
@@ -1,36 +1,35 @@
 RSpec.describe Handovers::HandoverListHelper do
-  let(:offender) { instance_double AllocatedOffender, :offender, com_responsible_date: nil }
+  let(:offender) { instance_double AllocatedOffender, :offender, model: double(handover_date: nil) }
 
   describe '#com_allocation_overdue_days' do
     def result
       helper.com_allocation_overdue_days(offender, relative_to_date: Date.new(2022, 1, 1))
     end
 
-    describe 'when COM responsible date is not set' do
+    describe 'when handover date is not set' do
       it 'raises error' do
-        allow(offender).to receive(:com_responsible_date).and_return(nil)
-        expect { result }.to raise_error(/com responsible date not set/i)
+        expect { result }.to raise_error(/handover date not set/i)
       end
     end
 
-    describe 'when COM responsible date now' do
+    describe 'when handover date is the current date' do
       it 'returns 0' do
-        allow(offender).to receive(:com_responsible_date).and_return(Date.new(2022, 1, 1))
+        allow(offender.model).to receive_messages(handover_date: Date.new(2022, 1, 1))
         expect(result).to be 0
       end
     end
 
     describe 'when COM responsible date is in the past' do
       it 'returns the days overdue' do
-        allow(offender).to receive(:com_responsible_date).and_return(Date.new(2021, 12, 30))
+        allow(offender.model).to receive_messages(handover_date: Date.new(2021, 12, 30))
         expect(result).to be 2
       end
     end
 
     describe 'when COM responsible date is in the future' do
       it 'raises error' do
-        allow(offender).to receive(:com_responsible_date).and_return(Date.new(2022, 1, 2))
-        expect { result }.to raise_error(/com responsible date.+in the future/i)
+        allow(offender.model).to receive_messages(handover_date: Date.new(2022, 1, 2))
+        expect { result }.to raise_error(/handover date.+in the future/i)
       end
     end
   end

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CalculatedHandoverDate do
             calculated_handover_date: build(:calculated_handover_date,
                                             responsibility: com_responsibility.responsibility,
                                             start_date: com_responsibility.start_date,
-                                            com_responsible_date: com_responsibility.com_responsible_date,
+                                            handover_date: com_responsibility.handover_date,
                                             reason: com_responsibility.reason))
     end
     let(:com_responsibility) { HandoverDateService::NO_HANDOVER_DATE }
@@ -29,7 +29,7 @@ RSpec.describe CalculatedHandoverDate do
     it 'allows nil handover dates' do
       expect(record).to be_valid
       expect(record.start_date).to be_nil
-      expect(record.com_responsible_date).to be_nil
+      expect(record.handover_date).to be_nil
       expect(record.reason_text).to eq('COM Responsibility')
     end
   end

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CalculatedHandoverDate do
       build(:offender,
             calculated_handover_date: build(:calculated_handover_date,
                                             responsibility: com_responsibility.responsibility,
-                                            com_allocated_date: com_responsibility.com_allocated_date,
+                                            start_date: com_responsibility.start_date,
                                             com_responsible_date: com_responsibility.com_responsible_date,
                                             reason: com_responsibility.reason))
     end
@@ -28,7 +28,7 @@ RSpec.describe CalculatedHandoverDate do
 
     it 'allows nil handover dates' do
       expect(record).to be_valid
-      expect(record.com_allocated_date).to be_nil
+      expect(record.start_date).to be_nil
       expect(record.com_responsible_date).to be_nil
       expect(record.reason_text).to eq('COM Responsibility')
     end
@@ -43,18 +43,6 @@ RSpec.describe CalculatedHandoverDate do
 
     it 'is not valid' do
       expect(subject.valid?).to be(false)
-    end
-  end
-
-  describe 'using official domain language compliant naming' do
-    it 'has #com_allocated_date' do
-      subject.com_allocated_date = Date.new(2022, 7, 7)
-      expect(subject.com_allocated_date).to eq Date.new(2022, 7, 7)
-    end
-
-    it 'has #com_responsible_date' do
-      subject.com_responsible_date = Date.new(2022, 9, 7)
-      expect(subject.com_responsible_date).to eq Date.new(2022, 9, 7)
     end
   end
 

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -172,18 +172,6 @@ RSpec.describe MpcOffender, type: :model do
     end
   end
 
-  describe '#com_responsible_date' do
-    it 'returns value from DB if that exists' do
-      FactoryBot.create :offender, id: offender.offender_no
-      chd = FactoryBot.create :calculated_handover_date, nomis_offender_id: offender.offender_no
-      expect(offender.com_responsible_date).to eq chd.com_responsible_date
-    end
-
-    it 'returns nil if saved value does not exist' do
-      expect(offender.com_responsible_date).to be_nil
-    end
-  end
-
   describe '#model' do
     it 'returns the Offender model instance' do
       expect(offender.model).to eq offender_model

--- a/spec/models/offender_spec.rb
+++ b/spec/models/offender_spec.rb
@@ -88,4 +88,17 @@ RSpec.describe Offender, type: :model do
       expect(offender.handover_progress_task_completion_data).to eq data
     end
   end
+
+  describe '#handover_date' do
+    it 'returns value from DB if that exists' do
+      chd = FactoryBot.create :calculated_handover_date, nomis_offender_id: offender.nomis_offender_id
+      expect(offender.handover_date).to eq chd.handover_date
+    end
+
+    it 'returns nil if saved value does not exist' do
+      raise 'There should not be a calculated handover date' if offender.calculated_handover_date.present?
+
+      expect(offender.handover_date).to be_nil
+    end
+  end
 end

--- a/spec/support/helpers/high_level_mocking_and_stubbing_helper.rb
+++ b/spec/support/helpers/high_level_mocking_and_stubbing_helper.rb
@@ -8,7 +8,7 @@ module HighLevelMockingAndStubbingHelper
 
     offender_no = mpc_offender_attributes[:offender_no] ||= FactoryBot.generate(:nomis_offender_id)
     mpc_offender_attributes = {
-      com_responsible_date: Faker::Date.forward,
+      model: double(handover_date: Faker::Date.forward),
       first_name: Faker::Name.first_name,
       full_name_ordered: Faker::Name.name,
       date_of_birth: Faker::Date.backward,

--- a/spec/views/handover_progress_checklists/edit.html.erb_spec.rb
+++ b/spec/views/handover_progress_checklists/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'handover_progress_checklists/edit' do
   let(:offender) do
     stub_mpc_offender(
       offender_no: nomis_offender_id,
-      com_responsible_date: Date.new(2022, 11, 1),
+      model: double(handover_date: Date.new(2022, 11, 1)),
       first_name: 'OFFENDERFIRSTNAME',
       full_name_ordered: 'Offenderfirstname Offenderlastname',
       date_of_birth: Date.new(1993, 2, 20),

--- a/spec/views/handovers/com_allocation_overdue.html.erb_spec.rb
+++ b/spec/views/handovers/com_allocation_overdue.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'handovers/com_allocation_overdue' do
                     allocated_com_name: 'Com One',
                     allocated_com_email: 'com1@example.org',
                     handover_progress_task_completion_data: all_false_hash,
-                    com_responsible_date: Faker::Date.backward,
+                    model: double(handover_date: Faker::Date.backward),
                     ldu_name: 'LDU Name',
                     ldu_email_address: 'ldu-email@example.org',
                    )


### PR DESCRIPTION
It is only a name used on the handover screens - internally we call it the handover date
