### PR TITLE
Handover pagination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,31 @@ references:
           --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
           -t app .
 
+  build_quick_docker_image: &build_quick_docker_image
+    run:
+      name: Build allocation-manager docker image - quick mode
+      command: |
+        set -euo pipefail
+        env_name="${K8S_NAMESPACE#offender-management-}"
+        . ~/env/"${env_name}"-ecr-secrets.sh
+
+        export BUILD_DATE=$(date -Is) >> $BASH_ENV
+        source $BASH_ENV
+
+        ecr_host="$(echo "${ECR_ENDPOINT}" | cut -f1 -d/)"
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "${ecr_host}"
+        
+        docker pull "${ECR_ENDPOINT}:latest"
+        docker tag "${ECR_ENDPOINT}:latest" offender-management-allocation-manager:latest
+
+        docker build \
+          --build-arg VERSION_NUMBER=${CIRCLE_BUILD_NUM} \
+          --build-arg COMMIT_ID=${CIRCLE_SHA1} \
+          --build-arg BUILD_DATE=${BUILD_DATE} \
+          --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
+          -f Dockerfile.quick \
+          -t app .
+
   push_docker_image: &push_docker_image
     run:
       name: Push allocation-manager docker image
@@ -282,6 +307,21 @@ jobs:
       - *build_docker_image
       - *push_docker_image
 
+  build_and_push_quick_docker_image:
+    <<: *defaults
+    <<: *deploy_container_config
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      - setup_remote_docker:
+          version: 20.10.14
+          docker_layer_caching: true
+      - aws-cli/install
+      - *configure_k8s
+      - *build_quick_docker_image
+      - *push_docker_image
+
   verify_docker_image_builds:
     <<: *defaults
     <<: *test_container_config
@@ -353,12 +393,12 @@ workflows:
       - fetch_secrets:
           filters: { branches: { only: [test2] } }
           context: [offender-management-shared, offender-management-test2]
-      - build_and_push_docker_image:
+      - build_and_push_quick_docker_image:
           requires: [fetch_secrets]
           filters: { branches: { only: [test2] } }
           context: [offender-management-shared, offender-management-test2]
       - deploy:
-          requires: [build_and_push_docker_image]
+          requires: [build_and_push_quick_docker_image]
           filters: { branches: { only: [test2] } }
           context: [offender-management-shared, offender-management-test2]
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -183,3 +183,6 @@ Style/EachForSimpleLoop:
 # so we allow `else  nil` so it's crystal clear
 Style/EmptyElse:
   Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false

--- a/Dockerfile.quick
+++ b/Dockerfile.quick
@@ -1,0 +1,33 @@
+FROM offender-management-allocation-manager:latest
+
+# Incremenent to bust Docker layer cache
+ENV DOCKER_CACHE_BUSTER=1
+
+ARG VERSION_NUMBER
+ARG COMMIT_ID
+ARG BUILD_DATE
+ARG BUILD_TAG
+
+WORKDIR /app
+
+USER root
+
+# Update Ruby and Node dependencies
+COPY Gemfile Gemfile.lock package.json ./
+RUN yarn install \
+    && bundle install --jobs 2 --retry 3
+
+# Non-cacheable layers. Everything below here is expected to change with every commit
+
+ENV APPVERSION=${VERSION_NUMBER}
+ENV APP_GIT_COMMIT=${COMMIT_ID}
+ENV APP_BUILD_DATE=${BUILD_DATE}
+ENV APP_BUILD_TAG=${BUILD_TAG}
+
+COPY . /app
+
+RUN chown -R appuser:appuser /app
+
+USER 1001
+
+RUN RAILS_ENV=production rails assets:precompile

--- a/app/controllers/handovers_controller.rb
+++ b/app/controllers/handovers_controller.rb
@@ -22,7 +22,9 @@ class HandoversController < PrisonsApplicationController
 
   def upcoming; end
 
-  def in_progress; end
+  def in_progress
+    @paginated_handover_cases = Kaminari.paginate_array(@handover_cases.in_progress).page(page)
+  end
 
   def overdue_tasks; end
 

--- a/app/controllers/handovers_controller.rb
+++ b/app/controllers/handovers_controller.rb
@@ -21,19 +21,19 @@ class HandoversController < PrisonsApplicationController
   end
 
   def upcoming
-    @paginated_handover_cases = paginated_handover_cases(@handover_cases.upcoming)
+    @filtered_handover_cases = filtered_handover_cases(@handover_cases.upcoming)
   end
 
   def in_progress
-    @paginated_handover_cases = paginated_handover_cases(@handover_cases.in_progress)
+    @filtered_handover_cases = filtered_handover_cases(@handover_cases.in_progress)
   end
 
   def overdue_tasks
-    @paginated_handover_cases = paginated_handover_cases(@handover_cases.overdue_tasks)
+    @filtered_handover_cases = filtered_handover_cases(@handover_cases.overdue_tasks)
   end
 
   def com_allocation_overdue
-    @paginated_handover_cases = paginated_handover_cases(@handover_cases.com_allocation_overdue)
+    @filtered_handover_cases = filtered_handover_cases(@handover_cases.com_allocation_overdue)
   end
 
 private
@@ -59,7 +59,7 @@ private
     flash[:current_handovers_url] = request.url
   end
 
-  def paginated_handover_cases(cases)
+  def filtered_handover_cases(cases)
     Kaminari.paginate_array(cases).page(page)
   end
 end

--- a/app/controllers/handovers_controller.rb
+++ b/app/controllers/handovers_controller.rb
@@ -20,15 +20,21 @@ class HandoversController < PrisonsApplicationController
     render :legacy_index, layout: 'application'
   end
 
-  def upcoming; end
-
-  def in_progress
-    @paginated_handover_cases = Kaminari.paginate_array(@handover_cases.in_progress).page(page)
+  def upcoming
+    @paginated_handover_cases = paginated_handover_cases(@handover_cases.upcoming)
   end
 
-  def overdue_tasks; end
+  def in_progress
+    @paginated_handover_cases = paginated_handover_cases(@handover_cases.in_progress)
+  end
 
-  def com_allocation_overdue; end
+  def overdue_tasks
+    @paginated_handover_cases = paginated_handover_cases(@handover_cases.overdue_tasks)
+  end
+
+  def com_allocation_overdue
+    @paginated_handover_cases = paginated_handover_cases(@handover_cases.com_allocation_overdue)
+  end
 
 private
 
@@ -51,5 +57,9 @@ private
 
     @prison_id = active_prison_id
     flash[:current_handovers_url] = request.url
+  end
+
+  def paginated_handover_cases(cases)
+    Kaminari.paginate_array(cases).page(page)
   end
 end

--- a/app/views/handovers/_shared_in_progress.html.erb
+++ b/app/views/handovers/_shared_in_progress.html.erb
@@ -48,6 +48,8 @@
 
 <% if cases.size == 0 %>
   <p><%= no_cases_message %></p>
+<% else %>
+  <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>
 <% end %>
 
 <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>

--- a/app/views/handovers/_shared_in_progress.html.erb
+++ b/app/views/handovers/_shared_in_progress.html.erb
@@ -15,7 +15,7 @@
                           { body: 'Handover progress', class: ['handover-progress'] },
                         ].compact) do %>
 
-  <% @paginated_handover_cases.each do |calc_handover, offender| %>
+  <% @filtered_handover_cases.each do |calc_handover, offender| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: offender %>
 
@@ -46,10 +46,10 @@
   <% end %>
 <% end %>
 
-<% if @paginated_handover_cases.size == 0 %>
+<% if @filtered_handover_cases.size == 0 %>
   <p><%= no_cases_message %></p>
 <% else %>
-  <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>
+  <%= render partial: 'shared/pagination', locals: { data: @filtered_handover_cases } %>
 <% end %>
 
 <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>

--- a/app/views/handovers/_shared_in_progress.html.erb
+++ b/app/views/handovers/_shared_in_progress.html.erb
@@ -15,7 +15,7 @@
                           { body: 'Handover progress', class: ['handover-progress'] },
                         ].compact) do %>
 
-  <% cases.each do |calc_handover, offender| %>
+  <% @paginated_handover_cases.each do |calc_handover, offender| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: offender %>
 
@@ -46,7 +46,7 @@
   <% end %>
 <% end %>
 
-<% if cases.size == 0 %>
+<% if @paginated_handover_cases.size == 0 %>
   <p><%= no_cases_message %></p>
 <% else %>
   <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>

--- a/app/views/handovers/cells/_earliest_release_date.html.erb
+++ b/app/views/handovers/cells/_earliest_release_date.html.erb
@@ -1,5 +1,5 @@
-<% rel_type, rel_date = offender.earliest_release.values_at(:type, :date) %>
-<td class="govuk-table__cell earliest-release-date" data-sort-value="<%= rel_date.iso8601 %>">
+<% rel_type, rel_date = offender.earliest_release&.values_at(:type, :date) || ['Unknown', nil] %>
+<td class="govuk-table__cell earliest-release-date" data-sort-value="<%= rel_date&.iso8601 %>">
   <%= rel_type %>: <br>
   <%= format_date(rel_date, replacement: "ERROR: Unknown") %>
 </td>

--- a/app/views/handovers/com_allocation_overdue.html.erb
+++ b/app/views/handovers/com_allocation_overdue.html.erb
@@ -28,7 +28,7 @@
                           { body: 'LDU details', class: %w[ldu-details govuk-!-width-one-quarter] },
                         ].compact) do %>
 
-  <% @paginated_handover_cases.each do |calc_handover, offender| %>
+  <% @filtered_handover_cases.each do |calc_handover, offender| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: offender %>
 
@@ -64,10 +64,10 @@
   <% end %>
 <% end %>
 
-<% if @paginated_handover_cases.size == 0 %>
+<% if @filtered_handover_cases.size == 0 %>
   <p>No handover cases missing COM details</p>
 <% else %>
-  <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>
+  <%= render partial: 'shared/pagination', locals: { data: @filtered_handover_cases } %>
 <% end %>
 
 <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>

--- a/app/views/handovers/com_allocation_overdue.html.erb
+++ b/app/views/handovers/com_allocation_overdue.html.erb
@@ -1,5 +1,3 @@
-<% cases = @handover_cases.com_allocation_overdue %>
-
 <h2 class="govuk-heading-l">
   COM allocation overdue
 </h2>
@@ -30,7 +28,7 @@
                           { body: 'LDU details', class: %w[ldu-details govuk-!-width-one-quarter] },
                         ].compact) do %>
 
-  <% cases.each do |calc_handover, offender| %>
+  <% @paginated_handover_cases.each do |calc_handover, offender| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: offender %>
 
@@ -66,8 +64,10 @@
   <% end %>
 <% end %>
 
-<% if cases.size == 0 %>
+<% if @paginated_handover_cases.size == 0 %>
   <p>No handover cases missing COM details</p>
+<% else %>
+  <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>
 <% end %>
 
 <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>

--- a/app/views/handovers/in_progress.html.erb
+++ b/app/views/handovers/in_progress.html.erb
@@ -11,6 +11,6 @@
          heading: 'Handovers in progress',
          description: description,
          table_class: 'in-progress-handovers',
-         cases: @handover_cases.in_progress,
+         cases: @paginated_handover_cases,
          no_cases_message: 'No handovers in progress right now'
 %>

--- a/app/views/handovers/in_progress.html.erb
+++ b/app/views/handovers/in_progress.html.erb
@@ -11,6 +11,5 @@
          heading: 'Handovers in progress',
          description: description,
          table_class: 'in-progress-handovers',
-         cases: @paginated_handover_cases,
          no_cases_message: 'No handovers in progress right now'
 %>

--- a/app/views/handovers/overdue_tasks.html.erb
+++ b/app/views/handovers/overdue_tasks.html.erb
@@ -3,6 +3,5 @@
            description: 'Responsibility for these cases has transferred to the community, ' \
                         'but some handover tasks are still recorded as incomplete.',
            table_class: 'overdue-tasks-handovers',
-           cases: @handover_cases.overdue_tasks,
            no_cases_message: 'No handover cases with overdue tasks'
 %>

--- a/app/views/handovers/upcoming.html.erb
+++ b/app/views/handovers/upcoming.html.erb
@@ -1,5 +1,3 @@
-<% cases = @handover_cases.upcoming %>
-
 <h2 class="govuk-heading-l">
   Upcoming handovers
 </h2>
@@ -23,7 +21,7 @@
                           { body: 'Handover progress', class: ['handover-progress'] },
                         ].compact) do %>
 
-  <% cases.each do |calc_handover, offender| %>
+  <% @paginated_handover_cases.each do |calc_handover, offender| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: offender %>
 
@@ -40,8 +38,10 @@
   <% end %>
 <% end %>
 
-<% if cases.size == 0 %>
+<% if @paginated_handover_cases.size == 0 %>
   <p>No upcoming handovers at the moment</p>
+<% else %>
+  <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>
 <% end %>
 
 <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>

--- a/app/views/handovers/upcoming.html.erb
+++ b/app/views/handovers/upcoming.html.erb
@@ -21,7 +21,7 @@
                           { body: 'Handover progress', class: ['handover-progress'] },
                         ].compact) do %>
 
-  <% @paginated_handover_cases.each do |calc_handover, offender| %>
+  <% @filtered_handover_cases.each do |calc_handover, offender| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: offender %>
 
@@ -38,10 +38,10 @@
   <% end %>
 <% end %>
 
-<% if @paginated_handover_cases.size == 0 %>
+<% if @filtered_handover_cases.size == 0 %>
   <p>No upcoming handovers at the moment</p>
 <% else %>
-  <%= render partial: 'shared/pagination', locals: { data: @paginated_handover_cases } %>
+  <%= render partial: 'shared/pagination', locals: { data: @filtered_handover_cases } %>
 <% end %>
 
 <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>

--- a/spec/controllers/handovers_controller_spec.rb
+++ b/spec/controllers/handovers_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe HandoversController, type: :controller do
     allow(controller).to receive_messages(current_user_is_pom?: current_user_is_pom_stub,
                                           current_user_is_spo?: current_user_is_spo_stub,
                                           page: page)
-    allow(controller).to receive(:paginated_handover_cases) { |arg| arg }
+    allow(controller).to receive(:filtered_handover_cases) { |arg| arg }
   end
 
   shared_examples 'handover cases list page' do |case_type|
@@ -49,7 +49,7 @@ RSpec.describe HandoversController, type: :controller do
     end
 
     it 'has correct paginated cases' do
-      expect(assigns(:paginated_handover_cases)).to eq handover_cases.send(case_type)
+      expect(assigns(:filtered_handover_cases)).to eq handover_cases.send(case_type)
     end
 
     it 'gets handover cases correctly' do

--- a/spec/controllers/handovers_controller_spec.rb
+++ b/spec/controllers/handovers_controller_spec.rb
@@ -4,22 +4,30 @@ RSpec.describe HandoversController, type: :controller do
   let(:default_params) { { prison_id: prison_code, pom: pom_param } }
   let(:staff_id) { 456_987 }
   let(:staff_member) { instance_double StaffMember, :staff_member, staff_id: staff_id }
-  let(:handover_cases) { double :handover_cases }
+  let(:handover_cases) do
+    double :handover_cases, upcoming: double(:upcoming),
+                            in_progress: double(:in_progress),
+                            overdue_tasks: double(:overdue_tasks),
+                            com_allocation_overdue: double(:com_allocation_overdue)
+  end
   let(:pom_param) { 'pom_param' }
   let(:pom_view_flag) { double :pom_view_flag }
   let(:current_user_is_pom_stub) { double :current_user_is_pom_stub }
   let(:current_user_is_spo_stub) { double :current_user_is_spo_stub }
+  let(:page) { double :page }
 
   before do
     session[:new_handovers_ui] = true
 
     stub_high_level_staff_member_auth(prison: prison, staff_member: staff_member)
     allow(controller.helpers).to receive_messages(handover_cases_view: [pom_view_flag, handover_cases])
-    allow(controller).to receive_messages(current_user_is_pom?: current_user_is_pom_stub)
-    allow(controller).to receive_messages(current_user_is_spo?: current_user_is_spo_stub)
+    allow(controller).to receive_messages(current_user_is_pom?: current_user_is_pom_stub,
+                                          current_user_is_spo?: current_user_is_spo_stub,
+                                          page: page)
+    allow(controller).to receive(:paginated_handover_cases) { |arg| arg }
   end
 
-  shared_examples 'handover cases list page' do
+  shared_examples 'handover cases list page' do |case_type|
     it 'renders successfully' do
       expect(response).to be_successful
     end
@@ -40,6 +48,10 @@ RSpec.describe HandoversController, type: :controller do
       expect(assigns[:pom_view]).to eq pom_view_flag
     end
 
+    it 'has correct paginated cases' do
+      expect(assigns(:paginated_handover_cases)).to eq handover_cases.send(case_type)
+    end
+
     it 'gets handover cases correctly' do
       expect(controller.helpers).to have_received(:handover_cases_view).with(
         current_user: staff_member,
@@ -57,7 +69,7 @@ RSpec.describe HandoversController, type: :controller do
         get :upcoming, params: default_params
       end
 
-      it_behaves_like 'handover cases list page'
+      it_behaves_like 'handover cases list page', :upcoming
     end
 
     describe 'in progress handovers page' do
@@ -65,7 +77,7 @@ RSpec.describe HandoversController, type: :controller do
         get :in_progress, params: default_params
       end
 
-      it_behaves_like 'handover cases list page'
+      it_behaves_like 'handover cases list page', :in_progress
     end
 
     describe 'overdue tasks page' do
@@ -73,7 +85,7 @@ RSpec.describe HandoversController, type: :controller do
         get :overdue_tasks, params: default_params
       end
 
-      it_behaves_like 'handover cases list page'
+      it_behaves_like 'handover cases list page', :overdue_tasks
     end
 
     describe 'COM allocation overdue page' do
@@ -81,7 +93,7 @@ RSpec.describe HandoversController, type: :controller do
         get :com_allocation_overdue, params: default_params
       end
 
-      it_behaves_like 'handover cases list page'
+      it_behaves_like 'handover cases list page', :com_allocation_overdue
     end
   end
 

--- a/spec/views/handovers/com_allocation_overdue.html.erb_spec.rb
+++ b/spec/views/handovers/com_allocation_overdue.html.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'handovers/com_allocation_overdue' do
 
   before do
     stub_template 'shared/_pagination.html.erb' => ''
-    assign(:paginated_handover_cases, cases)
+    assign(:filtered_handover_cases, cases)
     assign(:prison_id, prison_code)
     assign(:pom_view, true)
   end

--- a/spec/views/handovers/com_allocation_overdue.html.erb_spec.rb
+++ b/spec/views/handovers/com_allocation_overdue.html.erb_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe 'handovers/com_allocation_overdue' do
   let(:first_row_text) { first_row.text.strip.gsub(/\s+/, ' ') }
 
   before do
-    assign(:handover_cases, double(:handover_cases, com_allocation_overdue: cases))
+    stub_template 'shared/_pagination.html.erb' => ''
+    assign(:paginated_handover_cases, cases)
     assign(:prison_id, prison_code)
     assign(:pom_view, true)
   end

--- a/spec/views/handovers/in_progress.html.erb_spec.rb
+++ b/spec/views/handovers/in_progress.html.erb_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe 'handovers/in_progress' do
   let(:first_row_text) { first_row.text.strip.gsub(/\s+/, ' ') }
 
   before do
-    assign(:handover_cases, double(:handover_cases, in_progress: cases))
+    stub_template 'shared/_pagination.html.erb' => ''
+    assign(:paginated_handover_cases, cases)
     assign(:prison_id, prison_code)
     assign(:pom_view, true)
   end

--- a/spec/views/handovers/in_progress.html.erb_spec.rb
+++ b/spec/views/handovers/in_progress.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'handovers/in_progress' do
 
   before do
     stub_template 'shared/_pagination.html.erb' => ''
-    assign(:paginated_handover_cases, cases)
+    assign(:filtered_handover_cases, cases)
     assign(:prison_id, prison_code)
     assign(:pom_view, true)
   end

--- a/spec/views/handovers/upcoming.html.erb_spec.rb
+++ b/spec/views/handovers/upcoming.html.erb_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'handovers/upcoming' do
   let(:prison_code) { 'PRI' }
   let(:all_false_hash) { Hash.new { |h, k| h[k] = false } }
-  let(:upcoming_handover_cases) do
+  let(:cases) do
     [
       [
         double(:handover_date1, handover_date: Date.new(2022, 1, 12)),
@@ -33,7 +33,8 @@ RSpec.describe 'handovers/upcoming' do
   let(:first_row_text) { first_row.text.strip.gsub(/\s+/, ' ') }
 
   before do
-    assign(:handover_cases, double(:handover_cases, upcoming: upcoming_handover_cases))
+    stub_template 'shared/_pagination.html.erb' => ''
+    assign(:paginated_handover_cases, cases)
     assign(:prison_id, prison_code)
     assign(:pom_view, true)
   end

--- a/spec/views/handovers/upcoming.html.erb_spec.rb
+++ b/spec/views/handovers/upcoming.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'handovers/upcoming' do
 
   before do
     stub_template 'shared/_pagination.html.erb' => ''
-    assign(:paginated_handover_cases, cases)
+    assign(:filtered_handover_cases, cases)
     assign(:prison_id, prison_code)
     assign(:pom_view, true)
   end


### PR DESCRIPTION
1) Use Kaminari (stupid name) to paginate all handover case lists
2) Also speed up `test2` deployment at a very slight expense to security - system packages will now only be as fresh as production, so as long as production is regularly updated, we're good.
