### PR TITLE
Keyworker API unavailability is now handled by gracefully degrading

### DIFF
--- a/app/services/hmpps_api/keyworker_api.rb
+++ b/app/services/hmpps_api/keyworker_api.rb
@@ -8,6 +8,10 @@ module HmppsApi
       ApiDeserialiser.new.deserialise(HmppsApi::KeyworkerDetails, response)
     rescue Faraday::ResourceNotFound # 404 Not Found error
       HmppsApi::NullKeyworker.new
+    rescue Faraday::Error => e
+      Rails.logger.error(
+        "nomis_offender_id=#{offender_no},event=keyworker_api_error|#{e.inspect},#{e.backtrace.join(',')}")
+      HmppsApi::NullKeyworker.new
     end
 
     def self.client


### PR DESCRIPTION
The error is logged and a null keyworker is returned so the calling code can keep calm and carry on