### PR TITLE
Handover screens can now use different earliest release calculation

### DIFF
--- a/app/lib/named_date.rb
+++ b/app/lib/named_date.rb
@@ -1,0 +1,33 @@
+class NamedDate
+  def initialize(date, name)
+    raise ArgumentError 'Name cannot be blank' if name.blank?
+
+    @name = name
+    @date = date
+  end
+
+  # Custom constructor is like .new except returns nil if date is nil
+  def self.[](date, name)
+    return nil if date.nil?
+
+    new(date, name)
+  end
+
+  attr_reader :name, :date
+
+  def <=>(other)
+    date <=> other.date
+  end
+
+  def ==(other)
+    [date, name] == [other.date, other.name]
+  end
+
+  def inspect
+    "#<NamedDate:#{date.iso8601} (#{name})>"
+  end
+
+  def to_h
+    { 'name' => name, 'date' => date }
+  end
+end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -6,7 +6,7 @@
 #
 class AllocatedOffender
   delegate :first_name, :last_name, :full_name_ordered, :full_name,
-           :earliest_release_date, :earliest_release, :approaching_handover?, :tariff_date, :release_date,
+           :earliest_release_date, :earliest_release, :earliest_release_2, :approaching_handover?, :tariff_date, :release_date,
            :in_upcoming_handover_window?,
            :indeterminate_sentence?, :prison_id, :parole_review_date, :allocated_com_email,
            :handover_start_date, :responsibility_handover_date, :allocated_com_name, :has_com?, :case_allocation,

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -363,6 +363,31 @@ class MpcOffender
     allocated_com_name.present? || allocated_com_email.present?
   end
 
+  # We can not calculate the handover date for NPS Indeterminate
+  # with parole cases where the TED is in the past as we need
+  # the parole board decision which currently is not available to us.
+  def earliest_release_2
+    if indeterminate_sentence?
+      if tariff_date.present? && tariff_date.future?
+        NamedDate[tariff_date, 'TRD']
+      else
+        [
+          NamedDate[parole_review_date, 'PRD'],
+          NamedDate[parole_eligibility_date, 'PED'],
+        ].compact.reject { |nd| nd.date.past? }.min
+      end
+    elsif case_information&.nps_case?
+      possible_dates = [NamedDate[conditional_release_date, 'CRD'], NamedDate[automatic_release_date, 'ARD']]
+      NamedDate[parole_eligibility_date, 'PED'] || possible_dates.compact.min
+    else
+      # CRC can look at HDC date, NPS is not supposed to
+      NamedDate[home_detention_curfew_actual_date, 'HDCEA'].presence ||
+        [NamedDate[automatic_release_date, 'ARD'],
+         NamedDate[conditional_release_date, 'CRD'],
+         NamedDate[home_detention_curfew_eligibility_date, 'HDCED']].compact.min
+    end
+  end
+
 private
 
   def early_allocation_notes?

--- a/app/views/handovers/cells/_earliest_release_date.html.erb
+++ b/app/views/handovers/cells/_earliest_release_date.html.erb
@@ -1,4 +1,10 @@
-<% rel_type, rel_date = offender.earliest_release&.values_at(:type, :date) %>
+<%
+  if params[:rd2].present?
+    rel_type, rel_date = offender.earliest_release_2&.to_h&.values_at('name', 'date')
+  else
+    rel_type, rel_date = offender.earliest_release&.values_at(:type, :date)
+  end
+%>
 <td class="govuk-table__cell earliest-release-date">
   <% if rel_type && rel_date %>
     <%= rel_type %>: <br>


### PR DESCRIPTION
This new calculation is the same one used to calculate the handover date but is inconsistent with the earliest release calculation used throughout the rest of the site