### PR TITLE
Fix handover reminder email batch run - handle realistic data conditions

### DIFF
--- a/app/lib/handover/handover_email_batch_run.rb
+++ b/app/lib/handover/handover_email_batch_run.rb
@@ -73,8 +73,9 @@ class Handover::HandoverEmailBatchRun
         with_error_handling(offender.offender_no, 'com_allocation_overdue') do
           send_one_com_allocation_overdue(offender, for_date: for_date)
         end
-        Rails.logger.info("event=handover_email_batch_run_end,for_date=#{for_date.iso8601}")
       end
+    ensure
+      Rails.logger.info("event=handover_email_batch_run_end,for_date=#{for_date.iso8601}")
     end
 
   private

--- a/app/lib/handover/handover_email_batch_run.rb
+++ b/app/lib/handover/handover_email_batch_run.rb
@@ -2,7 +2,7 @@ class Handover::HandoverEmailBatchRun
   class << self
     def send_one_upcoming_handover_window(offender, deliver_now: false, for_date: Time.zone.now.to_date)
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
-      return unless chd.handover_date == for_date + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
+      return unless chd&.handover_date && chd.handover_date == for_date + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
 
       Handover::HandoverEmail.deliver_if_deliverable(
         :upcoming_handover_window,
@@ -21,7 +21,7 @@ class Handover::HandoverEmailBatchRun
 
     def send_one_handover_date(offender, deliver_now: false, for_date: Time.zone.now.to_date)
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
-      return unless chd.handover_date == for_date && offender.has_com?
+      return unless chd&.handover_date && chd.handover_date == for_date && offender.has_com?
 
       Handover::HandoverEmail.deliver_if_deliverable(
         :handover_date,
@@ -41,7 +41,7 @@ class Handover::HandoverEmailBatchRun
 
     def send_one_com_allocation_overdue(offender, deliver_now: false, for_date: Time.zone.now.to_date)
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
-      return unless chd.handover_date == for_date - 14.days && !offender.has_com?
+      return unless chd&.handover_date && chd.handover_date == for_date - 14.days && !offender.has_com?
 
       Handover::HandoverEmail.deliver_if_deliverable(
         :com_allocation_overdue,

--- a/spec/lib/handover/handover_email_batch_run_spec.rb
+++ b/spec/lib/handover/handover_email_batch_run_spec.rb
@@ -42,10 +42,14 @@ RSpec.describe Handover::HandoverEmailBatchRun do
           FactoryBot.create :calculated_handover_date,
                             offender: o, handover_date: today + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
         end
-        ignored = FactoryBot.create :calculated_handover_date, handover_date: today + 1.day
-        ignored_offender = instance_double(AllocatedOffender, offender_no: ignored.nomis_offender_id)
+        ignored = []
 
-        allow(AllocatedOffender).to receive(:all).and_return(allocated_to_process + [ignored_offender])
+        ignored1 = FactoryBot.create :calculated_handover_date, handover_date: today + 1.day
+        ignored.push instance_double(AllocatedOffender, offender_no: ignored1.nomis_offender_id)
+
+        ignored.push instance_double(AllocatedOffender, offender_no: 'NO_CHD', has_com?: true)
+
+        allow(AllocatedOffender).to receive(:all).and_return(allocated_to_process + ignored)
       end
 
       it "delivers the correct cases" do
@@ -94,6 +98,8 @@ RSpec.describe Handover::HandoverEmailBatchRun do
 
         ignored_no_com = FactoryBot.create :calculated_handover_date, handover_date: today
         ignored.push instance_double(AllocatedOffender, offender_no: ignored_no_com.offender.id, has_com?: false)
+
+        ignored.push instance_double(AllocatedOffender, offender_no: 'NO_CHD', has_com?: true)
 
         allow(AllocatedOffender).to receive(:all).and_return(allocated_to_process + ignored)
       end
@@ -146,6 +152,8 @@ RSpec.describe Handover::HandoverEmailBatchRun do
 
         ignored_has_com = FactoryBot.create :calculated_handover_date, handover_date: today - 14.days
         ignored.push instance_double(AllocatedOffender, offender_no: ignored_has_com.offender.id, has_com?: true)
+
+        ignored.push instance_double(AllocatedOffender, offender_no: 'NO_CHD', has_com?: true)
 
         allow(AllocatedOffender).to receive(:all).and_return(allocated_to_process + ignored)
       end


### PR DESCRIPTION
We assume stuff is there when it is not always there (e.g. CalculatedHandoverDate records). Do not assume - check for existence of required data.
