### PR TITLE
Staff and caseload pages now show upcoming handover count

### DIFF
--- a/app/assets/stylesheets/cards.scss
+++ b/app/assets/stylesheets/cards.scss
@@ -15,6 +15,7 @@
 }
 
 .card__heading {
+  font-family:"GDS Transport", Arial, sans-serif;
   margin-top: 0;
   margin-bottom: 15px;
 

--- a/app/controllers/prison_staff_application_controller.rb
+++ b/app/controllers/prison_staff_application_controller.rb
@@ -63,6 +63,8 @@ private
 
     @allocations = Kaminari.paginate_array(sort_allocations(filter_allocations(@pom.allocations))).page(page)
 
+    @handover_cases = Handover::CategorisedHandoverCasesForPom.new(@pom)
+
     @summary = {
       all_prison_cases: @prison.allocations.all.count,
       new_cases_count: @pom.allocations.count(&:new_case?),
@@ -72,7 +74,7 @@ private
         a.earliest_release_date.present? &&
           a.earliest_release_date.to_date <= 4.weeks.after && Date.current.beginning_of_day < a.earliest_release_date.to_date
       end,
-      pending_handover_count: @pom.allocations.count(&:approaching_handover?),
+      pending_handover_count: @handover_cases.upcoming.count,
       pending_task_count: PomTasks.new.for_offenders(@pom.allocations).count,
       last_allocated_date: @allocations.max_by(&:primary_pom_allocated_at)&.primary_pom_allocated_at&.to_date
     }

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -17,18 +17,9 @@
               <% end %>
             </div>
           </div>
-
-          <% unless use_new_handovers_ui? %>
-            <div class="govuk-grid-column-one-half">
-              <div class="card--caseload card-total">
-                <%= link_to prison_staff_caseload_handovers_path, class: 'govuk-link--no-visited-state' do %>
-                  <span class="card__heading--large"><%= @summary.fetch(:pending_handover_count) %></span>
-                  <p>handovers in progress</p>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-
+          <div class="govuk-grid-column-one-half">
+            <%= render 'caseload_global/upcoming_handovers_card', with_link: true %>
+          </div>
         </div>
 
         <div class="govuk-grid-column-row">

--- a/app/views/caseload_global/_upcoming_handovers_card.html.erb
+++ b/app/views/caseload_global/_upcoming_handovers_card.html.erb
@@ -1,0 +1,12 @@
+<% information = capture do %>
+  <span class="card__heading--large"><%= @summary.fetch(:pending_handover_count) %></span>
+  <p>upcoming handover<%= 's' if @summary.fetch(:pending_handover_count) != 1 %></p>
+<% end %>
+
+<div class="card--caseload card-total">
+  <% if local_assigns[:with_link] %>
+    <%= link_to information, upcoming_prison_handovers_path(@prison.code, pom: 1), class: 'govuk-link--no-visited-state' %>
+  <% else %>
+    <%= information %>
+  <% end %>
+</div>

--- a/app/views/poms/_overview_tab.html.erb
+++ b/app/views/poms/_overview_tab.html.erb
@@ -13,16 +13,9 @@
               <% end %>
             </div>
           </div>
-          <% unless use_new_handovers_ui? %>
-            <div class="govuk-grid-column-one-half">
-              <div class="card--caseload card-total">
-                <%= link_to prison_staff_caseload_handovers_path(@prison.code, @pom.staff_id, :caseload) do %>
-                  <span class="card__heading--large"><%= @summary.fetch(:pending_handover_count) %></span>
-                  <p>handover cases</p>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
+          <div class="govuk-grid-column-one-half">
+            <%= render 'caseload_global/upcoming_handovers_card' %>
+          </div>
         </div>
         <div class="govuk-grid-column-row">
           <h3 class="govuk-heading-m govuk-!-margin-top-8">


### PR DESCRIPTION
This replaces the old handover count boxes

Due to backend and frontend restraints, we cannot allow a POM to see all handovers for another staff member, so the box on the staff pages is not clickableW but is just a number.

MO-1202

Surprisingly, no tests broke. I'm not going to waste time testing this spaghetti mess, when we make a change that breaks stuff really badly then we can rewrite with tests.