### PR TITLE
Refactor MpcOffender#earliest_release_2

### DIFF
--- a/app/lib/handover/categorised_handover_cases.rb
+++ b/app/lib/handover/categorised_handover_cases.rb
@@ -24,7 +24,7 @@ module Handover
 
     def build_cases(cal_handover_dates)
       cal_handover_dates.map do |chd|
-        HandoverCase.new(chd, @all_offenders_by_no[chd.nomis_offender_id])
+        HandoverCase.new(@all_offenders_by_no[chd.nomis_offender_id], chd)
       end
     end
   end

--- a/app/lib/handover/handover_case.rb
+++ b/app/lib/handover/handover_case.rb
@@ -1,7 +1,7 @@
 class Handover::HandoverCase
   # we pass calculated handover date explicitly instead of finding it ourselves because: (1) its not our job to find it,
   # and (2) the CategorisedHandoverCases factories will have found them already when it initialises this class
-  def initialize(calculated_handover_date, allocated_offender)
+  def initialize(allocated_offender, calculated_handover_date)
     raise ArgumentError unless calculated_handover_date.is_a?(CalculatedHandoverDate)
     raise ArgumentError unless allocated_offender.is_a?(AllocatedOffender)
 

--- a/app/lib/handover/handover_case.rb
+++ b/app/lib/handover/handover_case.rb
@@ -16,8 +16,7 @@ class Handover::HandoverCase
   end
 
   delegate :last_name, to: :offender, prefix: true
-  delegate :staff_member, :allocated_com_name, :earliest_release_date, :tier, :handover_progress_complete?,
-           to: :offender
+  delegate :staff_member, :allocated_com_name, :tier, :handover_progress_complete?, to: :offender
   delegate :last_name, to: :staff_member, prefix: true
   delegate :handover_date, to: :calculated_handover_date
 

--- a/app/lib/handover/handover_case.rb
+++ b/app/lib/handover/handover_case.rb
@@ -1,14 +1,9 @@
 class Handover::HandoverCase
   # we pass calculated handover date explicitly instead of finding it ourselves because: (1) its not our job to find it,
   # and (2) the CategorisedHandoverCases factories will have found them already when it initialises this class
-  def initialize(allocated_offender, calculated_handover_date = nil)
+  def initialize(allocated_offender, calculated_handover_date)
+    raise ArgumentError unless calculated_handover_date.is_a?(CalculatedHandoverDate)
     raise ArgumentError unless allocated_offender.is_a?(AllocatedOffender)
-
-    if calculated_handover_date
-      raise ArgumentError unless calculated_handover_date.is_a?(CalculatedHandoverDate)
-    else
-      calculated_handover_date = CalculatedHandoverDate.find_by!(nomis_offender_id: allocated_offender.offender_no)
-    end
 
     @offender = allocated_offender
     @calculated_handover_date = calculated_handover_date

--- a/app/lib/handover/handover_case.rb
+++ b/app/lib/handover/handover_case.rb
@@ -30,4 +30,29 @@ class Handover::HandoverCase
 
     (relative_to_date - handover_date).to_i
   end
+
+  # We can not calculate the handover date for NPS Indeterminate
+  # with parole cases where the TED is in the past as we need
+  # the parole board decision which currently is not available to us.
+  def earliest_release_for_handover
+    if offender.indeterminate_sentence?
+      if offender.tariff_date&.future?
+        NamedDate[offender.tariff_date, 'TED']
+      else
+        [
+          NamedDate[offender.parole_review_date, 'PRD'],
+          NamedDate[offender.parole_eligibility_date, 'PED'],
+        ].compact.reject { |nd| nd.date.past? }.min
+      end
+    elsif offender.case_information&.nps_case?
+      possible_dates = [NamedDate[offender.conditional_release_date, 'CRD'], NamedDate[offender.automatic_release_date, 'ARD']]
+      NamedDate[offender.parole_eligibility_date, 'PED'] || possible_dates.compact.min
+    else
+      # CRC can look at HDC date, NPS is not supposed to
+      NamedDate[offender.home_detention_curfew_actual_date, 'HDCEA'] ||
+        [NamedDate[offender.automatic_release_date, 'ARD'],
+         NamedDate[offender.conditional_release_date, 'CRD'],
+         NamedDate[offender.home_detention_curfew_eligibility_date, 'HDCED']].compact.min
+    end
+  end
 end

--- a/app/lib/handover/handover_case.rb
+++ b/app/lib/handover/handover_case.rb
@@ -1,9 +1,14 @@
 class Handover::HandoverCase
   # we pass calculated handover date explicitly instead of finding it ourselves because: (1) its not our job to find it,
   # and (2) the CategorisedHandoverCases factories will have found them already when it initialises this class
-  def initialize(allocated_offender, calculated_handover_date)
-    raise ArgumentError unless calculated_handover_date.is_a?(CalculatedHandoverDate)
+  def initialize(allocated_offender, calculated_handover_date = nil)
     raise ArgumentError unless allocated_offender.is_a?(AllocatedOffender)
+
+    if calculated_handover_date
+      raise ArgumentError unless calculated_handover_date.is_a?(CalculatedHandoverDate)
+    else
+      calculated_handover_date = CalculatedHandoverDate.find_by!(nomis_offender_id: allocated_offender.offender_no)
+    end
 
     @offender = allocated_offender
     @calculated_handover_date = calculated_handover_date

--- a/app/lib/handover/handover_email_batch_run.rb
+++ b/app/lib/handover/handover_email_batch_run.rb
@@ -4,6 +4,7 @@ class Handover::HandoverEmailBatchRun
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
       return unless chd&.handover_date && chd.handover_date == for_date + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
 
+      handover_case = Handover::HandoverCase.new(offender, chd)
       Handover::HandoverEmail.deliver_if_deliverable(
         :upcoming_handover_window,
         offender.offender_no,
@@ -13,7 +14,7 @@ class Handover::HandoverEmailBatchRun
         first_name: offender.first_name.titleize,
         handover_date: format_date(chd.handover_date),
         service_provider: offender.case_allocation,
-        release_date: format_date(offender.earliest_release_2&.date),
+        release_date: format_date(handover_case.earliest_release_for_handover&.date),
         deliver_now: deliver_now,
       )
       Rails.logger.info("event=handover_email_delivered,nomis_offender_id=#{offender.offender_no},email=upcoming_handover_window,for_date=#{for_date.iso8601}")
@@ -23,6 +24,7 @@ class Handover::HandoverEmailBatchRun
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
       return unless chd&.handover_date && chd.handover_date == for_date && offender.has_com?
 
+      handover_case = Handover::HandoverCase.new(offender, chd)
       Handover::HandoverEmail.deliver_if_deliverable(
         :handover_date,
         offender.offender_no,
@@ -30,7 +32,7 @@ class Handover::HandoverEmailBatchRun
         email: offender.staff_member.email_address,
         full_name_ordered: offender.full_name_ordered,
         first_name: offender.first_name.titleize,
-        release_date: format_date(offender.earliest_release_2&.date),
+        release_date: format_date(handover_case.earliest_release_for_handover&.date),
         com_name: offender.allocated_com_name,
         com_email: offender.allocated_com_email,
         service_provider: offender.case_allocation,
@@ -43,6 +45,7 @@ class Handover::HandoverEmailBatchRun
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
       return unless chd&.handover_date && chd.handover_date == for_date - 14.days && !offender.has_com?
 
+      handover_case = Handover::HandoverCase.new(offender, chd)
       Handover::HandoverEmail.deliver_if_deliverable(
         :com_allocation_overdue,
         offender.offender_no,
@@ -50,7 +53,7 @@ class Handover::HandoverEmailBatchRun
         email: offender.staff_member.email_address,
         full_name_ordered: offender.full_name_ordered,
         handover_date: format_date(chd.handover_date),
-        release_date: format_date(offender.earliest_release_2&.date),
+        release_date: format_date(handover_case.earliest_release_for_handover&.date),
         ldu_name: offender.ldu_name,
         ldu_email: offender.ldu_email_address,
         service_provider: offender.case_allocation,

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -6,7 +6,7 @@
 #
 class AllocatedOffender
   delegate :first_name, :last_name, :full_name_ordered, :full_name,
-           :earliest_release_date, :earliest_release, :earliest_release_2, :tariff_date, :release_date,
+           :earliest_release_date, :earliest_release, :tariff_date, :release_date,
            :in_upcoming_handover_window?,
            :indeterminate_sentence?, :prison_id, :parole_review_date, :allocated_com_email,
            :handover_start_date, :responsibility_handover_date, :allocated_com_name, :has_com?, :case_allocation,

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -344,31 +344,6 @@ class MpcOffender
     allocated_com_name.present? || allocated_com_email.present?
   end
 
-  # We can not calculate the handover date for NPS Indeterminate
-  # with parole cases where the TED is in the past as we need
-  # the parole board decision which currently is not available to us.
-  def earliest_release_2
-    if indeterminate_sentence?
-      if tariff_date.present? && tariff_date.future?
-        NamedDate[tariff_date, 'TED']
-      else
-        [
-          NamedDate[parole_review_date, 'PRD'],
-          NamedDate[parole_eligibility_date, 'PED'],
-        ].compact.reject { |nd| nd.date.past? }.min
-      end
-    elsif case_information&.nps_case?
-      possible_dates = [NamedDate[conditional_release_date, 'CRD'], NamedDate[automatic_release_date, 'ARD']]
-      NamedDate[parole_eligibility_date, 'PED'] || possible_dates.compact.min
-    else
-      # CRC can look at HDC date, NPS is not supposed to
-      NamedDate[home_detention_curfew_actual_date, 'HDCEA'].presence ||
-        [NamedDate[automatic_release_date, 'ARD'],
-         NamedDate[conditional_release_date, 'CRD'],
-         NamedDate[home_detention_curfew_eligibility_date, 'HDCED']].compact.min
-    end
-  end
-
 private
 
   def early_allocation_notes?

--- a/app/views/handovers/_shared_in_progress.html.erb
+++ b/app/views/handovers/_shared_in_progress.html.erb
@@ -27,7 +27,7 @@
       <%= render 'handovers/cells/handover_dates', handover_cases: @handover_cases, handover_case: handover_case,
                  show_highlight: show_handover_date_highlight %>
 
-      <%= render 'handovers/cells/earliest_release_date', offender: handover_case.offender %>
+      <%= render 'handovers/cells/earliest_release_date', handover_case: handover_case %>
 
       <%= render 'handovers/cells/tier', offender: handover_case.offender %>
 

--- a/app/views/handovers/cells/_earliest_release_date.html.erb
+++ b/app/views/handovers/cells/_earliest_release_date.html.erb
@@ -1,4 +1,4 @@
-<% rel_type, rel_date = offender.earliest_release_2&.to_h&.values_at('name', 'date') %>
+<% rel_type, rel_date = handover_case.earliest_release_for_handover&.to_h&.values_at('name', 'date') %>
 <td class="govuk-table__cell earliest-release-date">
   <% if rel_type && rel_date %>
     <%= rel_type %>: <br>

--- a/app/views/handovers/com_allocation_overdue.html.erb
+++ b/app/views/handovers/com_allocation_overdue.html.erb
@@ -37,7 +37,7 @@
       <%= render 'handovers/cells/handover_dates',
                  handover_case: handover_case, show_highlight: nil %>
 
-      <%= render 'handovers/cells/earliest_release_date', offender: handover_case.offender %>
+      <%= render 'handovers/cells/earliest_release_date', handover_case: handover_case %>
 
       <%= render 'handovers/cells/tier', offender: handover_case.offender %>
 

--- a/spec/features/handovers_feature_spec.rb
+++ b/spec/features/handovers_feature_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Handovers feature:' do
 
   describe 'upcoming handovers' do
     it 'renders correctly' do
-      allow(handover_cases).to receive(:upcoming).and_return([Handover::HandoverCase.new(calc_handover_date, offender)])
+      allow(handover_cases).to receive(:upcoming).and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
       visit upcoming_prison_handovers_path(default_params)
 
       aggregate_failures do
@@ -59,7 +59,7 @@ RSpec.feature 'Handovers feature:' do
       allow(offender).to receive(:allocated_com_name).and_return('Mr COM')
       allow(offender).to receive(:allocated_com_email).and_return('mr-com@example.org')
       allow(handover_cases).to receive(:in_progress)
-                                 .and_return([Handover::HandoverCase.new(calc_handover_date, offender)])
+                                 .and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
       visit in_progress_prison_handovers_path(default_params)
 
       aggregate_failures do
@@ -74,7 +74,7 @@ RSpec.feature 'Handovers feature:' do
   describe 'overdue tasks' do
     it 'renders correctly' do
       allow(handover_cases).to receive(:overdue_tasks)
-                                 .and_return([Handover::HandoverCase.new(calc_handover_date, offender)])
+                                 .and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
       visit overdue_tasks_prison_handovers_path(default_params)
 
       aggregate_failures do
@@ -88,7 +88,7 @@ RSpec.feature 'Handovers feature:' do
   describe 'COM allocation overdue handovers page' do
     it 'renders correctly' do
       allow(handover_cases).to receive(:com_allocation_overdue)
-                                 .and_return([Handover::HandoverCase.new(calc_handover_date, offender)])
+                                 .and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
       visit com_allocation_overdue_prison_handovers_path(default_params)
 
       aggregate_failures do

--- a/spec/features/handovers_feature_spec.rb
+++ b/spec/features/handovers_feature_spec.rb
@@ -4,13 +4,11 @@ RSpec.feature 'Handovers feature:' do
   let(:user) { FactoryBot.build(:pom) }
   let(:default_params) { { prison_id: prison_code } }
   let(:offender_attrs) do
-    erd = Faker::Date.forward
     {
       full_name: 'Surname1, Firstname1',
       last_name: 'Surname1',
       offender_no: 'X1111XX',
       tier: 'A',
-      earliest_release_2: { type: 'TED', date: erd },
       case_allocation: 'HDCED',
       handover_progress_task_completion_data: {},
       allocated_com_email: nil,
@@ -22,14 +20,18 @@ RSpec.feature 'Handovers feature:' do
     }
   end
   let(:offender) { sneaky_instance_double AllocatedOffender, offender_attrs }
-  let(:calc_handover_date) do
-    sneaky_instance_double CalculatedHandoverDate, :calc_handover_date, handover_date: Faker::Date.forward
-  end
   let(:handover_cases) do
-    sneaky_instance_double(Handover::CategorisedHandoverCasesForPom, :handover_cases, upcoming: [],
-                                                                                      in_progress: [],
-                                                                                      overdue_tasks: [],
-                                                                                      com_allocation_overdue: [])
+    sneaky_instance_double(Handover::CategorisedHandoverCasesForPom, upcoming: [],
+                                                                     in_progress: [],
+                                                                     overdue_tasks: [],
+                                                                     com_allocation_overdue: [])
+  end
+  let(:handover_case) do
+    instance_double Handover::HandoverCase,
+                    earliest_release_for_handover: NamedDate[nil, nil],
+                    offender: offender,
+                    handover_date: Faker::Date.forward,
+                    com_allocation_days_overdue: 10
   end
 
   before do
@@ -43,7 +45,7 @@ RSpec.feature 'Handovers feature:' do
 
   describe 'upcoming handovers' do
     it 'renders correctly' do
-      allow(handover_cases).to receive(:upcoming).and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
+      allow(handover_cases).to receive(:upcoming).and_return([handover_case])
       visit upcoming_prison_handovers_path(default_params)
 
       aggregate_failures do
@@ -59,7 +61,7 @@ RSpec.feature 'Handovers feature:' do
       allow(offender).to receive(:allocated_com_name).and_return('Mr COM')
       allow(offender).to receive(:allocated_com_email).and_return('mr-com@example.org')
       allow(handover_cases).to receive(:in_progress)
-                                 .and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
+                                 .and_return([handover_case])
       visit in_progress_prison_handovers_path(default_params)
 
       aggregate_failures do
@@ -74,7 +76,7 @@ RSpec.feature 'Handovers feature:' do
   describe 'overdue tasks' do
     it 'renders correctly' do
       allow(handover_cases).to receive(:overdue_tasks)
-                                 .and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
+                                 .and_return([handover_case])
       visit overdue_tasks_prison_handovers_path(default_params)
 
       aggregate_failures do
@@ -88,7 +90,7 @@ RSpec.feature 'Handovers feature:' do
   describe 'COM allocation overdue handovers page' do
     it 'renders correctly' do
       allow(handover_cases).to receive(:com_allocation_overdue)
-                                 .and_return([Handover::HandoverCase.new(offender, calc_handover_date)])
+                                 .and_return([handover_case])
       visit com_allocation_overdue_prison_handovers_path(default_params)
 
       aggregate_failures do

--- a/spec/lib/handover/categorised_handover_cases_spec.rb
+++ b/spec/lib/handover/categorised_handover_cases_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Handover::CategorisedHandoverCases do
   describe '#upcoming' do
     it 'gets a list of handover cases whose handovers are upcoming' do
       expect(handover_cases.upcoming).to eq([
-        Handover::HandoverCase.new(upcoming_calculated_handover_dates[0], offenders['A']),
-        Handover::HandoverCase.new(upcoming_calculated_handover_dates[1], offenders['C'])
+        Handover::HandoverCase.new(offenders['A'], upcoming_calculated_handover_dates[0]),
+        Handover::HandoverCase.new(offenders['C'], upcoming_calculated_handover_dates[1])
       ])
     end
 
@@ -73,10 +73,10 @@ RSpec.describe Handover::CategorisedHandoverCases do
   describe '#in_progress' do
     it 'gets a list of handover cases whose handovers are in progress' do
       expect(handover_cases.in_progress).to eq([
-        Handover::HandoverCase.new(in_progress_calculated_handover_dates[0], offenders['D']),
-        Handover::HandoverCase.new(in_progress_calculated_handover_dates[1], offenders['F']),
-        Handover::HandoverCase.new(overdue_tasks_calculated_handover_dates[0], offenders['G']),
-        Handover::HandoverCase.new(overdue_tasks_calculated_handover_dates[1], offenders['H']),
+        Handover::HandoverCase.new(offenders['D'], in_progress_calculated_handover_dates[0]),
+        Handover::HandoverCase.new(offenders['F'], in_progress_calculated_handover_dates[1]),
+        Handover::HandoverCase.new(offenders['G'], overdue_tasks_calculated_handover_dates[0]),
+        Handover::HandoverCase.new(offenders['H'], overdue_tasks_calculated_handover_dates[1]),
       ])
     end
 
@@ -90,8 +90,8 @@ RSpec.describe Handover::CategorisedHandoverCases do
   describe '#overdue_tasks' do
     it 'gets a list of handover cases past handover and with tasks overdue' do
       expect(handover_cases.overdue_tasks).to eq([
-        Handover::HandoverCase.new(overdue_tasks_calculated_handover_dates[0], offenders['G']),
-        Handover::HandoverCase.new(overdue_tasks_calculated_handover_dates[1], offenders['H']),
+        Handover::HandoverCase.new(offenders['G'], overdue_tasks_calculated_handover_dates[0]),
+        Handover::HandoverCase.new(offenders['H'], overdue_tasks_calculated_handover_dates[1]),
       ])
     end
 
@@ -105,8 +105,8 @@ RSpec.describe Handover::CategorisedHandoverCases do
   describe '#com_allocation_overdue' do
     it 'gets a list of handover cases that are COM allocation overdue' do
       expect(handover_cases.com_allocation_overdue).to eq([
-        Handover::HandoverCase.new(com_allocation_overdue_calculated_handover_dates[0], offenders['J']),
-        Handover::HandoverCase.new(com_allocation_overdue_calculated_handover_dates[1], offenders['K'])
+        Handover::HandoverCase.new(offenders['J'], com_allocation_overdue_calculated_handover_dates[0]),
+        Handover::HandoverCase.new(offenders['K'], com_allocation_overdue_calculated_handover_dates[1])
       ])
     end
   end

--- a/spec/lib/handover/handover_case_spec.rb
+++ b/spec/lib/handover/handover_case_spec.rb
@@ -1,22 +1,22 @@
 RSpec.describe Handover::HandoverCase do
-  subject(:hcase) { described_class.new(chd, offender) }
+  subject(:hcase) { described_class.new(offender, chd) }
 
   let(:offender) { sneaky_instance_double AllocatedOffender, :offender }
   let(:chd) { sneaky_instance_double CalculatedHandoverDate, :chd, handover_date: nil }
 
   describe '#==' do
     it 'returns true when attributes are the same' do
-      obj1 = described_class.new(chd, offender)
-      obj2 = described_class.new(chd, offender)
+      obj1 = described_class.new(offender, chd)
+      obj2 = described_class.new(offender, chd)
       expect(obj1 == obj2).to eq true
     end
 
     it 'returns false when attributes are not the same' do
       aggregate_failures do
-        expect(described_class.new(sneaky_instance_double(CalculatedHandoverDate), offender) ==
-                 described_class.new(chd, offender)).to eq false
-        expect(described_class.new(chd, sneaky_instance_double(AllocatedOffender)) ==
-          described_class.new(chd, offender)).to eq false
+        expect(described_class.new(offender, sneaky_instance_double(CalculatedHandoverDate)) ==
+                 described_class.new(offender, chd)).to eq false
+        expect(described_class.new(sneaky_instance_double(AllocatedOffender), chd) ==
+          described_class.new(offender, chd)).to eq false
       end
     end
   end

--- a/spec/lib/handover/handover_case_spec.rb
+++ b/spec/lib/handover/handover_case_spec.rb
@@ -1,25 +1,8 @@
 RSpec.describe Handover::HandoverCase do
   subject(:hcase) { described_class.new(offender, chd) }
 
-  let(:offender) { sneaky_instance_double AllocatedOffender, :offender, offender_no: 'X1111XX' }
+  let(:offender) { sneaky_instance_double AllocatedOffender, :offender }
   let(:chd) { sneaky_instance_double CalculatedHandoverDate, :chd, handover_date: nil }
-
-  before do
-    allow(CalculatedHandoverDate).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound, 'Default stub')
-  end
-
-  describe '::new' do
-    it 'finds CalculatedHandoverDate by offender number if it is not given' do
-      allow(CalculatedHandoverDate).to receive(:find_by!).with(nomis_offender_id: 'X1111XX')
-                                                         .and_return(chd)
-      handover_case = described_class.new(offender)
-
-      aggregate_failures do
-        expect(handover_case.offender).to eq offender
-        expect(handover_case.calculated_handover_date).to eq chd
-      end
-    end
-  end
 
   describe '#==' do
     it 'returns true when attributes are the same' do

--- a/spec/support/helpers/high_level_mocking_and_stubbing_helper.rb
+++ b/spec/support/helpers/high_level_mocking_and_stubbing_helper.rb
@@ -22,6 +22,7 @@ module HighLevelMockingAndStubbingHelper
     mock_offender
   end
 
+  # Like instance double, but stubs `is_a?` so it can pretend to be of the same type as what it is doubling
   def sneaky_instance_double(the_class, *args, **kwargs)
     d = instance_double(the_class, *args, **kwargs.merge(is_a?: false))
     allow(d).to receive(:is_a?).with(the_class).and_return(true)


### PR DESCRIPTION
It has been moved from `MpcOffender#earliest_release_2` to `Handover::HandoverCase#earliest_release_for_handover` so now nobody can be confused as to it's purpose.

It is still untested. Testing it at this stage is ultra-low-value since there are no changes being made to it, and tests either provide a benefit from stopping regressions when changes occur, or helping design better code when it is written in the first place.
