### PR TITLE
Add a step to rerun failed specs after CircleCI runs specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,7 @@ jobs:
             env_name="${K8S_NAMESPACE#offender-management-}"
             . ~/env/"${env_name}"-hmpps-secrets.sh
             cc-test-reporter before-build
+            export SPEC_STATUS_PATH=~/spec_status
             bundle exec parallel_test -t rspec -- -t ~flaky --format progress -- spec
             cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
@@ -273,6 +274,24 @@ jobs:
           path: coverage
       - store_artifacts:
           path: ~/test-results
+
+  retest_only_failures:
+    <<: *defaults
+    <<: *test_container_config
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Rerun failing tests
+          command: |
+            env_name="${K8S_NAMESPACE#offender-management-}"
+            . ~/env/"${env_name}"-hmpps-secrets.sh
+            export SPEC_STATUS_PATH=~/spec_status
+            bundle exec parallel_test -t rspec -- -t ~flaky --format progress --only-failures -- spec
+          environment:
+            MOZ_HEADLESS: 1
+            ALLOCATION_MANAGER_HOST: https://dev.moic.service.justice.gov.uk
 
   cucumber:
     <<: *defaults
@@ -368,6 +387,10 @@ workflows:
           requires: [install_dependencies, fetch_secrets]
           filters: { branches: { ignore: [main, preprod, test, test2] } }
           context: [offender-management-shared, offender-management-staging]
+      - retest_only_failures:
+          requires: [test]
+          filters: { branches: { ignore: [main, preprod, test, test2] } }
+          context: [offender-management-shared, offender-management-staging]
       - verify_docker_image_builds:
           filters: { branches: { ignore: [main, preprod, test, test2] } }
       - cucumber:
@@ -434,6 +457,10 @@ workflows:
           filters: { branches: { only: [main] } }
       - test:
           requires: [install_dependencies, fetch_staging_secrets]
+          filters: { branches: { only: [main] } }
+          context: [offender-management-shared, offender-management-staging]
+      - retest_only_failures:
+          requires: [test]
           filters: { branches: { only: [main] } }
           context: [offender-management-shared, offender-management-staging]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ jobs:
             cc-test-reporter before-build
             export SPEC_STATUS_PATH=~/spec_status
             bundle exec parallel_test -t rspec -- -t ~flaky --format progress -- spec
+            [[ "${?}" == 0 ]] || (echo "Flaky tests detected, trying again..." && sleep 30 && bundle exec parallel_test -t rspec -- -t ~flaky --format progress --only-failures -- spec)
             cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
           environment:
             MOZ_HEADLESS: 1
@@ -274,24 +275,6 @@ jobs:
           path: coverage
       - store_artifacts:
           path: ~/test-results
-
-  retest_only_failures:
-    <<: *defaults
-    <<: *test_container_config
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Rerun failing tests
-          command: |
-            env_name="${K8S_NAMESPACE#offender-management-}"
-            . ~/env/"${env_name}"-hmpps-secrets.sh
-            export SPEC_STATUS_PATH=~/spec_status
-            bundle exec parallel_test -t rspec -- -t ~flaky --format progress --only-failures -- spec
-          environment:
-            MOZ_HEADLESS: 1
-            ALLOCATION_MANAGER_HOST: https://dev.moic.service.justice.gov.uk
 
   cucumber:
     <<: *defaults
@@ -387,10 +370,6 @@ workflows:
           requires: [install_dependencies, fetch_secrets]
           filters: { branches: { ignore: [main, preprod, test, test2] } }
           context: [offender-management-shared, offender-management-staging]
-      - retest_only_failures:
-          requires: [test]
-          filters: { branches: { ignore: [main, preprod, test, test2] } }
-          context: [offender-management-shared, offender-management-staging]
       - verify_docker_image_builds:
           filters: { branches: { ignore: [main, preprod, test, test2] } }
       - cucumber:
@@ -457,10 +436,6 @@ workflows:
           filters: { branches: { only: [main] } }
       - test:
           requires: [install_dependencies, fetch_staging_secrets]
-          filters: { branches: { only: [main] } }
-          context: [offender-management-shared, offender-management-staging]
-      - retest_only_failures:
-          requires: [test]
           filters: { branches: { only: [main] } }
           context: [offender-management-shared, offender-management-staging]
 

--- a/lib/deactivate_cnls.rb
+++ b/lib/deactivate_cnls.rb
@@ -6,7 +6,7 @@ class DeactivateCnls
   end
 
   def call
-    Rails.logger = Logger.new($stdout)
+    Rails.logger = Logger.new($stdout) if Rails.env.production?
 
     @inactivated_count = 0
     womens_prisons = Prison.where(code: PrisonService::WOMENS_PRISON_CODES)

--- a/lib/tasks/batch_push_pom_to_delius.rake
+++ b/lib/tasks/batch_push_pom_to_delius.rake
@@ -1,7 +1,7 @@
 namespace :batch_push_pom_to_delius do
   desc 'batch push pom to delius job'
   task populate_delius: :environment do
-    Rails.logger = Logger.new($stdout)
+    Rails.logger = Logger.new($stdout) if Rails.env.production?
 
     records = AllocationHistory.where.not(primary_pom_nomis_id: nil)
 

--- a/lib/tasks/community_api_import.rake
+++ b/lib/tasks/community_api_import.rake
@@ -3,7 +3,7 @@
 namespace :community_api do
   desc 'Import data from Community API'
   task import: :environment do |_task|
-    Rails.logger = Logger.new($stdout)
+    Rails.logger = Logger.new($stdout) if Rails.env.production?
 
     # Avoid filling up the in-memory SQL query cache – we're going to be reading lots of database records
     ActiveRecord::Base.connection.disable_query_cache!

--- a/lib/tasks/handover/handover_emails.rake
+++ b/lib/tasks/handover/handover_emails.rake
@@ -1,7 +1,7 @@
 namespace :handover do
   desc 'Send all handover reminder emails for today'
   task send_all_handover_reminders: :environment do
-    Rails.logger = Logger.new($stdout)
+    Rails.logger = Logger.new($stdout) if Rails.env.production?
     Handover::HandoverEmailBatchRun.send_all
   end
 end

--- a/lib/tasks/recalculate_handover_dates.rake
+++ b/lib/tasks/recalculate_handover_dates.rake
@@ -2,7 +2,7 @@
 
 desc 'Recalculate handover dates for all known offenders, and push changes into nDelius'
 task recalculate_handover_dates: :environment do |_task|
-  Rails.logger = Logger.new($stdout)
+  Rails.logger = Logger.new($stdout) if Rails.env.production?
 
   Rails.logger.info('Queueing RecalculateHandoverDateJob for all offenders')
 

--- a/lib/tasks/repush_all_handover_dates_to_delius.rake
+++ b/lib/tasks/repush_all_handover_dates_to_delius.rake
@@ -2,7 +2,7 @@
 
 desc 'Recalculate handover dates for all known offenders, and push changes into nDelius'
 task repush_all_handover_dates_to_delius: :environment do
-  Rails.logger = Logger.new($stdout)
+  Rails.logger = Logger.new($stdout) if Rails.env.production?
   Rails.logger.info 'Invoking rake task :recalculate_handover_dates'
   RepushAllHandoverDatesToDeliusJob.perform_later
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
   config.use_transactional_fixtures = false
-  config.example_status_persistence_file_path = 'tmp/example_status.txt'
+  config.example_status_persistence_file_path = "#{ENV.fetch('SPEC_STATUS_PATH', 'tmp/spec_status')}/#{ENV.fetch('TEST_ENV_NUMBER', 'all')}.txt"
   config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do


### PR DESCRIPTION
This should allow us to deploy quicker when APIs are being flaky