### PR TITLE
`enhanced_handover` boolean added to CaseInformation

### DIFF
--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -15,6 +15,8 @@ class CaseInformation < ApplicationRecord
 
   scope :nps, -> { where(case_allocation: NPS) }
 
+  before_save { self.enhanced_handover = (case_allocation == NPS) }
+
   def nps_case?
     case_allocation == NPS
   end

--- a/db/migrate/20230602102101_add_enhanced_handover_to_case_information.rb
+++ b/db/migrate/20230602102101_add_enhanced_handover_to_case_information.rb
@@ -1,0 +1,5 @@
+class AddEnhancedHandoverToCaseInformation < ActiveRecord::Migration[6.1]
+  def change
+    add_column :case_information, :enhanced_handover, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -149,7 +149,8 @@ CREATE TABLE public.case_information (
     local_delivery_unit_id bigint,
     ldu_code character varying,
     com_email character varying,
-    active_vlo boolean DEFAULT false
+    active_vlo boolean DEFAULT false,
+    enhanced_handover boolean
 );
 
 
@@ -592,8 +593,8 @@ ALTER SEQUENCE public.pom_details_id_seq OWNED BY public.pom_details.id;
 --
 
 CREATE TABLE public.prisons (
-    code character varying NOT NULL,
     prison_type character varying NOT NULL,
+    code character varying NOT NULL,
     name character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -1284,6 +1285,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230213000001'),
 ('20230213000002'),
 ('20230213000003'),
-('20230412150435');
+('20230412150435'),
+('20230602102101');
 
 

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -3,13 +3,6 @@ require 'rails_helper'
 RSpec.describe CaseInformation, type: :model do
   let(:case_info) { create(:case_information) }
 
-  it 'has timestamps' do
-    expect(case_info.created_at).not_to be_nil
-    sleep 2
-    case_info.touch
-    expect(case_info.updated_at).not_to eq(case_info.created_at)
-  end
-
   context 'with mappa level' do
     subject { build(:case_information) }
 
@@ -79,6 +72,16 @@ RSpec.describe CaseInformation, type: :model do
         subject.probation_service = service
         expect(subject).to be_valid
       end
+    end
+  end
+
+  it 'ensures enhanced_handover? flag is always set based on NPS/CRC value' do
+    crc_ci = FactoryBot.create :case_information, case_allocation: 'CRC'
+    nps_ci = FactoryBot.create :case_information, case_allocation: 'NPS'
+
+    aggregate_failures do
+      expect(crc_ci.enhanced_handover?).to eq false
+      expect(nps_ci.enhanced_handover?).to eq true
     end
   end
 end


### PR DESCRIPTION
Is automatically filled based on value of service provider (case allocation) field

A one-line is needed to correctly fill existing entries:

```
CaseInformation.find_each { |ci| ci.update! enhanced_handover: (ci.case_allocation == NPS) }
```

MO-1296