### PR TITLE
Convert handover reminder mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'matrix' # App does not use it directly but it has to be explicitly declared
 gem 'activeadmin'
 
 group :development, :test do
-  gem 'brakeman'
+  gem 'brakeman', '~> 6.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
-    brakeman (5.4.1)
+    brakeman (6.0.0)
     builder (3.2.4)
     business_time (0.13.0)
       activesupport (>= 3.2.0)
@@ -571,7 +571,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
-  brakeman
+  brakeman (~> 6.0)
   business_time
   byebug
   capybara

--- a/app/mailers/handover_mailer.rb
+++ b/app/mailers/handover_mailer.rb
@@ -1,64 +1,46 @@
 class HandoverMailer < GovukNotifyRails::Mailer
-  def upcoming_handover_window(email:,
-                               nomis_offender_id:,
-                               full_name_ordered:,
-                               first_name:,
-                               handover_date:,
-                               enhanced_handover:,
-                               release_date:)
+  def upcoming_handover_window
     set_template('7114ad9e-e71a-4424-a884-bcc72bd1a569')
-    set_personalisation(nomis_offender_id: nomis_offender_id,
-                        full_name_ordered: full_name_ordered,
-                        first_name: first_name,
-                        handover_date: handover_date,
-                        is_standard: enhanced_handover ? 'no' : 'yes',
-                        is_enhanced: enhanced_handover ? 'yes' : 'no',
-                        release_date: release_date)
-    mail(to: email)
+    set_personalisation(nomis_offender_id: params.fetch(:nomis_offender_id),
+                        full_name_ordered: params.fetch(:full_name_ordered),
+                        first_name: params.fetch(:first_name),
+                        handover_date: params.fetch(:handover_date),
+                        is_standard: params.fetch(:enhanced_handover) ? 'no' : 'yes',
+                        is_enhanced: params.fetch(:enhanced_handover) ? 'yes' : 'no',
+                        release_date: params.fetch(:release_date))
+    mail(to: params.fetch(:email))
   end
 
-  def handover_date(email:,
-                    nomis_offender_id:,
-                    first_name:,
-                    full_name_ordered:,
-                    release_date:,
-                    com_name:,
-                    com_email:,
-                    enhanced_handover:)
+  def handover_date
     set_template('95ddd96c-23f9-4066-b033-d4a1d83b702e')
-    set_personalisation(nomis_offender_id: nomis_offender_id,
-                        full_name_ordered: full_name_ordered,
-                        first_name: first_name,
-                        com_name: com_name,
-                        com_email: com_email,
-                        is_standard: enhanced_handover ? 'no' : 'yes',
-                        is_enhanced: enhanced_handover ? 'yes' : 'no',
-                        release_date: release_date)
-    mail(to: email)
+    set_personalisation(nomis_offender_id: params.fetch(:nomis_offender_id),
+                        full_name_ordered: params.fetch(:full_name_ordered),
+                        first_name: params.fetch(:first_name),
+                        com_name: params.fetch(:com_name),
+                        com_email: params[:com_email] || 'Unknown',
+                        is_standard: params.fetch(:enhanced_handover) ? 'no' : 'yes',
+                        is_enhanced: params.fetch(:enhanced_handover) ? 'yes' : 'no',
+                        release_date: params.fetch(:release_date))
+    mail(to: params.fetch(:email))
   end
 
-  def com_allocation_overdue(email:,
-                             nomis_offender_id:,
-                             full_name_ordered:,
-                             handover_date:,
-                             release_date:,
-                             ldu_name:,
-                             ldu_email:,
-                             enhanced_handover:)
+  def com_allocation_overdue
+    ldu_name = params.fetch(:ldu_name)
+    ldu_email = params.fetch(:ldu_email)
     ldu_information = ''
     ldu_information += "LDU: #{ldu_name}\n" if ldu_name.present?
     ldu_information += "LDU email: #{ldu_email}\n" if ldu_email.present?
 
     set_template('21d34a34-f2ec-42c2-82b3-720899b58a3b')
-    set_personalisation(nomis_offender_id: nomis_offender_id,
-                        full_name_ordered: full_name_ordered,
-                        handover_date: handover_date,
-                        release_date: release_date,
-                        is_standard: enhanced_handover ? 'no' : 'yes',
-                        is_enhanced: enhanced_handover ? 'yes' : 'no',
+    set_personalisation(nomis_offender_id: params.fetch(:nomis_offender_id),
+                        full_name_ordered: params.fetch(:full_name_ordered),
+                        handover_date: params.fetch(:handover_date),
+                        release_date: params.fetch(:release_date),
+                        is_standard: params.fetch(:enhanced_handover) ? 'no' : 'yes',
+                        is_enhanced: params.fetch(:enhanced_handover) ? 'yes' : 'no',
                         ldu_information: ldu_information,
                         has_ldu_email: ldu_email.present?,
                         missing_ldu_email: ldu_email.blank?)
-    mail(to: email)
+    mail(to: params.fetch(:email))
   end
 end


### PR DESCRIPTION
Did not get converted in the first Ruby 3.2.2 release

Also bump up Brakeman gem to 6.0.0

MO-1298