### PR TITLE
Fix of JSON::Validator not loading in production environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'govuk_notify_rails'
 # we need the extra is_csv parameter available in 5.2 and above
 gem 'notifications-ruby-client', '>= 5.2'
 gem 'govuk_design_system_formbuilder', '~> 2.5'
+gem 'json-schema', '~> 3.0'
 gem 'jsonb_accessor'
 gem 'jwt'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,6 +589,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
+  json-schema (~> 3.0)
   jsonb_accessor
   jwt
   kaminari


### PR DESCRIPTION
This broke after upgrading to Ruby 3.2 for some reason - now the `json-schema` gem must be explicitly mentioned in Gemfile for it to load its classes, including JSON::Validator. Before it was pulled in as a dependency of another gem and somehow worked.

