### PR TITLE
Tweak handover domain events

### DIFF
--- a/app/lib/domain_events/event_factory.rb
+++ b/app/lib/domain_events/event_factory.rb
@@ -5,7 +5,7 @@ module DomainEvents::EventFactory
         event_type: 'handover.changed',
         version: 1,
         description: 'Handover date and/or responsibility was updated',
-        detail_url: "#{host}/handovers/#{noms_number}",
+        detail_url: "#{host}/api/handovers/#{noms_number}",
         noms_number: noms_number,
       )
     end

--- a/app/lib/domain_events/event_factory.rb
+++ b/app/lib/domain_events/event_factory.rb
@@ -2,7 +2,7 @@ module DomainEvents::EventFactory
   class << self
     def build_handover_event(noms_number:, host:)
       DomainEvents::Event.new(
-        event_type: 'domain-events.handover.changed',
+        event_type: 'handover.changed',
         version: 1,
         description: 'Handover date and/or responsibility was updated',
         detail_url: "#{host}/handovers/#{noms_number}",

--- a/app/lib/mail_publish_audit_event_observer.rb
+++ b/app/lib/mail_publish_audit_event_observer.rb
@@ -8,10 +8,9 @@ class MailPublishAuditEventObserver
     params = message.govuk_notify_personalisation
     tags = message.govuk_notify_reference.present? ? message.govuk_notify_reference.split('.') : []
     Rails.logger.error "event=audit_event_created,nomis_offender_id=#{params[:nomis_offender_id]}|#{message.inspect}"
-    AuditEvent.create!(
+    AuditEvent.publish(
       nomis_offender_id: params[:nomis_offender_id],
       tags: tags,
-      published_at: Time.zone.now.utc,
       system_event: true,
       data: {
         'govuk_notify_message' => {

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -1,5 +1,21 @@
 class AuditEvent < ApplicationRecord
   class << self
+    def publish(**attrs)
+      attrs = attrs.stringify_keys
+      attrs['published_at'] ||= Time.zone.now.utc
+      record = create!(**attrs)
+
+      system_log = [
+        'event=audit_event_published',
+        "nomis_offender_id=#{record.nomis_offender_id}",
+        "audit_event_id=#{record.id}",
+        *record.tags.map { |t| "tag=#{t}" },
+      ].join(',')
+      Rails.logger.info system_log
+
+      record
+    end
+
     def tags(*tags)
       where('lower(ARRAY[?]::text)::text[] <@ tags', tags)
     end

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -26,6 +26,8 @@ class MpcOffender
 
   attr_reader :case_information, :prison
 
+  alias_method :nomis_offender_id, :offender_no
+
   def initialize(prison:, offender:, prison_record:)
     @prison = prison
     @offender = offender

--- a/spec/features/audit_events_feature_spec.rb
+++ b/spec/features/audit_events_feature_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Audit events' do
     end
   end
 
-  describe 'DB records' do
+  describe 'when delivering email' do
     it 'contain the govuk notify details for each emails' do
       TestOnlyMailer.with(to: 'test@example.org', template: 'test-template-x', personalisation: { 'test' => 'value' })
                     .test_mail.deliver_now

--- a/spec/lib/domain_events/event_factory_spec.rb
+++ b/spec/lib/domain_events/event_factory_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DomainEvents::EventFactory do
       event_type: 'handover.changed',
       version: 1,
       description: 'Handover date and/or responsibility was updated',
-      detail_url: 'https://example.com/handovers/X1111XX',
+      detail_url: 'https://example.com/api/handovers/X1111XX',
       noms_number: 'X1111XX',
     )
   end

--- a/spec/lib/domain_events/event_factory_spec.rb
+++ b/spec/lib/domain_events/event_factory_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DomainEvents::EventFactory do
 
     expect(response).to eq event
     expect(DomainEvents::Event).to have_received(:new).with(
-      event_type: 'domain-events.handover.changed',
+      event_type: 'handover.changed',
       version: 1,
       description: 'Handover date and/or responsibility was updated',
       detail_url: 'https://example.com/handovers/X1111XX',

--- a/spec/models/audit_event_spec.rb
+++ b/spec/models/audit_event_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe AuditEvent do
+  let(:attributes) { FactoryBot.attributes_for(:audit_event, :system, tags: %w[tag1 tag2]).except(:published_at) }
+
   it 'can have username and user_human_name if system_event is false', :aggregate_failures do
     event = FactoryBot.create :audit_event, :user
     expect(event.system_event?).to eq false
@@ -11,6 +13,29 @@ RSpec.describe AuditEvent do
       .to raise_error(/PG::CheckViolation: ERROR:.+audit_events.+system_event_cannot_have_user_details/)
     expect { FactoryBot.create :audit_event, :system, user_human_name: 'test' }
       .to raise_error(/PG::CheckViolation: ERROR:.+audit_events.+system_event_cannot_have_user_details/)
+  end
+
+  describe 'when published' do
+    it 'creates a record' do
+      expect { described_class.publish(**attributes) }
+        .to change(described_class, :count).by(1)
+    end
+
+    it 'logs the audit event to the system/Rails logger', :aggregate_failures do
+      line = ''
+      allow(Rails.logger).to receive(:info) { |data| line.replace(data) }
+      record = described_class.publish(**attributes)
+
+      expect(line).to match('event=audit_event_published')
+      expect(line).to match(record.nomis_offender_id)
+      expect(line).to match(record.id)
+      expect(line).to match(/tag1.+tag2/)
+    end
+
+    it 'saves a published_at date' do
+      record = described_class.publish(**attributes)
+      expect(record.published_at).to be_within(1.second).of(Time.zone.now.utc)
+    end
   end
 
   describe '::tags' do


### PR DESCRIPTION
* Change the domain event structure based on feedback from Delius team
* Create a better code API for publishing events rather than creating AuditEvent records directly

MO-1266