### PR TITLE
Fix handover calculations for early allocation parole cases

### DIFF
--- a/app/lib/handover/handover_calculation.rb
+++ b/app/lib/handover/handover_calculation.rb
@@ -12,12 +12,11 @@ module Handover::HandoverCalculation
                                 in_open_conditions:)
       if is_indeterminate
         [earliest_release_date - 8.months, in_open_conditions ? :indeterminate_open : :indeterminate]
-      elsif is_determinate_parole
-        [earliest_release_date - 8.months, :determinate_parole]
       else
         calculate_determinate_handover_date(sentence_start_date: sentence_start_date,
                                             earliest_release_date: earliest_release_date,
-                                            is_early_allocation: is_early_allocation)
+                                            is_early_allocation: is_early_allocation,
+                                            is_determinate_parole: is_determinate_parole)
       end
     end
 
@@ -87,11 +86,14 @@ module Handover::HandoverCalculation
 
     def calculate_determinate_handover_date(sentence_start_date:,
                                             earliest_release_date:,
-                                            is_early_allocation:)
+                                            is_early_allocation:,
+                                            is_determinate_parole:)
       if sentence_start_date + 10.months >= earliest_release_date
         [nil, :determinate_short]
       elsif is_early_allocation
         [earliest_release_date - 15.months, :early_allocation]
+      elsif is_determinate_parole
+        [earliest_release_date - 8.months, :determinate_parole]
       else
         [earliest_release_date - 8.months - 14.days, :determinate]
       end

--- a/spec/lib/handover/handover_calculation_spec.rb
+++ b/spec/lib/handover/handover_calculation_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe Handover::HandoverCalculation do
                                                            is_early_allocation: true)
           expect(result).to eq [Date.new(2024, 10, 1), :early_allocation]
         end
+
+        example 'then the 15 month rule overrides the determinate-with-parole (extended determinate) rule' do
+          result = described_class.calculate_handover_date(sentence_start_date: sentence_start_date,
+                                                           earliest_release_date: Date.new(2026, 1, 1),
+                                                           is_determinate_parole: true,
+                                                           is_indeterminate: false,
+                                                           in_open_conditions: false,
+                                                           is_early_allocation: true)
+          expect(result).to eq [Date.new(2024, 10, 1), :early_allocation]
+        end
       end
     end
 


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/wiki/spaces/OCM/pages/4466147395/Handover+and+Responsibility+Calculation#Handover-date-%26-responsibility-rules

MO-1351