### PR TITLE
Set up to use IRSA credentials and remove all hardcoded AWS credentials

### DIFF
--- a/deploy/preprod/cron-community-api-import.yaml
+++ b/deploy/preprod/cron-community-api-import.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: community-api-import
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/preprod/cron-community-api-import.yaml
+++ b/deploy/preprod/cron-community-api-import.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/preprod/cron-early-allocation-events.yaml
+++ b/deploy/preprod/cron-early-allocation-events.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: early-allocation-events
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/preprod/cron-early-allocation-events.yaml
+++ b/deploy/preprod/cron-early-allocation-events.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/preprod/cron-process-movements.yaml
+++ b/deploy/preprod/cron-process-movements.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: process-movements
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/preprod/cron-process-movements.yaml
+++ b/deploy/preprod/cron-process-movements.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-preprod
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: allocation-manager
     spec:
+      serviceAccountName: 'offender-management-allocation-manager'
       containers:
         - name: allocation-manager
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/preprod/deployment.yaml
+++ b/deploy/preprod/deployment.yaml
@@ -83,16 +83,6 @@ spec:
                 secretKeyRef:
                   name: elasticache-offender-management-allocation-manager-token-cache-preprod
                   key: url
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:
@@ -144,16 +134,6 @@ spec:
                 secretKeyRef:
                   name: elasticache-offender-management-allocation-manager-token-cache-preprod
                   key: url
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:

--- a/deploy/production/cron-community-api-import.yaml
+++ b/deploy/production/cron-community-api-import.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: community-api-import
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-community-api-import.yaml
+++ b/deploy/production/cron-community-api-import.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-deactivate-cnls.yaml
+++ b/deploy/production/cron-deactivate-cnls.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: deactivate-cnls
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-deactivate-cnls.yaml
+++ b/deploy/production/cron-deactivate-cnls.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-early-allocation-events.yaml
+++ b/deploy/production/cron-early-allocation-events.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: early-allocation-events
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-early-allocation-events.yaml
+++ b/deploy/production/cron-early-allocation-events.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/production/cron-early-allocation-suitability-email-job.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-early-allocation-suitability-email-job.yaml
+++ b/deploy/production/cron-early-allocation-suitability-email-job.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: early-allocation-suitability-email-job
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-handover-chase-email.yaml
+++ b/deploy/production/cron-handover-chase-email.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: handover-chase-email
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-handover-chase-email.yaml
+++ b/deploy/production/cron-handover-chase-email.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-handover-email-job.yaml
+++ b/deploy/production/cron-handover-email-job.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-handover-email-job.yaml
+++ b/deploy/production/cron-handover-email-job.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: handover-email-job
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-handover-reminders-job.yaml
+++ b/deploy/production/cron-handover-reminders-job.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: handover-reminders-job
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-handover-reminders-job.yaml
+++ b/deploy/production/cron-handover-reminders-job.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-offender-manager-process-movements.yaml
+++ b/deploy/production/cron-offender-manager-process-movements.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: offender-manager-process-movements
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-offender-manager-process-movements.yaml
+++ b/deploy/production/cron-offender-manager-process-movements.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/cron-recalculate-handover-dates.yaml
+++ b/deploy/production/cron-recalculate-handover-dates.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: recalculate-handover-dates
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/cron-recalculate-handover-dates.yaml
+++ b/deploy/production/cron-recalculate-handover-dates.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-production
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: allocation-manager
     spec:
+      serviceAccountName: 'offender-management-allocation-manager'
       containers:
         - name: allocation-manager
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -83,16 +83,6 @@ spec:
                 secretKeyRef:
                   name: elasticache-offender-management-allocation-manager-token-cache-production
                   key: url
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:
@@ -144,16 +134,6 @@ spec:
                 secretKeyRef:
                   name: elasticache-offender-management-allocation-manager-token-cache-production
                   key: url
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: access_key_id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hmpps-domain-events-topic
-                  key: secret_access_key
             - name: DOMAIN_EVENTS_TOPIC_ARN
               valueFrom:
                 secretKeyRef:

--- a/deploy/staging/cron-integration-test-cleanup.yaml
+++ b/deploy/staging/cron-integration-test-cleanup.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-staging
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/staging/cron-integration-test-cleanup.yaml
+++ b/deploy/staging/cron-integration-test-cleanup.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: integration-test-cleanup
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/staging/cron-recalculate-handover-dates.yaml
+++ b/deploy/staging/cron-recalculate-handover-dates.yaml
@@ -18,6 +18,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: recalculate-handover-dates
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest

--- a/deploy/staging/cron-recalculate-handover-dates.yaml
+++ b/deploy/staging/cron-recalculate-handover-dates.yaml
@@ -66,16 +66,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-staging
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/templates/cron_job_template.yaml.erb
+++ b/deploy/templates/cron_job_template.yaml.erb
@@ -60,16 +60,6 @@ spec:
                     secretKeyRef:
                       name: elasticache-offender-management-allocation-manager-token-cache-<%= env %>
                       key: url
-                - name: AWS_ACCESS_KEY_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: access_key_id
-                - name: AWS_SECRET_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-domain-events-topic
-                      key: secret_access_key
                 - name: DOMAIN_EVENTS_TOPIC_ARN
                   valueFrom:
                     secretKeyRef:

--- a/deploy/templates/cron_job_template.yaml.erb
+++ b/deploy/templates/cron_job_template.yaml.erb
@@ -12,6 +12,7 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          serviceAccountName: 'offender-management-allocation-manager'
           containers:
             - name: <%= name %>
               image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/offender-management/offender-management-allocation-manager:latest


### PR DESCRIPTION
To test it has worked, do the following:

Get a shell in the environment you are testing with kubectl

Check no AWS access keys are in the environment: `printenv | grep -E 'AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY'`

Start a Rails console: `./bin/rails c`

Publish a noop event: `DomainEvents::Event.new(event_type: 'noop', version: 1).publish` and check that no exceptions were raised

MP-1352
