### PR TITLE
Ensure handover API always has a handover start date so Delius always pulls it in

### DIFF
--- a/app/models/api/handover.rb
+++ b/app/models/api/handover.rb
@@ -23,7 +23,7 @@ class Api::Handover
   end
 
   def handover_start_date
-    (handover_date == @db_model.start_date) ? nil : @db_model.start_date
+    @db_model.start_date
   end
 
   def responsibility
@@ -38,7 +38,7 @@ class Api::Handover
     {
       'nomsNumber' => noms_number,
       'handoverDate' => handover_date.iso8601,
-      'handoverStartDate' => handover_start_date&.iso8601,
+      'handoverStartDate' => handover_start_date.iso8601,
       'responsibility' => responsibility,
     }.compact
   end

--- a/spec/api/handover_api_spec.rb
+++ b/spec/api/handover_api_spec.rb
@@ -44,6 +44,7 @@ describe 'Handover API', vcr: { cassette_name: 'prison_api/handover_api' } do
           let(:body) do
             {
               'nomsNumber' => nomsNumber,
+              'handoverStartDate' => '2021-12-01',
               'handoverDate' => '2021-12-01',
               'responsibility' => 'COM'
             }

--- a/spec/models/api/handover_spec.rb
+++ b/spec/models/api/handover_spec.rb
@@ -34,14 +34,15 @@ RSpec.describe Api::Handover do
     end
 
     describe 'when no handover window' do
-      it 'has no handover start date' do
-        expect(handover.handover_start_date).to eq nil
+      it 'handover start date is same as handover date' do
+        expect(handover.handover_start_date).to eq handover.handover_date
       end
 
       it 'serialises to JSON' do
         expect(handover.as_json).to eq({
           'nomsNumber' => nomis_offender_id,
           'handoverDate' => '2021-02-01',
+          'handoverStartDate' => '2021-02-01',
           'responsibility' => 'POM',
         })
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -146,3 +146,5 @@ FactoryBot.define do
     "T#{number}A#{letter}"
   end
 end
+
+Shoryuken::Logging.logger = Rails.logger


### PR DESCRIPTION
Delius was sometimes not updating the start date when responsibility handover date changed. Now there will always be a start date even if it is the same as the handover date.

MO-1359