### PR TITLE
DPS header integrated into layout, behind a feature flag

### DIFF
--- a/app/helpers/dps_header_footer_helper.rb
+++ b/app/helpers/dps_header_footer_helper.rb
@@ -1,4 +1,16 @@
 module DpsHeaderFooterHelper
+  def dps_header_html
+    dps_header_footer_enabled? ? dps_header_all.fetch('html').html_safe : ''
+  end
+
+  def dps_header_css
+    dps_header_footer_enabled? ? dps_header_all.fetch('css').map { |link| stylesheet_link_tag link }.join("\n").html_safe : ''
+  end
+
+  def dps_header_all
+    @dps_header_all ||= HmppsApi::DpsFrontendComponentsApi.header
+  end
+
   def dps_footer_html
     dps_header_footer_enabled? ? dps_footer_all.fetch('html').html_safe : ''
   end

--- a/app/helpers/dps_header_footer_helper.rb
+++ b/app/helpers/dps_header_footer_helper.rb
@@ -7,6 +7,10 @@ module DpsHeaderFooterHelper
     dps_header_footer_enabled? ? dps_header_all.fetch('css').map { |link| stylesheet_link_tag link }.join("\n").html_safe : ''
   end
 
+  def dps_header_js
+    dps_header_footer_enabled? ? dps_header_all.fetch('javascript').map { |source| javascript_include_tag source }.join("\n").html_safe : ''
+  end
+
   def dps_header_all
     @dps_header_all ||= HmppsApi::DpsFrontendComponentsApi.header
   end
@@ -17,6 +21,10 @@ module DpsHeaderFooterHelper
 
   def dps_footer_css
     dps_header_footer_enabled? ? dps_footer_all.fetch('css').map { |link| stylesheet_link_tag link }.join("\n").html_safe : ''
+  end
+
+  def dps_footer_js
+    dps_header_footer_enabled? ? dps_footer_all.fetch('javascript').map { |source| javascript_include_tag source }.join("\n").html_safe : ''
   end
 
   def dps_footer_all

--- a/app/services/hmpps_api/dps_frontend_components_api.rb
+++ b/app/services/hmpps_api/dps_frontend_components_api.rb
@@ -6,16 +6,24 @@ require 'typhoeus/adapters/faraday'
 module HmppsApi
   class DpsFrontendComponentsApi
     class << self
+      def header
+        get_component('header')
+      end
+
       def footer
+        get_component('footer')
+      end
+
+    private
+
+      def get_component(type)
         raw_response = connection.get do |req|
-          req.url("#{root}/footer")
-          req.headers['x-user-token'] = token.access_token
+          req.url("#{root}/#{type}")
+          req.headers['X-User-Token'] = token.access_token
         end
 
         ActiveSupport::JSON.decode(raw_response.body)
       end
-
-    private
 
       def connection
         Faraday.new do |faraday|

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,22 +1,27 @@
-<header class="govuk-header" role="banner">
-  <div class="govuk-header__container govuk-width-container">
-    <a href="<%= Rails.configuration.nomis_oauth_host %>/auth/" class="govuk-header__link govuk-header__link--homepage">
-      <span class="hmpps__logotype-crest"></span>
-      <span class="govuk-header__logotype">
-        <span class="govuk-header__logotype-text moj-header__logotype-text">HMPPS </span>
-      </span>
-    </a>
-    <ul id="navigation" class="hmpps-header__navigation" aria-label="Top Level Navigation">
-      <% if current_user.present? %>
-        <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-          <a href='#' class='govuk-header__link govuk-!-font-size-16 govuk-!-padding-left-1'>
-            <%= current_user %>
-          </a>
-        </li>
-        <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-          <%= link_to 'Sign out', signout_path %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-</header>
+<%# This file is only here while we need the old header; when we remove the feature flag, delete this file completely %>
+<% if dps_header_footer_enabled? %>
+  <%= dps_header_html %>
+<% else %>
+  <header class="govuk-header" role="banner">
+    <div class="govuk-header__container govuk-width-container">
+      <a href="<%= Rails.configuration.nomis_oauth_host %>/auth/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="hmpps__logotype-crest"></span>
+        <span class="govuk-header__logotype">
+          <span class="govuk-header__logotype-text moj-header__logotype-text">HMPPS </span>
+        </span>
+      </a>
+      <ul id="navigation" class="hmpps-header__navigation" aria-label="Top Level Navigation">
+        <% if current_user.present? %>
+          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+            <a href='#' class='govuk-header__link govuk-!-font-size-16 govuk-!-padding-left-1'>
+              <%= current_user %>
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+            <%= link_to 'Sign out', signout_path %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </header>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,8 @@
     <%= dps_header_css %>
     <%= dps_footer_css %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= dps_header_js %>
+    <%= dps_footer_js %>
   </head>
 
   <body class="govuk-template__body js-enabled">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
       <meta name="turbolinks-cache-control" content="no-cache">
     <% end %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= dps_header_css %>
     <%= dps_footer_css %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/spec/features/dps_header_footer_feature_spec.rb
+++ b/spec/features/dps_header_footer_feature_spec.rb
@@ -1,6 +1,20 @@
 # As these tests hit the actual components API, these tests will need updating if service owners change things around,
 # but it seems prudent to test the actual API responses at most once and stub them everywhere else
 feature 'DPS standard header and footer:', :aggregate_failures do
+  scenario 'standard DPS header is used', :skip_dps_header_footer_stubbing,
+           vcr: { cassette_name: 'dps_header_footer/standard_header' } do
+    signin_pom_user
+    visit '/'
+
+    expect(page).to have_css('header.connect-dps-external-header')
+    expect(page).to have_css('link[rel=stylesheet][href="https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/header.css"]', visible: :all)
+
+    # For when they add some JS
+    # expect(page).to have_css('script[src="https://frontend-components-dev.hmpps.service.justice.gov.uk/......."]', visible: :all)
+  end
+
+  scenario 'fallback DPS header is used when DPS components API times out', :skip_dps_header_footer_stubbing
+
   scenario 'standard DPS footer is used', :skip_dps_header_footer_stubbing,
            vcr: { cassette_name: 'dps_header_footer/standard_footer' } do
     signin_pom_user
@@ -8,6 +22,9 @@ feature 'DPS standard header and footer:', :aggregate_failures do
 
     expect(page).to have_css('footer.govuk-footer a.govuk-footer__link[href="https://sign-in-dev.hmpps.service.justice.gov.uk/auth/terms"]')
     expect(page).to have_css('link[rel=stylesheet][href="https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/footer.css"]', visible: :all)
+
+    # For when they add some JS
+    # expect(page).to have_css('script[src="https://frontend-components-dev.hmpps.service.justice.gov.uk/......."]', visible: :all)
   end
 
   scenario 'fallback DPS footer is used when DPS components API times out', :skip_dps_header_footer_stubbing

--- a/spec/services/hmpps_api/dps_frontend_components_api_spec.rb
+++ b/spec/services/hmpps_api/dps_frontend_components_api_spec.rb
@@ -10,10 +10,17 @@ RSpec.describe HmppsApi::DpsFrontendComponentsApi do
     allow(Rails.configuration).to receive(:dps_frontend_components_api_host).and_return('https://example.org')
 
     stub_request(:get, 'https://example.org/footer')
-      .with(headers: { 'x-user-token' => access_token })
-      .to_return(body: '{"html": "<f>", "css": ["https://example.org/f.css"], "javascript": []}')
+      .with(headers: { 'X-User-Token' => access_token })
+      .to_return(body: '{"html": "<f>", "css": ["https://example.org/f.css"], "javascript": ["f.js"]}')
     stub_request(:get, 'https://example.org/footer')
-      .with(headers: { 'x-user-token' => invalid_access_token })
+      .with(headers: { 'X-User-Token' => invalid_access_token })
+      .to_return(status: 401)
+
+    stub_request(:get, 'https://example.org/header')
+      .with(headers: { 'X-User-Token' => access_token })
+      .to_return(body: '{"html": "<h>", "css": ["https://example.org/h.css"], "javascript": ["h.js"]}')
+    stub_request(:get, 'https://example.org/header')
+      .with(headers: { 'X-User-Token' => invalid_access_token })
       .to_return(status: 401)
   end
 
@@ -21,12 +28,25 @@ RSpec.describe HmppsApi::DpsFrontendComponentsApi do
     it 'with valid access token, gets the footer HTML and CSS from the API' do
       stub_token(access_token)
       expect(described_class.footer)
-        .to eq({ 'html' => '<f>', 'css' => ['https://example.org/f.css'], 'javascript' => [] })
+        .to eq({ 'html' => '<f>', 'css' => ['https://example.org/f.css'], 'javascript' => ['f.js'] })
     end
 
     it 'with invalid access token, raises 401 unauthorized' do
       stub_token(invalid_access_token)
       expect { described_class.footer }.to raise_error(Faraday::UnauthorizedError)
+    end
+  end
+
+  describe '#header' do
+    it 'with valid access token, gets the header HTML and CSS from the API' do
+      stub_token(access_token)
+      expect(described_class.header)
+        .to eq({ 'html' => '<h>', 'css' => ['https://example.org/h.css'], 'javascript' => ['h.js'] })
+    end
+
+    it 'with invalid access token, raises 401 unauthorized' do
+      stub_token(invalid_access_token)
+      expect { described_class.header }.to raise_error(Faraday::UnauthorizedError)
     end
   end
 end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -47,9 +47,12 @@ module FeaturesHelper
       .to_return(body: [].to_json)
   end
 
-  def stub_dps_header_footer(html: '<f>', css: [], javascript: [])
+  def stub_dps_header_footer
+    stub_request(:get, "#{Rails.configuration.dps_frontend_components_api_host}/header")
+      .to_return(body: { 'html' => '<header>', css: [], javascript: [] }.to_json)
+
     stub_request(:get, "#{Rails.configuration.dps_frontend_components_api_host}/footer")
-      .to_return(body: { 'html' => html, css: css, javascript: javascript }.to_json)
+      .to_return(body: { 'html' => '<footer>', css: [], javascript: [] }.to_json)
   end
 
   def wait_for(maximum_wait_in_seconds = 10, &block)


### PR DESCRIPTION
Activate it by adding `dps_header_footer=1` as a URL param to any request.

MO-1393
