### PR TITLE
MO-1462: Swagger UI and OpenAI JSON paths for SRE

### DIFF
--- a/app/controllers/sre_swagger_docs_controller.rb
+++ b/app/controllers/sre_swagger_docs_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SreSwaggerDocsController < ApplicationController
+  def swagger_ui
+    redirect_to '/api-docs/index.html'
+  end
+
+  def open_api_json
+    render json: YAML.load_file('public/openapi.yml')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+  get '/swagger-ui.html', to: redirect('/api-docs/index.html')
 
   # Sidekiq admin interface
   constraints ->(request) { SsoIdentity.new(request.session).current_user_is_admin? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,8 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
-  get '/swagger-ui.html', to: redirect('/api-docs/index.html')
+  get '/swagger-ui.html', to: 'sre_swagger_docs#swagger_ui'
+  get '/v3/api-docs', to: 'sre_swagger_docs#open_api_json'
 
   # Sidekiq admin interface
   constraints ->(request) { SsoIdentity.new(request.session).current_user_is_admin? } do

--- a/spec/requests/swagger_discoverability_spec.rb
+++ b/spec/requests/swagger_discoverability_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Swagger Documentation surfaced for SRE discoverability' do
+  describe 'GET /swagger-ui.html' do
+    it 'redirects to the Swagger UI' do
+      get '/swagger-ui.html'
+
+      expect(response).to redirect_to("/api-docs/index.html")
+    end
+  end
+
+  describe 'GET /v3/api-docs' do
+    it 'renders the openapi.yml in json format' do
+      get '/v3/api-docs'
+
+      expect(response.body).to eq(YAML.load_file('public/openapi.yml').to_json)
+    end
+  end
+end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-describe 'GET /swagger-ui.html', type: :request do
-  it 'redirects to the Swagger UI' do
-    get '/swagger-ui.html'
-
-    expect(response).to redirect_to("/api-docs/index.html")
-  end
-end

--- a/spec/requests/swagger_spec.rb
+++ b/spec/requests/swagger_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'GET /swagger-ui.html', type: :request do
+  it 'redirects to the Swagger UI' do
+    get '/swagger-ui.html'
+
+    expect(response).to redirect_to("/api-docs/index.html")
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1462

- Added a redirect link from `/swagger-ui.html` to `/api-docs/index.html`
- Surfaced openapi.yml data as JSON endpoint at `/v3/api-docs`

Can be tested by visiting:

- https://test2.moic.service.justice.gov.uk/v3/api-docs
- https://test2.moic.service.justice.gov.uk/swagger-ui.html