### PR TITLE
Mo-1466: Remove flag ENABLE_EVENT_BASED_PROBATION_CHANGE

### DIFF
--- a/app/lib/domain_events/handlers/probation_change_handler.rb
+++ b/app/lib/domain_events/handlers/probation_change_handler.rb
@@ -2,12 +2,6 @@ module DomainEvents
   module Handlers
     class ProbationChangeHandler
       def handle(event, logger: Shoryuken::Logging.logger)
-        unless ENABLE_EVENT_BASED_PROBATION_CHANGE
-          logger.info "event=domain_event_handle_skip,domain_event_type=#{event.event_type},crn=#{event.crn_number}" \
-                      '|Skipping handling because feature flag is not set'
-          return
-        end
-
         case event.event_type
         when /probation-case\.registration\..+/
           handle_registration_change(event, logger)

--- a/app/lib/domain_events/handlers/tier_change_handler.rb
+++ b/app/lib/domain_events/handlers/tier_change_handler.rb
@@ -2,12 +2,6 @@ module DomainEvents
   module Handlers
     class TierChangeHandler
       def handle(event, logger: Shoryuken::Logging.logger)
-        unless ENABLE_EVENT_BASED_PROBATION_CHANGE
-          logger.info "event=domain_event_handle_skip,domain_event_type=#{event.event_type},crn=#{event.crn_number}" \
-                      '|Skipping handling because feature flag is not set'
-          return
-        end
-
         logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},crn=#{event.crn_number}"
         case_info = CaseInformation.find_by_crn(event.crn_number)
 

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,4 +1,2 @@
 # Feature Flags - super simple, they are just constants - it works
 # USE_FEATURE = ENV.fetch('USE_FEATURE', '').strip == '1'
-
-ENABLE_EVENT_BASED_PROBATION_CHANGE = ENV.fetch('ENABLE_EVENT_BASED_PROBATION_CHANGE', '').strip == '1'

--- a/spec/lib/domain_events/handlers/probation_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/probation_change_handler_spec.rb
@@ -21,66 +21,44 @@ RSpec.describe DomainEvents::Handlers::ProbationChangeHandler do
 
   let(:crn) { 'X08769' }
 
-  context 'when feature flag set' do
-    before { stub_const('ENABLE_EVENT_BASED_PROBATION_CHANGE', true) }
+  context 'with event type probation-case.registration.*' do
+    let(:event_type) { 'probation-case.registration.added' }
 
-    context 'with event type probation-case.registration.*' do
-      let(:event_type) { 'probation-case.registration.added' }
-
-      let(:additional_information) do
-        { 'registerTypeCode' => register_type }
-      end
-
-      context 'with cases whose registration type includes MAPP, DASO, INVI' do
-        let(:register_type) { 'MAPP' }
-
-        it 'updates case information' do
-          handler.handle(event)
-          expect(ProcessDeliusDataJob).to have_received(:perform_now).with(crn, identifier_type: :crn, trigger_method: :event)
-        end
-      end
-
-      context 'with cases whose registration type does not includes MAPP, DASO, INVI' do
-        let(:register_type) { 'BOBBINS' }
-
-        before { handler.handle(event) }
-
-        it 'does not update case information' do
-          expect(ProcessDeliusDataJob).not_to have_received(:perform_now)
-        end
-
-        it 'emits a noop log info message' do
-          expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_noop/).once
-        end
-      end
+    let(:additional_information) do
+      { 'registerTypeCode' => register_type }
     end
 
-    context 'with event type OFFENDER_MANAGER_CHANGED' do
-      let(:event_type) { 'OFFENDER_MANAGER_CHANGED' }
-      let(:additional_information) { {} }
+    context 'with cases whose registration type includes MAPP, DASO, INVI' do
+      let(:register_type) { 'MAPP' }
 
       it 'updates case information' do
         handler.handle(event)
         expect(ProcessDeliusDataJob).to have_received(:perform_now).with(crn, identifier_type: :crn, trigger_method: :event)
       end
     end
+
+    context 'with cases whose registration type does not includes MAPP, DASO, INVI' do
+      let(:register_type) { 'BOBBINS' }
+
+      before { handler.handle(event) }
+
+      it 'does not update case information' do
+        expect(ProcessDeliusDataJob).not_to have_received(:perform_now)
+      end
+
+      it 'emits a noop log info message' do
+        expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_noop/).once
+      end
+    end
   end
 
-  context 'when feature flag not set' do
-    before do
-      stub_const('ENABLE_EVENT_BASED_PROBATION_CHANGE', false)
-      handler.handle(event)
-    end
-
-    let(:event_type) { 'probation-case.registration.added' }
+  context 'with event type OFFENDER_MANAGER_CHANGED' do
+    let(:event_type) { 'OFFENDER_MANAGER_CHANGED' }
     let(:additional_information) { {} }
 
-    it 'emits a skip log info message' do
-      expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_skip/).once
-    end
-
-    it 'does not emit a start log info message' do
-      expect(Shoryuken::Logging.logger).not_to have_received(:info).with(/domain_event_handle_start/)
+    it 'updates case information' do
+      handler.handle(event)
+      expect(ProcessDeliusDataJob).to have_received(:perform_now).with(crn, identifier_type: :crn, trigger_method: :event)
     end
   end
 end

--- a/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
@@ -23,52 +23,40 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
   let(:crn) { 'X08769' }
   let(:tier_from_api) { 'D1' }
 
-  context 'when feature flag set' do
-    before { stub_const('ENABLE_EVENT_BASED_PROBATION_CHANGE', true) }
+  context 'when local case information found' do
+    let!(:case_information) { create(:case_information, crn: crn, tier: tier) }
+    let(:tier) { 'A' }
 
-    context 'when local case information found' do
-      let!(:case_information) { create(:case_information, crn: crn, tier: tier) }
-      let(:tier) { 'A' }
+    before { handler.handle(event) }
 
-      before { handler.handle(event) }
+    context 'when tier has not changed' do
+      let(:tier) { 'D' }
 
-      context 'when tier has not changed' do
-        let(:tier) { 'D' }
-
-        it 'emits a log noop message' do
-          expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_noop/)
-        end
-
-        it 'emits no audit event' do
-          expect(AuditEvent).not_to have_received(:publish)
-        end
+      it 'emits a log noop message' do
+        expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_noop/)
       end
 
-      context 'when case information update successful' do
-        it 'updates tier with first char of new value' do
-          expect(case_information.reload.tier).to eq('D')
-        end
-
-        it 'emits a log info message' do
-          expect(Shoryuken::Logging.logger).to have_received(:info).at_least(2).times
-        end
-
-        it 'emits an audit event' do
-          expect(AuditEvent).to have_received(:publish).once
-        end
-      end
-
-      context 'when case information update not successful' do
-        let(:tier_from_api) { 'Z1' }
-
-        it 'emits a log error message' do
-          expect(Shoryuken::Logging.logger).to have_received(:error).once
-        end
+      it 'emits no audit event' do
+        expect(AuditEvent).not_to have_received(:publish)
       end
     end
 
-    context 'when local case information not found' do
-      before { handler.handle(event) }
+    context 'when case information update successful' do
+      it 'updates tier with first char of new value' do
+        expect(case_information.reload.tier).to eq('D')
+      end
+
+      it 'emits a log info message' do
+        expect(Shoryuken::Logging.logger).to have_received(:info).at_least(2).times
+      end
+
+      it 'emits an audit event' do
+        expect(AuditEvent).to have_received(:publish).once
+      end
+    end
+
+    context 'when case information update not successful' do
+      let(:tier_from_api) { 'Z1' }
 
       it 'emits a log error message' do
         expect(Shoryuken::Logging.logger).to have_received(:error).once
@@ -76,18 +64,11 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
     end
   end
 
-  context 'when feature flag not set' do
-    before do
-      stub_const('ENABLE_EVENT_BASED_PROBATION_CHANGE', false)
-      handler.handle(event)
-    end
+  context 'when local case information not found' do
+    before { handler.handle(event) }
 
-    it 'emits a skip log info message' do
-      expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_skip/).once
-    end
-
-    it 'does not emit a start log info message' do
-      expect(Shoryuken::Logging.logger).not_to have_received(:info).with(/domain_event_handle_start/)
+    it 'emits a log error message' do
+      expect(Shoryuken::Logging.logger).to have_received(:error).once
     end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1466

Given ENABLE_EVENT_BASED_PROBATION_CHANGE is set to 1 in production, this feature is now live and the flag and associated logic should be removed.