### PR TITLE
MO-1439: Allow blank handover dates to be pushed to nDelius

### DIFF
--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -79,7 +79,7 @@ private
 
   def push_to_delius(record)
     # Don't push if the dates haven't changed
-    if (record.saved_change_to_start_date? || record.saved_change_to_handover_date?) && !record.handover_date.nil?
+    if record.saved_change_to_start_date? || record.saved_change_to_handover_date?
       event = DomainEvents::EventFactory.build_handover_event(host: Rails.configuration.allocation_manager_host,
                                                               noms_number: record.nomis_offender_id)
       event.publish(job: 'recalculate_handover_date')

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
       described_class.perform_now(offender_no)
     end
 
-    it 'does not publish handover.changed domain event', aggregate_failures: true do
-      expect(event).not_to have_received(:publish)
+    it 'publishes handover.changed domain event', aggregate_failures: true do
+      expect(event).to have_received(:publish)
     end
   end
 


### PR DESCRIPTION
Regarding support issue: https://mojdt.slack.com/archives/C03N99X465Q/p1712689975429049

Ticket: https://dsdmoj.atlassian.net/browse/MO-1439

Cases where a start/handover date is being recalculated as blank are not updating this in nDelius, this change fixes that.