### PR TITLE
MO-1500: Fix issue in parole case selection logic

### DIFF
--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -178,13 +178,13 @@ class MpcOffender
   end
 
   def approaching_parole?
-    [target_hearing_date, tariff_date].compact.any? do |date|
-      date.between?(Time.zone.now, 10.months.from_now.end_of_day)
-    end
+    next_parole_date.present?
   end
 
   def next_parole_date
-    target_hearing_date || [tariff_date, parole_eligibility_date].compact.min
+    [target_hearing_date, tariff_date].compact.sort.find do |date|
+      date.between?(Time.zone.now, 10.months.from_now.end_of_day)
+    end
   end
 
   # Separate from next_parole_date as parole case index view sorts by next_parole_date, so it seemed sensible to avoid changing default rails behaviour

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -177,29 +177,13 @@ class MpcOffender
     most_recent_completed_parole_review&.hearing_outcome_received_on
   end
 
-  # If the parole application is set for a hearing within 10 months, or the outcome for a hearing was received in the last 14 days,
-  # return true. If the hearing has an outcome but we do not have the date that it was received, assume that it is no longer
-  # approaching parole (return false).
   def approaching_parole?
-    earliest_date = next_parole_date
-    return false if earliest_date.blank?
-    return false unless earliest_date <= Time.zone.today + 10.months
-    return false if !most_recent_parole_review&.no_hearing_outcome? && hearing_outcome_received_on.blank?
-
-    if earliest_date.past? &&
-      hearing_outcome_received_on.present? &&
-      hearing_outcome_received_on <= Time.zone.today - 14.days
-
-      return false
-    end
-
-    true
+    next_parole_date&.between?(Time.zone.now, 10.months.from_now.end_of_day) ||
+    hearing_outcome_received_on&.between?(14.days.ago.beginning_of_day, Time.zone.now)
   end
 
   def next_parole_date
-    return target_hearing_date if target_hearing_date.present?
-
-    [tariff_date, parole_eligibility_date].compact.min
+    target_hearing_date || [tariff_date, parole_eligibility_date].compact.min
   end
 
   # Separate from next_parole_date as parole case index view sorts by next_parole_date, so it seemed sensible to avoid changing default rails behaviour

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -178,8 +178,9 @@ class MpcOffender
   end
 
   def approaching_parole?
-    next_parole_date&.between?(Time.zone.now, 10.months.from_now.end_of_day) ||
-    hearing_outcome_received_on&.between?(14.days.ago.beginning_of_day, Time.zone.now)
+    [target_hearing_date, tariff_date].compact.any? do |date|
+      date.between?(Time.zone.now, 10.months.from_now.end_of_day)
+    end
   end
 
   def next_parole_date

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Parole cases</h1>
-<p>All cases in this prison with a target hearing date, PED or TED in the next 10 months.</p>
+<p>All cases in this prison with a target hearing date or TED in the next 10 months.</p>
 
 <section id="approaching-parole">
   <% if @offenders.empty? %>

--- a/spec/controllers/parole_cases_controller_spec.rb
+++ b/spec/controllers/parole_cases_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe ParoleCasesController, type: :controller do
         context 'when sorting by next parole date' do
           it 'sorts' do
             get :index, params: { prison_id: prison, sort: 'next_parole_date desc' }
-            expect(assigns(:offenders).map(&:offender_no)).to eq(["G1234VV", "G7514GW"])
+            expect(assigns(:offenders).map(&:offender_no)).to eq(["G7514GW", "G1234VV"])
           end
         end
       end

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -205,7 +205,7 @@ feature "staff pages" do
       end
 
       it "has a heading" do
-        expect(page).to have_css('p', text: 'All cases in this prison with a target hearing date, PED or TED in the next 10 months')
+        expect(page).to have_css('p', text: 'All cases in this prison with a target hearing date or TED in the next 10 months.')
       end
     end
   end

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -489,32 +489,6 @@ RSpec.describe MpcOffender, type: :model do
   end
 
   describe 'parole-related methods' do
-    describe '#next_parole_date' do
-      context 'when target_hearing_date is unavailable' do
-        context 'when tariff_date is earlier than parole_eligibility_date' do
-          it 'returns tariff_date' do
-            expect(subject.next_parole_date).to eq tariff_date
-          end
-        end
-
-        context 'when parole_eligibility_date is earlier thhan tariff_date' do
-          let(:parole_eligibility_date) { Time.zone.today - 1.year }
-
-          it 'returns parole_eligibility_date' do
-            expect(subject.next_parole_date).to eq parole_eligibility_date
-          end
-        end
-      end
-
-      context 'when target_hearing_date is available' do
-        let(:target_hearing_date) { Time.zone.today + 5.years }
-
-        it 'returns the target_hearing_date regardless of whether it is the earliest date' do
-          expect(subject.next_parole_date).to eq target_hearing_date
-        end
-      end
-    end
-
     describe '#next_parole_date_type' do
       context 'when next_parole_date is tariff_date' do
         it 'returns "TED"' do
@@ -664,7 +638,7 @@ RSpec.describe MpcOffender, type: :model do
     end
   end
 
-  describe "#approaching_parole?" do
+  describe "approaching_parole? and next_parole_date" do
     subject { mpc_offender.approaching_parole? }
 
     let(:mpc_offender) { described_class.new(prison: nil, offender: double(:offender).as_null_object, prison_record: nil) }
@@ -681,6 +655,10 @@ RSpec.describe MpcOffender, type: :model do
           let(:earliest_date_value) { 10.months.from_now - 1.day }
 
           it { is_expected.to be_truthy }
+
+          specify "next parole date is #{date_field}" do
+            expect(mpc_offender.next_parole_date).to eq(mpc_offender.send(date_field))
+          end
         end
 
         context "when the date is later than 10 months in the future" do
@@ -699,6 +677,16 @@ RSpec.describe MpcOffender, type: :model do
 
     context "when both parole dates are blank" do
       it { is_expected.to be_falsey }
+    end
+
+    context "when THD is in 9 months, TED is in 5 months" do
+      before { allow(mpc_offender).to receive_messages(target_hearing_date: 9.months.from_now, tariff_date: 5.months.from_now) }
+
+      it { is_expected.to be_truthy }
+
+      specify "next parole date is the earlier date of the two (TED)" do
+        expect(mpc_offender.next_parole_date).to eq(mpc_offender.tariff_date)
+      end
     end
   end
 end

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -663,4 +663,70 @@ RSpec.describe MpcOffender, type: :model do
       end
     end
   end
+
+  describe "#approaching_parole?" do
+    subject { mpc_offender.approaching_parole? }
+
+    let(:mpc_offender) do
+      most_recent_parole_review = ParoleReview.new(hearing_outcome:, hearing_outcome_received_on:)
+
+      described_class.new(
+        prison: nil,
+        offender: double(:offender, most_recent_parole_review:).as_null_object,
+        prison_record: double(:api_offender, target_hearing_date:, tariff_date:, parole_eligibility_date:)
+      )
+    end
+
+    earliest_date_fields = %i[target_hearing_date tariff_date parole_eligibility_date]
+
+    earliest_date_fields.each do |earliest_date_field|
+      let(:hearing_outcome) { 'Not Specified' }
+      let(:hearing_outcome_received_on) { nil }
+      let(:target_hearing_date) { nil }
+      let(:tariff_date) { nil }
+      let(:parole_eligibility_date) { nil }
+
+      before { allow(mpc_offender).to receive(earliest_date_field).and_return(earliest_date_value) }
+
+      context "when next parole date (#{earliest_date_field}) is blank" do
+        let(:earliest_date_value) { nil }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "when next parole date (#{earliest_date_field}) is 10 months in the future or earlier" do
+        let(:earliest_date_value) { 10.months.from_now - 1.day }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when next parole date (#{earliest_date_field}) is later than 10 months in the future" do
+        let(:earliest_date_value) { 10.months.from_now + 1.day }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "when next parole date (#{earliest_date_field}) is in the past" do
+        let(:earliest_date_value) { 18.years.ago }
+
+        context "and the hearing outcome has not been received yet" do
+          let(:hearing_outcome_received_on) { nil }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context "and the hearing outcome was received more than 14 days ago" do
+          let(:hearing_outcome_received_on) { 15.days.ago }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context "and the hearing outcome was received within the past 14 days" do
+          let(:hearing_outcome_received_on) { 14.days.ago }
+
+          it { is_expected.to be_truthy }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/MO/boards/518?selectedIssue=MO-1500

The code was returning true when `hearing_outcome_received_on` was nil as it was not satisfying the final if statement.