### PR TITLE
MO-1511: Add PED to next parole date

### DIFF
--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -182,7 +182,7 @@ class MpcOffender
   end
 
   def next_parole_date
-    [target_hearing_date, tariff_date].compact.sort.find do |date|
+    [target_hearing_date, tariff_date, parole_eligibility_date].compact.sort.find do |date|
       date.between?(Time.zone.now, 10.months.from_now.end_of_day)
     end
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/MO/boards/518?selectedIssue=MO-1511

- Added PED to list of fields that make up next parole date, which can determine if cases show in parole screen.