### PR TITLE
Fix local failing test and some TLC

### DIFF
--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -228,19 +228,19 @@ describe HmppsApi::PrisonApi::OffenderApi do
       expect(bytes[-2, 2]).to eq(jpeg_end_sentinel)
     end
 
-    it "shows default image if there is no image available",
-       vcr: { cassette_name: 'prison_api/offender_api_image_not_found' }, local_only: true do
+    it "shows default image if there is no image available" do
       booking_id = 1_153_753
       image_id = 1_340_556
-      uri = "#{ApiHelper::T3}/images/#{image_id}/data"
+      details_uri = "#{ApiHelper::T3}/offender-sentences/bookings"
+      images_uri = "#{ApiHelper::T3}/images/#{image_id}/data"
 
-      stub_request(:get, uri).to_return(status: 404)
+      stub_request(:post, details_uri).to_return(body: [{ bookingId: booking_id, facialImageId: image_id }].to_json)
+      stub_request(:get, images_uri).to_return(status: 404)
 
       response = described_class.get_image(booking_id)
-      default_image_file = Rails.root.join('app/assets/images/default_profile_image.jpg')
+      default_image_file = described_class.default_image
 
-      image_bytes = File.read(default_image_file)
-      expect(image_bytes).to eq(response)
+      expect(default_image_file).to eq(response)
     end
 
     it "uses a default image if there is no available image",


### PR DESCRIPTION
One of these tests was not failing on CI because it was tagged as `local_only` but it was failing locally due to the fact the `#get_image` method performs 2 http requests (a post and a get) and both were being recorded by VCR as successful, however there was at the same time an “attempt” to stub the GET request with webmock to return 404, but this was never really happening as VCR takes precedence so the recorded response (non-404) was being returned instead, and that made the test assertion fail.

I found in this instance was easier to just stub both requests, given from the first post we only use one attribute `facialImageId` and use it in the second, get, request, and remove the VCR dependency.

A bit of TLC and reorg in some additional related tests, removing VCR and replacing it with webmock. Removed some repetition but as there are 2 requests being stubbed with multiple combinations there is still some repetition left, but is easier to read I hope!