### PR TITLE
MO-1479 New 403 error response in SAR API

### DIFF
--- a/app/controllers/api/sar_controller.rb
+++ b/app/controllers/api/sar_controller.rb
@@ -18,9 +18,13 @@ module Api
 
     # Overrides parent due to endpoint-specific roles
     def verify_token
+      unless token.valid?
+        return render_error('Valid authorisation token required', 1, 401)
+      end
+
       unless token.valid_token_with_scope?('read', role: SAR_ROLE) ||
              token.valid_token_with_scope?('read', role: MPC_ADMIN_ROLE)
-        render_error('Valid authorisation token required', 1, 401)
+        render_error('Invalid token role', 5, 403)
       end
     end
 

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -739,6 +739,12 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SarError"
+        '403':
+          description: Invalid token role
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SarError"
         '400':
           description: Both PRN and CRN parameter passed
           content:

--- a/spec/api/sar_api_spec.rb
+++ b/spec/api/sar_api_spec.rb
@@ -33,7 +33,37 @@ describe 'SAR API' do
                 description: 'Optional parameter denoting maximum date of event occurrence which should be returned in the response (if used, both dates must be provided)'
 
       describe 'when not authorised' do
+        let(:Authorization) { nil }
+
         response '401', 'Request is not authorised' do
+          security [Bearer: []]
+          schema '$ref' => '#/components/schemas/SarError'
+
+          let(:crn) { nil }
+          let(:prn) { 'A1111AA' }
+          let(:fromDate) { nil }
+          let(:toDate) { nil }
+
+          run_test!
+        end
+      end
+
+      describe 'when forbidden due to role' do
+        let(:payload) do
+          {
+            'internal_user' => false,
+            'scope' => %w[read],
+            'exp' => 1.hour.from_now.to_i,
+            'client_id' => 'offender-management-allocation-manager',
+            'authorities' => %w[ROLE_FOOBAR]
+          }
+        end
+
+        before do
+          allow(JwksDecoder).to receive(:decode_token).and_return([payload])
+        end
+
+        response '403', 'Invalid token role' do
           security [Bearer: []]
           schema '$ref' => '#/components/schemas/SarError'
 

--- a/spec/services/hmpps_api/oauth/token_spec.rb
+++ b/spec/services/hmpps_api/oauth/token_spec.rb
@@ -32,6 +32,44 @@ describe HmppsApi::Oauth::Token do
     expect(token.needs_refresh?).to be(false)
   end
 
+  describe '#valid?' do
+    subject(:token) { described_class.new(access_token:) }
+
+    before do
+      allow(Rails.logger).to receive(:error)
+    end
+
+    context 'with missing token' do
+      let(:access_token) { nil }
+
+      it 'logs the error' do
+        token.valid?
+        expect(Rails.logger).to have_received(:error).with(
+          'event=api_access_blocked|Nil JSON web token'
+        )
+      end
+
+      it 'returns false' do
+        expect(token).not_to be_valid
+      end
+    end
+
+    context 'with an invalid token' do
+      let(:access_token) { 'foobar' }
+
+      it 'logs the error' do
+        token.valid?
+        expect(Rails.logger).to have_received(:error).with(
+          'event=api_access_blocked|Not enough or too many segments'
+        )
+      end
+
+      it 'returns false' do
+        expect(token).not_to be_valid
+      end
+    end
+  end
+
   describe '#valid_token_with_scope?' do
     let(:role) { 'MY_FAB_ROLE' }
     let(:scope) { 'read' }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/MO-1479

MPC returns 401 response when a client hits the SAR endpoint with a valid token that is missing the required role - this should be a 403 instead.

The existing 401 error has been split into two:
- Leave `401` response for missing (no bearer) or invalid tokens (invalid being anything that cannot be decoded, or expired tokens).
- New `403` response when token, despite being valid, lacks the appropriate role.

Note this only affects SAR endpoint, which has its own implementation of the `#verify_token` method. It is not an app-wise change. We might decide to do the same in all other endpoints.