### PR TITLE
Update bundler and CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,9 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Setup bundler path
+          command: bundle config set path 'vendor/bundle'
+      - run:
           name: Security analysis
           command: bundle exec brakeman -o ~/test-results/brakeman/brakeman.json -o ~/test-results/brakeman/brakeman.html
       - run:
@@ -310,17 +313,16 @@ workflows:
     jobs:
       - install_dependencies:
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#      - fetch_env_vars:
-#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#          context: [offender-management-shared, offender-management-staging]
-
+      - fetch_env_vars:
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+          context: [offender-management-shared, offender-management-staging]
       - rubocop:
           requires: [install_dependencies]
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#      - test:
-#          requires: [install_dependencies, fetch_env_vars]
-#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#          context: [offender-management-shared, offender-management-staging]
+      - test:
+          requires: [install_dependencies, fetch_env_vars]
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+          context: [offender-management-shared, offender-management-staging]
 #      - verify_docker_image_builds:
 #          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,9 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Setup bundler path
+          command: bundle config set path 'vendor/bundle'
+      - run:
           name: Rubocop
           command: bundle exec rubocop
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,18 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          key: &yarn-cache yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install frontend modules
-          command: yarn install
+          command: yarn install --immutable
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: *yarn-cache
+          paths:
+            - .yarn/cache
+            - .yarn/unplugged
       - install_firefox
       - run:
           name: Download Code Climate
@@ -182,9 +191,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/
-      - run:
-          name: Setup bundler path
-          command: bundle config set path 'vendor/bundle'
       - run:
           name: Rubocop
           command: bundle exec rubocop
@@ -289,18 +295,18 @@ workflows:
     jobs:
       - install_dependencies:
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-      - fetch_env_vars:
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-          context: [offender-management-shared, offender-management-staging]
+#      - fetch_env_vars:
+#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+#          context: [offender-management-shared, offender-management-staging]
       - rubocop:
           requires: [install_dependencies]
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-      - test:
-          requires: [install_dependencies, fetch_env_vars]
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-          context: [offender-management-shared, offender-management-staging]
-      - verify_docker_image_builds:
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+#      - test:
+#          requires: [install_dependencies, fetch_env_vars]
+#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+#          context: [offender-management-shared, offender-management-staging]
+#      - verify_docker_image_builds:
+#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
 
   test_env:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,8 +163,8 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - vendor/bundle
-            - node_modules
+            - repo/vendor/bundle
+            - repo/node_modules
             - .local/bin
             - .bundle/config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,9 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
+          name: Setup bundler path
+          command: bundle config set path 'vendor/bundle'
+      - run:
           name: Rubocop
           command: bundle exec rubocop
   test:
@@ -295,18 +298,18 @@ workflows:
     jobs:
       - install_dependencies:
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#      - fetch_env_vars:
-#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#          context: [offender-management-shared, offender-management-staging]
+      - fetch_env_vars:
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+          context: [offender-management-shared, offender-management-staging]
       - rubocop:
           requires: [install_dependencies]
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#      - test:
-#          requires: [install_dependencies, fetch_env_vars]
-#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-#          context: [offender-management-shared, offender-management-staging]
-#      - verify_docker_image_builds:
-#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+      - test:
+          requires: [install_dependencies, fetch_env_vars]
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+          context: [offender-management-shared, offender-management-staging]
+      - verify_docker_image_builds:
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
 
   test_env:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,8 +299,8 @@ workflows:
           requires: [install_dependencies, fetch_env_vars]
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
           context: [offender-management-shared, offender-management-staging]
-#      - verify_docker_image_builds:
-#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+      - verify_docker_image_builds:
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
 
   test_env:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.4.4
   aws-cli: circleci/aws-cli@2.0.3
+  ruby: circleci/ruby@2.1.3
 
 commands:
   install_firefox:
@@ -122,27 +123,10 @@ jobs:
     <<: *test_container_config
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/
-      - restore_cache:
-          key: &gem-cache allocation-manager-{{ checksum "Gemfile.lock" }}-2022-10-05T13:43:00 # Set current time in iso8601 to bust cache
-      - run:
-          name: Which bundler?
-          # Install the version of bundler used in Gemfile.lock
-          command: gem install -v $(ruby -e 'puts /BUNDLED WITH\s+(\d+\.\d+\.\d+)/m.match(File.read("Gemfile.lock"))[1]') bundler && bundle -v
+      - ruby/install-deps
       - run:
           name: Install frontend modules
           command: yarn install
-      - run:
-          name: Install ruby gems
-          command: |
-            bundle config set path 'vendor/bundle'
-            bundle check || {
-              # Install CMake - required to install undercover gem
-              sudo apt update && sudo apt install cmake
-              # Install missing gems
-              bundle install
-            }
       - install_firefox
       - run:
           name: Download Code Climate
@@ -154,12 +138,6 @@ jobs:
               curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ~/.local/bin/cc-test-reporter
               chmod +x ~/.local/bin/cc-test-reporter
             fi
-      - save_cache:
-          key: *gem-cache
-          paths:
-            - vendor/bundle
-            - node_modules
-            - ~/.local/bin
       - persist_to_workspace:
           root: ~/
           paths:
@@ -172,8 +150,6 @@ jobs:
     <<: *defaults
     <<: *deploy_container_config
     steps:
-      - attach_workspace:
-          at: ~/
       - *configure_k8s
       - run:
           name: Fetch creds from K8s and store in workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - restore_cache:
-          key: allocation-manager-{{ checksum "Gemfile.lock" }}-2022-10-05T13:43:00 # Set current time in iso8601 to bust cache
+          key: &gem-cache allocation-manager-{{ checksum "Gemfile.lock" }}-2022-10-05T13:43:00 # Set current time in iso8601 to bust cache
       - run:
           name: Which bundler?
           # Install the version of bundler used in Gemfile.lock
@@ -155,16 +155,16 @@ jobs:
               chmod +x ~/.local/bin/cc-test-reporter
             fi
       - save_cache:
-          key: allocation-manager-{{ checksum "Gemfile.lock" }}-2022-10-05T13:43:00 # Set current time in iso8601 to bust cache
+          key: *gem-cache
           paths:
-            - ~/repo/vendor/bundle
-            - ~/repo/node_modules
+            - vendor/bundle
+            - node_modules
             - ~/.local/bin
       - persist_to_workspace:
           root: ~/
           paths:
-            - repo/vendor/bundle
-            - repo/node_modules
+            - vendor/bundle
+            - node_modules
             - .local/bin
             - .bundle/config
 
@@ -307,19 +307,19 @@ workflows:
     jobs:
       - install_dependencies:
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-      - fetch_env_vars:
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-          context: [offender-management-shared, offender-management-staging]
+#      - fetch_env_vars:
+#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+#          context: [offender-management-shared, offender-management-staging]
 
       - rubocop:
           requires: [install_dependencies]
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-      - test:
-          requires: [install_dependencies, fetch_env_vars]
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
-          context: [offender-management-shared, offender-management-staging]
-      - verify_docker_image_builds:
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+#      - test:
+#          requires: [install_dependencies, fetch_env_vars]
+#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+#          context: [offender-management-shared, offender-management-staging]
+#      - verify_docker_image_builds:
+#          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
 
   test_env:
     jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN \
     ca-certificates \
     gnupg \
   && timedatectl set-timezone Europe/London || true \
-  && gem install bundler -v 2.2.29 --no-document \
+  && gem install bundler -v 2.5.12 --no-document \
   && apt-get clean
 
 # Install official AWS CLI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
     memory_profiler (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.7)
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_xml (0.6.0)
@@ -303,6 +304,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
+    nokogiri (1.16.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.16.3-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -588,6 +592,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,6 @@ GEM
     memory_profiler (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_xml (0.6.0)
@@ -304,8 +303,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
-    nokogiri (1.16.3)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.3-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -590,7 +588,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
 
 DEPENDENCIES
   activeadmin
@@ -682,4 +680,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.2.29
+   2.5.12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,8 +307,6 @@ GEM
     nokogiri (1.16.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-darwin)
-      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -593,7 +591,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-21
 
 DEPENDENCIES
   activeadmin


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/MO-1496

This is part of a wider piece of work to update dependencies and, eventually, also ruby/rails.

At some point in the latest bundler major versions, a change was introduced that didn't play nice with our circle config. In particular, the path where the bundle is installed did not properly carry over to other jobs, meaning rubocop, or brakeman gems were not found.

Solution (at least for now, might be better solutions) was to be explicit about where the bundle is installed by using `bundle config set path 'vendor/bundle'` before attempting to run rubocop or brakeman.

Additionally, I've updated the circle config to use the ruby orb for bundler and cache management (`ruby/install-deps`) and added separate yarn caching too.