### PR TITLE
MO-1513 Add new weekly chaser email

### DIFF
--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -146,10 +146,10 @@ private
     CommunityMailer.with(
       email: case_info.ldu_email_address,
       offender_crn: case_info.crn,
-      offender_name: nomis_offender.full_name,
-      nomis_offender_id: nomis_offender.offender_no,
+      offender_name: nomis_offender.full_name_ordered,
+      prison_number: nomis_offender.offender_no,
       sentence_type: nomis_offender.indeterminate_sentence? ? 'Indeterminate' : 'Determinate',
-      prison: prison.name,
+      prison_name: prison.name,
       pom_name: pom.full_name,
       pom_email: pom.email_address,
     ).assign_com_less_than_10_months_chaser.deliver_later

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -55,10 +55,10 @@ class CommunityMailer < ApplicationMailer
 
     set_personalisation(
       crn: params.fetch(:offender_crn),
-      name: params.fetch(:offender_name),
-      noms_no: params.fetch(:nomis_offender_id),
+      prisoner_name: params.fetch(:offender_name),
+      prison_number: params.fetch(:prison_number),
       sentence_type: params.fetch(:sentence_type),
-      prison_name: params.fetch(:prison),
+      prison_name: params.fetch(:prison_name),
       pom_name: params.fetch(:pom_name),
       pom_email: params.fetch(:pom_email),
     )

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -49,4 +49,20 @@ class CommunityMailer < ApplicationMailer
 
     mail(to: params.fetch(:email))
   end
+
+  def assign_com_less_than_10_months_chaser
+    set_template('99286519-708d-4c9e-ac6b-8b128c3d3d2e')
+
+    set_personalisation(
+      crn: params.fetch(:offender_crn),
+      name: params.fetch(:offender_name),
+      noms_no: params.fetch(:nomis_offender_id),
+      sentence_type: params.fetch(:sentence_type),
+      prison_name: params.fetch(:prison),
+      pom_name: params.fetch(:pom_name),
+      pom_email: params.fetch(:pom_email),
+    )
+
+    mail(to: params.fetch(:email))
+  end
 end

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
 
         context 'when weekly chaser email' do
           let(:allocation_double) { instance_double(AllocationHistory, primary_pom_nomis_id: offender_no) }
-          let(:prison_double) { build(:prison) }
+          let(:prison_double) { build(:prison, code: 'LEI') }
           let(:pom_double) { double(full_name: 'John Doe', email_address: 'john@example.com') }
 
           before do
@@ -179,7 +179,28 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
             allow(prison_double).to receive(:get_single_pom).with(offender_no).and_return(pom_double)
           end
 
-          it 'sends a chaser email 1 week later from the first com email' do
+          it 'sends a chaser email 1 week after the first com email' do
+            described_class.perform_now(offender_no)
+
+            Timecop.travel one_week_later do
+              expect_any_instance_of(described_class).to receive(:assign_com_email)
+              described_class.perform_now(offender_no)
+
+              expect(CommunityMailer).to have_received(:with).with(
+                email: ldu.email_address,
+                offender_crn: case_info.crn,
+                offender_name: "#{nomis_offender.fetch(:firstName)} #{nomis_offender.fetch(:lastName)}",
+                prison_number: offender_no,
+                sentence_type: 'Determinate',
+                prison_name: 'Leeds (HMP)',
+                pom_name: 'John Doe',
+                pom_email: 'john@example.com',
+              )
+              expect(assign_com_less_than_10_months_chaser_mailer).to have_received(:deliver_later)
+            end
+          end
+
+          it 'records the email history' do
             expect {
               described_class.perform_now(offender_no)
             }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
   let(:prison) { create(:prison) }
   let(:event) { instance_double DomainEvents::Event, :event, publish: nil }
   let(:assign_com_less_than_10_months_mailer) { double :assign_com_less_than_10_months_mailer, deliver_later: nil }
+  let(:assign_com_less_than_10_months_chaser_mailer) { double :assign_com_less_than_10_months_chaser_mailer, deliver_later: nil }
   let(:open_prison_supporting_com_needed_mailer) { double :open_prison_supporting_com_needed_mailer, deliver_later: nil }
   let(:community_mailer_with) do
     double(:community_mailer_with,
            assign_com_less_than_10_months: assign_com_less_than_10_months_mailer,
+           assign_com_less_than_10_months_chaser: assign_com_less_than_10_months_chaser_mailer,
            open_prison_supporting_com_needed: open_prison_supporting_com_needed_mailer)
   end
   let(:published_args) { {} }
@@ -131,6 +133,8 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
         let!(:case_info) { create(:case_information, enhanced_resourcing: true, local_delivery_unit: ldu, offender: build(:offender, nomis_offender_id: offender_no)) }
         let(:one_day_later) { today + 1.day }
         let(:two_days_later) { today + 2.days }
+        let(:one_week_later) { today + 1.week }
+        let(:ten_days_later) { today + 10.days }
 
         it 'sends an email and records the fact', :aggregate_failures do
           expect {
@@ -161,6 +165,39 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
             expect {
               described_class.perform_now(offender_no)
             }.to change(EmailHistory, :count).by(1)
+          end
+        end
+
+        context 'when weekly chaser email' do
+          let(:allocation_double) { instance_double(AllocationHistory, primary_pom_nomis_id: offender_no) }
+          let(:prison_double) { build(:prison) }
+          let(:pom_double) { double(full_name: 'John Doe', email_address: 'john@example.com') }
+
+          before do
+            allow(AllocationHistory).to receive(:find_by).with(nomis_offender_id: offender_no).and_return(allocation_double)
+            allow(Prison).to receive(:find).with(nomis_offender.fetch(:prisonId)).and_return(prison_double)
+            allow(prison_double).to receive(:get_single_pom).with(offender_no).and_return(pom_double)
+          end
+
+          it 'sends a chaser email 1 week later from the first com email' do
+            expect {
+              described_class.perform_now(offender_no)
+            }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \
+              change(EmailHistory.immediate_community_allocation_chaser, :count).by(0)
+
+            Timecop.travel one_week_later do
+              expect {
+                described_class.perform_now(offender_no)
+              }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \
+                change(EmailHistory.immediate_community_allocation_chaser, :count).by(1)
+            end
+
+            Timecop.travel ten_days_later do
+              expect {
+                described_class.perform_now(offender_no)
+              }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \
+                change(EmailHistory.immediate_community_allocation_chaser, :count).by(0)
+            end
           end
         end
       end

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -125,4 +125,45 @@ RSpec.describe CommunityMailer, type: :mailer do
             )
     end
   end
+
+  describe '#assign_com_less_than_10_months_chaser' do
+    let(:mail) do
+      described_class.with(**params).assign_com_less_than_10_months_chaser
+    end
+
+    let(:params) do
+      {
+        email: 'ldu_email@example.com',
+        offender_crn: 'offender_crn',
+        offender_name: 'offender_name',
+        nomis_offender_id: 'nomis_offender_id',
+        sentence_type: 'sentence_type',
+        prison: 'prison',
+        pom_name: 'pom_name',
+        pom_email: 'pom_email',
+      }
+    end
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template).to eq('99286519-708d-4c9e-ac6b-8b128c3d3d2e')
+    end
+
+    it 'sets the email recipient' do
+      expect(mail.to).to eq([params.fetch(:email)])
+    end
+
+    it 'sets the personalisation' do
+      expect(
+        mail.govuk_notify_personalisation
+      ).to eq({
+        crn: 'offender_crn',
+        name: 'offender_name',
+        noms_no: 'nomis_offender_id',
+        sentence_type: 'sentence_type',
+        prison_name: 'prison',
+        pom_name: 'pom_name',
+        pom_email: 'pom_email',
+      })
+    end
+  end
 end

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe CommunityMailer, type: :mailer do
         email: 'ldu_email@example.com',
         offender_crn: 'offender_crn',
         offender_name: 'offender_name',
-        nomis_offender_id: 'nomis_offender_id',
+        prison_number: 'prison_number',
         sentence_type: 'sentence_type',
-        prison: 'prison',
+        prison_name: 'prison_name',
         pom_name: 'pom_name',
         pom_email: 'pom_email',
       }
@@ -157,10 +157,10 @@ RSpec.describe CommunityMailer, type: :mailer do
         mail.govuk_notify_personalisation
       ).to eq({
         crn: 'offender_crn',
-        name: 'offender_name',
-        noms_no: 'nomis_offender_id',
+        prisoner_name: 'offender_name',
+        prison_number: 'prison_number',
         sentence_type: 'sentence_type',
-        prison_name: 'prison',
+        prison_name: 'prison_name',
         pom_name: 'pom_name',
         pom_email: 'pom_email',
       })


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/MO-1513

Implement a new chaser email (`99286519-708d-4c9e-ac6b-8b128c3d3d2e`) that will trigger 1 week after the first immediate community allocation email (`6cae6890-6a5a-4ceb-82bd-43c8b43fc639`) has been sent, and weekly after that, while the conditions are still valid.