### PR TITLE
Allow handover api to show when no offender

### DIFF
--- a/app/models/api/handover.rb
+++ b/app/models/api/handover.rb
@@ -10,25 +10,29 @@ class Api::Handover
       'handoverDate' => @calculated_handover_date.handover_date&.iso8601,
       'handoverStartDate' => @calculated_handover_date.start_date&.iso8601,
       'responsibility' => @calculated_handover_date.responsibility_text,
-      **(@calculated_handover_date.com_responsible? ? com_responsibility : pom_responsibility)
+      'responsibleComName' => nil,
+      'responsibleComEmail' => nil,
+      'responsiblePomName' => nil,
+      'responsiblePomNomisId' => nil,
+      **(@calculated_handover_date.com_responsible? ? com_details : pom_details)
     }
   end
 
 private
 
-  def com_responsibility
+  def com_details
+    return {} unless @offender
+
     {
       'responsibleComName' => @offender.responsible_com_name,
-      'responsibleComEmail' => @offender.responsible_com_email,
-      'responsiblePomName' => nil,
-      'responsiblePomNomisId' => nil,
+      'responsibleComEmail' => @offender.responsible_com_email
     }
   end
 
-  def pom_responsibility
+  def pom_details
+    return {} unless @offender
+
     {
-      'responsibleComName' => nil,
-      'responsibleComEmail' => nil,
       'responsiblePomName' => @offender.responsible_pom_name,
       'responsiblePomNomisId' => @offender.responsible_pom_nomis_id,
     }

--- a/spec/controllers/api/handovers_api_controller_spec.rb
+++ b/spec/controllers/api/handovers_api_controller_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Api::HandoversApiController, type: :controller do
         context 'when the COM is responsible' do
           let(:responsibility) { CalculatedHandoverDate::COMMUNITY_RESPONSIBLE }
 
-          it "reports as COM responsible" do
-            create(:case_information, offender:, com_name: 'Com Nomis', com_email: 'com.nomis@community.gov.uk')
+          before { create(:case_information, offender:, com_name: 'Com Nomis', com_email: 'com.nomis@community.gov.uk') }
 
+          it "reports as COM responsible" do
             get :show, params: { id: nomis_offender_id }, format: :json
 
             expect(JSON.parse(response.body)).to include(
@@ -56,6 +56,22 @@ RSpec.describe Api::HandoversApiController, type: :controller do
               'responsiblePomName' => nil,
               'responsiblePomNomisId' => nil,
             )
+          end
+
+          context 'when the offender cannot be found' do
+            it 'returns empty details for the responsible officer' do
+              Offender.delete_all
+
+              get :show, params: { id: nomis_offender_id }, format: :json
+
+              expect(JSON.parse(response.body)).to include(
+                'responsibility' => 'COM',
+                'responsibleComName' => nil,
+                'responsibleComEmail' => nil,
+                'responsiblePomName' => nil,
+                'responsiblePomNomisId' => nil,
+              )
+            end
           end
         end
 
@@ -74,6 +90,22 @@ RSpec.describe Api::HandoversApiController, type: :controller do
               'responsiblePomName' => 'Pom Nomis',
               'responsiblePomNomisId' => 485_926,
             )
+          end
+
+          context 'when the offender cannot be found' do
+            it 'returns empty details for the responsible officer' do
+              Offender.delete_all
+
+              get :show, params: { id: nomis_offender_id }, format: :json
+
+              expect(JSON.parse(response.body)).to include(
+                'responsibility' => 'POM',
+                'responsibleComName' => nil,
+                'responsibleComEmail' => nil,
+                'responsiblePomName' => nil,
+                'responsiblePomNomisId' => nil,
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
The handover API fails when for some reason the Offender record does not exist.

This should not happen as the primary function of this endpoint us COM/POM responsibility.