### PR TITLE
MO-1533 Remove weekly email chaser

### DIFF
--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -49,20 +49,4 @@ class CommunityMailer < ApplicationMailer
 
     mail(to: params.fetch(:email))
   end
-
-  def assign_com_less_than_10_months_chaser
-    set_template('99286519-708d-4c9e-ac6b-8b128c3d3d2e')
-
-    set_personalisation(
-      crn: params.fetch(:offender_crn),
-      prisoner_name: params.fetch(:offender_name),
-      prison_number: params.fetch(:prison_number),
-      sentence_type: params.fetch(:sentence_type),
-      prison_name: params.fetch(:prison_name),
-      pom_name: params.fetch(:pom_name),
-      pom_email: params.fetch(:pom_email),
-    )
-
-    mail(to: params.fetch(:email))
-  end
 end

--- a/app/models/email_history.rb
+++ b/app/models/email_history.rb
@@ -7,7 +7,6 @@ class EmailHistory < ApplicationRecord
     SUITABLE_FOR_EARLY_ALLOCATION = 'suitable_for_early_allocation',
     OPEN_PRISON_COMMUNITY_ALLOCATION = 'open_prison_community_allocation',
     IMMEDIATE_COMMUNITY_ALLOCATION = 'immediate_community_allocation',
-    IMMEDIATE_COMMUNITY_ALLOCATION_CHASER = 'immediate_community_allocation_chaser',
   ].freeze
 
   belongs_to :offender,
@@ -26,7 +25,7 @@ class EmailHistory < ApplicationRecord
 
   # This scope removes history records which are not supposed to be displayed in the offender timeline (case history page)
   scope :in_offender_timeline, lambda {
-    where.not(event: [IMMEDIATE_COMMUNITY_ALLOCATION, IMMEDIATE_COMMUNITY_ALLOCATION_CHASER])
+    where.not(event: [IMMEDIATE_COMMUNITY_ALLOCATION])
   }
 
   def self.sent_within_current_sentence(offender, event)

--- a/lib/tasks/email_history.rake
+++ b/lib/tasks/email_history.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :emails do
+  desc 'Purge email history for a given event'
+  task :purge_event_history, [:event] => [:environment] do |_task, args|
+    event = args[:event]
+
+    if event.present?
+      total = EmailHistory.where(event:).count
+      puts "Purging email history for event '#{event}'. Total found: #{total}"
+      EmailHistory.where(event:).delete_all
+      puts 'Done.'
+    else
+      puts 'No event provided. Use: rake "emails:purge_event_history[event_name]"'
+    end
+  end
+end

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -4,12 +4,10 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
   let(:prison) { create(:prison) }
   let(:event) { instance_double DomainEvents::Event, :event, publish: nil }
   let(:assign_com_less_than_10_months_mailer) { double :assign_com_less_than_10_months_mailer, deliver_later: nil }
-  let(:assign_com_less_than_10_months_chaser_mailer) { double :assign_com_less_than_10_months_chaser_mailer, deliver_later: nil }
   let(:open_prison_supporting_com_needed_mailer) { double :open_prison_supporting_com_needed_mailer, deliver_later: nil }
   let(:community_mailer_with) do
     double(:community_mailer_with,
            assign_com_less_than_10_months: assign_com_less_than_10_months_mailer,
-           assign_com_less_than_10_months_chaser: assign_com_less_than_10_months_chaser_mailer,
            open_prison_supporting_com_needed: open_prison_supporting_com_needed_mailer)
   end
   let(:published_args) { {} }
@@ -133,8 +131,6 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
         let!(:case_info) { create(:case_information, enhanced_resourcing: true, local_delivery_unit: ldu, offender: build(:offender, nomis_offender_id: offender_no)) }
         let(:one_day_later) { today + 1.day }
         let(:two_days_later) { today + 2.days }
-        let(:one_week_later) { today + 1.week }
-        let(:ten_days_later) { today + 10.days }
 
         it 'sends an email and records the fact', :aggregate_failures do
           expect {
@@ -165,83 +161,6 @@ RSpec.describe RecalculateHandoverDateJob, type: :job do
             expect {
               described_class.perform_now(offender_no)
             }.to change(EmailHistory, :count).by(1)
-          end
-        end
-
-        context 'when weekly chaser email' do
-          let(:allocation_double) { instance_double(AllocationHistory, active?: true, primary_pom_nomis_id: offender_no) }
-          let(:prison_double) { build(:prison, code: 'LEI') }
-          let(:pom_double) { double(full_name: 'John Doe', email_address: 'john@example.com') }
-
-          before do
-            allow(AllocationHistory).to receive(:find_by).with(nomis_offender_id: offender_no).and_return(allocation_double)
-            allow(Prison).to receive(:find).with(nomis_offender.fetch(:prisonId)).and_return(prison_double)
-            allow(prison_double).to receive(:get_single_pom).with(offender_no).and_return(pom_double)
-          end
-
-          context 'when there is allocation history for the offender' do
-            it 'sends a chaser email 1 week after the first com email with POM details' do
-              described_class.perform_now(offender_no)
-
-              Timecop.travel one_week_later do
-                expect_any_instance_of(described_class).to receive(:assign_com_email)
-                described_class.perform_now(offender_no)
-
-                expect(CommunityMailer).to have_received(:with).with(
-                  email: ldu.email_address,
-                  offender_crn: case_info.crn,
-                  offender_name: "#{nomis_offender.fetch(:firstName)} #{nomis_offender.fetch(:lastName)}",
-                  prison_number: offender_no,
-                  sentence_type: 'Determinate',
-                  prison_name: 'Leeds (HMP)',
-                  pom_name: 'John Doe',
-                  pom_email: 'john@example.com',
-                )
-                expect(assign_com_less_than_10_months_chaser_mailer).to have_received(:deliver_later)
-              end
-            end
-          end
-
-          context 'when there is no allocation history for the offender' do
-            let(:allocation_double) { nil }
-
-            it 'sends a chaser email 1 week after the first com email without POM details' do
-              described_class.perform_now(offender_no)
-
-              Timecop.travel one_week_later do
-                expect_any_instance_of(described_class).to receive(:assign_com_email)
-                described_class.perform_now(offender_no)
-
-                expect(CommunityMailer).to have_received(:with).with(
-                  hash_including(
-                    pom_name: 'This offender does not have an allocated POM',
-                    pom_email: 'n/a',
-                  )
-                )
-                expect(assign_com_less_than_10_months_chaser_mailer).to have_received(:deliver_later)
-              end
-            end
-          end
-
-          it 'records the email history' do
-            expect {
-              described_class.perform_now(offender_no)
-            }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \
-              change(EmailHistory.immediate_community_allocation_chaser, :count).by(0)
-
-            Timecop.travel one_week_later do
-              expect {
-                described_class.perform_now(offender_no)
-              }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \
-                change(EmailHistory.immediate_community_allocation_chaser, :count).by(1)
-            end
-
-            Timecop.travel ten_days_later do
-              expect {
-                described_class.perform_now(offender_no)
-              }.to change(EmailHistory.immediate_community_allocation, :count).by(1).and \
-                change(EmailHistory.immediate_community_allocation_chaser, :count).by(0)
-            end
           end
         end
       end

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -125,45 +125,4 @@ RSpec.describe CommunityMailer, type: :mailer do
             )
     end
   end
-
-  describe '#assign_com_less_than_10_months_chaser' do
-    let(:mail) do
-      described_class.with(**params).assign_com_less_than_10_months_chaser
-    end
-
-    let(:params) do
-      {
-        email: 'ldu_email@example.com',
-        offender_crn: 'offender_crn',
-        offender_name: 'offender_name',
-        prison_number: 'prison_number',
-        sentence_type: 'sentence_type',
-        prison_name: 'prison_name',
-        pom_name: 'pom_name',
-        pom_email: 'pom_email',
-      }
-    end
-
-    it 'sets the template' do
-      expect(mail.govuk_notify_template).to eq('99286519-708d-4c9e-ac6b-8b128c3d3d2e')
-    end
-
-    it 'sets the email recipient' do
-      expect(mail.to).to eq([params.fetch(:email)])
-    end
-
-    it 'sets the personalisation' do
-      expect(
-        mail.govuk_notify_personalisation
-      ).to eq({
-        crn: 'offender_crn',
-        prisoner_name: 'offender_name',
-        prison_number: 'prison_number',
-        sentence_type: 'sentence_type',
-        prison_name: 'prison_name',
-        pom_name: 'pom_name',
-        pom_email: 'pom_email',
-      })
-    end
-  end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1533

This weekly email chaser was introduced recently as part of ticket MO-1513 but since then it has been decided it is unnecessary given we already have a 2-day chaser that triggers much more frequently.

This PR practically reverts the work done in PR #1513 (although some refactor/DRY has been maintained as it is useful). Only 88 emails have been sent as of today.

Includes a simple rake task to purge email history for this particular event although task can be used in the future for other events if needed.

Notify template will also be deleted after this has been deployed.