### PR TITLE
Flatten array in API call

### DIFF
--- a/app/services/hmpps_api/complexity_api.rb
+++ b/app/services/hmpps_api/complexity_api.rb
@@ -20,7 +20,7 @@ module HmppsApi
 
       def get_complexities(offender_nos)
         route = '/complexity-of-need/multiple/offender-no'
-        result = client.post route, [offender_nos], cache: false
+        result = client.post route, offender_nos, cache: false
         result.map { |complexity| [complexity.fetch('offenderNo'), complexity.fetch('level')] }.to_h
       end
 

--- a/spec/fixtures/vcr_cassettes/complexity/get_complexities.yml
+++ b/spec/fixtures/vcr_cassettes/complexity/get_complexities.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://complexity-of-need-staging.hmpps.service.justice.gov.uk/v1/complexity-of-need/multiple/offender-no
     body:
       encoding: UTF-8
-      string: '[["G0276VC","T0000FT"]]'
+      string: '["G0276VC","T0000FT"]'
     headers:
       User-Agent:
       - Faraday v1.10.0
@@ -53,7 +53,7 @@ http_interactions:
     uri: https://complexity-of-need-staging.hmpps.service.justice.gov.uk/v1/complexity-of-need/multiple/offender-no
     body:
       encoding: UTF-8
-      string: '[["G0276VC","T0000FT","X00887XX"]]'
+      string: '["G0276VC","T0000FT","X00887XX"]'
     headers:
       User-Agent:
       - Faraday v1.10.0


### PR DESCRIPTION
Tiny thing but this will help us to have better logs in CNL service.
This array payload was wrapped into another array for no reason.