### PR TITLE
chore: Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 5
-  ignore:
-  - dependency-name: parser
-    versions:
-    - 3.0.0.0
-  - dependency-name: rspec-rails
-    versions:
-    - 4.0.2
-    - 5.0.0
-  - dependency-name: database_cleaner
-    versions:
-    - 2.0.0
-    - 2.0.1
-  - dependency-name: simplecov
-    versions:
-    - 0.21.1
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    # Disable version updates, but leave security updates
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    # Disable version updates, but leave security updates
+    open-pull-requests-limit: 0

--- a/Gemfile
+++ b/Gemfile
@@ -61,9 +61,6 @@ gem 'aws-sdk-sqs', '~> 1.55'
 
 gem 'activeadmin'
 
-# Needed until Ruby 3.3.4 is released https://github.com/ruby/ruby/pull/11006
-gem 'net-pop', github: 'ruby/net-pop'
-
 group :development, :test do
   gem 'brakeman', '~> 6.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,10 @@ gem 'faraday', '~> 1.10.3'
 gem 'net-http' # needed to undo a conflict with system libs
 gem 'govuk_notify_rails'
 # we need the extra is_csv parameter available in 5.2 and above
-gem 'notifications-ruby-client', '>= 5.2'
+# TODO: update code to work with latest version
+gem 'notifications-ruby-client', '>= 5.2', '< 6.0.0'
 gem 'govuk_design_system_formbuilder', '~> 2.5'
-gem 'json-schema', '~> 3.0'
+gem 'json-schema', '~> 4.0'
 gem 'jsonb_accessor'
 gem 'jwt'
 gem 'lograge'
@@ -59,6 +60,9 @@ gem 'shoryuken', '~> 6.0'
 gem 'aws-sdk-sqs', '~> 1.55'
 
 gem 'activeadmin'
+
+# Needed until Ruby 3.3.4 is released https://github.com/ruby/ruby/pull/11006
+gem 'net-pop', github: 'ruby/net-pop'
 
 group :development, :test do
   gem 'brakeman', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/ruby/net-pop.git
+  revision: e8d0afe2773b9eb6a23c39e9e437f6fc0fc7c733
+  specs:
+    net-pop (0.1.2)
+      net-protocol
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -70,8 +77,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     arbre (1.7.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
@@ -79,17 +86,17 @@ GEM
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
     aws-eventstream (1.3.0)
-    aws-partitions (1.944.0)
-    aws-sdk-core (3.197.0)
+    aws-partitions (1.949.0)
+    aws-sdk-core (3.200.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-sns (1.77.0)
-      aws-sdk-core (~> 3, >= 3.197.0)
+    aws-sdk-sns (1.79.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.76.0)
-      aws-sdk-core (~> 3, >= 3.197.0)
+    aws-sdk-sqs (1.79.0)
+      aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
@@ -241,13 +248,13 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.7.2)
-    json-schema (3.0.0)
+    json-schema (4.3.0)
       addressable (>= 2.8)
     jsonb_accessor (1.4)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
       pg (>= 0.18.1)
-    jwt (2.8.1)
+    jwt (2.8.2)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -268,6 +275,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -290,7 +298,7 @@ GEM
     memory_profiler (1.0.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.23.1)
+    minitest (5.24.1)
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -298,10 +306,8 @@ GEM
     nenv (0.3.0)
     net-http (0.4.1)
       uri
-    net-imap (0.4.13)
+    net-imap (0.4.14)
       date
-      net-protocol
-    net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
@@ -353,12 +359,12 @@ GEM
       prawn-table
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    prometheus_exporter (2.1.0)
+    prometheus_exporter (2.1.1)
       webrick
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.1.1)
+    public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -420,7 +426,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.0)
+    rexml (3.3.1)
       strscan
     rouge (4.3.0)
     rspec (3.13.0)
@@ -505,19 +511,20 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.21.1)
+    selenium-webdriver (4.22.0)
       base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.17.3)
+    sentry-rails (5.18.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.17.3)
-    sentry-ruby (5.17.3)
+      sentry-ruby (~> 5.18.0)
+    sentry-ruby (5.18.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.17.3)
-      sentry-ruby (~> 5.17.3)
+    sentry-sidekiq (5.18.0)
+      sentry-ruby (~> 5.18.0)
       sidekiq (>= 3.0)
     shellany (0.0.1)
     shoryuken (6.2.1)
@@ -553,9 +560,9 @@ GEM
       sprockets (>= 3.0.0)
     stackprof (0.2.26)
     strscan (3.1.0)
-    test-prof (1.3.3)
+    test-prof (1.3.3.1)
     thor (1.3.1)
-    tilt (2.3.0)
+    tilt (2.4.0)
     timecop (0.9.10)
     timeout (0.4.1)
     ttfunk (1.8.0)
@@ -605,6 +612,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -633,7 +641,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
-  json-schema (~> 3.0)
+  json-schema (~> 4.0)
   jsonb_accessor
   jwt
   kaminari
@@ -645,7 +653,8 @@ DEPENDENCIES
   matrix
   memory_profiler
   net-http
-  notifications-ruby-client (>= 5.2)
+  net-pop!
+  notifications-ruby-client (>= 5.2, < 6.0.0)
   omniauth (~> 1.9.2)
   omniauth-oauth2
   paper_trail (~> 15.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/ruby/net-pop.git
-  revision: e8d0afe2773b9eb6a23c39e9e437f6fc0fc7c733
-  specs:
-    net-pop (0.1.2)
-      net-protocol
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -308,6 +301,8 @@ GEM
       uri
     net-imap (0.4.14)
       date
+      net-protocol
+    net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
@@ -653,7 +648,6 @@ DEPENDENCIES
   matrix
   memory_profiler
   net-http
-  net-pop!
   notifications-ruby-client (>= 5.2, < 6.0.0)
   omniauth (~> 1.9.2)
   omniauth-oauth2


### PR DESCRIPTION
Minor bump to some gems to close dependabots.

`json-schema` had a major bump. We had a lock in its version but I've checked and everything seems to work fine with latest version.

There is [some work needed](https://github.com/alphagov/notifications-ruby-client/blob/main/CHANGELOG.md#600) to be able to update notifications client to latest version. Will be done separately as we need to agree copy changes to the filename of the documents upon download.

Update `dependabot.yml` to include docker, and to only raise PRs for security versions, and not for version updates. This will keep the repo updated and notify us whenever there are security issues but not flood us with minor, unnecessary versions. Minor bumps can be bundled together and done periodically as part of the general maintenance of the app.