### PR TITLE
Quicker pipeline on merge to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,10 @@ workflows:
           name: deploy_staging
           requires: [build_and_push_docker_image]
           context: [offender-management-shared, offender-management-staging]
+      - deploy:
+          name: deploy_preprod
+          requires: [build_and_push_docker_image]
+          context: [offender-management-shared, offender-management-preprod]
       - deploy_production_approval:
           type: approval
           requires: [deploy_staging]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,23 +215,22 @@ workflows:
   test_build_deploy:
     jobs:
       - install_dependencies:
-          filters: { branches: { ignore: [staging, preprod, test, test2] } }
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
       - fetch_env_vars:
-          filters: { branches: { ignore: [staging, preprod, test, test2] } }
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
           context: [offender-management-shared, offender-management-staging]
       - rubocop:
           requires: [install_dependencies]
-          filters: { branches: { ignore: [staging, preprod, test, test2] } }
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
       - test:
           requires: [install_dependencies, fetch_env_vars]
-          filters: { branches: { ignore: [staging, preprod, test, test2] } }
+          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
           context: [offender-management-shared, offender-management-staging]
       - hmpps/build_docker:
           <<: *verify_docker_image_config
           filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
       - hmpps/build_docker:
           <<: *build_and_push_docker_image_config
-          requires: [rubocop, test]
           filters: { branches: { only: [main] } }
           context: [offender-management-shared, offender-management-staging]
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 references:
-  github_team_name_slug: &github_team_name_slug
-    GITHUB_TEAM_NAME_SLUG: offender-management
+  ignore_deployable_branches: &ignore_deployable_branches
+    filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
 
   docker_image_name: &docker_image_name
     image_name: quay.io/hmpps/offender-management
@@ -215,20 +215,18 @@ workflows:
   test_build_deploy:
     jobs:
       - install_dependencies:
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+          <<: *ignore_deployable_branches
       - fetch_env_vars:
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
+          <<: *ignore_deployable_branches
           context: [offender-management-shared, offender-management-staging]
       - rubocop:
           requires: [install_dependencies]
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
       - test:
           requires: [install_dependencies, fetch_env_vars]
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
           context: [offender-management-shared, offender-management-staging]
       - hmpps/build_docker:
+          <<: *ignore_deployable_branches
           <<: *verify_docker_image_config
-          filters: { branches: { ignore: [main, staging, preprod, test, test2] } }
       - hmpps/build_docker:
           <<: *build_and_push_docker_image_config
           filters: { branches: { only: [main] } }


### PR DESCRIPTION
Removed the need to run tests and linters on `main` branch, given our feature branches / pull requests enforce the branch to be up to date with main before being able to merge. So if the tests/linters are ok in the PR, we are certain there will be no failures upon merge to main. Removing these from running on main branch will cut some time to the deploys particularly in MPC where there are many tests and a bit slow.

Also added job to auto-deploy to preprod parallel to staging.
This ensures preprod env is always up to date (code, not database) with production.

https://mojdt.slack.com/archives/C04DQVDJ4MQ/p1719914249560179
