### PR TITLE
Fix duplicated log traces in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,8 +82,6 @@ Rails.application.configure do
   end
 
   config.lograge.enabled = true
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
-  config.lograge.logger = ActiveSupport::Logger.new($stdout)
 
   if Rails.configuration.redis_url.present?
     config.cache_store = :redis_cache_store,

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,6 +1,13 @@
 Rails.application.configure do
-  stdout_logger = ActiveSupport::Logger.new($stdout)
-  config.lograge.logger = ActiveSupport::BroadcastLogger.new(stdout_logger, config.lograge.logger)
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+
+  # Reduce noise in the logs by ignoring the healthcheck actions
+  config.lograge.ignore_actions = %w[
+    HealthController#index
+    HealthController#ping
+  ]
+
   config.lograge.custom_options = lambda do |event|
     ex = event.payload[:exception_object]
     if ex


### PR DESCRIPTION
I've been noticing this as part of the helm work. while observing the pod logs.

We had duplicated log traces for each and all requests. Also a lot of noise due to the health checks endpoints.

Example:
```
[allocation-manager-55cd7b9cb9-75t7w allocation-manager] {"method":"GET","path":"/api/allocation/xxx","format":"html","controller":"Api::AllocationApiController","action":"show","status":200,"allocations":6394,"duration":86.33,"view":0.15,"db":1.81,"@timestamp":"2024-07-18T07:46:37.687Z","@version":"1","message":"[200] GET /api/allocation/xxx (Api::AllocationApiController#show)"}
[allocation-manager-55cd7b9cb9-75t7w allocation-manager] {"method":"GET","path":"/api/allocation/xxx","format":"html","controller":"Api::AllocationApiController","action":"show","status":200,"allocations":6394,"duration":86.33,"view":0.15,"db":1.81,"@timestamp":"2024-07-18T07:46:37.687Z","@version":"1","message":"[200] GET /api/allocation/xxx (Api::AllocationApiController#show)"}
```