### PR TITLE
Tweak ProcessDeliusDataJob audit logs

### DIFF
--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AutomaticHandoverEmailJob < ApplicationJob
-  queue_as :default
+  queue_as :mailers
+
   HEADERS = ['Prisoner', 'CRN', 'Prisoner number', 'Handover completion due', 'Release/Parole Date', 'Prison', 'Current POM', 'POM email', 'COM'].freeze
   # Turns out that between? is inclusive at both ends, so a 45-day gap needs a 44-day threshold
   SEND_THRESHOLD = 44.days.freeze

--- a/app/jobs/handover_follow_up_job.rb
+++ b/app/jobs/handover_follow_up_job.rb
@@ -1,5 +1,5 @@
 class HandoverFollowUpJob < ApplicationJob
-  queue_as :default
+  queue_as :mailers
 
   def perform(ldu)
     offenders_due_handover_follow_up = OffenderService

--- a/app/jobs/process_delius_data_job.rb
+++ b/app/jobs/process_delius_data_job.rb
@@ -97,6 +97,10 @@ private
                                     error_type: error_type(error.attribute)
         end
       end
+    else
+      logger.info(
+        "nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_delius_data_job,event=case_information_unchanged"
+      )
     end
   end
 


### PR DESCRIPTION
The `ProcessDeliusDataJob` writes to the `AuditEvent` table the before/after attributes but not just the changed ones, all of them.

This is verbose and difficult to actually see what was changed, which is necessary for a related piece of work MO-1227.

Limit the audit to only the attribute(s) that really changed.

Example:
> {"after"=>{"team_name"=>"Warrington 1"}, "before"=>{"team_name"=>"Warrington 1 test"}}

Added some additional logging to facilitate searches in Kibana.