### PR TITLE
Separate prometheus exporter service pod

### DIFF
--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -27,7 +27,7 @@ class MetricsService
   include Singleton
 
   def initialize
-    @client = ClientClass.new(host: 'localhost', port: 9394)
+    @client = ClientClass.new
   end
 
   def increment_search_count(by: 1)

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -10,8 +10,6 @@ if Rails.configuration.collect_prometheus_metrics
   # :nocov:
 else
   ClientClass = Class.new do
-    def initialize(_opts); end
-
     # rubocop:disable Style/MissingRespondToMissing
     def method_missing(_method, *_args, &_block); end
     # rubocop:enable Style/MissingRespondToMissing

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,8 +34,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # Render exception templates for rescuable exceptions and raise for other exceptions.
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/initializers/00_shoryuken_config.rb
+++ b/config/initializers/00_shoryuken_config.rb
@@ -2,6 +2,11 @@ Shoryuken.configure_server do |config|
   # NOTE: this entire block is only run by the processor, so we don't overwrite
   #       the logger when the app is running as usual.
 
+  config.server_middleware do |chain|
+    require 'prometheus_exporter/instrumentation'
+    chain.add PrometheusExporter::Instrumentation::Shoryuken
+  end
+
   Shoryuken::Logging.logger.formatter = lambda do |severity, datetime, _, msg|
     "[#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{severity.ljust(5)}: #{msg}\n"
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,7 +4,12 @@ if Rails.env.production?
     if ENV['PROMETHEUS_METRICS']&.strip == 'on'
       config.on :startup do
         require 'prometheus_exporter/instrumentation'
-        PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+        PrometheusExporter::Instrumentation::Process.start(
+          type: 'sidekiq', labels: { hostname: ENV['HOSTNAME'] }
+        )
+        PrometheusExporter::Instrumentation::SidekiqProcess.start
+        PrometheusExporter::Instrumentation::SidekiqQueue.start
+        PrometheusExporter::Instrumentation::SidekiqStats.start
       end
 
       at_exit do

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -18,7 +18,13 @@ if ENV['PROMETHEUS_METRICS']&.strip == 'on'
   after_worker_boot do
     require 'prometheus_exporter/instrumentation'
     require 'prometheus_exporter/client'
-    PrometheusExporter::Instrumentation::Puma.start
+
+    unless PrometheusExporter::Instrumentation::Puma.started?
+      PrometheusExporter::Instrumentation::Puma.start(
+        labels: { type: 'puma_worker', hostname: ENV['HOSTNAME'] }
+      )
+    end
+
     PrometheusExporter::Instrumentation::Process.start(type: 'web')
 
     PrometheusExporter::Instrumentation::ActiveRecord.start(

--- a/helm_deploy/offender-management-allocation-manager/templates/background-jobs-processor.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/background-jobs-processor.yaml
@@ -28,7 +28,7 @@ spec:
         securityContext:
           {{- with index .Values "generic-service" }}{{ toYaml .securityContext | nindent 10 }}{{ end }}
         command: ['sh', '-c', "bundle exec sidekiq -C config/sidekiq.yml"]
-          {{- include "moic-helpers.envs_without_prometheus_metrics" . | nindent 8 }}
+          {{- include "moic-helpers.envs" . | nindent 8 }}
         resources:
           {{- with index .Values "generic-service" }}{{ toYaml .resources | nindent 10 }}{{ end }}
 ---

--- a/helm_deploy/offender-management-allocation-manager/templates/domain-events-consumer.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/domain-events-consumer.yaml
@@ -28,7 +28,7 @@ spec:
         securityContext:
           {{- with index .Values "generic-service" }}{{ toYaml .securityContext | nindent 10 }}{{ end }}
         command: ['sh', '-c', 'bin/rake shoryuken:start']
-          {{- include "moic-helpers.envs_without_prometheus_metrics" . | nindent 8 }}
+          {{- include "moic-helpers.envs" . | nindent 8 }}
         resources:
           {{- with index .Values "generic-service" }}{{ toYaml .resources | nindent 10 }}{{ end }}
 ---

--- a/helm_deploy/offender-management-allocation-manager/templates/prometheus-exporter.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/prometheus-exporter.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.custom_templates_config.prometheus_exporter.enabled }}
+{{- $appName := "offender-management-prometheus-exporter" }}
+{{- $appPort := 9394 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $appName }}
+  labels:
+    app: {{ $appName }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  strategy:
+    {{- with index .Values "generic-service" }}{{ toYaml .strategy | nindent 4 }}{{ end }}
+  selector:
+    matchLabels:
+      app: {{ $appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ $appName }}
+    spec:
+      serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}
+      containers:
+      - name: {{ $appName }}
+        image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}
+        imagePullPolicy: Always
+        securityContext:
+          {{- with index .Values "generic-service" }}{{ toYaml .securityContext | nindent 10 }}{{ end }}
+        command: ['sh', '-c', 'bundle exec prometheus_exporter --bind 0.0.0.0']
+        ports:
+          - name: metrics
+            containerPort: {{ $appPort }}
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: {{ $appPort }}
+          periodSeconds: 60
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: {{ $appPort }}
+          periodSeconds: 60
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 50m
+          requests:
+            memory: 100Mi
+            cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $appName }}
+  labels:
+    app: {{ $appName }}
+spec:
+  selector:
+    app: {{ $appName }}
+  ports:
+    - port: {{ $appPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $appName }}
+  labels:
+    app: {{ $appName }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $appName }}
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $appName }}
+  labels:
+    app: {{ $appName }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appName }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: monitoring
+---
+{{- end }}

--- a/helm_deploy/offender-management-allocation-manager/values.yaml
+++ b/helm_deploy/offender-management-allocation-manager/values.yaml
@@ -11,6 +11,9 @@ custom_templates_config:
     enabled: true
   domain_events_consumer:
     enabled: true
+  prometheus_exporter:
+    enabled: true
+
   # One grafana dashboard covers all namespaces, so only needs
   # to be applied in one environment, usually `staging`
   grafana_dashboard:
@@ -83,11 +86,6 @@ generic-service:
       - prisons
       - private_prisons
 
-  custommetrics:
-    enabled: true
-    metricsPort: &metricsPort 9394
-    metricsPath: /metrics
-
   livenessProbe:
     httpGet:
       path: /health/ping
@@ -115,43 +113,6 @@ generic-service:
       memory: 500Mi
       cpu: 50m
 
-  extraContainers:
-    - name: offender-management-metrics
-      image: quay.io/hmpps/offender-management:latest
-      imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'bundle exec prometheus_exporter --bind 0.0.0.0']
-      ports:
-        - name: metrics
-          containerPort: *metricsPort
-          protocol: TCP
-      securityContext:
-        capabilities:
-          drop:
-            - ALL
-        runAsNonRoot: true
-        allowPrivilegeEscalation: false
-        seccompProfile:
-          type: RuntimeDefault
-      resources:
-        limits:
-          memory: 200Mi
-          cpu: 50m
-        requests:
-          memory: 100Mi
-          cpu: 10m
-      livenessProbe:
-        httpGet:
-          path: /ping
-          port: *metricsPort
-        initialDelaySeconds: 10
-        periodSeconds: 60
-      readinessProbe:
-        httpGet:
-          path: /ping
-          port: *metricsPort
-        initialDelaySeconds: 10
-        periodSeconds: 60
-
   # Environment variables to load into the deployment
   env:
     RAILS_ENV: production
@@ -159,6 +120,7 @@ generic-service:
     RAILS_LOG_TO_STDOUT: on
     RAILS_SERVE_STATIC_FILES: on
     PROMETHEUS_METRICS: "on" # do not remove quotes!
+    PROMETHEUS_EXPORTER_HOST: offender-management-prometheus-exporter
     USE_PPUD_PAROLE_DATA: "1"
     LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so
 


### PR DESCRIPTION
Follow-up to the helm migration we did recently. This solves a few issues found:

By using a separate service pod for the prometheus exporter, instead of sidecar containers, all other pods can submit metrics to this pod. This enables a better horizontal pod scaling strategy.

Get rid of an annoying "duplicate port definition" warning when applying the chart.

Allow us to download the tagged docker release instead of the generic "latest" (which can be dangerous if `latest` contains code not yet intended for production).

Enable shoryuken and sidekiq metrics.