### PR TITLE
Some more active job tweaks

### DIFF
--- a/app/jobs/handover_follow_up_job.rb
+++ b/app/jobs/handover_follow_up_job.rb
@@ -9,7 +9,7 @@ class HandoverFollowUpJob < ApplicationJob
     offenders_due_handover_follow_up.each do |offender|
       CommunityMailer
         .with(FollowUpEmailDetails.for(offender:))
-        .urgent_pipeline_to_community.deliver_now
+        .urgent_pipeline_to_community.deliver_later
     end
   end
 end

--- a/app/jobs/handover_follow_up_job.rb
+++ b/app/jobs/handover_follow_up_job.rb
@@ -1,8 +1,6 @@
 class HandoverFollowUpJob < ApplicationJob
   queue_as :mailers
 
-  self.log_arguments = false
-
   def perform(ldu)
     offenders_due_handover_follow_up = OffenderService
       .get_offenders(ldu.case_information.without_com.pluck(:nomis_offender_id))

--- a/app/jobs/handover_follow_up_job/follow_up_email_details.rb
+++ b/app/jobs/handover_follow_up_job/follow_up_email_details.rb
@@ -30,6 +30,12 @@ private
     pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
 
     { pom_name: pom.full_name, pom_email: pom.email_address || 'unknown' }
+  rescue StandardError => e
+    # `get_single_pom` can raise an exception if the `primary_pom_nomis_id`
+    # is not found in the list of all poms for this prison
+    Rails.logger.error(e.message)
+
+    { pom_name: 'unknown', pom_email: 'unknown' }
   end
 
   def no_active_pom_details

--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -3,8 +3,6 @@
 class RecalculateHandoverDateJob < ApplicationJob
   queue_as :default
 
-  self.log_arguments = false
-
   def perform(nomis_offender_id)
     offender = OffenderService.get_offender(nomis_offender_id)
     if offender&.inside_omic_policy?

--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -3,8 +3,6 @@
 class SuitableForEarlyAllocationEmailJob < ApplicationJob
   queue_as :mailers
 
-  self.log_arguments = false
-
   EQUIP_URL = 'https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777'
 
   def perform(offender_no)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,8 @@
 class ApplicationMailer < GovukNotifyRails::Mailer
+  # Disable logging of arguments when sending emails
+  # as they usually contain PII details
+  delivery_job.log_arguments = false
+
   before_action :store_default_tags
 
   class << self

--- a/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
+++ b/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
@@ -59,6 +59,19 @@ describe HandoverFollowUpJob::FollowUpEmailDetails, vcr: { cassette_name: "priso
       end
     end
 
+    context "when the offender has a POM allocated but is not included in the list of POMs for that prison" do
+      before { FactoryBot.create(:allocation_history, nomis_offender_id: offender.offender_no, prison: prison.code, primary_pom_nomis_id: "9999") }
+
+      it "includes fallback POM details in the email" do
+        details = described_class.for(offender:)
+
+        expect(details).to include(
+          pom_email: "unknown",
+          pom_name: "unknown",
+        )
+      end
+    end
+
     context "when the offender has no POM allocated" do
       it "does not include the POM details in the email" do
         details = described_class.for(offender:)

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -13,7 +13,7 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
   end
 
   let(:local_delivery_unit) { FactoryBot.create(:local_delivery_unit, email_address: "ldu@email.com") }
-  let(:mailer_double) { double("CommunityMailer", deliver_now: true) }
+  let(:mailer_double) { double("CommunityMailer", deliver_later: true) }
 
   before do
     allow(CommunityMailer).to receive(:with).and_return(
@@ -23,7 +23,7 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
 
   def expect_to_have_sent_email_to(offender)
     expect(CommunityMailer).to have_received(:with).with(include(nomis_offender_id: offender.nomis_offender_id, ldu_email: "ldu@email.com"))
-    expect(mailer_double).to have_received(:deliver_now)
+    expect(mailer_double).to have_received(:deliver_later)
   end
 
   def expect_not_to_have_sent_email_to(offender)


### PR DESCRIPTION
Continuation to PR #2466.

Mails use its own internal job class (`ActionMailer::MailDeliveryJob`) that also requires the `log_arguments = false`

Fallback email details when the allocated POM is not included in the list of prison POMs.