### PR TITLE
MO-1554 Handle two additional offender events

### DIFF
--- a/app/lib/domain_events/handlers/probation_change_handler.rb
+++ b/app/lib/domain_events/handlers/probation_change_handler.rb
@@ -5,7 +5,7 @@ module DomainEvents
         case event.event_type
         when /probation-case\.registration\..+/
           handle_registration_change(event, logger)
-        when 'OFFENDER_MANAGER_CHANGED'
+        when 'OFFENDER_MANAGER_CHANGED', 'OFFENDER_OFFICER_CHANGED', 'OFFENDER_DETAILS_CHANGED'
           call_delius_data_job(event, logger)
         end
       end
@@ -25,7 +25,7 @@ module DomainEvents
 
       def call_delius_data_job(event, logger)
         logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},crn=#{event.crn_number}"
-        ProcessDeliusDataJob.perform_now(event.crn_number, identifier_type: :crn, trigger_method: :event)
+        ProcessDeliusDataJob.perform_now(event.crn_number, identifier_type: :crn, trigger_method: :event, event_type: event.event_type)
         logger.info "event=domain_event_handle_success,domain_event_type=#{event.event_type},crn=#{event.crn_number}"
       end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -110,6 +110,8 @@ module OffenderManagementAllocationClient
       'probation-case.registration.updated' => 'DomainEvents::Handlers::ProbationChangeHandler',
       'tier.calculation.complete' => 'DomainEvents::Handlers::TierChangeHandler',
       'OFFENDER_MANAGER_CHANGED' => 'DomainEvents::Handlers::ProbationChangeHandler',
+      'OFFENDER_OFFICER_CHANGED' => 'DomainEvents::Handlers::ProbationChangeHandler',
+      'OFFENDER_DETAILS_CHANGED' => 'DomainEvents::Handlers::ProbationChangeHandler',
     }
   end
 end

--- a/spec/lib/domain_events/handlers/probation_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/probation_change_handler_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe DomainEvents::Handlers::ProbationChangeHandler do
 
       it 'updates case information' do
         handler.handle(event)
-        expect(ProcessDeliusDataJob).to have_received(:perform_now).with(crn, identifier_type: :crn, trigger_method: :event)
+        expect(ProcessDeliusDataJob).to have_received(:perform_now).with(
+          crn, identifier_type: :crn, trigger_method: :event, event_type:
+        )
       end
     end
 
@@ -58,7 +60,33 @@ RSpec.describe DomainEvents::Handlers::ProbationChangeHandler do
 
     it 'updates case information' do
       handler.handle(event)
-      expect(ProcessDeliusDataJob).to have_received(:perform_now).with(crn, identifier_type: :crn, trigger_method: :event)
+      expect(ProcessDeliusDataJob).to have_received(:perform_now).with(
+        crn, identifier_type: :crn, trigger_method: :event, event_type:
+      )
+    end
+  end
+
+  context 'with event type OFFENDER_OFFICER_CHANGED' do
+    let(:event_type) { 'OFFENDER_OFFICER_CHANGED' }
+    let(:additional_information) { {} }
+
+    it 'updates case information' do
+      handler.handle(event)
+      expect(ProcessDeliusDataJob).to have_received(:perform_now).with(
+        crn, identifier_type: :crn, trigger_method: :event, event_type:
+      )
+    end
+  end
+
+  context 'with event type OFFENDER_DETAILS_CHANGED' do
+    let(:event_type) { 'OFFENDER_DETAILS_CHANGED' }
+    let(:additional_information) { {} }
+
+    it 'updates case information' do
+      handler.handle(event)
+      expect(ProcessDeliusDataJob).to have_received(:perform_now).with(
+        crn, identifier_type: :crn, trigger_method: :event, event_type:
+      )
     end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1554

We are trying to reduce and possibly eliminate the need for our daily job, by listening to events and triggering the `ProcessDeliusDataJob` in real time.

So far we've reduced the batch job changed records by half what it used to be, but ideally we want to make the batch job obsolete and this is kind of exploratory work to see if we can use additional events to update these records in real time and not having to wait for the daily batch job to run and update them.