### PR TITLE
MO-1098 Fix illogical heading structure (a11y)

### DIFF
--- a/app/views/application/_dashboard_partition.html.erb
+++ b/app/views/application/_dashboard_partition.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-column-one-third card-group__item">
   <div class="card card--clickable">
-    <h1 class="govuk-heading-m card__heading">
-      <%= link_to title, link, class:"govuk-link card__link" %>
-    </h1>
-    <p class="govuk-body card__description"><%=content%></p>
+    <h3 class="govuk-heading-m card__heading">
+      <%= link_to title, link, class: %w[govuk-link govuk-link--no-visited-state card__link] %>
+    </h3>
+    <p class="govuk-body card__description"><%= content %></p>
   </div>
 </div>

--- a/app/views/layouts/_caseload.html.erb
+++ b/app/views/layouts/_caseload.html.erb
@@ -1,4 +1,6 @@
-<h2 class="govuk-heading-xl govuk-!-margin-bottom-6">Caseload</h2>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+  Caseload
+</h1>
 <%= render "search/search_box" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/poms/_overview_tab.html.erb
+++ b/app/views/poms/_overview_tab.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Overview</h1>
+    <h2 class="govuk-heading-l">Overview</h2>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">Current workload</h2>
+        <h3 class="govuk-heading-m">Current workload</h3>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-<%= USE_PPUD_PAROLE_DATA ? 'third' : 'half' %>">
             <div class="card--caseload card-total">

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -21,11 +21,11 @@ feature 'Navigation' do
       end
 
       it 'has a help tile' do
-        expect(page).to have_css('h1.card__heading a', text: 'Get help with this service')
+        expect(page).to have_css('h3.card__heading a', text: 'Get help with this service')
       end
 
       it 'has a parole tile' do
-        expect(page).to have_css('h1.card__heading a', text: 'Parole cases')
+        expect(page).to have_css('h3.card__heading a', text: 'Parole cases')
       end
     end
 
@@ -40,11 +40,11 @@ feature 'Navigation' do
       end
 
       it 'has a help tile' do
-        expect(page).to have_css('h1.card__heading a', text: 'Get help with this service')
+        expect(page).to have_css('h3.card__heading a', text: 'Get help with this service')
       end
 
       it 'has a parole tile' do
-        expect(page).to have_css('h1.card__heading a', text: 'Parole cases')
+        expect(page).to have_css('h3.card__heading a', text: 'Parole cases')
       end
     end
 

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -81,7 +81,7 @@ feature "staff pages" do
     end
 
     it "has a heading" do
-      expect(page).to have_css('h1', text: 'Overview')
+      expect(page).to have_css('h2', text: 'Overview')
     end
 
     it "has 4 sub-navigation tab links" do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1098

A few pages were using an illogical heading structure, including repeated H1's and non-sequential subheadings.