### PR TITLE
MO-1550 Update govuk_notify_rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,7 @@ gem 'coffee-rails', '~> 5.0'
 gem 'date_validator'
 gem 'faraday', '~> 1.10.3'
 gem 'net-http' # needed to undo a conflict with system libs
-gem 'govuk_notify_rails'
-# we need the extra is_csv parameter available in 5.2 and above
-# TODO: update code to work with latest version
-gem 'notifications-ruby-client', '>= 5.2', '< 6.0.0'
+gem 'govuk_notify_rails', '~> 3.0.0'
 gem 'govuk_design_system_formbuilder', '~> 2.5'
 gem 'json-schema', '~> 4.0'
 gem 'jsonb_accessor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activeadmin (3.2.2)
+    activeadmin (3.2.3)
       arbre (~> 1.2, >= 1.2.1)
       csv
       formtastic (>= 3.1)
@@ -95,8 +95,8 @@ GEM
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
     aws-eventstream (1.3.0)
-    aws-partitions (1.960.0)
-    aws-sdk-core (3.201.3)
+    aws-partitions (1.962.0)
+    aws-sdk-core (3.201.4)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
@@ -117,7 +117,7 @@ GEM
     bigdecimal (3.1.8)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
-    bootsnap (1.18.3)
+    bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (6.1.2)
       racc
@@ -135,7 +135,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (5.0.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -218,8 +219,8 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
-    govuk_notify_rails (2.2.0)
-      notifications-ruby-client (~> 5.1)
+    govuk_notify_rails (3.0.0)
+      notifications-ruby-client (~> 6.2)
       rails (>= 4.1.0)
     guard (2.18.1)
       formatador (>= 0.2.4)
@@ -241,7 +242,7 @@ GEM
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
-    hashdiff (1.1.0)
+    hashdiff (1.1.1)
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -340,7 +341,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    notifications-ruby-client (5.4.0)
+    notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -358,10 +359,10 @@ GEM
     paper_trail (15.1.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
-    parallel (1.25.1)
+    parallel (1.26.1)
     parallel_tests (4.7.1)
       parallel
-    parser (3.3.4.0)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     pdf-core (0.10.0)
@@ -669,7 +670,7 @@ DEPENDENCIES
   fast_underscore
   flamegraph
   govuk_design_system_formbuilder (~> 2.5)
-  govuk_notify_rails
+  govuk_notify_rails (~> 3.0.0)
   guard-rspec
   guard-rubocop
   hashdiff (>= 1.0.0.beta1, < 2.0.0)
@@ -686,7 +687,6 @@ DEPENDENCIES
   memory_profiler
   mutex_m
   net-http
-  notifications-ruby-client (>= 5.2, < 6.0.0)
   omniauth (~> 1.9.2)
   omniauth-oauth2
   paper_trail (~> 15.1.0)

--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -35,10 +35,10 @@ class AutomaticHandoverEmailJob < ApplicationJob
           end
         end
         # deliver_now - this is all we are doing, so we want the whole job to repeat if it fails
-        CommunityMailer.with(ldu_name: ldu.name, ldu_email: ldu.email_address, csv_data: csv_data).pipeline_to_community.deliver_now
+        CommunityMailer.with(ldu:, csv_data:).pipeline_to_community.deliver_now
         logger.info "event=ldu_handover_email_with_csv,ldu_code=#{ldu.code},offender_count=#{offenders.size}|Email sent to LDU with CSV"
       else
-        CommunityMailer.with(ldu_name: ldu.name, ldu_email: ldu.email_address).pipeline_to_community_no_handovers.deliver_now
+        CommunityMailer.with(ldu:).pipeline_to_community_no_handovers.deliver_now
         logger.info "event=ldu_handover_email_no_csv,ldu_code=#{ldu.code}|Email sent to LDU no CSV"
       end
     end

--- a/app/lib/audit_events_mail_observer.rb
+++ b/app/lib/audit_events_mail_observer.rb
@@ -17,8 +17,13 @@ class AuditEventsMailObserver
   end
 
   class AuditDetails < SimpleDelegator
-    def personalisation = govuk_notify_personalisation
     def template = govuk_notify_template
+
+    def personalisation
+      Hash(govuk_notify_personalisation).tap do |hash|
+        hash.deep_merge!(link_to_document: { file: 'REDACTED' }) if hash.key?(:link_to_document)
+      end
+    end
 
     def tags
       tags = String(govuk_notify_reference).split('.')

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -3,17 +3,25 @@
 class CommunityMailer < ApplicationMailer
   def pipeline_to_community
     set_template('6e2f7565-a0e3-4fd7-b814-ee9dd5148924')
-    set_personalisation(ldu_name: params.fetch(:ldu_name),
-                        link_to_document: Notifications.prepare_upload(StringIO.new(params.fetch(:csv_data)), true))
 
-    mail(to: params.fetch(:ldu_email))
+    ldu = params.fetch(:ldu)
+
+    filename = "community_allocation_cases_#{ldu.code}.csv"
+    link_to_document = Notifications.prepare_upload(StringIO.new(params[:csv_data]), filename:)
+
+    set_personalisation(ldu_name: ldu.name, link_to_document:)
+
+    mail(to: ldu.email_address)
   end
 
   def pipeline_to_community_no_handovers
     set_template('bac3628c-aabe-4043-af11-147467720e04')
-    set_personalisation(ldu_name: params.fetch(:ldu_name))
 
-    mail(to: params.fetch(:ldu_email))
+    ldu = params.fetch(:ldu)
+
+    set_personalisation(ldu_name: ldu.name)
+
+    mail(to: ldu.email_address)
   end
 
   def urgent_pipeline_to_community

--- a/app/mailers/early_allocation_mailer.rb
+++ b/app/mailers/early_allocation_mailer.rb
@@ -3,8 +3,11 @@
 class EarlyAllocationMailer < ApplicationMailer
   def auto_early_allocation
     set_template('dfaeb1b1-26c3-4646-8ef4-1f0ebd18e2e7')
-    params[:link_to_document] = Notifications.prepare_upload(StringIO.new(params[:pdf]))
+
+    filename = "early_allocation_assessment_approved_#{params[:prisoner_number]}.pdf"
+    params[:link_to_document] = Notifications.prepare_upload(StringIO.new(params[:pdf]), filename:)
     params[:pom_email_address] = params.fetch(:pom_email)
+
     set_personalisation(**params.slice(:prisoner_name, :prisoner_number, :pom_name, :pom_email_address, :prison_name,
                                        :link_to_document))
 
@@ -13,8 +16,11 @@ class EarlyAllocationMailer < ApplicationMailer
 
   def community_early_allocation
     set_template('5e546d65-57ff-49e1-8fae-c955a7b1da80')
-    params[:link_to_document] = Notifications.prepare_upload(StringIO.new(params.fetch(:pdf)))
+
+    filename = "early_allocation_assessment_review_#{params[:prisoner_number]}.pdf"
+    params[:link_to_document] = Notifications.prepare_upload(StringIO.new(params[:pdf]), filename:)
     params[:pom_email_address] = params.fetch(:pom_email)
+
     set_personalisation(**params.slice(:prisoner_name, :prisoner_number, :pom_name, :pom_email_address, :prison_name,
                                        :link_to_document))
 

--- a/spec/jobs/automatic_handover_email_job_spec.rb
+++ b/spec/jobs/automatic_handover_email_job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
              pipeline_to_community_no_handovers: mail_instance)
     end
 
-    context 'when it finds handovers' do
+    context 'when it finds LDU offenders and there are handovers' do
       let(:mpc_offenders) do
         [
           double(MpcOffender, prison_id: prison_code, sentenced?: true,
@@ -90,11 +90,21 @@ RSpec.describe AutomaticHandoverEmailJob, type: :job do
 
       it 'sends email with CSV' do
         expect(CommunityMailer).to have_received(:with)
-          .with(ldu_name: 'X', ldu_email: 'x@x.com', csv_data: anything)
+          .with(ldu:, csv_data: anything)
       end
     end
 
-    context 'when it finds no handovers' do
+    context 'when it finds LDU offenders but none are handovers' do
+      let(:mpc_offenders) do
+        [double(MpcOffender, prison_id: prison_code, sentenced?: false)]
+      end
+
+      it 'sends email without CSV' do
+        expect(CommunityMailer).to have_received(:with).with(ldu:)
+      end
+    end
+
+    context 'when the LDU is empty with no offenders' do
       let(:mpc_offenders) { [] }
 
       it 'sends no email' do

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe CommunityMailer, type: :mailer do
       ).to include(
         ldu_name: ldu.name,
         link_to_document: hash_including(
+          file: a_kind_of(String),
           filename: "community_allocation_cases_#{ldu.code}.csv",
           confirm_email_before_download: nil,
           retention_period: nil

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -54,29 +54,30 @@ RSpec.describe CommunityMailer, type: :mailer do
   end
 
   describe '#pipeline_to_community' do
-    subject { described_class.with(**params).pipeline_to_community }
+    subject { described_class.with(ldu:, csv_data: 'Comma, Separated, Values').pipeline_to_community }
 
     let(:ldu) { build(:local_delivery_unit) }
-
-    let(:params) do
-      {
-        ldu_name: ldu.name,
-        ldu_email: ldu.email_address,
-        csv_data: "Comma, Separated, Values"
-      }
-    end
 
     it 'sends to the LDU email address' do
       expect(subject.to).to eq([ldu.email_address])
     end
 
-    it 'sets the LDU name' do
-      expect(subject.govuk_notify_personalisation).to include(ldu_name: ldu.name)
+    it 'sets the personalisation' do
+      expect(
+        subject.govuk_notify_personalisation
+      ).to include(
+        ldu_name: ldu.name,
+        link_to_document: hash_including(
+          filename: "community_allocation_cases_#{ldu.code}.csv",
+          confirm_email_before_download: nil,
+          retention_period: nil
+        )
+      )
     end
   end
 
   describe '#pipeline_to_community_no_handovers' do
-    subject { described_class.with(ldu_name: ldu.name, ldu_email: ldu.email_address).pipeline_to_community_no_handovers }
+    subject { described_class.with(ldu:).pipeline_to_community_no_handovers }
 
     let(:ldu) { build(:local_delivery_unit) }
 

--- a/spec/mailers/early_allocation_mailer_spec.rb
+++ b/spec/mailers/early_allocation_mailer_spec.rb
@@ -45,8 +45,41 @@ RSpec.describe EarlyAllocationMailer, type: :mailer do
       }
     end
 
-    before do
-      allow(Notifications).to receive(:prepare_upload)
+    it 'sets the To address of the email using the provided user' do
+      expect(mail.to).to eq(['to@example.com'])
+    end
+
+    it 'personalises the email' do
+      expect(
+        mail.govuk_notify_personalisation
+      ).to include(
+        prisoner_name: 'TESTNAME',
+        prisoner_number: '1111',
+        pom_name: 'POMNAME',
+        pom_email_address: 'pom@example.com',
+        prison_name: 'PRISONMAME',
+        link_to_document: hash_including(
+          filename: "early_allocation_assessment_review_#{params[:prisoner_number]}.pdf",
+          confirm_email_before_download: nil,
+          retention_period: nil
+        )
+      )
+    end
+  end
+
+  describe 'auto_early_allocation' do
+    subject(:mail) { described_class.with(**params).auto_early_allocation }
+
+    let(:params) do
+      {
+        prisoner_name: 'TESTNAME',
+        prisoner_number: '1111',
+        pom_name: 'POMNAME',
+        pom_email: 'pom@example.com',
+        prison_name: 'PRISONMAME',
+        email: 'to@example.com',
+        pdf: 'FAKEPDF',
+      }
     end
 
     it 'sets the To address of the email using the provided user' do
@@ -54,11 +87,20 @@ RSpec.describe EarlyAllocationMailer, type: :mailer do
     end
 
     it 'personalises the email' do
-      expect(mail.govuk_notify_personalisation).to include(prisoner_name: 'TESTNAME',
-                                                           prisoner_number: '1111',
-                                                           pom_name: 'POMNAME',
-                                                           pom_email_address: 'pom@example.com',
-                                                           prison_name: 'PRISONMAME')
+      expect(
+        mail.govuk_notify_personalisation
+      ).to include(
+        prisoner_name: 'TESTNAME',
+        prisoner_number: '1111',
+        pom_name: 'POMNAME',
+        pom_email_address: 'pom@example.com',
+        prison_name: 'PRISONMAME',
+        link_to_document: hash_including(
+          filename: "early_allocation_assessment_approved_#{params[:prisoner_number]}.pdf",
+          confirm_email_before_download: nil,
+          retention_period: nil
+        )
+      )
     end
   end
 end

--- a/spec/mailers/early_allocation_mailer_spec.rb
+++ b/spec/mailers/early_allocation_mailer_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe EarlyAllocationMailer, type: :mailer do
         pom_email_address: 'pom@example.com',
         prison_name: 'PRISONMAME',
         link_to_document: hash_including(
+          file: a_kind_of(String),
           filename: "early_allocation_assessment_review_#{params[:prisoner_number]}.pdf",
           confirm_email_before_download: nil,
           retention_period: nil
@@ -96,6 +97,7 @@ RSpec.describe EarlyAllocationMailer, type: :mailer do
         pom_email_address: 'pom@example.com',
         prison_name: 'PRISONMAME',
         link_to_document: hash_including(
+          file: a_kind_of(String),
           filename: "early_allocation_assessment_approved_#{params[:prisoner_number]}.pdf",
           confirm_email_before_download: nil,
           retention_period: nil


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1550

Make code compatible with latest version of the `notifications-ruby-client` (which is a transitive dependency of the `govuk_notify_rails` gem), and was stopping us from updating these dependencies.