### PR TITLE
Fix additional ISP logic

### DIFF
--- a/app/domains/offender_handover.rb
+++ b/app/domains/offender_handover.rb
@@ -16,7 +16,7 @@ private
       CalculatedHandoverDate.new(responsibility: com, reason: :parole_mappa_2_3)
     elsif parole_outcome_not_release? && thd_12_or_more_months_from_now? && mappa_level.in?([nil, 1])
       CalculatedHandoverDate.new(responsibility: pom_with_com, reason: :thd_over_12_months)
-    elsif sentences.multiple_indeterminate_sentences?
+    elsif sentences.sentenced_to_additional_future_isp?
       CalculatedHandoverDate.new(responsibility: pom_only, reason: :additional_isp)
     end
   end

--- a/app/domains/offenders/sentences.rb
+++ b/app/domains/offenders/sentences.rb
@@ -7,8 +7,9 @@ class Offenders::Sentences
     sentences.count == 1
   end
 
-  def multiple_indeterminate_sentences?
-    sentences.select(&:indeterminate?).count > 1
+  def sentenced_to_additional_future_isp?
+    isp_start_dates = sentences.select(&:indeterminate?).map(&:sentence_start_date)
+    isp_start_dates.count > 1 && isp_start_dates.last > isp_start_dates.first
   end
 
   def concurrent_sentence_of_12_months_or_under?

--- a/spec/domains/offender_handover_spec.rb
+++ b/spec/domains/offender_handover_spec.rb
@@ -78,7 +78,7 @@ describe OffenderHandover do
       end
 
       context 'when offender is sentenced to an additional ISP' do
-        let(:sentences) { double(multiple_indeterminate_sentences?: true) }
+        let(:sentences) { double(sentenced_to_additional_future_isp?: true) }
 
         it 'is POM responsible as additional_isp' do
           expect(subject).to be_pom_responsible

--- a/spec/domains/offenders/sentences_spec.rb
+++ b/spec/domains/offenders/sentences_spec.rb
@@ -7,17 +7,37 @@ describe Offenders::Sentences do
 
   before { allow(Sentences).to receive(:for).with(booking_id: 123_456).and_return(sentence_sequences) }
 
-  describe "#multiple_indeterminate_sentences?" do
-    context 'when there is more than one indeterminate sentence' do
-      let(:sentence_sequences) { [double(indeterminate?: true), double(indeterminate?: true)] }
+  describe "#sentenced_to_additional_future_isp?" do
+    context 'when there is more than one indeterminate sentence but they have the same start date' do
+      let(:sentence_sequences) { [double(indeterminate?: true, sentence_start_date: 1.year.ago.beginning_of_day), double(indeterminate?: true, sentence_start_date: 1.year.ago.beginning_of_day)] }
 
-      it 'returns true' do
-        expect(sentences.multiple_indeterminate_sentences?).to be_truthy
+      it 'returns false' do
+        expect(sentences.sentenced_to_additional_future_isp?).to be_falsey
       end
     end
 
-    it 'returns false' do
-      expect(sentences.multiple_indeterminate_sentences?).to be_falsey
+    context 'when there is more than one indeterminate sentence and they have different start dates' do
+      let(:sentence_sequences) { [double(indeterminate?: true, sentence_start_date: 2.years.ago), double(indeterminate?: true, sentence_start_date: 1.year.ago)] }
+
+      it 'returns true' do
+        expect(sentences.sentenced_to_additional_future_isp?).to be_truthy
+      end
+    end
+
+    context 'when there is one ISP sentence' do
+      let(:sentence_sequences) { [double(indeterminate?: true, sentence_start_date: 1.day.ago)] }
+
+      it 'returns false' do
+        expect(sentences.sentenced_to_additional_future_isp?).to be_falsey
+      end
+    end
+
+    context 'when there are no ISP sentences' do
+      let(:sentence_sequences) { [double(indeterminate?: false, sentence_start_date: 1.day.ago)] }
+
+      it 'returns false' do
+        expect(sentences.sentenced_to_additional_future_isp?).to be_falsey
+      end
     end
   end
 


### PR DESCRIPTION
My previous change introduced a bug where multiple sentences with the same start date were being classed as "additional ISPs" when only ISPs that are at different dates should be used.