### PR TITLE
MO-1490 Cleanup PPUD feat-flag leftovers

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,8 +17,6 @@ TIERING_API_HOST="https://hmpps-tier-dev.hmpps.service.justice.gov.uk"
 
 PROMETHEUS_METRICS=off
 
-USE_PPUD_PAROLE_DATA=1
-
 # These lines enable localstack support and allow publishing of domain events to a fake SNS topic
 AWS_PROFILE=local
 DOMAIN_EVENTS_SQS_QUEUE_NAME='domain-events'

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -71,9 +71,4 @@ private
     params.require(:case_information)
       .permit(:nomis_offender_id, :tier, :enhanced_resourcing)
   end
-
-  def target_hearing_date_params
-    params.require(:target_hearing_date_form)
-      .permit(:target_hearing_date)
-  end
 end

--- a/app/domains/offender_handover.rb
+++ b/app/domains/offender_handover.rb
@@ -10,7 +10,7 @@ class OffenderHandover < SimpleDelegator
 private
 
   def indeterminate_sentences
-    return unless USE_PPUD_PAROLE_DATA && indeterminate_sentence?
+    return unless indeterminate_sentence?
 
     if parole_outcome_not_release? && thd_12_or_more_months_from_now? && mappa_level.in?([2, 3])
       CalculatedHandoverDate.new(responsibility: com, reason: :parole_mappa_2_3)

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -482,8 +482,7 @@ private
     # We don't want the task to be created if there's no parole review, if the
     # most recent parole review is yet to have a hearing outcome, or if there is
     # already a date that the hearing outcome was received.
-    if USE_PPUD_PAROLE_DATA &&
-      most_recent_parole_review.present? &&
+    if most_recent_parole_review.present? &&
       !most_recent_parole_review.no_hearing_outcome? &&
       most_recent_parole_review.hearing_outcome_received_on.blank?
       tasks << PomTask.new(self, :parole_outcome_date, most_recent_parole_review.review_id)

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -50,7 +50,7 @@ class Offender < ApplicationRecord
     (handover_progress_checklist || build_handover_progress_checklist).task_completion_data
   end
 
-  # Returns the most recent parole record (can be a future parole application), regardless of activity status and outcome.
+  # Returns the most recent parole review (can be a future parole application), regardless of activity status and outcome.
   def most_recent_parole_review
     @most_recent_parole_review ||= parole_reviews.ordered_by_sortable_date.to_a.last
   end
@@ -60,7 +60,7 @@ class Offender < ApplicationRecord
     most_recent_parole_review.no_hearing_outcome? ? most_recent_parole_review : nil
   end
 
-  # Returns the most recent parole record that has an outcome
+  # Returns the most recent parole review that has an outcome
   def most_recent_completed_parole_review
     @most_recent_completed_parole_review ||= parole_reviews.ordered_by_sortable_date.with_hearing_outcome.to_a.last
   end
@@ -75,13 +75,13 @@ class Offender < ApplicationRecord
     @previous_parole_reviews
   end
 
-  # @current_parole_review is the most recent parole record and will either be
+  # @current_parole_review is the most recent parole review and will either be
   # currently active, or will have had its hearing outcome within the last 14 days
   #
-  # @previous_parole_reviews are all other parole records, those that are inactive
+  # @previous_parole_reviews are all other parole reviews, those that are inactive
   # and/or had hearing outcomes more than 14 days ago.
   #
-  # There are situations where parole records will be inactive and not have
+  # There are situations where parole reviews will be inactive and not have
   # hearing outcomes.
   def build_parole_review_sections
     @parole_review_sections_built = true

--- a/app/models/parole_record.rb
+++ b/app/models/parole_record.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
+# TODO: this table is no longer used as we've moved to use
+# PPUD parole data imports that creates `ParoleReview`
+# records instead. It's still used in the SAR endpoint tho.
+#
+# TBD when is a good time to cleanup DB table and leftovers.
+#
 class ParoleRecord < ApplicationRecord
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
 
   belongs_to :offender, foreign_key: :nomis_offender_id, inverse_of: :parole_record
-
-  validates :parole_review_date, presence: true
-
-  def target_hearing_date
-    parole_review_date
-  end
 end

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -83,14 +83,13 @@
 
   <%= render partial: 'shared/offence_info' %>
 
-  <% if USE_PPUD_PAROLE_DATA %>
-    <% if @prisoner.display_current_parole_info? %>
-      <%= render partial: 'shared/parole_info' %>
-    <% end %>
-    <% if @prisoner.previous_parole_reviews.any? %>
-      <%= render partial: 'shared/historical_parole' %>
-    <% end %>
+  <% if @prisoner.display_current_parole_info? %>
+    <%= render partial: 'shared/parole_info' %>
   <% end %>
+
+  <% if @prisoner.previous_parole_reviews.any? %>
+    <%= render partial: 'shared/historical_parole' %>
+  <% end%>
 
   <table class="govuk-table">
     <tbody class="govuk-table__body">

--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -9,7 +9,7 @@
         <h3 class="govuk-heading-m govuk-!-margin-top-2">Current workload</h3>
         <div class="govuk-grid-row">
 
-          <div class="govuk-grid-column-one-<%= USE_PPUD_PAROLE_DATA ? 'third' : 'half' %>">
+          <div class="govuk-grid-column-one-third">
             <div class="card--caseload card-total">
               <%= link_to prison_staff_caseload_cases_path, class: 'govuk-link--no-visited-state' do %>
                 <span class="card__heading--large"><%= @summary.fetch(:total_cases) %></span>
@@ -17,19 +17,17 @@
               <% end %>
             </div>
           </div>
-          <div class="govuk-grid-column-one-<%= USE_PPUD_PAROLE_DATA ? 'third' : 'half' %>">
+          <div class="govuk-grid-column-one-third">
             <%= render 'caseload_global/upcoming_handovers_card', with_link: true %>
           </div>
-          <% if USE_PPUD_PAROLE_DATA %>
-            <div class="govuk-grid-column-one-third">
-              <div class="card--caseload card-total">
-                <%= link_to prison_staff_caseload_parole_cases_path, class: 'govuk-link--no-visited-state' do %>
-                  <span class="card__heading--large"><%= @summary.fetch(:parole_cases_count) %></span>
-                  <p>parole cases</p>
-                <% end %>
-              </div>
+          <div class="govuk-grid-column-one-third">
+            <div class="card--caseload card-total">
+              <%= link_to prison_staff_caseload_parole_cases_path, class: 'govuk-link--no-visited-state' do %>
+                <span class="card__heading--large"><%= @summary.fetch(:parole_cases_count) %></span>
+                <p>parole cases</p>
+              <% end %>
             </div>
-          <% end %>
+          </div>
         </div>
 
         <div class="govuk-grid-column-row">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -48,13 +48,11 @@
                content: "Track the progress of cases being handed over to the community probation team."
     %>
 
-    <% if USE_PPUD_PAROLE_DATA %>
-      <%= render 'dashboard_partition',
-                 title: "Parole cases",
-                 link: prison_parole_cases_path(@prison.code),
-                 content: t('parole.upcoming.spo')
-      %>
-    <% end %>
+    <%= render 'dashboard_partition',
+               title: "Parole cases",
+               link: prison_parole_cases_path(@prison.code),
+               content: t('parole.upcoming.spo')
+    %>
 
     <%= render 'dashboard_partition',
                title: "Newly arrived cases",
@@ -106,13 +104,11 @@
   </div>
 
   <div class="govuk-grid-row card-group">
-    <% if USE_PPUD_PAROLE_DATA %>
-      <%= render 'dashboard_partition',
-                 title: 'Parole cases',
-                 link: prison_staff_caseload_parole_cases_path(@prison.code, @staff_id),
-                 content: t('parole.upcoming.pom')
-      %>
-    <% end %>
+    <%= render 'dashboard_partition',
+               title: 'Parole cases',
+               link: prison_staff_caseload_parole_cases_path(@prison.code, @staff_id),
+               content: t('parole.upcoming.pom')
+    %>
 
     <%= render 'dashboard_partition',
                title: "Case updates needed",

--- a/app/views/help/case_responsibility.html.erb
+++ b/app/views/help/case_responsibility.html.erb
@@ -58,19 +58,6 @@
       <li>make sure parole cases have a PED or TED</li>
     </ul>
     <p></p>
-    <% unless USE_PPUD_PAROLE_DATA %>
-      <p>If a PED or TED has passed, the POM allocated to the case will need to:</p>
-      <p></p>
-      <ul class="govuk-list govuk-list--number">
-        <li>
-          select the prisoner’s name from the
-          <a class="govuk-link govuk-link--no-visited-state" href="<%= @case_updates_path %>">Case updates needed</a>
-          page of the service
-        </li>
-        <li>enter a new parole hearing date</li>
-      </ul>
-      <p></p>
-    <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       Changing responsibility

--- a/app/views/layouts/_caseload.html.erb
+++ b/app/views/layouts/_caseload.html.erb
@@ -19,15 +19,13 @@
                       aria: { current: current_page?(controller: :caseload, action: 'cases') ? 'page' : '' }
           %>
         </li>
-        <% if USE_PPUD_PAROLE_DATA %>
-          <li class="moj-sub-navigation__item">
-            <%= link_to "Parole cases (#{@summary.fetch(:parole_cases_count)})",
-                        { controller: :caseload, action: :parole_cases},
-                        class: "moj-sub-navigation__link govuk-link--no-visited-state",
-                        aria: { current: current_page?(controller: :caseload, action: 'parole_cases') ? 'page' : '' }
-            %>
-          </li>
-        <% end %>
+        <li class="moj-sub-navigation__item">
+          <%= link_to "Parole cases (#{@summary.fetch(:parole_cases_count)})",
+                      { controller: :caseload, action: :parole_cases},
+                      class: "moj-sub-navigation__link govuk-link--no-visited-state",
+                      aria: { current: current_page?(controller: :caseload, action: 'parole_cases') ? 'page' : '' }
+          %>
+        </li>
         <li class="moj-sub-navigation__item">
           <%= link_to "Case updates needed (#{@summary.fetch(:pending_task_count)})",
                       { controller: :caseload, action: 'updates_required' },

--- a/app/views/layouts/_primary_navigation.html.erb
+++ b/app/views/layouts/_primary_navigation.html.erb
@@ -19,9 +19,7 @@
           <% end %>
 
           <% if @is_spo %>
-            <% if USE_PPUD_PAROLE_DATA %>
-              <%= render 'layouts/controller_nav_link', text: 'Parole', path: prison_parole_cases_path(@prison.code), controllers: {} %>
-            <% end %>
+            <%= render 'layouts/controller_nav_link', text: 'Parole', path: prison_parole_cases_path(@prison.code), controllers: {} %>
             <%= render 'layouts/controller_nav_link', text: 'Handover', path: upcoming_prison_handovers_path(@prison.code), controllers: { handovers: [] } %>
             <%= render 'layouts/controller_nav_link', text: 'Staff', path: prison_poms_path(@prison.code), controllers: { poms: [] } %>
           <% else %>

--- a/app/views/poms/_overview_tab.html.erb
+++ b/app/views/poms/_overview_tab.html.erb
@@ -5,7 +5,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h3 class="govuk-heading-m">Current workload</h3>
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-<%= USE_PPUD_PAROLE_DATA ? 'third' : 'half' %>">
+          <div class="govuk-grid-column-one-third">
             <div class="card--caseload card-total">
               <%= link_to prison_show_pom_tab_path(@prison.code, @pom.staff_id, :caseload) do %>
                 <span class="card__heading--large"><%= @summary.fetch(:total_cases) %></span>
@@ -13,19 +13,17 @@
               <% end %>
             </div>
           </div>
-          <div class="govuk-grid-column-one-<%= USE_PPUD_PAROLE_DATA ? 'third' : 'half' %>">
+          <div class="govuk-grid-column-one-third">
             <%= render 'caseload_global/in_progress_handovers_card', with_link: true %>
           </div>
-          <% if USE_PPUD_PAROLE_DATA %>
-            <div class="govuk-grid-column-one-third">
-              <div class="card--caseload card-total">
-                <%= link_to prison_show_pom_tab_path(@prison.code, @pom.staff_id, :parole) do %>
-                  <span class="card__heading--large"><%= @summary.fetch(:parole_cases_count) %></span>
-                  <p>parole cases</p>
-                <% end %>
-              </div>
+          <div class="govuk-grid-column-one-third">
+            <div class="card--caseload card-total">
+              <%= link_to prison_show_pom_tab_path(@prison.code, @pom.staff_id, :parole) do %>
+                <span class="card__heading--large"><%= @summary.fetch(:parole_cases_count) %></span>
+                <p>parole cases</p>
+              <% end %>
             </div>
-          <% end %>
+          </div>
         </div>
         <div class="govuk-grid-column-row">
           <h3 class="govuk-heading-m govuk-!-margin-top-8">

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -30,16 +30,14 @@
         <%= link_to "Handover cases (#{@summary[:in_progress_handover_count]})", prison_show_pom_tab_path(@prison.code, @pom.staff_id, :handover), class: 'moj-sub-navigation__link' %>
       <% end %>
     </li>
-    <% if USE_PPUD_PAROLE_DATA %>
-      <li class="moj-sub-navigation__item">
-        <% link_text = "Parole (#{@summary[:parole_cases_count]})" %>
-        <% if @tab == 'parole' %>
-          <%= link_to link_text, prison_show_pom_tab_path(@prison.code, @pom.staff_id, :parole), class: 'moj-sub-navigation__link', aria: { current: "page" } %>
-        <% else %>
-          <%= link_to link_text, prison_show_pom_tab_path(@prison.code, @pom.staff_id, :parole), class: 'moj-sub-navigation__link' %>
-        <% end %>
-      </li>
-    <% end %>
+    <li class="moj-sub-navigation__item">
+      <% link_text = "Parole (#{@summary[:parole_cases_count]})" %>
+      <% if @tab == 'parole' %>
+        <%= link_to link_text, prison_show_pom_tab_path(@prison.code, @pom.staff_id, :parole), class: 'moj-sub-navigation__link', aria: { current: "page" } %>
+      <% else %>
+        <%= link_to link_text, prison_show_pom_tab_path(@prison.code, @pom.staff_id, :parole), class: 'moj-sub-navigation__link' %>
+      <% end %>
+    </li>
   </ul>
 </nav>
 
@@ -47,7 +45,7 @@
   <%= render 'caseload_tab' %>
 <% elsif @tab == 'handover' %>
   <%= render 'handover_tab' %>
-<% elsif USE_PPUD_PAROLE_DATA && @tab == 'parole'%>
+<% elsif @tab == 'parole'%>
   <%= render 'parole_tab' %>
 <% else %>
   <%= render 'overview_tab' %>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -80,16 +80,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <%= render 'prisoner_information' %>
+
     <%= render partial: 'shared/offence_info' %>
 
-    <% if USE_PPUD_PAROLE_DATA %>
-      <% if @prisoner.current_parole_review.present? %>
-        <%= render 'shared/parole_info' %>
-      <% end %>
+    <% if @prisoner.display_current_parole_info? %>
+      <%= render partial: 'shared/parole_info' %>
+    <% end %>
 
-      <% if @prisoner.previous_parole_reviews.any? %>
-        <%= render 'shared/historical_parole' %>
-      <% end%>
+    <% if @prisoner.previous_parole_reviews.any? %>
+      <%= render partial: 'shared/historical_parole' %>
     <% end%>
 
     <%= render 'prison_allocation' %>

--- a/app/views/shared/_parole_info.html.erb
+++ b/app/views/shared/_parole_info.html.erb
@@ -18,7 +18,7 @@
     <% end %>
     <% if @prisoner.parole_eligibility_date.present? %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-!-width-one-half">Parole Eligibility Date</td>
+        <td class="govuk-table__cell govuk-!-width-one-half">Parole eligibility date</td>
         <td id='parole-eligibility-date' class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half"><%= format_date(@prisoner.parole_eligibility_date) %></td>
       </tr>
     <% end %>

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,4 +1,2 @@
 # Feature Flags - super simple, they are just constants - it works
 # USE_FEATURE = ENV.fetch('USE_FEATURE', '').strip == '1'
-
-USE_PPUD_PAROLE_DATA = ENV.fetch('USE_PPUD_PAROLE_DATA', '').strip == '1'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,12 +59,6 @@ en:
   activemodel:
     errors:
       models:
-        target_hearing_date_form:
-          format: "%{message}"
-          attributes:
-            target_hearing_date:
-              date_after: The new target hearing date must be in the future
-              blank: Enter a new target hearing date
         complexity_form:
           format: "%{message}"
           attributes:
@@ -177,8 +171,6 @@ en:
         ldu_uncontactable: "We can’t automatically contact the LDU because their details are missing. You need to find an alternative way of contacting them."
   helpers:
     fieldset:
-      case_information:
-        target_hearing_date: "What is the next target hearing date?"
       early_allocation:
         oasys_risk_assessment_date: 'When was the last OASys risk assessment?'
     page_entries_info:

--- a/helm_deploy/offender-management-allocation-manager/values.yaml
+++ b/helm_deploy/offender-management-allocation-manager/values.yaml
@@ -121,7 +121,6 @@ generic-service:
     RAILS_SERVE_STATIC_FILES: on
     PROMETHEUS_METRICS: "on" # do not remove quotes!
     PROMETHEUS_EXPORTER_HOST: offender-management-prometheus-exporter
-    USE_PPUD_PAROLE_DATA: "1"
     LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/lib/tasks/parole_data_import.rake
+++ b/lib/tasks/parole_data_import.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :parole do
-  desc 'fetch updates to active parole records'
+  desc 'fetch updates to active parole reviews'
   task import: :environment do |_task|
     ParoleDataImportJob.perform_later(Time.zone.today - 1)
   end

--- a/spec/controllers/parole_cases_controller_spec.rb
+++ b/spec/controllers/parole_cases_controller_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe ParoleCasesController, type: :controller do
 
     describe '#index' do
       before do
-        stub_const('USE_PPUD_PAROLE_DATA', true)
         stub_movements
       end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe TasksController, :allocation, type: :controller do
   end
 
   before do
-    stub_const('USE_PPUD_PAROLE_DATE', true)
     stub_poms(prison, pom)
     stub_signed_in_pom(prison, staff_id)
     stub_offenders_for_prison(prison, offenders)
@@ -44,8 +43,6 @@ RSpec.describe TasksController, :allocation, type: :controller do
   end
 
   context 'when showing early allocation decisions required' do
-    before { stub_const('USE_PPUD_PAROLE_DATA', false) }
-
     let(:offender_nos) { %w[G1234AB G1234GG G1234VV] }
     let(:test_offender_no) { 'G1234AB' }
 
@@ -74,8 +71,6 @@ RSpec.describe TasksController, :allocation, type: :controller do
   end
 
   context 'when showing missing hearing outcome confirmed date' do
-    before { stub_const('USE_PPUD_PAROLE_DATA', true) }
-
     let(:offender_nos) { %w[G1234AB G1234GG G1234VV] }
     let(:test_offender_no) { 'G1234AB' }
 
@@ -110,8 +105,6 @@ RSpec.describe TasksController, :allocation, type: :controller do
 
   context 'when showing tasks' do
     before do
-      stub_const('USE_PPUD_PAROLE_DATA', true)
-
       create(:case_information, tier: 'A', mappa_level: 1,
                                 offender: build(:offender, nomis_offender_id: 'G1234AB', parole_reviews: [build(:parole_review, hearing_outcome_received_on: today)]))
       create(:allocation_history, nomis_offender_id: 'G1234AB', primary_pom_nomis_id: staff_id, prison: prison)

--- a/spec/domains/offender_handover_spec.rb
+++ b/spec/domains/offender_handover_spec.rb
@@ -44,8 +44,6 @@ describe OffenderHandover do
             )
     end
 
-    before { stub_const('USE_PPUD_PAROLE_DATA', true) }
-
     context 'when offender is an ISP' do
       let(:indeterminate_sentence) { true }
 

--- a/spec/domains/offender_handover_with_standard_recalls_spec.rb
+++ b/spec/domains/offender_handover_with_standard_recalls_spec.rb
@@ -46,8 +46,6 @@ describe OffenderHandoverWithStandardRecalls do
             )
     end
 
-    before { stub_const('USE_PPUD_PAROLE_DATA', true) }
-
     context 'when offender is an ISP' do
       let(:indeterminate_sentence) { true }
 

--- a/spec/factories/parole_review.rb
+++ b/spec/factories/parole_review.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     sequence(:review_id) { |x| x + 300_000 }
 
-    # Defaults a parole record to be the currently active record
+    # Defaults a parole review to be the currently active record
     review_status {'Active'}
     hearing_outcome {'Not Specified'} # = no hearing outcome
 

--- a/spec/features/navigation_feature_spec.rb
+++ b/spec/features/navigation_feature_spec.rb
@@ -5,8 +5,6 @@ feature 'Navigation' do
   let(:link_css) { '.moj-primary-navigation__link' }
   let(:nav_links) { all(link_css) }
 
-  before { stub_const('USE_PPUD_PAROLE_DATA', true) }
-
   # This is a legitimate VCR test - we really don't care how/if the various
   # APIs are called in this test
   describe 'navigation menus', vcr: { cassette_name: 'prison_api/navigation_menus' } do

--- a/spec/features/parole_set_hearing_outcome_date_feature_spec.rb
+++ b/spec/features/parole_set_hearing_outcome_date_feature_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Parole set hearing outcome date', type: :feature do
   let!(:parole_review) { create(:parole_review, :pom_task, nomis_offender_id: offender.nomis_offender_id) }
 
   before do
-    stub_const('USE_PPUD_PAROLE_DATA', true)
     stub_keyworker(prison_code, offender_no, build(:keyworker))
     stub_signin_spo(pom, [prison_code])
     stub_poms(prison_code, [pom])

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -23,7 +23,6 @@ feature 'View a prisoner profile page', flaky: true do
     before do
       create(:case_information,
              offender: build(:offender, nomis_offender_id: 'G7266VD',
-                                        parole_record: build(:parole_record, parole_review_date: Time.zone.today + 1.year),
                                         early_allocations: [build(:early_allocation, created_within_referral_window: within_window)]))
       visit prison_prisoner_path(prison.code, 'G7266VD')
     end

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -42,8 +42,6 @@ feature "staff pages" do
     let(:offender) { sneaky_instance_double AllocatedOffender, **offender_attrs }
 
     before do
-      stub_const('USE_PPUD_PAROLE_DATA', true)
-
       stub_signin_spo pom, [prison.code]
       stub_offenders_for_prison(prison.code, offenders_in_prison)
       stub_poms(prison.code, (prison_poms + [pom]))

--- a/spec/intergration/responsibility_and_handover_spec.rb
+++ b/spec/intergration/responsibility_and_handover_spec.rb
@@ -5,7 +5,6 @@ describe "Responsibility and Handover",  handover_calculations: true do
   let(:isps) { [Sentences::SentenceSequence.new] }
 
   before do
-    stub_const('USE_PPUD_PAROLE_DATA', true)
     allow(Sentences).to receive(:for).with(booking_id: mpc_offender.booking_id).and_return(isps)
     Timecop.freeze(Time.zone.local(2024, 5, 20))
   end

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe MpcOffender, type: :model do
   let(:recalled) { false }
 
   before do
-    stub_const('USE_PPUD_PAROLE_DATA', true)
     allow(offender_model).to receive(:most_recent_parole_review).and_return(parole_review)
     allow(offender_model).to receive(:parole_review_awaiting_hearing).and_return(parole_review)
     allow(offender_model).to receive(:most_recent_completed_parole_review).and_return(completed_parole_review)

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -516,13 +516,13 @@ RSpec.describe MpcOffender, type: :model do
 
     context 'when the offender has an upcoming parole hearing' do
       describe '#next_thd' do
-        it 'returns the target hearing date of the incomplete parole record' do
+        it 'returns the target hearing date of the incomplete parole review' do
           expect(subject.next_thd).to eq(parole_review.target_hearing_date)
         end
       end
 
       describe '#target_hearing_date' do
-        it 'returns the target hearing date of the incomplete parole record' do
+        it 'returns the target hearing date of the incomplete parole review' do
           expect(subject.target_hearing_date).to eq(parole_review.target_hearing_date)
         end
       end
@@ -534,7 +534,7 @@ RSpec.describe MpcOffender, type: :model do
       end
 
       describe '#last_hearing_outcome_received_on' do
-        it 'returns the hearing outcome received date of the most recent completed parole record' do
+        it 'returns the hearing outcome received date of the most recent completed parole review' do
           expect(subject.last_hearing_outcome_received_on).to eq(completed_parole_review.hearing_outcome_received_on)
         end
       end
@@ -553,19 +553,19 @@ RSpec.describe MpcOffender, type: :model do
       end
 
       describe '#target_hearing_date' do
-        it 'returns the target hearing date of the most recent completed parole record' do
+        it 'returns the target hearing date of the most recent completed parole review' do
           expect(subject.target_hearing_date).to eq(completed_parole_review.target_hearing_date)
         end
       end
 
       describe '#hearing_outcome_received_on' do
-        it 'returns the hearing outcome received date of the most recent completed parole record' do
+        it 'returns the hearing outcome received date of the most recent completed parole review' do
           expect(subject.hearing_outcome_received_on).to eq(completed_parole_review.hearing_outcome_received_on)
         end
       end
 
       describe '#last_hearing_outcome_received_on' do
-        it 'returns the hearing outcome received date of the most recent completed parole record' do
+        it 'returns the hearing outcome received date of the most recent completed parole review' do
           expect(subject.last_hearing_outcome_received_on).to eq(completed_parole_review.hearing_outcome_received_on)
         end
       end

--- a/spec/models/offender_spec.rb
+++ b/spec/models/offender_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Offender, type: :model do
       end
     end
 
-    describe '#build_parole_record_sections' do
+    describe '#build_parole_review_sections' do
       let(:completed_parole_review_1) do
         create(:parole_review, custody_report_due: Time.zone.today - 2.years,
                                target_hearing_date: Time.zone.today - 2.years,
@@ -206,24 +206,24 @@ RSpec.describe Offender, type: :model do
 
       before { offender.build_parole_review_sections }
 
-      context 'with a completed parole record whose outcome was received within the last 14 days' do
-        it 'sets current_parole_record to the most recent completed parole record' do
+      context 'with a completed parole review whose outcome was received within the last 14 days' do
+        it 'sets current_parole_review to the most recent completed parole review' do
           expect(offender.current_parole_review).to eq(completed_parole_review_2)
         end
 
-        it 'adds any older parole records to the previous_parole_records' do
+        it 'adds any older parole reviews to the previous parole reviews' do
           expect(offender.previous_parole_reviews).to match_array([completed_parole_review_1])
         end
       end
 
-      context 'with a completed parole record whose outcome was received over 14 days ago' do
+      context 'with a completed parole review whose outcome was received over 14 days ago' do
         let(:completed_parole_review_2) { create(:parole_review, custody_report_due: Time.zone.today - 15.days, target_hearing_date: Time.zone.today - 15.days, hearing_outcome: 'Stay in closed [*]', hearing_outcome_received_on: Time.zone.today - 15.days, review_status: 'Inactive') }
 
-        it 'sets the current_parole_record to the incomplete parole record' do
+        it 'sets the current_parole_review to the incomplete parole review' do
           expect(offender.current_parole_review).to eq(incomplete_parole_review)
         end
 
-        it 'adds any older parole records to the previous_parole_records, in descending date order' do
+        it 'adds any older parole reviews to the previous parole reviews, in descending date order' do
           expect(offender.previous_parole_reviews).to eq([completed_parole_review_2, completed_parole_review_1])
         end
       end

--- a/spec/models/parole_review_spec.rb
+++ b/spec/models/parole_review_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ParoleReview, type: :model do
   it 'always belongs to an offender' do
-    expect(build(:parole_record).offender).not_to be_nil
+    expect(build(:parole_review).offender).not_to be_nil
   end
 
   describe '#hearing_outcome_as_current' do

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe "allocations/show", type: :view do
 
   describe 'Parole section' do
     before do
-      stub_const('USE_PPUD_PAROLE_DATA', true)
       stub_template 'shared/_vlo_information.html.erb' => ''
       render
     end

--- a/spec/views/shared/badges.html.erb_spec.rb
+++ b/spec/views/shared/badges.html.erb_spec.rb
@@ -77,10 +77,6 @@ RSpec.describe "shared/badges", type: :view do
 
   context "when there is a parole review date" do
     let(:offender_no) { 'G7514GW' }
-    let(:case_info) do
-      build(:case_information, offender: build(:offender, nomis_offender_id: offender_no,
-                                                          parole_record: build(:parole_record, parole_review_date: Date.new(2019, 0o1, 3).to_s)))
-    end
     let(:api_offender) do
       build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :indeterminate), prisonerNumber: offender_no)
     end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1490

Follow-up to PR #2473 to actually remove unnecessary feat-flag branching code, as this functionality is now live in all envs.

NOTE: pending removal of the `ParoleRecord` DB table. Keeping it for now as it is used in the SAR endpoint and in case we need to rollback or refer to old data. A ticket will be created so we don't forget to cleanup this whenever is decided.