### PR TITLE
Only show parole eligible badge when they are eligible

### DIFF
--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -14,12 +14,4 @@ module BadgeHelper
       'Determinate'
     end
   end
-
-  def badge_for_parole?(offender)
-    offender.tariff_date.present? || offender.parole_eligibility_date.present? || target_hearing_date?(offender)
-  end
-
-  def target_hearing_date?(offender)
-    offender.indeterminate_sentence? && offender.target_hearing_date.present?
-  end
 end

--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -1,6 +1,6 @@
 <span id="prisoner-case-type" class="govuk-tag govuk-tag--<%= badge_colour(offender) %>"><%= badge_text(offender) %></span>
 <%= render('shared/badges/recall_badge') if offender.recalled? %>
-<%= render('shared/badges/parole_badge') if badge_for_parole?(offender) %>
+<%= render('shared/badges/parole_badge') if offender.approaching_parole? %>
 
 <% status = offender.early_allocation_state %>
 <% if EarlyAllocationHelper::EARLY_ALLOCATION_STATUSES.key?(status) %>

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -94,6 +94,15 @@ FactoryBot.define do
       indeterminateSentence { false }
     end
 
+    trait :recall do
+      recall { true }
+    end
+
+    trait :approaching_parole do
+      # If this ever fails, check mpc_offender#approaching_parole? logic
+      paroleEligibilityDate { 1.day.from_now }
+    end
+
     trait :indeterminate_recall do
       indeterminateSentence { true }
       recall { true }

--- a/spec/views/shared/badges.html.erb_spec.rb
+++ b/spec/views/shared/badges.html.erb_spec.rb
@@ -41,86 +41,41 @@ RSpec.describe "shared/badges", type: :view do
 
   context "when recall" do
     let(:api_offender) do
-      build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :indeterminate_recall))
+      build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :recall))
     end
 
     it "displays a recall case type badge and a indeterminate badge" do
-      expect(case_type_badge.first.attributes['class'].value).to include 'govuk-tag--purple'
-      expect(case_type_badge.text).to include 'Indeterminate'
       assert_you_have_a_recall_badge
     end
   end
 
-  context "when parole eligibility(PED)" do
+  context "when eligibile for parole" do
+    let(:api_offender) do
+      build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :approaching_parole))
+    end
+
+    it "displays an parole eligibility badge" do
+      assert_you_have_a_parole_eligibility_badge
+    end
+  end
+
+  context "when indeterminate, a recall case" do
     let(:api_offender) do
       build(:hmpps_api_offender,
-            sentence: attributes_for(:sentence_detail,
-                                     :indeterminate, paroleEligibilityDate: Time.zone.today.to_s))
-    end
-
-    it "displays an parole eligibility case type badge" do
-      assert_you_have_a_parole_eligibility_badge
-      assert_you_have_an_indeterminate_badge
-    end
-  end
-
-  context "when parole eligibility(TED)" do
-    let(:api_offender) do
-      build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :determinate, tariffDate: Time.zone.today.to_s))
-    end
-
-    it "displays an parole eligibility case type badge and determinate badge" do
-      assert_you_have_a_parole_eligibility_badge
-      assert_you_have_a_determinate_badge
-    end
-  end
-
-  context "when there is a parole review date" do
-    let(:offender_no) { 'G7514GW' }
-    let(:api_offender) do
-      build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :indeterminate), prisonerNumber: offender_no)
-    end
-
-    it "displays an parole eligibility case type badge" do
-      assert_you_have_an_indeterminate_badge
-      assert_you_have_a_parole_eligibility_badge
-    end
-  end
-
-  context 'when parole eligibility (both TED and THD) and target hearing date are nil' do
-    let(:offender_no) { 'G7514GW' }
-    let(:case_info) { build(:case_information, offender: build(:offender, nomis_offender_id: offender_no)) }
-    let(:api_offender) do
-      build(:hmpps_api_offender, prisonerNumber: offender_no,
-                                 sentence: attributes_for(:sentence_detail, :indeterminate, tariffDate: nil))
-    end
-
-    it 'does not display the badge' do
-      expect(offender.tariff_date).to eq nil
-      expect(offender.parole_eligibility_date).to eq nil
-      expect(parole_badge.text).not_to include 'Parole eligible'
-    end
-  end
-
-  context "when indeterminate, a recall case and parole eligibility(PED)" do
-    let(:api_offender) do
-      build(:hmpps_api_offender,
-            sentence: attributes_for(:sentence_detail, :indeterminate_recall, paroleEligibilityDate: Time.zone.today.to_s))
+            sentence: attributes_for(:sentence_detail, :indeterminate_recall))
     end
 
     it "displays an indeterminate, parole eligibility and recall case type badges" do
       assert_you_have_an_indeterminate_badge
-      assert_you_have_a_parole_eligibility_badge
       assert_you_have_a_recall_badge
     end
   end
 
-  context "when determinate, a recall case and parole eligibility(PED)" do
-    let(:api_offender) { build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :determinate_recall, paroleEligibilityDate: Time.zone.today)) }
+  context "when determinate, a recall case" do
+    let(:api_offender) { build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :determinate_recall)) }
 
     it "displays an determinate, parole eligibility and recall case type badges" do
       assert_you_have_a_determinate_badge
-      assert_you_have_a_parole_eligibility_badge
       assert_you_have_a_recall_badge
     end
   end


### PR DESCRIPTION
Unify the logic for if offenders show as parole eligible, with the existing logic that decides if they should show on the parole cases screen.