### PR TITLE
Take mappa level 0 into account for SD recalls

### DIFF
--- a/app/domains/offender_handover_with_standard_recalls.rb
+++ b/app/domains/offender_handover_with_standard_recalls.rb
@@ -26,7 +26,7 @@ private
 
     if most_recent_parole_review&.cancelled? && mappa_level.in?([2, 3])
       CalculatedHandoverDate.new(responsibility: com, reason: :recall_release_later_mappa_2_3)
-    elsif most_recent_parole_review&.cancelled? && mappa_level.in?([nil, 1])
+    elsif most_recent_parole_review&.cancelled?
       CalculatedHandoverDate.new(responsibility: pom_with_com, reason: :recall_release_later_mappa_empty_1)
     elsif most_recent_parole_review.present?
       CalculatedHandoverDate.new(responsibility: com, reason: :recall_release_later_no_outcome)

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -8,6 +8,10 @@ class CalculatedHandoverDate < ApplicationRecord
   REASONS = {
     com_responsibility: 'COM Responsibility',
     recall_case: 'Recall case',
+    recall_release_soon: 'Recall case',
+    recall_release_later_mappa_2_3: 'Recall case',
+    recall_release_later_mappa_empty_1: 'Recall case',
+    recall_release_later_no_outcome: 'Recall case',
     immigration_case: 'Immigration Case',
     release_date_unknown: 'Release Date Unknown',
 

--- a/spec/domains/offender_handover_with_standard_recalls_spec.rb
+++ b/spec/domains/offender_handover_with_standard_recalls_spec.rb
@@ -145,8 +145,8 @@ describe OffenderHandoverWithStandardRecalls do
             end
           end
 
-          context 'and mappa level is empty or 1' do
-            [nil, 1].each do |mappa|
+          context 'and mappa level is empty, 0, or 1' do
+            [nil, 0, 1].each do |mappa|
               let(:mappa_level) { mappa }
 
               it 'is POM responsible as recall_release_later_mappa_empty_1' do


### PR DESCRIPTION
mappa_level can technically be 0 and the old code was explicitly looking for nil/1 when 0 would also work.