### PR TITLE
Tweak prometheus rules values

### DIFF
--- a/helm_deploy/offender-management-allocation-manager/templates/background-jobs-processor.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/background-jobs-processor.yaml
@@ -30,6 +30,11 @@ spec:
         command: ['sh', '-c', "bundle exec sidekiq -C config/sidekiq.yml"]
           {{- include "moic-helpers.envs" . | nindent 8 }}
         resources:
-          {{- with index .Values "generic-service" }}{{ toYaml .resources | nindent 10 }}{{ end }}
+          limits:
+            memory: 2Gi
+            cpu: 1000m
+          requests:
+            memory: 500Mi
+            cpu: 100m
 ---
 {{- end }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-community-api-import.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-community-api-import.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-deactivate-cnls.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-deactivate-cnls.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-early-allocation-suitability-email.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-early-allocation-suitability-email.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-handover-chase-email.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-handover-chase-email.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-handover-email.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-handover-email.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-handover-reminder-email.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-handover-reminder-email.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-integration-tests-cleanup.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-integration-tests-cleanup.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-parole-data-import.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-parole-data-import.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-process-movements.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-process-movements.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-recalculate-handover-dates.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-recalculate-handover-dates.yaml
@@ -12,7 +12,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 120
       template:
         spec:
           serviceAccountName: {{ index .Values "generic-service" "serviceAccountName" }}

--- a/helm_deploy/offender-management-allocation-manager/values.yaml
+++ b/helm_deploy/offender-management-allocation-manager/values.yaml
@@ -64,8 +64,8 @@ generic-prometheus-alerts:
   hpaTargetOverride: ".*"
   podTargetOverride: ".*"
   deploymentTargetOverride: ".*"
-  applicationCronJobStatusFailedWindowMinutes: 30
-  sqsAlertsOldestThreshold: 30 # minutes
+  applicationCronJobStatusFailedWindowMinutes: 60
+  sqsAlertsOldestThreshold: 45 # minutes
   sqsAlertsTotalMessagesThreshold: "0" # DLQ alert triggers if messages > 0
 
 generic-service:

--- a/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
+++ b/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
@@ -47,14 +47,14 @@ describe HandoverFollowUpJob::FollowUpEmailDetails, vcr: { cassette_name: "priso
     end
 
     context "when the offender has a POM allocated" do
-      before { FactoryBot.create(:allocation_history, nomis_offender_id: offender.offender_no, prison: prison.code, primary_pom_nomis_id: "485982") }
+      before { FactoryBot.create(:allocation_history, nomis_offender_id: offender.offender_no, prison: prison.code, primary_pom_nomis_id: "486154") }
 
       it "includes the POM details in the email" do
         details = described_class.for(offender:)
 
         expect(details).to include(
-          pom_email: "jon.hindle@digital.justice.gov.uk", # comes from the elite2_staff_api_get_email VCR
-          pom_name: "Hindle, Jon", # comes from the pom_api_list_spec VCR
+          pom_email: "tom.rooker@digital.justice.gov.uk", # comes from the elite2_staff_api_get_email VCR
+          pom_name: "Rooker, Tom", # comes from the pom_api_list_spec VCR
         )
       end
     end

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -35,7 +35,7 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
       valid_offender = FactoryBot.create(:offender, nomis_offender_id: "G7266VD")
       FactoryBot.create(:calculated_handover_date, start_date: Time.zone.today - 1.week, offender: valid_offender)
       FactoryBot.create(:case_information, local_delivery_unit:, offender: valid_offender)
-      FactoryBot.create(:allocation_history, nomis_offender_id: valid_offender.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "485982")
+      FactoryBot.create(:allocation_history, nomis_offender_id: valid_offender.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "486154")
 
       described_class.new.perform(local_delivery_unit)
 
@@ -47,7 +47,7 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
     it "does not send the follow up email to that offender" do
       offender_without_a_handover_date = FactoryBot.create(:offender, nomis_offender_id: "G7260UD")
       FactoryBot.create(:case_information, local_delivery_unit:, offender: offender_without_a_handover_date)
-      FactoryBot.create(:allocation_history, nomis_offender_id: offender_without_a_handover_date.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "485982")
+      FactoryBot.create(:allocation_history, nomis_offender_id: offender_without_a_handover_date.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "486154")
 
       described_class.new.perform(local_delivery_unit)
 
@@ -60,7 +60,7 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
       offender_with_a_handover_in_future = FactoryBot.create(:offender, nomis_offender_id: "G5241UH")
       FactoryBot.create(:calculated_handover_date, start_date: 1.week.from_now, offender: offender_with_a_handover_in_future)
       FactoryBot.create(:case_information, local_delivery_unit:, offender: offender_with_a_handover_in_future)
-      FactoryBot.create(:allocation_history, nomis_offender_id: offender_with_a_handover_in_future.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "485982")
+      FactoryBot.create(:allocation_history, nomis_offender_id: offender_with_a_handover_in_future.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "486154")
 
       described_class.new.perform(local_delivery_unit)
 


### PR DESCRIPTION
Follow-up to previous PR #2479.

And increase a bit the resources for the background processor as it seems to be OOM killed when running some of the import jobs.

Deleted `ttlSecondsAfterFinished` from the cronjob definitions as these will be cleaned up automatically instead.