### PR TITLE
MO-1188 Show not found error page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,7 @@ class ApplicationController < ActionController::Base
         'footer' => HmppsApi::DpsFrontendComponentsApi.footer(sso_identity.token),
         'status' => 'ok',
       }
-    rescue Faraday::ServerError, Faraday::ResourceNotFound, Faraday::TimeoutError, Faraday::UnauthorizedError => e
+    rescue Faraday::ServerError, Faraday::ClientError, NoMethodError => e
       logger.error "event=dps_header_footer_retrieval_error|#{e.inspect},#{e.backtrace.join(',')}"
       @dps_header_footer ||= { 'status' => 'fallback' }
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  delegate :current_user, to: :sso_identity
+  delegate :current_user, to: :sso_identity, allow_nil: true
 
   delegate :current_user_is_spo?, to: :sso_identity
   helper_method :current_user_is_spo?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,4 +194,8 @@ Rails.application.routes.draw do
   end
   # Redirect to 'unauthorized' page if user isn't an admin
   get '/sidekiq', to: redirect('/401')
+
+  # catch-all route
+  match '*path', to: 'errors#not_found', via: :all, constraints:
+    ->(_req) { !Rails.application.config.consider_all_requests_local }
 end

--- a/spec/features/errors_feature_spec.rb
+++ b/spec/features/errors_feature_spec.rb
@@ -1,21 +1,66 @@
 require 'rails_helper'
 
 feature 'Errors' do
-  it "handles missing pages", vcr: { cassette_name: 'prison_api/errors_feature_missing' } do
-    visit "/404"
-    expect(page).to have_http_status(:not_found)
-    expect(page).to have_content('Page not found')
+  before do
+    # So we can simulate what would happen on production
+    allow(
+      Rails.application.config
+    ).to receive(:consider_all_requests_local).and_return(false)
   end
 
-  it "handles unauthorized access", vcr: { cassette_name: 'prison_api/errors_feature_unauthorized' } do
-    visit "/401"
-    expect(page).to have_http_status(:unauthorized)
-    expect(page).to have_content('You do not have permission to access this')
+  context 'when signed in' do
+    it "handles missing pages (nonexistent path)" do
+      visit "/foobar"
+      expect(page).to have_http_status(:not_found)
+      expect(page).to have_content('Page not found')
+    end
+
+    it "handles missing pages" do
+      visit "/404"
+      expect(page).to have_http_status(:not_found)
+      expect(page).to have_content('Page not found')
+    end
+
+    it "handles unauthorized access" do
+      visit "/401"
+      expect(page).to have_http_status(:unauthorized)
+      expect(page).to have_content('You do not have permission to access this')
+    end
+
+    it "handles errors" do
+      visit "/500"
+      expect(page).to have_http_status(:error)
+      expect(page).to have_content('Sorry, there is a problem with the POM caseload service')
+    end
   end
 
-  it "handles errors", vcr: { cassette_name: 'prison_api/errors_feature_handles_500' } do
-    visit "/500"
-    expect(page).to have_http_status(:error)
-    expect(page).to have_content('Sorry, there is a problem with the POM caseload service')
+  context 'when signed out' do
+    before do
+      allow(SsoIdentity).to receive(:new).and_return(nil)
+    end
+
+    it "handles missing pages (nonexistent path)" do
+      visit "/foobar"
+      expect(page).to have_http_status(:not_found)
+      expect(page).to have_content('Page not found')
+    end
+
+    it "handles missing pages" do
+      visit "/404"
+      expect(page).to have_http_status(:not_found)
+      expect(page).to have_content('Page not found')
+    end
+
+    it "handles unauthorized access" do
+      visit "/401"
+      expect(page).to have_http_status(:unauthorized)
+      expect(page).to have_content('You do not have permission to access this')
+    end
+
+    it "handles errors" do
+      visit "/500"
+      expect(page).to have_http_status(:error)
+      expect(page).to have_content('Sorry, there is a problem with the POM caseload service')
+    end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1188

If the user is not signed in and access an inexistent URL, instead of the nice "not found" error page, it was blowing up with a 500 internal server error.

Fixed by improving the handling of exceptions in the `dps_header_footer` method.

As a separate PR (awaiting copy confirmation) we will also have a nice error page (different to the not found) for the auth failure scenario.