### PR TITLE
Added console debugging helpers

### DIFF
--- a/app/lib/console_audit_helpers.rb
+++ b/app/lib/console_audit_helpers.rb
@@ -1,0 +1,10 @@
+module ConsoleAuditHelpers
+  def with_audit_notes(user_first_name:, user_last_name:, note:)
+    whodunnit = "#{user_first_name} #{user_last_name}"
+    controller_info = { user_first_name:, user_last_name:, system_admin_note: note }
+
+    PaperTrail.request(whodunnit:, controller_info:) do
+      yield if block_given?
+    end
+  end
+end

--- a/app/lib/console_debug_offender_helpers.rb
+++ b/app/lib/console_debug_offender_helpers.rb
@@ -1,0 +1,114 @@
+module ConsoleDebugOffenderHelpers
+  def debug_offender(nomis_offender_id)
+    offender = OffenderService.get_offender(nomis_offender_id)
+
+    CalculatedHandoverDate.find_by(nomis_offender_id:)
+    OffenderHandover.new(offender).as_calculated_handover_date
+    sentences = Sentences.for(booking_id: offender.booking_id)
+    parole_reviews = ParoleReview.where(nomis_offender_id:).order('updated_at DESC')
+
+    $stdout.puts <<~TXT
+
+      #{display_title 'General'}
+      ISP / SD:                       #{offender.indeterminate_sentence? ? 'ISP' : 'SD'}
+      Sentence start date:            #{display_date(offender.sentence_start_date)}
+      Recall?                         #{display_tick_cross(offender.recalled?)}
+      Early allocation?               #{display_tick_cross(offender.early_allocation?)}
+      Determinate parole?             #{display_tick_cross(offender.determinate_parole?)}
+      Open rules apply?               #{display_tick_cross(offender.open_prison_rules_apply?)}
+      Womens?                         #{display_tick_cross(offender.in_womens_prison?)}
+      Mappa level                     #{offender.mappa_level}
+
+      #{display_title 'General / Dates'}
+      ERD Earliest release date (FH): #{
+        if offender.earliest_release_for_handover
+          "#{display_date(offender.earliest_release_for_handover.date)} (#{offender.earliest_release_for_handover.name})"
+        else
+          ''
+        end
+      }
+      TED Tariff end date:            #{display_date(offender.tariff_date)}
+      THD Target hearing date:        #{display_date(offender.target_hearing_date)}
+      PED Parole eligibility date:    #{display_date(offender.parole_eligibility_date)}
+      CRD Conditional release date:   #{display_date(offender.conditional_release_date)}
+      ARD Automatic release date:     #{display_date(offender.automatic_release_date)}
+
+      #{display_title 'Responsibility/Handover'}
+      #{debug_handover_history offender}
+
+      #{display_title "Parole Reviews (#{parole_reviews.count})"}
+      #{
+        display_table(
+          headings: ['Id', 'Updated', 'Status', 'Outcome', 'THD', 'Current?', 'Most Recent?', 'MR Completed?'],
+          rows: parole_reviews.map do |parole_review|
+            [
+              parole_review.id,
+              display_date_time(parole_review.updated_at),
+              parole_review.review_status,
+              parole_review.hearing_outcome,
+              display_date(parole_review.target_hearing_date),
+              display_tick_cross(parole_review.id == offender.current_parole_review&.id),
+              display_tick_cross(parole_review.id == offender.most_recent_parole_review&.id),
+              display_tick_cross(parole_review.id == offender.most_recent_completed_parole_review&.id),
+            ]
+          end
+        )
+      }
+
+      #{display_title "Sentences (#{sentences.count})"}
+      Single sentence?               #{display_tick_cross(offender.sentences.single_sentence?)}
+      Conc. sentences <=12 months?   #{display_tick_cross(offender.sentences.concurrent_sentence_of_12_months_or_under?)}
+      Conc. sentences >=20 months?   #{display_tick_cross(offender.sentences.concurrent_sentence_of_20_months_or_over?)}
+
+      #{
+        display_table(
+          headings: ['ISP/SD', 'Sentence Start Date', 'Duration'],
+          rows: sentences.map do |sentence|
+            [
+              sentence.indeterminate? ? 'ISP' : 'SD',
+              display_date(sentence.sentence_start_date),
+              sentence.duration > 0.days ? sentence.duration.inspect : ''
+            ]
+          end
+        )
+      }
+
+    TXT
+  end
+
+  def debug_handover_history(offender)
+    handover_row = lambda do |handover, version|
+      [
+        display_date_time(handover.updated_at),
+        handover.responsibility,
+        handover.reason,
+        display_date(handover.start_date),
+        display_date(handover.handover_date),
+
+        if (erd = version.offender_attributes_to_archive['earliest_release_for_handover'])
+          "(#{erd['name']}) #{display_date(erd['date'])}"
+        elsif (erd = version.offender_attributes_to_archive['earliest_release'])
+          "(#{erd['type']}) #{display_date(erd['date'])} *"
+        elsif (erd = version.offender_attributes_to_archive['earliest_release_date'])
+          "#{display_date(erd)} **"
+        end,
+
+        version.offender_attributes_to_archive['mappa_level'],
+        display_tick_cross(version.offender_attributes_to_archive['recalled?']),
+        display_tick_cross(version.offender_attributes_to_archive['indeterminate_sentence?'])
+      ]
+    end
+
+    persisted_handover = CalculatedHandoverDate.find_by(nomis_offender_id: offender.nomis_offender_id)
+
+    display_table(
+      headings: ['Updated', 'Responsibility', 'Reason', 'Start', 'Handover', 'ERD', 'Mappa', 'Recall', 'ISP'],
+      rows: persisted_handover.versions.reverse.map do |version|
+        handover = CalculatedHandoverDate.new(
+          YAML.load(version.object, permitted_classes: [Date, Time], aliases: true)
+        )
+        handover_row[handover, version]
+      end
+    )
+  end
+end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,12 +1,9 @@
+require 'console_display_helpers'
+
 Rails.application.configure do
   console do
-    def with_audit_notes(user_first_name:, user_last_name:, note:)
-      whodunnit = "#{user_first_name} #{user_last_name}"
-      controller_info = { user_first_name:, user_last_name:, system_admin_note: note }
-
-      PaperTrail.request(whodunnit:, controller_info:) do
-        yield if block_given?
-      end
-    end
+    Rails::ConsoleMethods.include(ConsoleDisplayHelpers)
+    Rails::ConsoleMethods.include(ConsoleAuditHelpers)
+    Rails::ConsoleMethods.include(ConsoleDebugOffenderHelpers)
   end
 end

--- a/lib/console_display_helpers.rb
+++ b/lib/console_display_helpers.rb
@@ -1,0 +1,52 @@
+module ConsoleDisplayHelpers
+  def display_title(text)
+    "#{text}\n#{'=' * text.length}"
+  end
+
+  def display_table(headings: [], rows: [], key: nil)
+    col_max_widths = ([headings] + rows).each_with_object(Array.new(headings.length, 0)) do |row, results|
+      row.each_with_index do |col, col_i|
+        results[col_i] = [results[col_i], col.to_s.length].max
+      end
+    end
+
+    output = []
+
+    output << headings.map
+      .with_index { |heading, col_i| heading.ljust(col_max_widths[col_i]) }
+
+    rows.each do |row|
+      output << row.map
+        .with_index { |col, col_i| col.to_s.ljust(col_max_widths[col_i]) }
+    end
+
+    output.map.with_index { |row, i|
+      to_output = row.join(' | ')
+      to_output += "\n#{'-' * to_output.length}" if i == 0
+
+      to_output
+    }
+      .join("\n")
+      .then { |table| table + (key ? "\nKey: #{key}" : '').to_s }
+  end
+
+  def display_date(date)
+    if date.is_a?(String)
+      Date.parse(date).strftime('%d/%m/%Y')
+    else
+      date&.strftime('%d/%m/%Y')
+    end
+  end
+
+  def display_date_time(date_time)
+    date_time&.strftime('%d/%m/%Y %H:%M:%S')
+  end
+
+  def display_diff(current_val, new_val)
+    current_val == new_val ? current_val : [current_val, new_val].join(' => ')
+  end
+
+  def display_tick_cross(value)
+    value ? '✔' : '✘'
+  end
+end


### PR DESCRIPTION
Added `debug_offender` helper to show the main important fields on an offender which is useful for debugging support queries.

Also fixed `with_audit_notes` which wasn't actually accessible from the console.