### PR TITLE
MO-911 Add missing confirmation messages

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -53,7 +53,8 @@ class PomsController < PrisonStaffApplicationController
         AllocationHistory.deallocate_primary_pom(nomis_staff_id, active_prison_id)
         AllocationHistory.deallocate_secondary_pom(nomis_staff_id, active_prison_id)
       end
-      redirect_to prison_pom_path(active_prison_id, id: nomis_staff_id)
+      redirect_to prison_pom_path(active_prison_id, id: nomis_staff_id),
+                  notice: "Profile updated for #{helpers.full_name_ordered(@pom)}"
     else
       @errors = pom_detail.errors
       render :edit

--- a/app/controllers/victim_liaison_officers_controller.rb
+++ b/app/controllers/victim_liaison_officers_controller.rb
@@ -27,8 +27,7 @@ class VictimLiaisonOfficersController < PrisonsApplicationController
     @vlo = @offender.victim_liaison_officers.new vlo_parameters
 
     if @vlo.save
-      flash[:notice] = 'VLO contact added'
-      redirect_to referrer
+      redirect_to referrer, notice: 'VLO contact added'
     else
       render 'new'
     end
@@ -38,8 +37,7 @@ class VictimLiaisonOfficersController < PrisonsApplicationController
 
   def update
     if @vlo.update vlo_parameters
-      flash[:notice] = 'VLO contact updated'
-      redirect_to referrer
+      redirect_to referrer, notice: 'VLO contact updated'
     else
       render 'edit'
     end

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, "Allocation information – Digital Prison Services" %>
 
+<%= render 'layouts/notice', notice: flash[:notice] %>
+
 <% if @prisoner.needs_a_com? %>
   <%= render partial: 'shared/notifications/offender_needs_a_com', locals: {offender: @prisoner, email_history: @emails_sent_to_ldu} %>
 <% end %>

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -1,6 +1,9 @@
 <% content_for :title, "View a POM's caseload – Digital Prison Services" %>
 
 <%= back_link %>
+
+<%= render 'layouts/notice', notice: flash[:notice] %>
+
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
   <span class="govuk-caption-xl">
     <%= pom_level_long(@pom.position) %>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, "View case information – Digital Prison Services" %>
 
+<%= render 'layouts/notice', notice: flash[:notice] %>
+
 <% if @prisoner.needs_a_com? %>
   <%= render partial: 'shared/notifications/offender_needs_a_com', locals: {offender: @prisoner, email_history: @emails_sent_to_ldu} %>
 <% end %>


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-911

Some confirmation messages after certain actions were missing. Added where needed and in some cases it was because the `layouts/notice` partial was not being rendered.