### PR TITLE
MO-1423 Improve handling of 401 errors

### DIFF
--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class AllocationApiController < Api::ApiController
+    rescue_from HmppsApi::Error::Unauthorized, with: :unauthorized_error
+
     def show
       render_404('Not ready for allocation') && return if allocation.nil?
       render_404('Not allocated') && return unless offender_allocated?

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -10,19 +10,23 @@ module Api
       render json: { status: 'ok' }
     end
 
-    def render_404(msg = 'Not found')
-      render json:  { status: 'error', message: msg }, status: :not_found
-    end
-
   private
 
-    def render_error(msg)
-      render json: { status: 'error', message: msg }, status: :unauthorized
+    def render_404(message = 'Not found')
+      render_error(message, :not_found)
+    end
+
+    def unauthorized_error(exception)
+      render_error(exception.message, :unauthorized)
+    end
+
+    def render_error(message, status)
+      render json: { status: 'error', message: }, status:
     end
 
     def verify_token
       unless token.valid_token_with_scope?('read', role: API_ROLE)
-        render_error('Valid authorisation token required')
+        render_error('Valid authorisation token required', :unauthorized)
       end
     end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,13 +1,22 @@
 class ErrorsController < ApplicationController
   def not_found
-    render(status: :not_found)
+    respond_with_status(:not_found)
   end
 
   def unauthorized
-    render(status: :unauthorized)
+    respond_with_status(:unauthorized)
   end
 
   def internal_server_error
-    render(status: :internal_server_error)
+    respond_with_status(:internal_server_error)
+  end
+
+private
+
+  def respond_with_status(status)
+    respond_to do |format|
+      format.html { render status: }
+      format.all  { head status }
+    end
   end
 end

--- a/app/services/hmpps_api/error/unauthorized.rb
+++ b/app/services/hmpps_api/error/unauthorized.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module HmppsApi
+  module Error
+    class Unauthorized < StandardError; end
+  end
+end

--- a/spec/services/hmpps_api/client_spec.rb
+++ b/spec/services/hmpps_api/client_spec.rb
@@ -41,8 +41,17 @@ describe HmppsApi::Client do
         .to_return(status: status)
     end
 
-    describe 'a 4xx error' do
+    describe 'a 401 error' do
       let(:status) { 401 }
+
+      it 'raises a HmppsApi::Error::Unauthorized error' do
+        expect { client.get(route) }
+          .to raise_error(HmppsApi::Error::Unauthorized, "the server responded with status #{status}")
+      end
+    end
+
+    describe 'a 4xx error' do
+      let(:status) { 403 }
 
       it 'raises a Faraday::ClientError error' do
         expect { client.get(route) }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1423

There are a few occurrences a day of 401 sentry errors when calling downstream services.

This improves the error responses (so they are actually 401 and json instead of 500 and html) and also logs them so we get some more information.

This PR also improves the catch-all route for formats other than html, so we don't get unnecessary `ActionView::MissingTemplate` sentry errors.