### PR TITLE
Limit prometheus alerts in test to business hours

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -7,6 +7,9 @@ custom_templates_config:
   domain_events_consumer:
     enabled: false
 
+generic-prometheus-alerts:
+  businessHoursOnly: true
+
 generic-service:
   ingress:
     hosts:


### PR DESCRIPTION
Forgot we also have this non-prod env.

Same as we did in previous PR #2491 with staging and preprod, we are disabling prometheus alerts outside of business hours to reduce some of the noise.