### PR TITLE
Improved table spacing on parole history debug table

### DIFF
--- a/app/views/debugging/_parole_history.html.erb
+++ b/app/views/debugging/_parole_history.html.erb
@@ -14,29 +14,25 @@
             <th scope="col" class="govuk-table__header">Outcome received</th>
             <th scope="col" class="govuk-table__header">THD</th>
             <th scope="col" class="govuk-table__header">Custody report due</th>
-            <th scope="col" class="govuk-table__header">Note</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           <% parole_reviews.each do |parole_review| %>
             <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header" data-record-id="<%= parole_review.id %>">
-                <%= parole_review.updated_at.strftime('%d/%m/%Y %H:%M:%S') %>
+              <th scope="row" class="govuk-table__header" data-record-id="<%= parole_review.id %>" data-note="<%=
+                case parole_review.id
+                when @offender.most_recent_completed_parole_review&.id then 'MRC'
+                when @offender.most_recent_parole_review&.id           then 'MR'
+                when @offender.parole_review_awaiting_hearing&.id      then 'AH'
+                end
+              %>" title="<%= parole_review.updated_at.strftime('%d/%m/%Y %H:%M:%S') %>">
+                <%= parole_review.updated_at.strftime('%d/%m/%Y') %>
               </th>
               <td class="govuk-table__cell"><%= parole_review.review_status %></td>
               <td class="govuk-table__cell"><%= parole_review.hearing_outcome %></td>
               <td class="govuk-table__cell"><%= parole_review.hearing_outcome_received_on&.strftime('%d/%m/%Y') %></td>
               <td class="govuk-table__cell"><%= parole_review.target_hearing_date&.strftime('%d/%m/%Y') %></td>
               <td class="govuk-table__cell"><%= parole_review.custody_report_due&.strftime('%d/%m/%Y') %></td>
-              <td class="govuk-table__cell">
-                <%=
-                  case parole_review.id
-                  when @offender.most_recent_completed_parole_review&.id then 'MRC'
-                  when @offender.most_recent_parole_review&.id           then 'MR'
-                  when @offender.parole_review_awaiting_hearing&.id      then 'AH'
-                  end
-                %>
-              </td>
             </tr>
           <% end %>
         </tbody>


### PR DESCRIPTION
When looking at the data in prod it I realised we don't need to see exact time for this so I have moved it to a tooltip which improves the readability of the table by taking up less space

Also the "note" column is more for devs so I have moved that to a data attribute