### PR TITLE
Fix for bad data throwing error in non-prod envs

### DIFF
--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -5,6 +5,8 @@ require 'working_day_calculator'
 module HmppsApi
   class Offender
     def awaiting_allocation_for(only_working_days: false)
+      return if prison_arrival_date.nil?
+
       if only_working_days
         WorkingDayCalculator.working_days_between(prison_arrival_date, Time.zone.today)
       else

--- a/app/views/prisoners/_female_missing_information.html.erb
+++ b/app/views/prisoners/_female_missing_information.html.erb
@@ -50,7 +50,7 @@
         <%= offender.offender_no %>
           </span>
         </td>
-        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %> days</td>
+        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for.presence || 'N/A' %> days</td>
         <td aria-label="Action" class="govuk-table__cell" id="<%= "edit_#{offender.offender_no}" %>">
           <%= link_to "Add missing details", prison_prisoner_new_missing_info_path(@prison.code, offender.offender_no) %>
         </td>

--- a/app/views/prisoners/_male_missing_information.html.erb
+++ b/app/views/prisoners/_male_missing_information.html.erb
@@ -51,7 +51,7 @@
             <%= offender.offender_no %>
           </span>
         </td>
-        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for %></td>
+        <td aria-label="Waiting" class="govuk-table__cell"><%= offender.awaiting_allocation_for.presence || 'N/A' %> days</td>
         <td aria-label="Action" class="govuk-table__cell" id="<%= "edit_#{offender.offender_no}" %>">
           <%= link_to "Add missing details", new_prison_case_information_path(@prison.code, offender.offender_no, sort: params[:sort], page: params[:page] || 1) %>
         </td>

--- a/app/views/prisoners/unallocated.html.erb
+++ b/app/views/prisoners/unallocated.html.erb
@@ -117,7 +117,7 @@
           <%= offender.additional_information.join('<br />').html_safe %>
         </td>
         <td aria-label="Working days since entering this prison" class="govuk-table__cell">
-          <%= offender.awaiting_allocation_for(only_working_days: true) %> days
+          <%= offender.awaiting_allocation_for(only_working_days: true).presence || 'N/A' %> days
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1571

In local and staging, a prisoner had a nil `prison_arrival_date` making the `awaiting_allocation_for` calculation throw an error in the "missing information" page.

If the offender was not in the first page of the pagination, it would throw an error when ordering the table.

Handle potentially bad data in non-prod envs by taking care of nils and presenting "N/A" as a fallback in the lists.