### PR TITLE
MO-1556: Performance improvements to parole cases screen

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --require rails_helper
 -t ~flaky
---exclude-pattern "spec/features/allocate_feature_spec.rb, spec/features/dps_header_footer_feature_spec.rb, spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb, spec/views/allocations/allocation_history.html.erb_spec.rb"

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require rails_helper
 -t ~flaky
+--exclude-pattern "spec/features/allocate_feature_spec.rb, spec/features/dps_header_footer_feature_spec.rb, spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb, spec/views/allocations/allocation_history.html.erb_spec.rb"

--- a/app/controllers/parole_cases_controller.rb
+++ b/app/controllers/parole_cases_controller.rb
@@ -6,43 +6,19 @@ class ParoleCasesController < PrisonsApplicationController
   before_action :ensure_spo_user
 
   def index
-    offenders = params[:old].present? ? offenders_with_allocs_old : offenders_with_allocs_new
-
-    sorted_offenders_with_allocs = sort_collection offenders, default_sort: :last_name
+    sorted_offenders_with_allocs = sort_collection offenders_with_allocs, default_sort: :last_name
     @offenders = Kaminari.paginate_array(sorted_offenders_with_allocs).page(page)
   end
 
 private
 
-  # Find the allocated offenders in this prison which are approaching parole
-
-  def offenders_with_allocs_new
+  def offenders_with_allocs
     allocations = AllocationHistory.active_allocations_for_prison(@prison.code)
-    allocations = AllocationHistory.active_allocations_for_prison(@prison.code).index_by(&:nomis_offender_id) if params[:lookup] == "index"
     offenders   = @prison.offenders.select(&:approaching_parole?)
 
     offenders.map { |offender|
-      allocation = allocations.find_by(nomis_offender_id: offender.nomis_offender_id)            if params[:lookup] == "query"
-      allocation = allocations[offender.nomis_offender_id]                                       if params[:lookup] == "index"
-      allocation = allocations.find {|all| all.nomis_offender_id == offender.nomis_offender_id } if params[:lookup] == "find" || params[:lookup].nil?
+      allocation = allocations.find_by(nomis_offender_id: offender.nomis_offender_id)
       OffenderWithAllocationPresenter.new(offender, allocation) if allocation
     }.compact
-  end
-
-  def offenders_with_allocs_old
-    parole_offenders.map { |offender|
-      parole_allocation = parole_allocations.detect { |alloc| alloc.nomis_offender_id == offender.offender_no }
-      next if parole_allocation.nil? # Only show allocated offenders
-
-      OffenderWithAllocationPresenter.new(offender, parole_allocation)
-    }.compact
-  end
-
-  def parole_offenders
-    @prison.offenders.select(&:approaching_parole?)
-  end
-
-  def parole_allocations
-    @prison.allocations.where(nomis_offender_id: parole_offenders.map(&:offender_no))
   end
 end

--- a/app/controllers/parole_cases_controller.rb
+++ b/app/controllers/parole_cases_controller.rb
@@ -6,7 +6,9 @@ class ParoleCasesController < PrisonsApplicationController
   before_action :ensure_spo_user
 
   def index
-    sorted_offenders_with_allocs = sort_collection offenders_with_allocs, default_sort: :last_name
+    offenders = params[:old].present? ? offenders_with_allocs_old : offenders_with_allocs_new
+
+    sorted_offenders_with_allocs = sort_collection offenders, default_sort: :last_name
     @offenders = Kaminari.paginate_array(sorted_offenders_with_allocs).page(page)
   end
 
@@ -14,7 +16,7 @@ private
 
   # Find the allocated offenders in this prison which are approaching parole
 
-  def offenders_with_allocs
+  def offenders_with_allocs_new
     allocations = AllocationHistory.active_allocations_for_prison(@prison.code).index_by(&:nomis_offender_id)
     offenders   = @prison.offenders.select(&:approaching_parole?)
 
@@ -23,5 +25,22 @@ private
         OffenderWithAllocationPresenter.new(offender, allocation)
       end
     }.compact
+  end
+
+  def offenders_with_allocs_old
+    parole_offenders.map { |offender|
+      parole_allocation = parole_allocations.detect { |alloc| alloc.nomis_offender_id == offender.offender_no }
+      next if parole_allocation.nil? # Only show allocated offenders
+
+      OffenderWithAllocationPresenter.new(offender, parole_allocation)
+    }.compact
+  end
+
+  def parole_offenders
+    @prison.offenders.select(&:approaching_parole?)
+  end
+
+  def parole_allocations
+    @prison.allocations.where(nomis_offender_id: parole_offenders.map(&:offender_no))
   end
 end

--- a/app/controllers/parole_cases_controller.rb
+++ b/app/controllers/parole_cases_controller.rb
@@ -17,13 +17,13 @@ private
   # Find the allocated offenders in this prison which are approaching parole
 
   def offenders_with_allocs_new
-    allocations = AllocationHistory.active_allocations_for_prison(@prison.code).index_by(&:nomis_offender_id)
+    allocations = AllocationHistory.active_allocations_for_prison(@prison.code)
     offenders   = @prison.offenders.select(&:approaching_parole?)
 
     offenders.map { |offender|
-      if (allocation = allocations[offender.nomis_offender_id])
-        OffenderWithAllocationPresenter.new(offender, allocation)
-      end
+      allocation = allocations.find_by(nomis_offender_id: offender.nomis_offender_id)            if params[:lookup] == "query"
+      allocation = allocations.find {|all| all.nomis_offender_id == offender.nomis_offender_id } if params[:lookup] == "find" || params[:lookup].nil?
+      OffenderWithAllocationPresenter.new(offender, allocation) if allocation
     }.compact
   end
 

--- a/app/controllers/parole_cases_controller.rb
+++ b/app/controllers/parole_cases_controller.rb
@@ -18,10 +18,12 @@ private
 
   def offenders_with_allocs_new
     allocations = AllocationHistory.active_allocations_for_prison(@prison.code)
+    allocations = AllocationHistory.active_allocations_for_prison(@prison.code).index_by(&:nomis_offender_id) if params[:lookup] == "index"
     offenders   = @prison.offenders.select(&:approaching_parole?)
 
     offenders.map { |offender|
       allocation = allocations.find_by(nomis_offender_id: offender.nomis_offender_id)            if params[:lookup] == "query"
+      allocation = allocations[offender.nomis_offender_id]                                       if params[:lookup] == "index"
       allocation = allocations.find {|all| all.nomis_offender_id == offender.nomis_offender_id } if params[:lookup] == "find" || params[:lookup].nil?
       OffenderWithAllocationPresenter.new(offender, allocation) if allocation
     }.compact

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -51,7 +51,7 @@ class Offender < ApplicationRecord
 
   # Returns the most recent parole review (can be a future parole application), regardless of activity status and outcome.
   def most_recent_parole_review
-    @most_recent_parole_review ||= parole_reviews.ordered_by_sortable_date.to_a.last
+    @most_recent_parole_review ||= parole_reviews.ordered_by_sortable_date.last
   end
 
   # Returns the most recent parole application if it has not yet had a hearing.
@@ -61,7 +61,7 @@ class Offender < ApplicationRecord
 
   # Returns the most recent parole review that has an outcome
   def most_recent_completed_parole_review
-    @most_recent_completed_parole_review ||= parole_reviews.ordered_by_sortable_date.with_hearing_outcome.to_a.last
+    @most_recent_completed_parole_review ||= parole_reviews.ordered_by_sortable_date.with_hearing_outcome.last
   end
 
   def current_parole_review

--- a/app/models/parole_review.rb
+++ b/app/models/parole_review.rb
@@ -12,8 +12,7 @@ class ParoleReview < ApplicationRecord
   # If neither the THD or custody_report_due date are defined, we have no method
   # of determining when the parole hearing was, which is vital for MPC.
   scope :ordered_by_sortable_date, lambda {
-    where(Arel.sql('COALESCE(target_hearing_date, custody_report_due) IS NOT NULL'))
-    .order(Arel.sql('COALESCE(target_hearing_date, custody_report_due)'))
+    order(Arel.sql('COALESCE(target_hearing_date, custody_report_due, \'1900-01-01\')') => :asc)
   }
 
   scope :with_hearing_outcome, -> { where.not(hearing_outcome: ['Not Applicable', 'Not Specified', nil]).or(where.not(hearing_outcome_received_on: nil)) }

--- a/app/models/parole_review.rb
+++ b/app/models/parole_review.rb
@@ -13,7 +13,7 @@ class ParoleReview < ApplicationRecord
   # of determining when the parole hearing was, which is vital for MPC.
   scope :ordered_by_sortable_date, lambda {
     where(Arel.sql('target_hearing_date IS NOT NULL OR custody_report_due IS NOT NULL'))
-    .order(Arel.sql('target_hearing_date ASC, custody_report_due ASC'))
+    .order(Arel.sql('COALESCE(target_hearing_date, custody_report_due)') => :asc)
   }
 
   scope :with_hearing_outcome, -> { where.not(hearing_outcome: ['Not Applicable', 'Not Specified', nil]).or(where.not(hearing_outcome_received_on: nil)) }

--- a/app/models/parole_review.rb
+++ b/app/models/parole_review.rb
@@ -12,7 +12,8 @@ class ParoleReview < ApplicationRecord
   # If neither the THD or custody_report_due date are defined, we have no method
   # of determining when the parole hearing was, which is vital for MPC.
   scope :ordered_by_sortable_date, lambda {
-    order(Arel.sql('COALESCE(target_hearing_date, custody_report_due, \'1900-01-01\')') => :asc)
+    where(Arel.sql('COALESCE(target_hearing_date, custody_report_due) IS NOT NULL'))
+    .order(Arel.sql('COALESCE(target_hearing_date, custody_report_due)') => :asc)
   }
 
   scope :with_hearing_outcome, -> { where.not(hearing_outcome: ['Not Applicable', 'Not Specified', nil]).or(where.not(hearing_outcome_received_on: nil)) }

--- a/app/models/parole_review.rb
+++ b/app/models/parole_review.rb
@@ -12,8 +12,8 @@ class ParoleReview < ApplicationRecord
   # If neither the THD or custody_report_due date are defined, we have no method
   # of determining when the parole hearing was, which is vital for MPC.
   scope :ordered_by_sortable_date, lambda {
-    where(Arel.sql('COALESCE(target_hearing_date, custody_report_due) IS NOT NULL'))
-    .order(Arel.sql('COALESCE(target_hearing_date, custody_report_due)') => :asc)
+    where(Arel.sql('target_hearing_date IS NOT NULL OR custody_report_due IS NOT NULL'))
+    .order(Arel.sql('target_hearing_date ASC, custody_report_due ASC'))
   }
 
   scope :with_hearing_outcome, -> { where.not(hearing_outcome: ['Not Applicable', 'Not Specified', nil]).or(where.not(hearing_outcome_received_on: nil)) }


### PR DESCRIPTION
- Removed some duplicate work being done in the controller.
- Removed `to_a` conversion which was resource intensive and replaced with proper use of SQL as intended.
