### PR TITLE
MO-1562: THD is now Review Date

### DIFF
--- a/app/models/parole_review_import.rb
+++ b/app/models/parole_review_import.rb
@@ -14,24 +14,7 @@ class ParoleReviewImport < ApplicationRecord
     nomis_id.tr('.', '') # They sometimes end with a period
   end
 
-  def curr_target_date
-    parse_date self[:curr_target_date]
-  end
-
-  def ms13_target_date
-    parse_date self[:ms13_target_date]
-  end
-
   def no_hearing_outcome?
     final_result == 'Not Applicable' || final_result == 'Not Specified'
-  end
-
-private
-
-  # The dates are stored as different formats, depending on whether initial import or not
-  def parse_date(str)
-    return nil if str.blank? || str == 'NULL'
-
-    Date.strptime(str, single_day_snapshot ? '%d-%m-%Y' : '%m/%d/%y')
   end
 end

--- a/app/services/parole_data_process_service.rb
+++ b/app/services/parole_data_process_service.rb
@@ -45,7 +45,7 @@ class ParoleDataProcessService
                                         import_row.snapshot_date
                                       end
 
-        record.target_hearing_date = import_row.curr_target_date
+        record.target_hearing_date = import_row.review_date
         record.custody_report_due = import_row.ms13_target_date
         record.review_status = import_row.review_status
         record.hearing_outcome_received_on = hearing_outcome_received_on

--- a/db/migrate/20241008145210_migrate_parole_review_th_ds.rb
+++ b/db/migrate/20241008145210_migrate_parole_review_th_ds.rb
@@ -1,0 +1,19 @@
+class MigrateParoleReviewThDs < ActiveRecord::Migration[7.1]
+  def up
+   execute <<-SQL
+      UPDATE parole_reviews AS pr
+      SET target_hearing_date = to_date(pri.review_date, 'DD-MM-YYYY')
+      FROM parole_review_imports AS pri
+      WHERE pri.review_id::integer = pr.review_id
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE parole_reviews AS pr
+      SET target_hearing_date = to_date(pri.curr_target_date, 'DD-MM-YYYY')
+      FROM parole_review_imports AS pri
+      WHERE pri.review_id::integer = pr.review_id
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1259,6 +1259,7 @@ ALTER TABLE ONLY public.offender_email_sent
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241008145210'),
 ('20240924134717'),
 ('20240724134026'),
 ('20240614083226'),

--- a/spec/services/parole_data_process_service_spec.rb
+++ b/spec/services/parole_data_process_service_spec.rb
@@ -274,4 +274,27 @@ RSpec.describe ParoleDataProcessService do
       expect(results[:other_error_count]).to eq(1)
     end
   end
+
+  describe 'target hearing date' do
+    it 'is populated with the review_date value' do
+      create(:offender, nomis_offender_id: 'A1111AA')
+      create(:parole_review_import, nomis_id: 'A1111AA',
+                                    review_type: 'GPP ISP OnPost Tariff',
+                                    review_date: '10/10/2021',
+                                    review_id: '123456',
+                                    review_milestone_date_id: '12345678',
+                                    review_status: 'Active - Referred',
+                                    curr_target_date: '2/1/2022',
+                                    ms13_target_date: '2/1/2021',
+                                    ms13_completion_date: 'NULL',
+                                    final_result: 'Not Applicable',
+                                    snapshot_date: snapshot_date,
+                                    single_day_snapshot: false)
+
+      described_class.process
+
+      parole_review = ParoleReview.find_by(nomis_offender_id: 'A1111AA')
+      expect(parole_review.target_hearing_date).to eq(Date.parse('10/10/2021'))
+    end
+  end
 end


### PR DESCRIPTION
Part of the ticket MO-1562

- THD is now populated from parole import "Review Date" rather than "Current Target Date (Review)"
- Migration to update existing THDs in the system to be the "Review Date" value