### PR TITLE
MO-1578 Update CNL ping check

### DIFF
--- a/config/initializers/health.rb
+++ b/config/initializers/health.rb
@@ -17,7 +17,7 @@ config.health_checks = Health.new(timeout_in_seconds_per_check: 2, num_retries_p
     get_response: -> { HmppsApi::Client.new(config.community_api_host).get('/health/ping') })
   .add_check(
     name: 'complexityOfNeedsApi',
-    get_response: -> { HmppsApi::Client.new(config.complexity_api_host).raw_get('/health') },
+    get_response: -> { HmppsApi::Client.new(config.complexity_api_host).raw_get('/health/ping') },
     check_response: ->(response) { response == 'pong' })
   .add_check(
     name: 'dpsFrontendComponentsApi',


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1578

Previously CNL /health endpoint was behaving as a ping, and returning `pong`.

Now the health endpoint correctly returns health checks, and the ping has moved to standard DPS path `/health/ping`.