### PR TITLE
Add missing sorting method

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -18,7 +18,7 @@ class AllocatedOffender
            :earliest_release_for_handover, :handover_type,
            :early_allocation?, :licence_expiry_date, :approaching_parole?, :allocated_pom_role, :next_parole_date, :next_parole_date_type,
            :pom_tasks, to: :@offender
-  delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id,
+  delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id, :primary_pom_name,
            to: :@allocation
 
   COMPLEXITIES = { 'high' => 3, 'medium' => 2, 'low' => 1 }.freeze
@@ -32,6 +32,11 @@ class AllocatedOffender
   # this is required for sorting only
   def complexity_level_number
     ComplexityLevelHelper::COMPLEXITIES.fetch(complexity_level)
+  end
+
+  # this is required for sorting only
+  def formatted_pom_name
+    primary_pom_name.split(',').reverse.map(&:strip).join(' ').titleize
   end
 
   def high_complexity?

--- a/spec/models/allocated_offender_spec.rb
+++ b/spec/models/allocated_offender_spec.rb
@@ -13,4 +13,26 @@ RSpec.describe AllocatedOffender do
       expect(described_class.all).to match_array(allocations1 + allocations2)
     end
   end
+
+  describe '#formatted_pom_name' do
+    subject { described_class.new(staff_id, allocation, offender) }
+
+    let(:staff_id) { 123 }
+    let(:allocation) { instance_double(AllocationHistory, primary_pom_name:) }
+    let(:offender) { instance_double(Offender) }
+
+    let(:primary_pom_name) { 'DOE, JOHN' }
+
+    it 'formats the POM name' do
+      expect(subject.formatted_pom_name).to eq('John Doe')
+    end
+
+    context 'when there is no comma separator' do
+      let(:primary_pom_name) { 'JOHN' }
+
+      it 'formats the POM name' do
+        expect(subject.formatted_pom_name).to eq('John')
+      end
+    end
+  end
 end


### PR DESCRIPTION
There is already a similar method in the `OffenderWithAllocationPresenter` but in some pages it seems we have an `AllocatedOffender` instance instead, and the method call is throwing a few errors in Sentry and might be related to a user support query.

https://ministryofjustice.sentry.io/issues/5858044124/events/6414803091b04603bfad7a173d1e287e/events/?project=5584139

I can't reproduce it locally tho so this is my best guess at what is going on judging by the logs/sentry.