### PR TITLE
Revert "MO-1291 Change caseload handovers link (#2506)"

### DIFF
--- a/app/views/caseload/index.html.erb
+++ b/app/views/caseload/index.html.erb
@@ -20,7 +20,7 @@
             </div>
           </div>
           <div class="govuk-grid-column-one-third">
-            <%= render 'caseload_global/in_progress_handovers_card', with_link: true %>
+            <%= render 'caseload_global/upcoming_handovers_card', with_link: true %>
           </div>
           <div class="govuk-grid-column-one-third">
             <div class="card--caseload card-total">

--- a/app/views/caseload_global/_in_progress_handovers_card.html.erb
+++ b/app/views/caseload_global/_in_progress_handovers_card.html.erb
@@ -1,6 +1,6 @@
 <% information = capture do %>
   <span class="card__heading--large"><%= @summary.fetch(:in_progress_handover_count) %></span>
-  <p><%= 'handover'.pluralize(@summary.fetch(:in_progress_handover_count)) %> in progress</p>
+  <p>handovers in progress</p>
 <% end %>
 
 <div class="card--caseload card-total">


### PR DESCRIPTION
This reverts commit e70d4e206385fefc1f27a784d040722ad7d79a78.

Some combinations of users/prisons were reporting the link going to handovers in progress was producing an error page. Reverted back as it solves the issues while investigating the root cause.