### PR TITLE
Parole Rs import with proper date format

### DIFF
--- a/app/models/parole_review_import.rb
+++ b/app/models/parole_review_import.rb
@@ -10,11 +10,28 @@ class ParoleReviewImport < ApplicationRecord
     where(processed_on: nil)
   }
 
+  def review_date
+    parse_date super
+  end
+
+  def ms13_target_date
+    parse_date super
+  end
+
   def sanitized_nomis_id
     nomis_id.tr('.', '') # They sometimes end with a period
   end
 
   def no_hearing_outcome?
     final_result == 'Not Applicable' || final_result == 'Not Specified'
+  end
+
+private
+
+  # The dates are stored as different formats, depending on whether initial import or not
+  def parse_date(str)
+    return nil if str.blank? || str == 'NULL'
+
+    Date.strptime(str, single_day_snapshot ? '%d-%m-%Y' : '%m/%d/%y')
   end
 end

--- a/spec/models/parole_review_import_spec.rb
+++ b/spec/models/parole_review_import_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe ParoleReviewImport do
+  describe "Review date" do
+    specify 'for single day snapshots the date comes in %d-%m-%Y format' do
+      import = described_class.new(single_day_snapshot: true, review_date: '20-11-2024')
+      expect(import.review_date).to eq(Date.parse('20/11/2024'))
+    end
+
+    specify 'for non single day snapshots the date comes in %m/%d/%y format' do
+      import = described_class.new(single_day_snapshot: false, review_date: '3/28/18')
+      expect(import.review_date).to eq(Date.parse('28/03/2018'))
+    end
+  end
+end

--- a/spec/services/parole_data_process_service_spec.rb
+++ b/spec/services/parole_data_process_service_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe ParoleDataProcessService do
       create(:offender, nomis_offender_id: 'A1111AA')
       create(:parole_review_import, nomis_id: 'A1111AA',
                                     review_type: 'GPP ISP OnPost Tariff',
-                                    review_date: '10/10/2021',
+                                    review_date: '10/10/21',
                                     review_id: '123456',
                                     review_milestone_date_id: '12345678',
                                     review_status: 'Active - Referred',


### PR DESCRIPTION
Put back in code that was deleted incorrectly but still required. Added tests to document the need for this behaviour.