### PR TITLE
MO-1549 Add sidekiq probe and update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,16 +27,15 @@ gem 'paper_trail', '~> 15.1.0'
 gem 'pg'
 gem 'puma', '~> 6.4.2'
 gem 'prometheus_exporter'
-gem 'sidekiq', '>= 6.4.0', '< 6.5.0'
+gem 'sidekiq', '~> 7.2.4'
 gem 'sentry-ruby'
 gem 'sentry-rails'
 gem 'sentry-sidekiq'
 gem 'turbolinks', '~> 5'
 gem 'terser' # javascript compressor
 gem 'typhoeus'
-gem 'redis', '~> 4.6.0'
+gem 'redis'
 gem 'fast_underscore', require: false
-gem 'hashdiff', ['>= 1.0.0.beta1', '< 2.0.0']
 gem 'rubyzip', '< 3'
 gem 'turnout'
 gem 'kaminari' # pagination

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ GEM
     nenv (0.3.0)
     net-http (0.4.1)
       uri
-    net-imap (0.4.17)
+    net-imap (0.5.0)
       date
       net-protocol
     net-pop (0.1.2)
@@ -449,7 +449,10 @@ GEM
       ffi (~> 1.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    redis (4.6.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -564,10 +567,11 @@ GEM
       thor
     shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.4.2)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
+    sidekiq (7.2.4)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.19.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -674,7 +678,6 @@ DEPENDENCIES
   govuk_notify_rails (~> 3.0.0)
   guard-rspec
   guard-rubocop
-  hashdiff (>= 1.0.0.beta1, < 2.0.0)
   json-schema (~> 4.0)
   jsonb_accessor
   jwt
@@ -701,7 +704,7 @@ DEPENDENCIES
   rails (~> 7.1.3)
   rails-controller-testing
   rails-i18n
-  redis (~> 4.6.0)
+  redis
   rspec-rails
   rswag-api
   rswag-specs
@@ -716,7 +719,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoryuken (~> 6.0)
   shoulda-matchers
-  sidekiq (>= 6.4.0, < 6.5.0)
+  sidekiq (~> 7.2.4)
   simplecov
   simplecov-lcov (< 0.9)
   spring

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,6 +5,17 @@ class ApplicationMailer < GovukNotifyRails::Mailer
 
   before_action :store_default_tags
 
+  # Report the exception but do not re-raise it, as these errors
+  # are not recoverable so it is not useful to retry failed jobs
+  # :nocov:
+  rescue_from 'Notifications::Client::BadRequestError' do |ex|
+    Rails.logger.warn("[#{self.class}] #{ex} - #{message.to}")
+    Sentry.capture_exception(
+      ex, contexts: { recipient: { emails: message.to.join(',') } }
+    )
+  end
+  # :nocov:
+
   class << self
     attr_reader :mailer_tag
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,7 +69,6 @@ module OffenderManagementAllocationClient
     config.collect_prometheus_metrics = ENV['PROMETHEUS_METRICS']&.strip == 'on'
     config.support_email = ENV['SUPPORT_EMAIL']&.strip
     config.redis_url = ENV['REDIS_URL']&.strip
-    config.redis_auth = ENV['REDIS_AUTH']&.strip
 
     config.cache_expiry = (ENV['CACHE_TIMEOUT']&.strip || 60.minutes).to_i
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379" } %>
   channel_prefix: offender_management_allocation_client_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,7 +85,6 @@ Rails.application.configure do
     config.cache_store = :redis_cache_store,
                          {
                            url: config.redis_url.to_s,
-                           network_timeout: 5,
                            read_timeout: 1.0,
                            write_timeout: 1.0,
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -26,7 +26,6 @@ if Rails.env.production?
 
     config.redis = {
       url: Rails.configuration.redis_url.to_s,
-      network_timeout: 5,
       read_timeout: 1.0,
       write_timeout: 1.0
     }
@@ -38,7 +37,6 @@ if Rails.env.production?
   Sidekiq.configure_client do |config|
     config.redis = {
       url: Rails.configuration.redis_url.to_s,
-      network_timeout: 5,
       read_timeout: 1.0,
       write_timeout: 1.0
     }

--- a/helm_deploy/offender-management-allocation-manager/templates/background-jobs-processor.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/background-jobs-processor.yaml
@@ -27,8 +27,24 @@ spec:
         imagePullPolicy: Always
         securityContext:
           {{- with index .Values "generic-service" }}{{ toYaml .securityContext | nindent 10 }}{{ end }}
-        command: ['sh', '-c', "bundle exec sidekiq -C config/sidekiq.yml"]
+        command: ["./sidekiq.sh", "start"]
           {{- include "moic-helpers.envs" . | nindent 8 }}
+        readinessProbe:
+          exec:
+            command: ["./sidekiq.sh", "probe"]
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command: ["./sidekiq.sh", "probe"]
+          initialDelaySeconds: 45
+          periodSeconds: 60
+          timeoutSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command: ["./sidekiq.sh", "stop"]
         resources:
           limits:
             memory: 2Gi

--- a/sidekiq.sh
+++ b/sidekiq.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+ACTION=$1
+RETRY_LIMIT=3
+RETRY_WAIT=5
+
+start_function(){
+  bundle exec sidekiq -C config/sidekiq.yml
+}
+
+stop_function(){
+  # SIGTERM triggers a quick exit; gracefully terminate instead.
+  # Find PID
+  SIDEKIQ_PID=$(ps aux | grep sidekiq | grep busy | awk '{ print $2 }')
+
+  if [ -z "$SIDEKIQ_PID" ]; then
+    echo "No Sidekiq PIDs found."
+  else
+    echo "Sending TSTP signal..."
+    kill -TSTP ${SIDEKIQ_PID}
+
+    # Wait until it finishes all the jobs and then send a TERM signal to it
+    wait_function
+
+    echo "Sending TERM signal..."
+    kill -TERM ${SIDEKIQ_PID}
+  fi
+}
+
+wait_function(){
+  sleep 2
+
+  i=0
+  while [ ${i} -lt ${RETRY_LIMIT} ]; do
+    i=$((i+1))
+
+    IS_SIDEKIQ_DONE=$(sidekiqmon processes | grep -q "(0 busy)"; echo $?)
+
+    if [ ${IS_SIDEKIQ_DONE} -eq 0 ]; then
+      echo "Sidekiq finished all jobs."
+      break
+    else
+      echo "Sidekiq is still busy. Retry $i/$RETRY_LIMIT Waiting $RETRY_WAIT seconds..."
+      sleep ${RETRY_WAIT}
+    fi
+  done
+}
+
+# This is used in the kubernetes deployment readinessProbe and livenessProbe.
+probe_function(){
+  MONITOR_OUTPUT=$(sidekiqmon processes) || exit 1
+
+  # Check redis connection
+  REDIS_CHECK=$(echo ${MONITOR_OUTPUT} | grep -q "ECONNREFUSED"; echo $?)
+
+  # Check there is at least 1 process running
+  PROCESSES_CHECK=$(echo ${MONITOR_OUTPUT} | grep -q "Processes (0)"; echo $?)
+
+  # Check there is more than 1 thread running (normally will be 3)
+  THREADS_CHECK=$(echo ${MONITOR_OUTPUT} | grep -qE "Threads: \b[0-1]\b"; echo $?)
+
+  # If any of the above checks returns '0' it means the regex found a match
+  if [ ${REDIS_CHECK} -eq 0 ] || [ ${PROCESSES_CHECK} -eq 0 ] || [ ${THREADS_CHECK} -eq 0 ]; then
+    echo 'Sidekiq probe: KO'
+    exit 1
+  fi
+
+  echo 'Sidekiq probe: OK'
+}
+
+if [ -z "$REDIS_URL" ]; then
+  echo 'REDIS_URL env variable not set. Defaulting to redis://localhost:6379'
+fi
+
+case "$ACTION" in
+  start)
+    start_function
+    ;;
+  stop)
+    stop_function
+    ;;
+  restart)
+    stop_function && start_function
+    ;;
+  probe)
+    probe_function
+    ;;
+  *)
+  echo "Usage: $0 [start|stop|restart|probe]"
+esac


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1549

Adds a simple sidekiq probe script to ensure the process is healthy and also to perform a graceful quit, waiting for any in-progress jobs to finish before the pod stops.

Updates redis and sidekiq gems as these were locked to some old versions. Fixed deprecations.