### PR TITLE
MO-1573: Parole reviews per sentence

### DIFF
--- a/app/lib/console_debug_offender_helpers.rb
+++ b/app/lib/console_debug_offender_helpers.rb
@@ -49,7 +49,7 @@ module ConsoleDebugOffenderHelpers
               display_date(parole_review.target_hearing_date),
               display_tick_cross(parole_review.id == offender.current_parole_review&.id),
               display_tick_cross(parole_review.id == offender.most_recent_parole_review&.id),
-              display_tick_cross(parole_review.id == offender.most_recent_completed_parole_review&.id),
+              display_tick_cross(parole_review.id == offender.most_recent_completed_parole_review_for_sentence&.id),
             ]
           end
         )

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -19,7 +19,7 @@ class MpcOffender
 
   delegate :victim_liaison_officers, :handover_progress_task_completion_data, :handover_progress_complete?,
            :handover_type, :current_parole_review, :previous_parole_reviews, :build_parole_review_sections,
-           :most_recent_parole_review, :most_recent_completed_parole_review, to: :@offender
+           :most_recent_parole_review, :parole_reviews, to: :@offender
 
   attr_reader :case_information, :prison
 
@@ -150,19 +150,6 @@ class MpcOffender
     most_recent_parole_review&.target_hearing_date
   end
 
-  # Returns the target hearing date for the offender's next active parole application, or nil if there isn't one.
-
-  # Returns the date that the most recent hearing outcome was received.
-  def hearing_outcome_received_on
-    most_recent_parole_review&.hearing_outcome_received_on
-  end
-
-  # Returns the date that the most recent COMPLETED hearing outcome was received.
-  # Used to exclude any active parole applications.
-  def last_hearing_outcome_received_on
-    most_recent_completed_parole_review&.hearing_outcome_received_on
-  end
-
   def approaching_parole?
     next_parole_date.present?
   end
@@ -186,6 +173,13 @@ class MpcOffender
     when target_hearing_date
       'Target hearing date'
     end
+  end
+
+  def most_recent_completed_parole_review
+    @most_recent_completed_parole_review_for_sentence ||= parole_reviews
+      .completed
+      .for_sentences_starting(sentence_start_date)
+      .last
   end
 
   def no_parole_outcome?

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -175,19 +175,20 @@ class MpcOffender
     end
   end
 
-  def most_recent_completed_parole_review
+  def most_recent_completed_parole_review_for_sentence
     @most_recent_completed_parole_review_for_sentence ||= parole_reviews
+      .ordered_by_sortable_date
       .completed
       .for_sentences_starting(sentence_start_date)
       .last
   end
 
   def no_parole_outcome?
-    most_recent_completed_parole_review&.no_hearing_outcome?
+    most_recent_completed_parole_review_for_sentence&.no_hearing_outcome?
   end
 
   def parole_outcome_not_release?
-    most_recent_completed_parole_review&.outcome_is_not_release?
+    most_recent_completed_parole_review_for_sentence&.outcome_is_not_release?
   end
 
   def thd_12_or_more_months_from_now?

--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -54,11 +54,6 @@ class Offender < ApplicationRecord
     @most_recent_parole_review ||= parole_reviews.ordered_by_sortable_date.last
   end
 
-  # Returns the most recent parole review that has an outcome
-  def most_recent_completed_parole_review
-    @most_recent_completed_parole_review ||= parole_reviews.ordered_by_sortable_date.with_hearing_outcome.last
-  end
-
   def current_parole_review
     @current_parole_review ||= parole_reviews.ordered_by_sortable_date.current.first
   end

--- a/app/models/parole_review.rb
+++ b/app/models/parole_review.rb
@@ -27,6 +27,8 @@ class ParoleReview < ApplicationRecord
 
   scope :previous, -> { where.not(id: current.pluck(:id)) }
 
+  scope :completed, -> { ordered_by_sortable_date.with_hearing_outcome }
+
   validate :hearing_outcome_received_on_must_be_in_past, on: :manual_update
 
   # Used when POM manually enters this date

--- a/app/views/debugging/_parole_history.html.erb
+++ b/app/views/debugging/_parole_history.html.erb
@@ -21,7 +21,7 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header" data-record-id="<%= parole_review.id %>" data-note="<%=
                 case parole_review.id
-                when @offender.most_recent_completed_parole_review&.id then 'MRC'
+                when @offender.most_recent_completed_parole_review_for_sentence&.id then 'MRC'
                 when @offender.most_recent_parole_review&.id           then 'MR'
                 end
               %>" title="<%= parole_review.updated_at.strftime('%d/%m/%Y %H:%M:%S') %>">

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -99,9 +99,7 @@ FactoryBot.define do
           prison: build(:prison),
           offender: create(:offender,
             nomis_offender_id: api_offender.offender_no,
-            case_information: build(:case_information,
-              mappa_level:
-            )
+            case_information: build(:case_information, mappa_level:)
           ),
           prison_record: api_offender
         )

--- a/spec/factories/parole_review.rb
+++ b/spec/factories/parole_review.rb
@@ -8,6 +8,16 @@ FactoryBot.define do
     review_status {'Active'}
     hearing_outcome {'Not Specified'} # = no hearing outcome
 
+    trait :active do
+      hearing_outcome { nil }
+      review_status { 'Active' }
+    end
+
+    trait :completed do
+      target_hearing_date { 1.year.from_now }
+      hearing_outcome { 'Release [*]' }
+    end
+
     trait :approaching_parole do
       target_hearing_date { Time.zone.today + 7.days } # Must be within the next 10 months
       hearing_outcome { 'Not Specified' } # = no hearing outcome

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -541,7 +541,6 @@ RSpec.describe MpcOffender, type: :model do
           expect(subject.target_hearing_date).to eq(completed_parole_review.target_hearing_date)
         end
       end
-
     end
   end
 

--- a/spec/models/offender_spec.rb
+++ b/spec/models/offender_spec.rb
@@ -171,12 +171,6 @@ RSpec.describe Offender, type: :model do
       end
     end
 
-    describe '#most_recent_completed_parole_review' do
-      it 'returns the most recently completed parole review' do
-        expect(offender.most_recent_completed_parole_review).to eq(completed_parole_review)
-      end
-    end
-
     describe 'Parole queries' do
       let(:completed_parole_review_1) do
         create(:parole_review, custody_report_due: Time.zone.today - 2.years,


### PR DESCRIPTION
Use the sentence start date to find the most recent completed review for this particular sentence.
This prevents parole review outcomes for previous sentences (mostly recalls) being used for responsibility calculations.

Removed unused methods `hearing_outcome_received_on` and `last_hearing_outcome_received_on`.