### PR TITLE
Tidying up sorting, filtering and pagination

### DIFF
--- a/app/controllers/caseload_controller.rb
+++ b/app/controllers/caseload_controller.rb
@@ -10,7 +10,7 @@ class CaseloadController < PrisonStaffApplicationController
   end
 
   def updates_required
-    sorted_tasks = @current_user.pom_tasks
-    @pom_tasks = Kaminari.paginate_array(sorted_tasks.map { |pom_task| PomTaskPresenter.for(pom_task) }).page(page)
+    sorted_tasks = @current_user.pom_tasks.map { |pom_task| PomTaskPresenter.for(pom_task) }
+    @pom_tasks = paginate_array(sorted_tasks)
   end
 end

--- a/app/controllers/concerns/sorting.rb
+++ b/app/controllers/concerns/sorting.rb
@@ -14,6 +14,15 @@ module Sorting
     end
   end
 
+  def sort_and_paginate(collection, default_sort: :handover_date, default_direction: :asc)
+    sorted_collection = sort_collection(collection, default_sort:, default_direction:)
+    paginate_array(sorted_collection)
+  end
+
+  def paginate_array(collection)
+    Kaminari.paginate_array(collection).page(page)
+  end
+
 private
 
   def sort_with_public_send(items, field, direction)
@@ -40,5 +49,9 @@ private
     else
       1
     end
+  end
+
+  def page
+    params.fetch('page', 1).to_i
   end
 end

--- a/app/controllers/handovers_controller.rb
+++ b/app/controllers/handovers_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class HandoversController < PrisonsApplicationController
-  include Sorting
-
   layout 'handovers'
 
   before_action :check_prerequisites_and_prepare_variables

--- a/app/controllers/parole_cases_controller.rb
+++ b/app/controllers/parole_cases_controller.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 class ParoleCasesController < PrisonsApplicationController
-  include Sorting
-
   before_action :ensure_spo_user
 
   def index
-    sorted_offenders_with_allocs = sort_collection offenders_with_allocs, default_sort: :last_name
-    @offenders = Kaminari.paginate_array(sorted_offenders_with_allocs).page(page)
+    @offenders = sort_and_paginate(offenders_with_allocs, default_sort: :last_name)
   end
 
 private

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PomsController < PrisonStaffApplicationController
-  include Sorting
-
   before_action :ensure_spo_user
 
   before_action :load_pom_staff_member, only: [:show, :edit, :update]

--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -66,10 +66,6 @@ private
     @service_notifications = ServiceNotificationsService.notifications(roles)
   end
 
-  def page
-    params.fetch('page', 1).to_i
-  end
-
   def set_referrer
     @referrer = referrer
   end
@@ -80,11 +76,6 @@ private
 
   def store_referrer_in_session
     session[:referrer] = request.referer
-  end
-
-  def sort_and_paginate(cases)
-    sorted_cases = sort_collection cases, default_sort: :handover_date, default_direction: :asc
-    Kaminari.paginate_array(sorted_cases).page(page)
   end
 
   def check_active_caseload

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < PrisonsApplicationController
   def index
     offenders = @current_user.allocations
     sorted_tasks = sort_tasks(offenders.map(&:pom_tasks).flatten)
-    @pomtasks = Kaminari.paginate_array(sorted_tasks).page(page)
+    @pomtasks = paginate_array(sorted_tasks)
   end
 
 private
@@ -32,9 +32,5 @@ private
     poms_list = @prison.get_list_of_poms
 
     @pom = poms_list.find { |p| p.staff_id.to_i == user.staff_id.to_i }
-  end
-
-  def page
-    params.fetch('page', 1).to_i
   end
 end

--- a/app/lib/handover/handover_case.rb
+++ b/app/lib/handover/handover_case.rb
@@ -18,7 +18,7 @@ class Handover::HandoverCase
   delegate :last_name, to: :offender, prefix: true
   delegate :staff_member, :allocated_com_name, :tier, :handover_progress_complete?,
            :earliest_release_for_handover, to: :offender
-  delegate :last_name, to: :staff_member, prefix: true
+  delegate :full_name_ordered, to: :staff_member, prefix: true
   delegate :handover_date, to: :calculated_handover_date
 
   def com_allocation_days_overdue(relative_to_date: Time.zone.now.to_date)

--- a/app/presenters/offender_with_allocation_presenter.rb
+++ b/app/presenters/offender_with_allocation_presenter.rb
@@ -5,10 +5,15 @@
 class OffenderWithAllocationPresenter
   include SortableAllocation
 
-  delegate :offender_no, :full_name, :last_name, :earliest_release_date, :earliest_release, :latest_temp_movement_date, :allocated_com_name,
-           :enhanced_handover?, :date_of_birth, :tier, :probation_record, :handover_start_date, :restricted_patient?,
-           :location, :responsibility_handover_date, :pom_responsible?, :pom_supporting?, :coworking?, :prison, :active_allocation,
-           :next_parole_date, :next_parole_date_type, to: :@offender
+  delegate :offender_no, :full_name,
+           # used in the parole page
+           :next_parole_date, :next_parole_date_type,
+           # used in the allocated page
+           :last_name, :location, :restricted_patient?, :earliest_release, :earliest_release_date, :tier, :latest_temp_movement_date,
+           # needed in the caseload global page
+           :pom_responsible?, :pom_supporting?,
+           # needed for search
+           :active_allocation, :probation_record, to: :@offender
 
   def initialize(offender, allocation)
     @offender = offender
@@ -23,9 +28,5 @@ class OffenderWithAllocationPresenter
     if @allocation
       (@allocation.primary_pom_allocated_at || @allocation.updated_at)&.to_date
     end
-  end
-
-  def primary_pom_allocated_at
-    @allocation.primary_pom_allocated_at
   end
 end

--- a/app/views/handovers/_shared_in_progress.html.erb
+++ b/app/views/handovers/_shared_in_progress.html.erb
@@ -6,7 +6,7 @@
                         anchor: local_assigns[:anchor],
                         headers: [
                           { sort: 'offender_last_name', body: 'Prisoner details' },
-                          @pom_view ? nil : { sort: 'staff_member_last_name', body: 'POM' },
+                          @pom_view ? nil : { sort: 'staff_member_full_name_ordered', body: 'POM' },
                           local_assigns[:hide_com_details] ? nil : { sort: 'allocated_com_name', body: 'COM details' },
                           { sort: 'handover_date', body: 'COM responsible' },
                           { sort: 'earliest_release_date', body: 'Earliest release date' },

--- a/app/views/handovers/com_allocation_overdue.html.erb
+++ b/app/views/handovers/com_allocation_overdue.html.erb
@@ -20,7 +20,7 @@
 <%= handover_list_table(table_class: %w[com-allocation-overdue],
                         headers: [
                           { sort: 'offender_last_name', body: 'Prisoner details' },
-                          @pom_view ? nil : { sort: 'staff_member_last_name', body: 'POM' },
+                          @pom_view ? nil : { sort: 'staff_member_full_name_ordered', body: 'POM' },
                           { sort: 'handover_date', body: 'COM responsible' },
                           { sort: 'earliest_release_date', body: 'Earliest release date' },
                           { sort: 'tier', body: 'Tier' },

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -51,11 +51,7 @@
               </span>
             </td>
             <td aria-label="POM" class="govuk-table__cell">
-              <% if offender.formatted_pom_name %>
-                <%= link_to offender.formatted_pom_name, prison_pom_path(@prison.code, nomis_staff_id: offender.allocated_pom_nomis_id) %>
-              <% else %>
-                'Not allocated'
-              <% end %>
+              <%= link_to offender.formatted_pom_name, prison_pom_path(@prison.code, nomis_staff_id: offender.allocated_pom_nomis_id) %>
             </td>
             <td aria-label="POM Role" class="govuk-table__cell">
               <%= offender.allocated_pom_role %>

--- a/app/views/prisoners/allocated.html.erb
+++ b/app/views/prisoners/allocated.html.erb
@@ -101,7 +101,7 @@
           <%= offender.tier %>
         </td>
         <td aria-label="POM" class="govuk-table__cell">
-          <%= link_to offender.formatted_pom_name, prison_pom_path(offender.prison.code, offender.allocated_pom_nomis_id), class: "govuk-link" %>
+          <%= link_to offender.formatted_pom_name, prison_pom_path(@prison.code, offender.allocated_pom_nomis_id), class: "govuk-link" %>
         </td>
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
       </tr>


### PR DESCRIPTION
Reorganise and avoid some code repetition.
Centralise anything related to sorting and pagination in the module, and delete duplicated inclusion of the module where it is part of the parent controller.

Also make sure the sorting by POM name in handovers list is done by full name instead of last name, as we are now showing POM name as "Forename Surname".