### PR TITLE
Reintroduce prison refactoring changes

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -13,7 +13,7 @@ class AllocationStaffController < PrisonsApplicationController
     @case_info = Offender.find_by!(nomis_offender_id: prisoner_id_from_url).case_information
     @allocation = AllocationHistory.find_by nomis_offender_id: prisoner_id_from_url
     previous_pom_ids = @allocation ? @allocation.previously_allocated_poms : []
-    poms = @prison.get_list_of_poms.index_by(&:staff_id)
+    poms = @prison.poms.index_by(&:staff_id)
     @previous_poms = previous_pom_ids.map { |staff_id| poms[staff_id] }.compact
     @current_pom = poms[@allocation.primary_pom_nomis_id] if @allocation&.primary_pom_nomis_id
     @oasys_assessment = HmppsApi::AssessRisksAndNeedsApi.get_latest_oasys_date(@prisoner.offender_no)
@@ -74,7 +74,7 @@ private
   end
 
   def load_pom_types
-    poms = @prison.get_list_of_poms.map { |pom| StaffMember.new(@prison, pom.staff_id) }.sort_by(&:last_name)
+    poms = @prison.poms.map { |pom| StaffMember.new(@prison, pom.staff_id) }.sort_by(&:last_name)
     @probation_poms, @prison_poms = poms.partition(&:probation_officer?)
   end
 

--- a/app/controllers/caseload_global_controller.rb
+++ b/app/controllers/caseload_global_controller.rb
@@ -5,7 +5,7 @@ class CaseloadGlobalController < PrisonStaffApplicationController
 
   def index
     @allocated = @prison.allocated.map do |offender|
-      OffenderWithAllocationPresenter.new(offender, @prison.allocations.detect { |a| a.nomis_offender_id == offender.offender_no })
+      OffenderWithAllocationPresenter.new(offender, @prison.allocation_for(offender))
     end
 
     @recent_allocations = paginate_array(sort_allocations(recent_allocations))

--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -6,7 +6,7 @@ class CoworkingController < PrisonsApplicationController
   def new
     @prisoner = offender(nomis_offender_id_from_url)
     current_pom_id = AllocationHistory.find_by!(nomis_offender_id: nomis_offender_id_from_url).primary_pom_nomis_id
-    poms = @prison.get_list_of_poms
+    poms = @prison.poms
     @current_pom = poms.detect { |pom| pom.staff_id == current_pom_id }
 
     @active_poms, @unavailable_poms = poms.reject { |p| p.staff_id == current_pom_id }.partition do |pom|
@@ -19,8 +19,8 @@ class CoworkingController < PrisonsApplicationController
 
   def confirm
     @prisoner = offender(nomis_offender_id_from_url)
-    @primary_pom = @prison.get_single_pom(primary_pom_id_from_url)
-    @secondary_pom = @prison.get_single_pom(secondary_pom_id_from_url)
+    @primary_pom = @prison.pom_with_id(primary_pom_id_from_url)
+    @secondary_pom = @prison.pom_with_id(secondary_pom_id_from_url)
     @latest_allocation_details = session[:latest_allocation_details] = format_allocation(
       offender: @prisoner, pom: @primary_pom, view_context: view_context, co_working_pom: @secondary_pom)
   end
@@ -42,7 +42,7 @@ class CoworkingController < PrisonsApplicationController
       nomis_offender_id: coworking_nomis_offender_id_from_url
     )
     @prisoner = offender(@allocation.nomis_offender_id)
-    @primary_pom = @prison.get_single_pom(@allocation.primary_pom_nomis_id)
+    @primary_pom = @prison.pom_with_id(@allocation.primary_pom_nomis_id)
   end
 
   def destroy

--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -119,7 +119,7 @@ private
 
   def pdf_as_string
     allocation = AllocationHistory.find_by!(offender_id_from_url)
-    pom = @prison.get_single_pom(allocation.primary_pom_nomis_id)
+    pom = @prison.pom_with_id(allocation.primary_pom_nomis_id)
 
     view_context.render_early_alloc_pdf(early_allocation: @early_allocation,
                                         offender: @prisoner,

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -8,7 +8,7 @@ class PomsController < PrisonStaffApplicationController
   before_action :set_referrer
 
   def index
-    @poms = @prison.get_list_of_poms.sort_by(&:last_name)
+    @poms = @prison.poms.sort_by(&:last_name)
   end
 
   def show

--- a/app/controllers/prison_staff_application_controller.rb
+++ b/app/controllers/prison_staff_application_controller.rb
@@ -65,7 +65,7 @@ private
     @handover_cases = Handover::CategorisedHandoverCasesForPom.new(@pom)
 
     @summary = {
-      all_prison_cases: @prison.allocations.all.count,
+      all_prison_cases: @prison.allocations.count,
       new_cases_count: @pom.allocations.count(&:new_case?),
       total_cases: @pom.allocations.count,
       last_seven_days: @pom.allocations.count { |a| a.primary_pom_allocated_at.to_date >= 7.days.ago },

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -21,7 +21,7 @@ class PrisonersController < PrisonsApplicationController
 
   def search
     @q = search_term
-    offenders = SearchService.search_for_offenders(@q, @prison.all_policy_offenders)
+    offenders = SearchService.search_for_offenders(@q, @prison.policy_offenders)
     @offenders, @user_allocations = get_slice_for_page(offenders, @current_user.staff_id)
     MetricsService.instance.increment_search_count
 
@@ -100,7 +100,7 @@ private
     @missing_info = @prison.missing_info
     @unallocated = @prison.unallocated
     @allocated = @prison.allocated.map do |offender|
-      OffenderWithAllocationPresenter.new(offender, @prison.allocations.detect { |a| a.nomis_offender_id == offender.offender_no })
+      OffenderWithAllocationPresenter.new(offender, @prison.allocation_for(offender))
     end
   end
 
@@ -119,7 +119,7 @@ private
     user_allocations = []
 
     offender_list.map do |offender|
-      allocation = @prison.allocations.detect { |a| a.nomis_offender_id == offender.offender_no }
+      allocation = @prison.allocation_for(offender)
       if !allocation.nil? && allocation.primary_pom_nomis_id == user_id
         user_allocations.push OffenderWithAllocationPresenter.new(offender, allocation)
       else

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,7 +29,7 @@ private
 
   def load_pom
     user = HmppsApi::PrisonApi::UserApi.user_details(current_user)
-    poms_list = @prison.get_list_of_poms
+    poms_list = @prison.poms
 
     @pom = poms_list.find { |p| p.staff_id.to_i == user.staff_id.to_i }
   end

--- a/app/jobs/auto_early_allocation_email_job.rb
+++ b/app/jobs/auto_early_allocation_email_job.rb
@@ -10,7 +10,7 @@ class AutoEarlyAllocationEmailJob < ApplicationJob
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)
     allocation = AllocationHistory.find_by!(nomis_offender_id: offender_no)
-    pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
+    pom = prison.pom_with_id(allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.with(email: offender.ldu_email_address,
                                prisoner_name: offender.full_name,

--- a/app/jobs/community_early_allocation_email_job.rb
+++ b/app/jobs/community_early_allocation_email_job.rb
@@ -8,7 +8,7 @@ class CommunityEarlyAllocationEmailJob < ApplicationJob
   def perform(prison, offender_no, encoded_pdf)
     offender = OffenderService.get_offender(offender_no)
     allocation = AllocationHistory.find_by!(nomis_offender_id: offender_no)
-    pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
+    pom = prison.pom_with_id(allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.with(email: offender.ldu_email_address,
                                prisoner_name: offender.full_name,

--- a/app/jobs/handover_follow_up_job/follow_up_email_details.rb
+++ b/app/jobs/handover_follow_up_job/follow_up_email_details.rb
@@ -27,11 +27,11 @@ class HandoverFollowUpJob::FollowUpEmailDetails
 private
 
   def active_pom_details
-    pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
+    pom = prison.pom_with_id(allocation.primary_pom_nomis_id)
 
     { pom_name: pom.full_name, pom_email: pom.email_address || 'unknown' }
   rescue StandardError => e
-    # `get_single_pom` can raise an exception if the `primary_pom_nomis_id`
+    # `pom_with_id` can raise an exception if the `primary_pom_nomis_id`
     # is not found in the list of all poms for this prison
     Rails.logger.error(e.message)
 

--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -17,7 +17,7 @@ class SuitableForEarlyAllocationEmailJob < ApplicationJob
 
       if already_emailed.empty?
         prison = Prison.find(prisoner.prison_id)
-        pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
+        pom = prison.pom_with_id(allocation.primary_pom_nomis_id)
         EarlyAllocationMailer.with(
           email: pom.email_address,
           prisoner_name: prisoner.full_name,

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -75,6 +75,10 @@ class MpcOffender
     @offender.responsibility.present?
   end
 
+  def allocatable?
+    case_information.present? && (prison.womens? ? complexity_level.present? : true)
+  end
+
   # Early allocation methods
   def early_allocation?
     latest_early_allocation.present? && !licence_expiry_date&.before?(Time.zone.today)
@@ -375,9 +379,7 @@ class MpcOffender
   end
 
   def released?(relative_to_date: Time.zone.now.utc.to_date)
-    return false if earliest_release_date.nil?
-
-    earliest_release_date <= relative_to_date
+    earliest_release_date.present? && earliest_release_date <= relative_to_date
   end
 
   def has_com?

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -11,6 +11,13 @@ class PomDetail < ApplicationRecord
 
   belongs_to :prison, foreign_key: :prison_code, inverse_of: :pom_details
 
+  def self.find_or_create_new_active_by!(prison:, nomis_staff_id:)
+    find_or_create_by!(prison:, nomis_staff_id:) do |pom|
+      pom.working_pattern = 0.0
+      pom.status = 'active'
+    end
+  end
+
   def allocations
     @allocations ||= begin
       allocations = AllocationHistory.active_pom_allocations(nomis_staff_id, prison_code).pluck(:nomis_offender_id)

--- a/app/models/pom_wrapper.rb
+++ b/app/models/pom_wrapper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# The return value from get_list_of_poms - a combo of PomDetails and PrisonOffenderManager from the API
+# The return value from poms - a combo of PomDetails and PrisonOffenderManager from the API
 class PomWrapper
   delegate :email_address, :full_name, :full_name_ordered, :position_description, :first_name, :last_name,
            :probation_officer?, :prison_officer?, :staff_id, :agency_id, to: :@pom

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -3,32 +3,36 @@ class Prison < ApplicationRecord
 
   validates :prison_type, presence: true
   validates :code, :name, presence: true, uniqueness: true
+
   has_many :pom_details, dependent: :destroy, foreign_key: :prison_code, inverse_of: :prison
 
   enum prison_type: { womens: 'womens', mens_open: 'mens_open', mens_closed: 'mens_closed' }
 
   scope :active, -> { where(code: AllocationHistory.distinct.pluck(:prison)) }
 
-  def get_list_of_poms
+  def poms
     # This API call doesn't do what it says on the tin. It can return duplicate
     # staff_ids in the situation where someone has more than one role.
     poms = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(code)
-      .select { |pom| pom.prison_officer? || pom.probation_officer? }.uniq(&:staff_id)
+      .select { |pom| pom.prison_officer? || pom.probation_officer? }
+      .uniq(&:staff_id)
 
-    details = pom_details.where(nomis_staff_id: poms.map(&:staff_id))
+    poms.map do |pom|
+      pom_detail = PomDetail.find_or_create_new_active_by!(
+        prison: self,
+        nomis_staff_id: pom.staff_id
+      )
 
-    poms.map { |pom| PomWrapper.new(pom, get_pom_detail(details,  pom.staff_id.to_i)) }
+      PomWrapper.new(pom, pom_detail)
+    end
   end
 
-  def get_single_pom(nomis_staff_id)
-    raise ArgumentError, 'Prison#get_single_pom(nil)' if nomis_staff_id.nil?
+  def pom_with_id(nomis_staff_id)
+    raise ArgumentError, 'Prison#pom_with_id(nil)' if nomis_staff_id.nil?
 
-    poms_list = get_list_of_poms
-    pom = poms_list.find { |p| p.staff_id == nomis_staff_id.to_i }
-    if pom.blank?
-      pom_staff_ids = poms_list.map(&:staff_id)
-      raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{code} - list is #{pom_staff_ids}"
-    end
+    pom = poms.find { |p| p.staff_id == nomis_staff_id.to_i }
+
+    raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{code}" if pom.blank?
 
     pom
   end
@@ -41,56 +45,38 @@ class Prison < ApplicationRecord
     allocated + unallocated
   end
 
-  def unfiltered_offenders
-    # Returns all offenders at the provided prison, and does not
-    # filter out under 18s or non-sentenced offenders
-    @unfiltered_offenders ||= OffenderService.get_offenders_in_prison(self)
-  end
-
-  def all_policy_offenders
+  def policy_offenders
     unfiltered_offenders.select(&:inside_omic_policy?)
   end
 
   def allocations
     @allocations ||= AllocationHistory.active_allocations_for_prison(code)
-      .where(nomis_offender_id: all_policy_offenders.map(&:offender_no))
   end
 
   delegate :for_pom, to: :allocations, prefix: true
 
   def primary_allocated_offenders
-    alloc_hash = allocations.index_by(&:nomis_offender_id)
+    allocated.reject(&:released?).map do |offender|
+      allocation = allocation_for(offender)
 
-    allocated.select { |offender| alloc_hash.key?(offender.offender_no) && !offender.released? }.map do |offender|
-      AllocatedOffender.new(alloc_hash[offender.offender_no].primary_pom_nomis_id,
-                            alloc_hash.fetch(offender.offender_no), offender)
+      AllocatedOffender.new(allocation.primary_pom_nomis_id, allocation, offender)
     end
-  end
-
-  def offender_allocatable?(offender)
-    offender.case_information.present? && (womens? ? offender.complexity_level.present? : true)
-  end
-
-  def offender_allocated?(offender)
-    @allocations_by_offender_nomis_id ||= allocations.index_by(&:nomis_offender_id)
-    @allocations_by_offender_nomis_id.key?(offender.nomis_offender_id)
   end
 
   delegate :allocated, to: :summary
   delegate :unallocated, to: :summary
   delegate :missing_info, to: :summary
+  delegate :allocation_for, to: :summary
 
 private
 
   def summary
-    @summary ||= AllocationsSummary.new(self)
+    @summary ||= AllocationsSummary.new(allocations:, offenders: policy_offenders)
   end
 
-  def get_pom_detail(details, nomis_staff_id)
-    details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
-      PomDetail.find_or_create_by!(prison_code: code, nomis_staff_id: nomis_staff_id) do |pom|
-        pom.working_pattern = 0.0
-        pom.status = 'active'
-      end
+  def unfiltered_offenders
+    # Returns all offenders at the provided prison, and does not
+    # filter out under 18s or non-sentenced offenders
+    @unfiltered_offenders ||= OffenderService.get_offenders_in_prison(self)
   end
 end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -50,7 +50,9 @@ class Prison < ApplicationRecord
   end
 
   def allocations
-    @allocations ||= AllocationHistory.active_allocations_for_prison(code)
+    @allocations ||= AllocationHistory
+      .active_allocations_for_prison(code)
+      .where(nomis_offender_id: policy_offenders.map(&:offender_no))
   end
 
   delegate :for_pom, to: :allocations, prefix: true

--- a/app/models/prison/allocations_summary.rb
+++ b/app/models/prison/allocations_summary.rb
@@ -1,28 +1,29 @@
 class Prison::AllocationsSummary
-  def initialize(prison)
-    @prison = prison
-    build_summary
+  def initialize(allocations:, offenders:)
+    @allocations = allocations
+    @offenders = offenders
   end
 
-  def allocated = @summary[:allocated]
-  def unallocated = @summary[:unallocated]
-  def missing_info = @summary[:missing_info]
-  def outside_omic_policy = @summary[:outside_omic_policy]
+  def allocated = summary.fetch(:allocated, [])
+  def unallocated = summary.fetch(:unallocated, [])
+  def missing_info = summary.fetch(:missing_info, [])
+
+  def allocation_for(offender_or_id)
+    id = offender_or_id.try(:nomis_offender_id) || offender_or_id
+
+    @allocations_by_id ||= @allocations.index_by(&:nomis_offender_id)
+    @allocations_by_id[id]
+  end
 
 private
 
-  def build_summary
-    @summary = @prison.unfiltered_offenders.group_by do |offender|
-      if !offender.inside_omic_policy?
-        :outside_omic_policy
-      elsif @prison.offender_allocatable?(offender) && @prison.offender_allocated?(offender)
-        :allocated
-      elsif @prison.offender_allocatable?(offender)
-        :unallocated
+  def summary
+    @summary ||= @offenders.group_by do |offender|
+      if offender.allocatable?
+        allocation_for(offender).present? ? :allocated : :unallocated
       else
         :missing_info
       end
     end
-    @summary.default = []
   end
 end

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -69,7 +69,7 @@ class EmailService
     end
 
     def pom_for(allocation, pom_nomis_id)
-      Prison.find(allocation.prison).get_single_pom(pom_nomis_id)
+      Prison.find(allocation.prison).pom_with_id(pom_nomis_id)
     end
 
     def current_responsibility(offender)

--- a/lib/tasks/community_api_import.rake
+++ b/lib/tasks/community_api_import.rake
@@ -14,7 +14,7 @@ namespace :community_api do
       prison_log_prefix = "[#{prison_index + 1}/#{prison_count}]"
       Rails.logger.info("#{prison_log_prefix} Getting offenders for prison #{prison.name} (#{prison.code})")
 
-      offender_count = prison.all_policy_offenders.each { |offender|
+      offender_count = prison.policy_offenders.each { |offender|
         ProcessDeliusDataJob.perform_later offender.offender_no
         Rails.logger.info("#{prison_log_prefix} Queued job for offender #{offender.offender_no}")
       }.count

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
 
       context 'when offender has 18 months or less of sentence remaining' do
         before do
-          allow_any_instance_of(Prison).to receive(:get_single_pom).and_return(pom)
+          allow_any_instance_of(Prison).to receive(:pom_with_id).and_return(pom)
         end
 
         context 'when no previous Early Allocation reminder email sent for this offender' do

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -34,90 +34,53 @@ RSpec.describe Prison do
     end
   end
 
-  describe '#unfiltered_offenders' do
-    subject { described_class.new(code: 'LEI').unfiltered_offenders }
-
-    it "get first page of offenders for a specific prison",
-       vcr: { cassette_name: 'prison_api/offender_service_offenders_by_prison_first_page_spec' } do
-      offender_array = subject.first(9)
-      expect(offender_array).to be_kind_of(Array)
-      expect(offender_array.length).to eq(9)
+  describe 'Validations' do
+    subject do
+      described_class.new(prison_type: 'mens_open',
+                          code: 'ACI',
+                          name: 'HMP Altcourse')
     end
 
-    it "get last page of offenders for a specific prison", vcr: { cassette_name: 'prison_api/offender_service_offenders_by_prison_last_page_spec' } do
-      offender_array = subject.to_a
-      expect(offender_array).to be_kind_of(Array)
-      expect(offender_array.length).to be > 800
+    it "is not valid without a prison_type" do
+      subject.prison_type = nil
+      expect(subject).to be_invalid
     end
 
-    context 'when recall flag set' do
-      let(:offenders) { build_list(:nomis_offender, 2, sentence: attributes_for(:sentence_detail, recall: true)) }
-
-      before do
-        stub_auth_token
-        stub_offenders_for_prison('LEI', offenders)
-        create(:offender, nomis_offender_id: offenders.first.fetch(:prisonerNumber))
-      end
-
-      it 'populates the recall flag' do
-        expect(subject.map(&:recalled?)).to eq [true, true]
-      end
-
-      it 'creates the missing offender object' do
-        expect(Offender.count).to eq(1)
-        expect(subject.count).to eq(2)
-        expect(Offender.count).to eq(2)
-      end
+    it "is not valid without a code" do
+      subject.code = nil
+      expect(subject).to be_invalid
     end
 
-    describe 'Validations' do
-      subject do
-        described_class.new(prison_type: 'mens_open',
-                            code: 'ACI',
-                            name: 'HMP Altcourse')
-      end
+    it 's code must be unique' do
+      described_class.create!(prison_type: 'mens_open',
+                              code: 'ACI',
+                              name: 'HMP Altcourse')
 
-      it "is not valid without a prison_type" do
-        subject.prison_type = nil
-        expect(subject).to be_invalid
-      end
-
-      it "is not valid without a code" do
-        subject.code = nil
-        expect(subject).to be_invalid
-      end
-
-      it 's code must be unique' do
-        described_class.create!(prison_type: 'mens_open',
-                                code: 'ACI',
-                                name: 'HMP Altcourse')
-
-        expect(subject).to be_invalid
-      end
-
-      it 's name must be unique' do
-        described_class.create!(prison_type: 'mens_open',
-                                code: 'AGI',
-                                name: 'HMP Altcourse')
-
-        expect(subject).to be_invalid
-      end
-
-      it "is valid when all values are present" do
-        expect(subject).to be_valid
-      end
+      expect(subject).to be_invalid
     end
 
-    describe 'Associations with PomDetail' do
-      let!(:prison) { create(:prison) }
+    it 's name must be unique' do
+      described_class.create!(prison_type: 'mens_open',
+                              code: 'AGI',
+                              name: 'HMP Altcourse')
 
-      before do
-        create_list(:pom_detail, 5, prison: prison)
-      end
+      expect(subject).to be_invalid
+    end
 
-      it 'has many pom details' do
-        expect(described_class.find(prison.code).pom_details.size).to be(5)
-      end
+    it "is valid when all values are present" do
+      expect(subject).to be_valid
+    end
+  end
+
+  describe 'Associations with PomDetail' do
+    let!(:prison) { create(:prison) }
+
+    before do
+      create_list(:pom_detail, 5, prison: prison)
+    end
+
+    it 'has many pom details' do
+      expect(described_class.find(prison.code).pom_details.size).to be(5)
     end
   end
 
@@ -147,7 +110,8 @@ RSpec.describe Prison do
                                                                           nomis_offender_id:,
                                                                           inside_omic_policy?: true,
                                                                           case_information: double,
-                                                                          released?: false
+                                                                          released?: false,
+                                                                          allocatable?: true
       end
     end
     let(:allocated_offenders) do

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -13,9 +13,9 @@ describe PrisonOffenderManagerService do
   context 'when using T3 and VCR' do
     let(:prison)  { Prison.find('LEI') }
 
-    describe '#get_list_of_poms' do
+    describe '#poms' do
       subject do
-        prison.get_list_of_poms
+        prison.poms
       end
 
       let(:moic_integration_tests) { subject.detect { |x| x.first_name == 'MOIC' } }
@@ -27,17 +27,17 @@ describe PrisonOffenderManagerService do
       end
     end
 
-    describe '#get_single_pom' do
+    describe '#pom_with_id' do
       it "can fetch a single POM for a prison",
          vcr: { cassette_name: 'prison_api/pom_service_get_pom_ok' } do
-        pom = prison.get_single_pom(staff_id)
+        pom = prison.pom_with_id(staff_id)
         expect(pom).not_to be nil
       end
 
       it "raises an exception when fetching a pom if they are not a POM",
          vcr: { cassette_name: 'prison_api/pom_service_get_pom_none' } do
         expect {
-          prison.get_single_pom(1234)
+          prison.pom_with_id(1234)
         }.to raise_exception(StandardError, /^Failed to find POM/)
       end
     end
@@ -54,7 +54,7 @@ describe PrisonOffenderManagerService do
       stub_auth_token
     end
 
-    describe '#get_list_of_poms' do
+    describe '#poms' do
       let!(:prison)  { create(:prison) }
 
       let(:alice) do
@@ -107,11 +107,11 @@ describe PrisonOffenderManagerService do
       end
 
       it 'removes duplicate staff ids, keeping the valid position' do
-        expect(prison.get_list_of_poms.map(&:first_name)).to eq([alice, billy].map(&:firstName))
+        expect(prison.poms.map(&:first_name)).to eq([alice, billy].map(&:firstName))
       end
     end
 
-    describe '#get_single_pom' do
+    describe '#pom_with_id' do
       context 'when pom not existing at a prison' do
         before do
           stub_auth_token
@@ -160,7 +160,7 @@ describe PrisonOffenderManagerService do
 
         it "raises" do
           expect {
-            described_class.get_single_pom(1234)
+            described_class.pom_with_id(1234)
           }.to raise_exception(StandardError)
         end
       end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe SearchService do
-  let(:offenders) { Prison.new(code: 'LEI').unfiltered_offenders }
-  let(:oakwood_offenders) { Prison.new(code: 'OWI').unfiltered_offenders }
+  let(:offenders) { OffenderService.get_offenders_in_prison(Prison.new(code: 'LEI')) }
+  let(:oakwood_offenders) { OffenderService.get_offenders_in_prison(Prison.new(code: 'OWI')) }
 
   it "will return all of the records if no search", vcr: { cassette_name: 'prison_api/search_service_all' } do
     expect(described_class.search_for_offenders('', offenders).count).to be > 800


### PR DESCRIPTION
Un revert my refactoring changes, this time reinstating a scope to the allocations query which I think has been causing memory spikes.