### PR TITLE
Add in attr_reader to make delegate work

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -24,7 +24,7 @@ class AllocatedOffender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id, :primary_pom_name,
            to: :@allocation
   delegate :full_name_ordered, to: :staff_member, prefix: true
-  
+
   attr_reader :offender
 
   COMPLEXITIES = { 'high' => 3, 'medium' => 2, 'low' => 1 }.freeze

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -73,8 +73,8 @@ class AllocatedOffender
       end
     end
   end
-  
+
 private
-  
+
   attr_reader :offender # only to allow #offender_last_name delegation to work, better fix to come...
 end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -24,6 +24,8 @@ class AllocatedOffender
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id, :primary_pom_name,
            to: :@allocation
   delegate :full_name_ordered, to: :staff_member, prefix: true
+  
+  attr_reader :offender
 
   COMPLEXITIES = { 'high' => 3, 'medium' => 2, 'low' => 1 }.freeze
 
@@ -73,8 +75,4 @@ class AllocatedOffender
       end
     end
   end
-
-private
-
-  attr_reader :offender # only to allow #offender_last_name delegation to work, better fix to come...
 end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -73,4 +73,8 @@ class AllocatedOffender
       end
     end
   end
+  
+private
+  
+  attr_reader :offender # only to allow #offender_last_name delegation to work, better fix to come...
 end

--- a/app/views/handovers/_shared_in_progress.html.erb
+++ b/app/views/handovers/_shared_in_progress.html.erb
@@ -19,7 +19,7 @@
   <% (local_assigns[:handover_data] || @filtered_handover_cases).each do |handover_case| %>
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: handover_case.offender, anchor: local_assigns[:anchor] %>
-      <%= render 'handovers/cells/staff_member', staff_member: handover_case.offender.staff_member unless @pom_view %>
+      <%= render 'handovers/cells/staff_member', staff_member: handover_case.staff_member unless @pom_view %>
 
       <%= render 'handovers/cells/com_details', offender: handover_case.offender,
                  handover_date: handover_case.handover_date unless local_assigns[:hide_com_details] %>

--- a/app/views/handovers/com_allocation_overdue.html.erb
+++ b/app/views/handovers/com_allocation_overdue.html.erb
@@ -32,7 +32,7 @@
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: handover_case.offender %>
 
-      <%= render 'handovers/cells/staff_member', staff_member: handover_case.offender.staff_member unless @pom_view %>
+      <%= render 'handovers/cells/staff_member', staff_member: handover_case.staff_member unless @pom_view %>
 
       <%= render 'handovers/cells/handover_dates',
                  handover_case: handover_case, show_highlight: nil %>

--- a/spec/models/allocated_offender_spec.rb
+++ b/spec/models/allocated_offender_spec.rb
@@ -35,4 +35,10 @@ RSpec.describe AllocatedOffender do
       end
     end
   end
+  
+  describe '#offender_last_name' do
+    it 'returns the last_name of the offender' do
+      expect(described_class.new(nil, nil, double(last_name: "Atreides")).offender_last_name).to eq("Atreides")
+    end
+  end
 end

--- a/spec/models/allocated_offender_spec.rb
+++ b/spec/models/allocated_offender_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AllocatedOffender do
       end
     end
   end
-  
+
   describe '#offender_last_name' do
     it 'returns the last_name of the offender' do
       expect(described_class.new(nil, nil, double(last_name: "Atreides")).offender_last_name).to eq("Atreides")


### PR DESCRIPTION
I have previously moved fields into AllocatedOffender to be delegated to MpcOffender. 

The following line would not work as there is no `offender` method only `@offender`:
```
delegate :last_name, to: :offender, prefix: true
```

So I put in a `attr_reader :offender` for now