### PR TITLE
New tests to cover handover summary

### DIFF
--- a/spec/factories/calculated_handover_date.rb
+++ b/spec/factories/calculated_handover_date.rb
@@ -19,17 +19,23 @@ FactoryBot.define do
         CalculatedHandoverDate::COMMUNITY_RESPONSIBLE
       ].sample
     }
+    
+    trait :upcoming_handover do
+      before_handover
+    end
 
     trait :before_handover do
       responsibility { CalculatedHandoverDate::CUSTODY_ONLY }
-      start_date { Faker::Date.forward }
-      handover_date { Faker::Date.forward }
+      handover_date { rand(1.week.from_now..((DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION-1).days.from_now)) }
+    end
+    
+    trait :handover_in_progress do
+      after_handover
     end
 
     trait :after_handover do
-      start_date { Faker::Date.backward }
-      handover_date { Faker::Date.backward }
       responsibility { CalculatedHandoverDate::COMMUNITY_RESPONSIBLE }
+      handover_date { Faker::Date.backward }
     end
   end
 end

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -52,6 +52,10 @@ FactoryBot.define do
 
   factory :offender do
     nomis_offender_id
+    
+    trait :allocatable do
+      case_information { create(:case_information) }
+    end
 
     trait :enhanced_handover do
       case_information { create(:case_information, enhanced_resourcing: true) }

--- a/spec/features/handover/homd_views_handover_summary_spec.rb
+++ b/spec/features/handover/homd_views_handover_summary_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+describe "HOMD views handover summary for a Prison" do
+  let(:prison) { create(:prison, code: 'LEI') }
+
+  let(:all_offenders_at_prison) do
+    build_list(:nomis_offender, 2, prisonId: prison.code).tap do |offenders|
+      stub_offenders_for_prison(prison.code, offenders)
+    end
+  end
+
+  let(:offender_records) do
+    all_offenders_at_prison.map { |offender| create(:offender, :allocatable, id: offender[:prisonerNumber]) }
+  end
+
+  let(:poms_at_prison) do
+    {
+      'emily' => build(:pom),
+      'frank' => build(:pom)
+    }.tap do |poms|
+      stub_poms(prison.code, poms.values)
+    end
+  end
+
+  before do
+    homd = build(:pom)
+    stub_signin_spo(homd)
+  end
+
+  specify 'HOMD can view upcoming handovers' do
+    offender_with_upcoming_handover = offender_records.first
+    create(:allocation_history, primary_pom_nomis_id: poms_at_prison['emily'].staffId, prison: prison.code, offender: offender_with_upcoming_handover)
+    create(:calculated_handover_date, :upcoming_handover, offender: offender_with_upcoming_handover)
+
+    visit upcoming_prison_handovers_path(prison_id: prison.code)
+    expect(page).to have_content("Upcoming handovers (1)")
+    expect(page).to have_content(offender_with_upcoming_handover.nomis_offender_id)
+  end
+
+  specify 'HOMD can view in progress handovers' do
+    offender_with_in_progress_handover = offender_records.second
+    create(:allocation_history, primary_pom_nomis_id: poms_at_prison['frank'].staffId, prison: prison.code, offender: offender_with_in_progress_handover)
+    create(:calculated_handover_date, :handover_in_progress, offender: offender_with_in_progress_handover)
+
+    visit in_progress_prison_handovers_path(prison_id: prison.code)
+    expect(page).to have_content("Handovers in progress (1)")
+    expect(page).to have_content(offender_with_in_progress_handover.nomis_offender_id)
+  end
+
+  specify 'HOMD can handovers with overdue tasks' do
+    offender_with_overdue_handover_tasks = offender_records.second
+    create(:allocation_history, primary_pom_nomis_id: poms_at_prison['frank'].staffId, prison: prison.code, offender: offender_with_overdue_handover_tasks)
+    create(:calculated_handover_date, :handover_in_progress, offender: offender_with_overdue_handover_tasks)
+    # ensure offender has standard handover - contacted_com is a required task for standard handover
+    offender_with_overdue_handover_tasks.case_information.update!(enhanced_resourcing: false)
+    create(:handover_progress_checklist, contacted_com: false, offender: offender_with_overdue_handover_tasks)
+
+    visit overdue_tasks_prison_handovers_path(prison_id: prison.code)
+    expect(page).to have_content("Handovers in progress (1)")
+    expect(page).to have_content("Overdue tasks (1)")
+    within 'tr', text: offender_with_overdue_handover_tasks.nomis_offender_id do
+      expect(page).to have_content('Handover tasks overdue')
+    end
+  end
+
+  specify 'HOMD can view handovers with com allocation overdue' do
+    offender_with_com_allocation_overdue = offender_records.first
+    create(:allocation_history, primary_pom_nomis_id: poms_at_prison['emily'].staffId, prison: prison.code, offender: offender_with_com_allocation_overdue)
+    create(:calculated_handover_date, :handover_in_progress, offender: offender_with_com_allocation_overdue)
+    offender_with_com_allocation_overdue.case_information.update!(com_email: nil, com_name: nil)
+
+    visit com_allocation_overdue_prison_handovers_path(prison_id: prison.code)
+    expect(page).to have_content("Handovers in progress (1)")
+    expect(page).to have_content("COM allocation overdue (1)")
+    expect(page).to have_content(offender_with_com_allocation_overdue.nomis_offender_id)
+  end
+end


### PR DESCRIPTION
Starting to make the tests as end to end as possible to allow proper refactoring.
As new tests get written in this style we will look at simplifying setup where possible and improving existing
test setup methods.