### PR TITLE
Check for allowed sorting fields

### DIFF
--- a/app/controllers/concerns/sorting.rb
+++ b/app/controllers/concerns/sorting.rb
@@ -1,17 +1,40 @@
 # frozen_string_literal: true
 
 module Sorting
+  SORTABLE_FIELDS = %i[
+    action_label
+    additional_information
+    allocated_com_name
+    allocated_pom_role
+    allocation_date
+    awaiting_allocation_for
+    case_owner
+    com_allocation_days_overdue
+    complexity_level_number
+    coworking_allocations_count
+    earliest_release_date
+    formatted_pom_name
+    handover_date
+    last_name
+    location
+    new_allocations_count
+    next_parole_date
+    offender_last_name
+    offender_name
+    pom_responsibility
+    position
+    primary_pom_allocated_at
+    responsible_allocations_count
+    staff_member_full_name_ordered
+    supporting_allocations_count
+    tier
+    total_allocations_count
+    working_pattern
+  ].freeze
+
   def sort_collection(items, default_sort:, default_direction: :asc)
     field, direction = sort_params(default_sort: default_sort, default_direction: default_direction)
     sort_with_public_send items, field, direction
-  end
-
-  def sort_params(default_sort:, default_direction: :asc)
-    if params['sort']
-      params['sort'].split.map { |s| s.downcase.to_sym }
-    else
-      [default_sort, default_direction]
-    end
   end
 
   def sort_and_paginate(collection, default_sort: :handover_date, default_direction: :asc)
@@ -26,7 +49,7 @@ module Sorting
 private
 
   def sort_with_public_send(items, field, direction)
-    return items if field.nil?
+    return items if SORTABLE_FIELDS.exclude?(field)
 
     items.sort do |x, y|
       compare_via_public_send field, direction, x, y
@@ -48,6 +71,14 @@ private
       -1
     else
       1
+    end
+  end
+
+  def sort_params(default_sort:, default_direction: :asc)
+    if params['sort']
+      params['sort'].split.map { |s| s.downcase.to_sym }
+    else
+      [default_sort, default_direction]
     end
   end
 

--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -4,6 +4,8 @@ module SortHelper
   DEFAULT_SORT = 'last_name'
 
   def sort_link(field_name, anchor: nil)
+    raise ArgumentError, "`#{field_name}` is not an allowed sortable field" unless sortable_field?(field_name)
+
     if anchor.nil?
       link_for_field(field_name, URI.parse(request.original_url))
     else
@@ -12,6 +14,8 @@ module SortHelper
   end
 
   def sort_arrow(field_name)
+    raise ArgumentError, "`#{field_name}` is not an allowed sortable field" unless sortable_field?(field_name)
+
     arrow_for_field(field_name, URI.parse(request.original_url))
   end
 
@@ -69,5 +73,9 @@ private
     return 'desc' if param.end_with?('asc')
 
     'asc'
+  end
+
+  def sortable_field?(field_name)
+    Sorting::SORTABLE_FIELDS.include?(field_name.to_sym)
   end
 end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -25,8 +25,6 @@ class AllocatedOffender
            to: :@allocation
   delegate :full_name_ordered, to: :staff_member, prefix: true
 
-  attr_reader :offender
-
   COMPLEXITIES = { 'high' => 3, 'medium' => 2, 'low' => 1 }.freeze
 
   def initialize(staff_id, allocation, offender)

--- a/spec/controllers/concerns/sorting_spec.rb
+++ b/spec/controllers/concerns/sorting_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Sorting do
+  controller(ApplicationController) do
+    include Sorting # rubocop:disable RSpec/DescribedClass
+  end
+
+  let(:date1) { Date.new(2023, 1, 1) }
+  let(:date2) { Date.new(2023, 2, 1) }
+  let(:date3) { Date.new(2023, 3, 1) }
+
+  let(:items) do
+    [
+      double('Item', last_name: 'Smith', handover_date: date1),
+      double('Item', last_name: 'Jones', handover_date: date2),
+      double('Item', last_name: 'Brown', handover_date: date3),
+    ]
+  end
+
+  describe '#sort_collection' do
+    it 'sorts by last_name ascending' do
+      sorted_items = controller.sort_collection(items, default_sort: :last_name, default_direction: :asc)
+      expect(sorted_items.map(&:last_name)).to eq %w[Brown Jones Smith]
+    end
+
+    it 'sorts by last_name descending' do
+      sorted_items = controller.sort_collection(items, default_sort: :last_name, default_direction: :desc)
+      expect(sorted_items.map(&:last_name)).to eq %w[Smith Jones Brown]
+    end
+
+    it 'sorts by handover_date ascending' do
+      sorted_items = controller.sort_collection(items, default_sort: :handover_date, default_direction: :asc)
+      expect(sorted_items.map(&:handover_date)).to eq [date1, date2, date3]
+    end
+
+    it 'sorts by handover_date descending' do
+      sorted_items = controller.sort_collection(items, default_sort: :handover_date, default_direction: :desc)
+      expect(sorted_items.map(&:handover_date)).to eq [date3, date2, date1]
+    end
+
+    it 'returns the original collection if the field is not sortable' do
+      sorted_items = controller.sort_collection(items, default_sort: :invalid_field, default_direction: :asc)
+      expect(sorted_items).to eq items
+    end
+  end
+
+  describe '#sort_and_paginate' do
+    let(:paginated_items) { controller.sort_and_paginate(items, default_sort: :last_name, default_direction: :asc) }
+
+    context 'when on page 1' do
+      it 'sorts and paginates the collection' do
+        allow(controller).to receive(:params).and_return({ 'page' => 1 })
+        expect(paginated_items.map(&:last_name)).to eq %w[Brown Jones Smith]
+      end
+    end
+
+    context 'when on page 2' do
+      it 'sorts and paginates the collection' do
+        allow(controller).to receive(:params).and_return({ 'page' => 2 })
+        expect(paginated_items.map(&:last_name)).to eq []
+      end
+    end
+  end
+end

--- a/spec/helpers/sort_helper_spec.rb
+++ b/spec/helpers/sort_helper_spec.rb
@@ -36,4 +36,16 @@ RSpec.describe SortHelper do
     result = sort_link('last_name', anchor: 'anchortag')
     expect(result).to eq('/unallocated?sort=last_name+asc#anchortag')
   end
+
+  it "raises an error when generating the link if the field is not sortable" do
+    expect {
+      sort_link('invalid_field')
+    }.to raise_error(ArgumentError, "`invalid_field` is not an allowed sortable field")
+  end
+
+  it "raises an error when generating the arrow if the field is not sortable" do
+    expect {
+      sort_arrow('invalid_field')
+    }.to raise_error(ArgumentError, "`invalid_field` is not an allowed sortable field")
+  end
 end


### PR DESCRIPTION
There are many tables in the application with sortable columns.

Compile a list of allowed ones we use, and reject anything else, as a precaution, and also to help avoid mistakes in code when referencing a field that is not part of the list.
Increased test coverage for some sorting fields where it was missing.