### PR TITLE
MO-1588 Change allocation POM name format

### DIFF
--- a/app/controllers/api/allocation_api_controller.rb
+++ b/app/controllers/api/allocation_api_controller.rb
@@ -42,7 +42,7 @@ module Api
     def primary_pom_details
       {
         staff_id: @allocation.primary_pom_nomis_id,
-        name: PrisonOffenderManagerService.fetch_pom_name(@allocation.primary_pom_nomis_id)
+        name: PrisonOffenderManagerService.fetch_pom_name(@allocation.primary_pom_nomis_id, ordered: false)
       }
     end
 
@@ -51,7 +51,7 @@ module Api
 
       {
         staff_id: @allocation.secondary_pom_nomis_id,
-        name: PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id)
+        name: PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id, ordered: false)
       }
     end
 

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -47,7 +47,7 @@ class PrisonersController < PrisonsApplicationController
       end
 
       if @allocation.secondary_pom_name.present?
-        @secondary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
+        @secondary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id)
         @secondary_pom_email = PrisonOffenderManagerService.fetch_pom_email(@allocation.secondary_pom_nomis_id)
       end
     end
@@ -73,11 +73,10 @@ class PrisonersController < PrisonsApplicationController
 
     if @allocation.present?
       @primary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.primary_pom_nomis_id)
-          .titleize
     end
 
     if @allocation.present? && @allocation.secondary_pom_name.present?
-      @secondary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id).titleize
+      @secondary_pom_name = PrisonOffenderManagerService.fetch_pom_name(@allocation.secondary_pom_nomis_id)
     end
 
     @keyworker = HmppsApi::KeyworkerApi.get_keyworker(

--- a/app/helpers/early_allocation_helper.rb
+++ b/app/helpers/early_allocation_helper.rb
@@ -66,7 +66,7 @@ module EarlyAllocationHelper
   }.freeze
 
   def pom_full_name(early_allocation)
-    "#{early_allocation.created_by_lastname}, #{early_allocation.created_by_firstname}"
+    "#{early_allocation.created_by_firstname} #{early_allocation.created_by_lastname}"
   end
 
   EARLY_ALLOCATION_STATUSES = {

--- a/app/presenters/early_allocation_decision.rb
+++ b/app/presenters/early_allocation_decision.rb
@@ -10,7 +10,7 @@ class EarlyAllocationDecision
   end
 
   def created_by_name
-    "#{@early_allocation.updated_by_lastname}, #{@early_allocation.updated_by_firstname}"
+    "#{@early_allocation.updated_by_firstname} #{@early_allocation.updated_by_lastname}"
   end
 
   def to_partial_path

--- a/app/presenters/early_allocation_history.rb
+++ b/app/presenters/early_allocation_history.rb
@@ -8,7 +8,7 @@ class EarlyAllocationHistory
   end
 
   def created_by_name
-    "#{@early_allocation.created_by_lastname}, #{@early_allocation.created_by_firstname}"
+    "#{@early_allocation.created_by_firstname} #{@early_allocation.created_by_lastname}"
   end
 
   def to_partial_path

--- a/app/presenters/offender_with_allocation_presenter.rb
+++ b/app/presenters/offender_with_allocation_presenter.rb
@@ -11,7 +11,7 @@ class OffenderWithAllocationPresenter
            # used in the allocated page
            :last_name, :location, :restricted_patient?, :earliest_release, :earliest_release_date, :tier, :latest_temp_movement_date,
            # needed in the caseload global page
-           :pom_responsible?, :pom_supporting?,
+           :pom_responsible?, :pom_supporting?, :coworking?,
            # needed for search
            :active_allocation, :probation_record, to: :@offender
 

--- a/app/services/prison_offender_manager_service.rb
+++ b/app/services/prison_offender_manager_service.rb
@@ -2,9 +2,14 @@
 
 class PrisonOffenderManagerService
   class << self
-    def fetch_pom_name(staff_id)
+    def fetch_pom_name(staff_id, ordered: true)
       staff = HmppsApi::PrisonApi::PrisonOffenderManagerApi.staff_detail(staff_id)
-      "#{staff.last_name}, #{staff.first_name}"
+
+      if ordered
+        [staff.first_name, staff.last_name].compact_blank.join(' ').titleize
+      else
+        [staff.last_name, staff.first_name].compact_blank.join(', ')
+      end
     end
 
     def fetch_pom_email(staff_id)

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
         describe "format: #{format}" do
           it 'shows the record specified in :id param' do
             early_allocations.each do |record|
-              get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: record.id }, format: :html
+              get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: record.id }, format: format
               expect(assigns(:early_allocation)).to eq(record)
             end
           end
@@ -91,7 +91,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
             it 'raises a "Not Found" error' do
               somebody_else = create(:early_allocation)
               expect {
-                get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: somebody_else.id }, format: :html
+                get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: somebody_else.id }, format: format
               }.to raise_error(ActiveRecord::RecordNotFound)
             end
           end
@@ -100,7 +100,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
             it 'raises a "Not Found" error' do
               id = 48_753
               expect {
-                get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: id }, format: :html
+                get :show, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: id }, format: format
               }.to raise_error(ActiveRecord::RecordNotFound)
             end
           end
@@ -217,6 +217,40 @@ RSpec.describe EarlyAllocationsController, type: :controller do
         }
 
         assert_template 'landing_ineligible'
+      end
+    end
+  end
+
+  describe '#edit' do
+    let(:release_date) { Time.zone.today + 17.months }
+    let(:early_allocation) { create(:early_allocation, nomis_offender_id: nomis_offender_id) }
+
+    it 'renders the edit page' do
+      get :edit, params: { prison_id: prison, prisoner_id: nomis_offender_id, id: early_allocation.id }
+      assert_template 'edit'
+    end
+  end
+
+  describe '#oasys_date' do
+    let(:release_date) { Time.zone.today + 17.months }
+
+    context 'when form is valid' do
+      it 'renders the eligible page' do
+        post :oasys_date, params: { prison_id: prison,
+                                    prisoner_id: nomis_offender_id,
+                                    early_allocation: { oasys_risk_assessment_date: valid_date } }
+
+        assert_template 'eligible'
+      end
+    end
+
+    context 'when form is invalid' do
+      it 'renders the new page' do
+        post :oasys_date, params: { prison_id: prison,
+                                    prisoner_id: nomis_offender_id,
+                                    early_allocation: { oasys_risk_assessment_date: nil } }
+
+        assert_template 'new'
       end
     end
   end

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -43,8 +43,12 @@ describe PrisonOffenderManagerService do
     end
 
     describe 'fetch_pom_name', vcr: { cassette_name: 'prison_api/pom_helper_fetch_pom_name' } do
-      it 'fetches the POM name from NOMIS' do
-        expect(described_class.fetch_pom_name(485_926)).to eq('POM, MOIC')
+      it 'fetches the ordered POM name from NOMIS' do
+        expect(described_class.fetch_pom_name(485_926)).to eq('Moic Pom')
+      end
+
+      it 'fetches the unordered POM name from NOMIS' do
+        expect(described_class.fetch_pom_name(485_926, ordered: false)).to eq('POM, MOIC')
       end
     end
   end

--- a/spec/views/allocations/allocation_history.html.erb_spec.rb
+++ b/spec/views/allocations/allocation_history.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "allocations/history", type: :view do
       it 'shows a single record' do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome: not eligible.')
       end
@@ -57,7 +57,7 @@ RSpec.describe "allocations/history", type: :view do
       it 'shows a single record' do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome: eligible.')
         expect(page.css('.moj-timeline__description')).to have_content('The assessment has not been sent to the community probation team.')
@@ -74,7 +74,7 @@ RSpec.describe "allocations/history", type: :view do
       it 'shows a single record' do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome: not eligible.')
       end
@@ -89,7 +89,7 @@ RSpec.describe "allocations/history", type: :view do
       it 'shows a single record' do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome: discretionary.')
         expect(page.css('.moj-timeline__description')).to have_content('The assessment has not been sent to the community probation team.')
@@ -106,7 +106,7 @@ RSpec.describe "allocations/history", type: :view do
       it 'shows a single record' do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome: eligible.')
         expect(page.css('.moj-timeline__description')).to have_content('The case handover date has been updated. The community probation team will allocate a COM to take responsibility for this case early.')
@@ -122,7 +122,7 @@ RSpec.describe "allocations/history", type: :view do
       it 'shows a single record' do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome is discretionary.')
         expect(page.css('.moj-timeline__description')).to have_content('The community probation team will need to make a decision.')
@@ -140,8 +140,8 @@ RSpec.describe "allocations/history", type: :view do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ['Early allocation decision recorded', "Early allocation assessment form completed"]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("21st November 2060 (11:35)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.updated_by_lastname}, #{ea.updated_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.updated_by_firstname} #{ea.updated_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome is discretionary.')
         expect(page.css('.moj-timeline__description')).to have_content('The community probation team will need to make a decision.')
@@ -161,8 +161,8 @@ RSpec.describe "allocations/history", type: :view do
         expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ['Early allocation decision recorded', "Early allocation assessment form completed",]
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("21st November 2060 (11:35)")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_lastname}, #{ea.created_by_firstname}")
-        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.updated_by_lastname}, #{ea.updated_by_firstname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
+        expect(page.css('.moj-timeline__date')).to have_text("by #{ea.updated_by_firstname} #{ea.updated_by_lastname}")
 
         expect(page.css('.moj-timeline__description')).to have_content('Assessment outcome is discretionary.')
         expect(page.css('.moj-timeline__description')).to have_content('The community probation team will need to make a decision.')

--- a/spec/views/early_allocations/early_allocations_list.html.erb_spec.rb
+++ b/spec/views/early_allocations/early_allocations_list.html.erb_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "early_allocations/early_allocations_list", type: :view do
 
         it 'shows the name of the POM who created the record' do
           pom_names = early_allocations.map do |record|
-            "#{record.created_by_lastname}, #{record.created_by_firstname}"
+            "#{record.created_by_firstname} #{record.created_by_lastname}"
           end
           expect(rendered_values).to eq(pom_names)
         end

--- a/spec/views/early_allocations/show.html.erb_spec.rb
+++ b/spec/views/early_allocations/show.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "early_allocations/show", type: :view do
   let(:page) { Nokogiri::HTML(rendered) }
   let(:referrer) { nil }
 
-  context 'when reviewing an elibigle early assessment' do
+  context 'when reviewing an eligible early assessment' do
     let(:early_allocation) {  create(:early_allocation, :eligible, created_at: '05/11/2021', created_by_firstname: 'Olivia', created_by_lastname: 'Mann') }
 
     it 'shows the previous assessment date' do
@@ -24,7 +24,7 @@ RSpec.describe "early_allocations/show", type: :view do
 
     it 'shows the previous POM who made the assessment' do
       expect(page.css('#pom-name-label')).to have_text('POM name')
-      expect(page.css('#pom-name')).to have_text('Mann, Olivia')
+      expect(page.css('#pom-name')).to have_text('Olivia Mann')
     end
 
     describe 'outcome' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1588

Follow-up to PR https://github.com/ministryofjustice/offender-management-allocation-manager/pull/2550.
A few more places where the name has been normalised.

Note I've done an exception for the API controller as I'm assuming this endpoint is used by events consumers to retrieve information about the allocation and a change in the name format might break some of these integrations.