### PR TITLE
MO-1127 Disallow edit case info for linked cases

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -15,10 +15,10 @@ class CaseInformationController < PrisonsApplicationController
   end
 
   def edit
-    return if @prisoner.manual_entry?
-
-    Rails.logger.warn("[#{self.class}] Prisoner #{@prisoner.nomis_offender_id} is not marked as manual entry, refusing edit")
-    redirect_to('/404')
+    unless @prisoner.manual_entry?
+      Rails.logger.warn("[#{self.class}] Prisoner #{@prisoner.nomis_offender_id} is not marked as manual entry, refusing edit")
+      redirect_to('/404')
+    end
   end
 
   def create

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -14,7 +14,12 @@ class CaseInformationController < PrisonsApplicationController
     @case_info = offender.build_case_information
   end
 
-  def edit; end
+  def edit
+    return if @prisoner.manual_entry?
+
+    Rails.logger.warn("[#{self.class}] Prisoner #{@prisoner.nomis_offender_id} is not marked as manual entry, refusing edit")
+    redirect_to('/404')
+  end
 
   def create
     prisoner = Offender.find_by! nomis_offender_id: case_information_params[:nomis_offender_id]

--- a/app/views/prisoners/review_case_details.html.erb
+++ b/app/views/prisoners/review_case_details.html.erb
@@ -68,7 +68,9 @@
             <tr class="govuk-table__row" id="tier">
               <th scope="row" class="govuk-table__header govuk-!-width-one-third">Tier</th>
               <td class="govuk-table__cell govuk-!-width-one-third"><%= @prisoner.tier.presence || 'No tier found' %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= link_to('Change', edit_prison_case_information_path(@prison, @prisoner.offender_no), class: 'govuk-link govuk-link--no-visited-state') %></td>
+              <td class="govuk-table__cell govuk-!-width-one-third">
+                <%= link_to('Change', edit_prison_case_information_path(@prison, @prisoner.offender_no), class: 'govuk-link govuk-link--no-visited-state') if @prisoner.manual_entry? %>
+              </td>
             </tr>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header govuk-!-width-one-third">Category</th>

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -46,6 +46,17 @@ feature 'case information feature', flaky: true do
         expect(page).to have_no_button('Save and allocate')
       end
     end
+
+    context 'when trying to edit a non manual entry' do
+      before do
+        create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)), manual_entry: false)
+      end
+
+      it 'does not allow the user to edit the case information', :js do
+        visit edit_prison_case_information_path(prison.code, offender.fetch(:prisonerNumber))
+        expect(page).to have_current_path('/404')
+      end
+    end
   end
 
   context 'with vcr' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1127

This was mostly already done in most places, I only found a place where the link was still there for linked cases.

In case we missed some other place, and also to not allow editing by changing the URL, I added a check to the controller action and some logging, just in case.