### PR TITLE
MO-912 Update 'missing COM' notification copy

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -23,7 +23,6 @@ class AllocationsController < PrisonsApplicationController
       end
     end
     @keyworker = HmppsApi::KeyworkerApi.get_keyworker(active_prison_id, @prisoner.offender_no)
-    @emails_sent_to_ldu = EmailHistory.sent_within_current_sentence(@prisoner, EmailHistory::OPEN_PRISON_COMMUNITY_ALLOCATION)
     retrieve_latest_allocation_details
   end
 

--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -82,8 +82,6 @@ class PrisonersController < PrisonsApplicationController
     @keyworker = HmppsApi::KeyworkerApi.get_keyworker(
       active_prison_id, @prisoner.offender_no
     )
-
-    @emails_sent_to_ldu = EmailHistory.sent_within_current_sentence(@prisoner, EmailHistory::OPEN_PRISON_COMMUNITY_ALLOCATION)
   end
 
   def image

--- a/app/views/allocation_staff/index.html.erb
+++ b/app/views/allocation_staff/index.html.erb
@@ -2,7 +2,7 @@
 <%= link_to "Back", 'javascript:history.back()', class: "govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6" %>
 
 <% if @prisoner.needs_a_com? %>
-  <%= render partial: 'shared/notifications/offender_needs_a_com', locals: {offender: @prisoner, email_history: @emails_sent_to_ldu} %>
+  <%= render partial: 'shared/notifications/offender_needs_a_com', locals: { offender: @prisoner } %>
 <% end %>
 <% if flash[:alert] %>
   <div id="pom-selection-error">

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -3,7 +3,7 @@
 <%= render 'layouts/notice', notice: flash[:notice] %>
 
 <% if @prisoner.needs_a_com? %>
-  <%= render partial: 'shared/notifications/offender_needs_a_com', locals: {offender: @prisoner, email_history: @emails_sent_to_ldu} %>
+  <%= render partial: 'shared/notifications/offender_needs_a_com', locals: { offender: @prisoner } %>
 <% end %>
 
 <% if @latest_allocation_details.present? %>

--- a/app/views/prisoners/show.html.erb
+++ b/app/views/prisoners/show.html.erb
@@ -3,7 +3,7 @@
 <%= render 'layouts/notice', notice: flash[:notice] %>
 
 <% if @prisoner.needs_a_com? %>
-  <%= render partial: 'shared/notifications/offender_needs_a_com', locals: {offender: @prisoner, email_history: @emails_sent_to_ldu} %>
+  <%= render partial: 'shared/notifications/offender_needs_a_com', locals: { offender: @prisoner } %>
 <% end %>
 
 <% @tasks.each do |task| %>

--- a/app/views/shared/notifications/_offender_needs_a_com.html.erb
+++ b/app/views/shared/notifications/_offender_needs_a_com.html.erb
@@ -1,29 +1,22 @@
 <div class="govuk-error-summary" aria-labelledby="com-error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="com-error-summary-title">
-    <%=
-      if email_history.present?
-        I18n.t('views.notifications.offender_needs_a_com.maybe_contact_ldu')
-      else
-        I18n.t('views.notifications.offender_needs_a_com.must_contact_ldu')
-      end
-    %>
+    COM allocation overdue
   </h2>
   <div class="govuk-error-summary__body">
-    <ul class="govuk-list govuk-error-summary__list">
-      <li id="com_warning"><%= link_to I18n.t('views.notifications.offender_needs_a_com.com_needed'), "#com-name", data: { turbolinks: false } %></li>
-
-      <% if email_history.present? %>
-        <li id="ldu_warning">
-          <%=
-            date_sent = email_history.map(&:created_at).max.to_date
-            link_to I18n.t('views.notifications.offender_needs_a_com.ldu_emailed', date: format_date(date_sent)), "#com-name", data: { turbolinks: false }
-          %>
-        </li>
-      <% elsif offender.ldu_email_address.blank? %>
-        <li id="ldu_warning">
-          <%= link_to I18n.t('views.notifications.offender_needs_a_com.ldu_uncontactable'), "#com-name", data: { turbolinks: false } %>
-        </li>
-      <% end %>
-    </ul>
+    <% if offender.ldu_email_address.present? %>
+      <p class="govuk-body">
+        Contact <%= offender.ldu_name %>
+        on <%= mail_to offender.ldu_email_address, offender.ldu_email_address, class: %w[govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold] %>
+        to see if a COM can be allocated.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        We do not know which LDU will be responsible for this person.
+      </p>
+      <p class="govuk-body govuk-!-margin-top-2">
+        Check their <%= link_to 'full Digital Prison Services profile', digital_prison_service_profile_path(offender.offender_no), class: %w[govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold], target: '_blank' %>
+        to see where they were sentenced and then try contacting the LDU for that area.
+      </p>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,13 +162,6 @@ en:
       previous: "&lsaquo; Previous"
       next: "Next &rsaquo;"
       truncate: "&hellip;"
-    notifications:
-      offender_needs_a_com:
-        maybe_contact_ldu: "You may need to contact the community probation office"
-        must_contact_ldu: "You must contact the community probation office"
-        com_needed: "A Community Offender Manager (COM) must be allocated to this case."
-        ldu_emailed: "We automatically emailed the LDU asking them to allocate a COM on %{date}."
-        ldu_uncontactable: "We can’t automatically contact the LDU because their details are missing. You need to find an alternative way of contacting them."
   helpers:
     fieldset:
       early_allocation:

--- a/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
+++ b/spec/views/shared/notifications/offender_needs_a_com.html.erb_spec.rb
@@ -1,14 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "shared/notifications/offender_needs_a_com", type: :view do
-  let(:page) { Nokogiri::HTML(rendered) }
-  let(:title) { page.css('#com-error-summary-title').text.strip }
-  let(:com_warning) { page.css('#com_warning') }
-  let(:ldu_warning) { page.css('#ldu_warning') }
-
   let(:case_info) { build(:case_information, enhanced_resourcing: true, local_delivery_unit: ldu, manual_entry: ldu.nil?) }
   let(:ldu) { build(:local_delivery_unit) }
-  let(:email_history) { [] }
   let(:prison) { build(:prison) }
 
   let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
@@ -17,56 +11,21 @@ RSpec.describe "shared/notifications/offender_needs_a_com", type: :view do
   end
 
   before do
-    render partial: 'shared/notifications/offender_needs_a_com',
-           locals: { offender: offender, email_history: email_history }
+    render partial: 'shared/notifications/offender_needs_a_com', locals: { offender: offender }
   end
 
-  context 'when an email has been sent to the LDU' do
-    let(:date_sent) { Time.zone.today }
-    let(:email_history) { create_list(:email_history, 1, :open_prison_community_allocation, offender: case_info.offender, created_at: date_sent) }
-
-    it 'says "You may need to contact the community probation office"' do
-      expect(title).to eq(I18n.t('views.notifications.offender_needs_a_com.maybe_contact_ldu'))
-    end
-
-    it 'says a supporting COM is needed' do
-      text = I18n.t('views.notifications.offender_needs_a_com.com_needed')
-      href = '#com-name'
-      expect(com_warning).to have_link(text, href: href)
-    end
-
-    it 'says when the LDU was emailed' do
-      text = I18n.t('views.notifications.offender_needs_a_com.ldu_emailed', date: format_date(date_sent))
-      href = '#com-name'
-      expect(ldu_warning).to have_link(text, href: href)
+  context 'when we know the LDU details' do
+    it 'includes the LDU details' do
+      expect(rendered).to include(ldu.name)
+      expect(rendered).to include(ldu.email_address)
     end
   end
 
-  context 'when an email has not been sent' do
-    it 'says "You must contact the community probation office"' do
-      expect(title).to eq(I18n.t('views.notifications.offender_needs_a_com.must_contact_ldu'))
-    end
+  context 'when we do not know the LDU details' do
+    let(:ldu) { nil }
 
-    it 'says a supporting COM is needed' do
-      text = I18n.t('views.notifications.offender_needs_a_com.com_needed')
-      href = '#com-name'
-      expect(com_warning).to have_link(text, href: href)
-    end
-
-    context 'when the LDU email address is unknown' do
-      let(:ldu) { nil }
-
-      it 'says the LDU cannot be contacted' do
-        text = I18n.t('views.notifications.offender_needs_a_com.ldu_uncontactable')
-        href = '#com-name'
-        expect(ldu_warning).to have_link(text, href: href)
-      end
-    end
-
-    context 'when we know the LDU email address' do
-      it 'does not warn that the LDU is un-contactable' do
-        expect(ldu_warning).to be_empty
-      end
+    it 'does not show the LDU details' do
+      expect(rendered).to include('We do not know which LDU will be responsible for this person')
     end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-912

As per ticket, new copy implemented (it actually simplifies previous copy/code) in the notifications displayed when someone is in their handover window without a COM and either we have details of the relevant LDU or we don’t.

Refer to ticket for more details.

![Screenshot 2025-02-18 at 09 41 54](https://github.com/user-attachments/assets/d28f95d8-2c78-4a02-8f7f-5e4d79d399dd)
![Screenshot 2025-02-18 at 09 42 38](https://github.com/user-attachments/assets/85ab8f75-abd0-4cc2-b49f-32b8f04fdee9)
