### PR TITLE
MO-1662 Mailbox register API client

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,6 +17,7 @@ PRISONER_SEARCH_HOST="https://prisoner-search-dev.prison.service.justice.gov.uk"
 PRISON_API_HOST="https://prison-api-dev.prison.service.justice.gov.uk"
 TIERING_API_HOST="https://hmpps-tier-dev.hmpps.service.justice.gov.uk"
 PRISON_ALERTS_API_HOST="https://alerts-api-dev.hmpps.service.justice.gov.uk"
+MAILBOX_REGISTER_API_HOST="https://manage-custody-mailbox-register-api-dev.hmpps.service.justice.gov.uk"
 
 PROMETHEUS_METRICS=off
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /public/assets
 .byebug_history
 .env
+.env.local
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $  bundle install
 yarn install
 ```
 
-4. Create a .env file in the root of the folder and add any necessary [environment variables](#environment-variables) (or copy from .env.example). Load your environment variables into your current session ...
+4. Create a .env file in the root of the folder and add any necessary [environment variables](#environment-variables) (or copy from .env.example). If you need to further configure the environment, you can add a `.env.local` file that will take precedence over the default values declared in `.env.development`.
 
 5. Create and seed database
 

--- a/app/admin/local_delivery_units.rb
+++ b/app/admin/local_delivery_units.rb
@@ -3,20 +3,21 @@
 ActiveAdmin.register LocalDeliveryUnit do
   menu label: 'Local Delivery Units'
 
-  permit_params :code, :name, :email_address, :country, :enabled
+  actions :index
+  config.sort_order = 'name_asc'
 
-  form do |_form|
-    inputs do
-      input :code
-      input :name
-      input :email_address
-      input :country, as: :select, collection: LocalDeliveryUnit::VALID_COUNTRIES
-      input :enabled
-    end
-    actions
+  index do
+    column :id
+    column :code
+    column :name
+    column :email_address
+    column :country
+    column :created_at
+    column :updated_at
+    column :mailbox_register_id
   end
 
   # Filter fields
   preserve_default_filters!
-  remove_filter :case_information
+  remove_filter :case_information, :enabled
 end

--- a/app/services/hmpps_api/mailbox_register_api.rb
+++ b/app/services/hmpps_api/mailbox_register_api.rb
@@ -1,0 +1,13 @@
+module HmppsApi
+  class MailboxRegisterApi
+    def self.client
+      host = Rails.configuration.mailbox_register_api_host
+      HmppsApi::Client.new(host)
+    end
+
+    # https://manage-custody-mailbox-register-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html
+    def self.get_local_delivery_units
+      client.get('/local-delivery-unit-mailboxes')
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,7 @@ module OffenderManagementAllocationClient
     config.dps_frontend_components_api_host = ENV['DPS_FRONTEND_COMPONENTS_API_HOST']&.strip
     config.community_api_host = ENV['COMMUNITY_API_HOST']&.strip
     config.prison_alerts_api_host = ENV['PRISON_ALERTS_API_HOST']&.strip
+    config.mailbox_register_api_host = ENV['MAILBOX_REGISTER_API_HOST']&.strip
 
     config.hmpps_oauth_client_id = ENV['HMPPS_OAUTH_CLIENT_ID']&.strip
     config.hmpps_oauth_client_secret = ENV['HMPPS_OAUTH_CLIENT_SECRET']&.strip

--- a/config/initializers/ignore_db_tables.rb
+++ b/config/initializers/ignore_db_tables.rb
@@ -1,0 +1,7 @@
+# Needed because we are pointing new kotlin service to
+# the same database as the rails app, and we don't want
+# the flyway stuff showing up in the structure.sql file
+#
+ActiveRecord::SchemaDumper.ignore_tables += [
+  'flyway_schema_history',
+]

--- a/db/migrate/20250325141546_add_mailbox_register_ids_to_ldus_table.rb
+++ b/db/migrate/20250325141546_add_mailbox_register_ids_to_ldus_table.rb
@@ -1,0 +1,5 @@
+class AddMailboxRegisterIdsToLdusTable < ActiveRecord::Migration[7.1]
+  def change
+    add_column :local_delivery_units, :mailbox_register_id, :uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -359,7 +359,8 @@ CREATE TABLE public.local_delivery_units (
     country character varying NOT NULL,
     enabled boolean NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    mailbox_register_id uuid
 );
 
 
@@ -1162,6 +1163,7 @@ ALTER TABLE ONLY public.offender_email_sent
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250325141546'),
 ('20250127094859'),
 ('20241115094637'),
 ('20241008145210'),

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -41,3 +41,4 @@ generic-service:
     DPS_FRONTEND_COMPONENTS_API_HOST: https://frontend-components-preprod.hmpps.service.justice.gov.uk
     DIGITAL_PRISON_SERVICE_HOST: https://digital-preprod.prison.service.justice.gov.uk
     PRISON_ALERTS_API_HOST: https://alerts-api-preprod.hmpps.service.justice.gov.uk
+    MAILBOX_REGISTER_API_HOST: https://manage-custody-mailbox-register-api-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -63,6 +63,7 @@ generic-service:
     DPS_FRONTEND_COMPONENTS_API_HOST: https://frontend-components.hmpps.service.justice.gov.uk
     DIGITAL_PRISON_SERVICE_HOST: https://digital.prison.service.justice.gov.uk
     PRISON_ALERTS_API_HOST: https://alerts-api.hmpps.service.justice.gov.uk
+    MAILBOX_REGISTER_API_HOST: https://manage-custody-mailbox-register-api.hmpps.service.justice.gov.uk
 
   namespace_secrets:
     allocation-manager-secrets:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -53,6 +53,7 @@ generic-service:
     DPS_FRONTEND_COMPONENTS_API_HOST: https://frontend-components-dev.hmpps.service.justice.gov.uk
     DIGITAL_PRISON_SERVICE_HOST: https://digital-dev.prison.service.justice.gov.uk
     PRISON_ALERTS_API_HOST: https://alerts-api-dev.hmpps.service.justice.gov.uk
+    MAILBOX_REGISTER_API_HOST: https://manage-custody-mailbox-register-api-dev.hmpps.service.justice.gov.uk
 
   namespace_secrets:
     parole-data-import:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -37,6 +37,7 @@ generic-service:
     DPS_FRONTEND_COMPONENTS_API_HOST: https://frontend-components-dev.hmpps.service.justice.gov.uk
     DIGITAL_PRISON_SERVICE_HOST: https://digital-dev.prison.service.justice.gov.uk
     PRISON_ALERTS_API_HOST: https://alerts-api-dev.hmpps.service.justice.gov.uk
+    MAILBOX_REGISTER_API_HOST: https://manage-custody-mailbox-register-api-dev.hmpps.service.justice.gov.uk
 
   # Following secrets are not present in `test`
   # so we unset them so the deployment does not fail

--- a/spec/features/admin_feature_spec.rb
+++ b/spec/features/admin_feature_spec.rb
@@ -99,15 +99,8 @@ feature 'admin urls' do
         visit('/admin/local_delivery_units')
       end
 
-      it 'can create one' do
-        expect {
-          click_link 'New Localdeliveryunit'
-          fill_in 'Code', with: Faker::Alphanumeric.alphanumeric(number: 4)
-          fill_in 'Name', with: Faker::Lorem.sentence
-          fill_in 'Email address', with: Faker::Internet.email
-          select 'England'
-          click_button 'Create Local delivery unit'
-        }.to change(LocalDeliveryUnit, :count).by(1)
+      it 'cannot create one' do
+        expect(page).not_to have_content('New Localdeliveryunit')
       end
     end
   end

--- a/spec/services/hmpps_api/mailbox_register_api_spec.rb
+++ b/spec/services/hmpps_api/mailbox_register_api_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmppsApi::MailboxRegisterApi do
+  describe '.get_local_delivery_units' do
+    it 'returns all the LDUs' do
+      response = [
+        { "id" => "06b84bb5-f925-4b34-a964-5c29e337dc2e", "unitCode" => "12345", "areaCode" => "45678", "emailAddress" => "test@example.com", "country" => "UK", "name" => "Test LDU", "createdAt" => "2025-02-05T14:32:20.340651Z", "updatedAt" => "2025-02-06T11:29:34.838613Z" },
+        { "id" => "444e537b-8e20-46a7-94b5-8985e73c3e90", "unitCode" => "444", "areaCode" => "555", "emailAddress" => "test2@example.com", "country" => "Wales", "name" => "Another one", "createdAt" => "2025-02-06T11:29:54.652923Z", "updatedAt" => "2025-02-06T11:29:54.652943Z" }
+      ]
+
+      stub_request(:get, "#{Rails.configuration.mailbox_register_api_host}/local-delivery-unit-mailboxes")
+        .to_return(body: response.to_json)
+
+      expect(described_class.get_local_delivery_units).to eq(response)
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1662

Basic setup in preparation to retrieve the LDUs from the new mailbox register service.

Role has been added to the token and tested correctly against DEV.

A new `mailbox_register_id` has been added to the `local_delivery_units` table to be able to marry records once we start using the service.

Disabled write access to LDU table in active admin as going forward, this will be done in mailbox register.