### PR TITLE
MO-1662 Enable LDUs import in preprod and prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -6,6 +6,8 @@ cronjobs:
     enabled: true
   community_api_import:
     enabled: true
+  mailbox_register_import:
+    enabled: true
 
 generic-prometheus-alerts:
   alertSeverity: mpc-alerts-nonprod-preprod

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -1,5 +1,8 @@
 ---
 cronjobs:
+  mailbox_register_import:
+    enabled: true
+    schedule: 0 1 * * *
   process_movements:
     enabled: true
     schedule: 0 2 * * *


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1662

DB refresh has been sorted out so we can proceed with enabling this in the remaining envs.

Currently mailbox register preprod/prod have the exact same LDU data as MPC preprod/prod.