### PR TITLE
MO-1676 Preparing Parole Review DB table for S3

### DIFF
--- a/db/migrate/20250403141647_add_s3_object_key_to_parole_review_import.rb
+++ b/db/migrate/20250403141647_add_s3_object_key_to_parole_review_import.rb
@@ -1,0 +1,5 @@
+class AddS3ObjectKeyToParoleReviewImport < ActiveRecord::Migration[7.1]
+  def change
+    add_column :parole_review_imports, :s3_object_key, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -486,7 +486,8 @@ CREATE TABLE public.parole_review_imports (
     single_day_snapshot boolean,
     processed_on date,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    s3_object_key character varying
 );
 
 
@@ -1163,6 +1164,7 @@ ALTER TABLE ONLY public.offender_email_sent
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250403141647'),
 ('20250325141546'),
 ('20250127094859'),
 ('20241115094637'),


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1676

In preparation of the new S3 import mechanism, I'm adding this column to the existing `parole_review_imports` to have traceability of which file in the bucket was used for each import.

This is a non-breaking change with the existing IMAP import mechanism.