### PR TITLE
Update LDU finder query to use new FMB uuids

### DIFF
--- a/app/models/local_delivery_unit.rb
+++ b/app/models/local_delivery_unit.rb
@@ -14,7 +14,6 @@ class LocalDeliveryUnit < ApplicationRecord
   validates :email_address,  presence: true, 'valid_email_2/email': true
 
   scope :enabled, -> { where(enabled: true) }
-  scope :by_code_or_mailbox_register_id, ->(code, mailbox_register_id) { where(code:).or(where(mailbox_register_id:)) }
 
   has_many :case_information, dependent: :restrict_with_exception
 

--- a/lib/import_local_delivery_units.rb
+++ b/lib/import_local_delivery_units.rb
@@ -35,7 +35,7 @@ class ImportLocalDeliveryUnits
       uuid = mailbox['id']
 
       ldu = LocalDeliveryUnit
-              .by_code_or_mailbox_register_id(code, uuid)
+              .where(mailbox_register_id: uuid)
               .first_or_initialize.tap do |record|
         record.code = code
         record.mailbox_register_id = uuid


### PR DESCRIPTION
Now that LDUs in all MPC envs have been updated to have a reference to their corresponding mailbox register ID, we can update the query to stop using the `code` as that was a temporary fallback.