### PR TITLE
Change db refresh scheduled time

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -53,7 +53,7 @@ generic-service:
 
   postgresDatabaseRestore:
     enabled: true
-    schedule: "30 7 * * 3" # At 07:30 on Wednesdays
+    schedule: "15 6 * * 3" # At 06:15 on Wednesdays
     jobName: "db-refresh-job"
     env:
       MIGRATIONS_VENDOR: "active_record"


### PR DESCRIPTION
This time (6:15am) should avoid any long-running jobs on preprod and hopefully solve the DB deadlock problem we recently had.

Can't be scheduled before 6am as RDS is auto turned off 10pm-6am UTC in non-prod envs.