### PR TITLE
MO-1676 Enable PPUD S3 import in production

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -5,3 +5,4 @@ feature_flags:
   ppud_s3_bucket:
     staging: true
     preprod: true
+    production: true

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -12,9 +12,6 @@ cronjobs:
   deactivate_cnls:
     enabled: true
     schedule: 45 3 * * *
-  parole_data_import:
-    enabled: true
-    schedule: 0 4 * * *
   early_allocation_suitability_email:
     enabled: true
     schedule: 30 4 * * *
@@ -30,6 +27,9 @@ cronjobs:
   community_api_import:
     enabled: true
     schedule: 0 6 * * *
+  parole_data_import:
+    enabled: true
+    schedule: 15 7 * * *
 
 generic-prometheus-alerts:
   alertSeverity: mpc-alerts-prod


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1676

Turn on the S3 import in production. It was already enabled and working fine in the rest of environments.

Not cleaning up email code just yet in case we have to go back for whatever reason (we can wait until MS migration finishes).

Cronjob schedule time changed to align better with new S3 replication time.