### PR TITLE
MO-1687 Refactor get_offender

### DIFF
--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -13,19 +13,47 @@ module HmppsApi
       # will show up as `SENTENCED` legal status, and we need to filter by their sentence type code.
       EXCLUDED_IMPRISONMENT_STATUSES = %w[A_FINE].freeze
 
-      def self.get_offenders_in_prison(prison, ignore_legal_status: false)
-        unfiltered = get_search_api_offenders_in_prison(prison)
-        offenders = ignore_legal_status ? unfiltered : filtered_offenders(unfiltered)
+      def self.get_offenders_in_prison(prison, *args)
+        offenders = get_search_api_offenders_in_prison(prison)
+
+        build_offenders(offenders, prison, *args)
+      end
+
+      # Get a single offender
+      #
+      # Returns nil if the offender's legal status is not in the list ALLOWED_LEGAL_STATUSES
+      # To ignore the ALLOWED_LEGAL_STATUSES list and return the offender anyway, set `ignore_legal_status` to true.
+      # Warning: when you ignore the offender's legal status, you could potentially receive an offender who wouldn't
+      # normally appear within the service. This should only be done under certain circumstances –
+      # e.g. when deallocating an offender who has since left the service due to a change in legal status
+      def self.get_offender(offender_no, *args)
+        offender = get_search_api_offenders(offender_no).first
+        return if offender.nil?
+
+        # Restricted Patients use supportingPrisonId, since the offender is currently in hospital
+        prison_id = offender.fetch(offender['restrictedPatient'] ? 'supportingPrisonId' : 'prisonId')
+
+        build_offenders([offender], prison_id, *args).first
+      end
+
+      def self.build_offenders(unfiltered_offenders, prison_id, *args)
+        default_options = {
+          ignore_legal_status: false, fetch_complexities: true, fetch_categories: true, fetch_movements: true
+        }.freeze
+
+        options = default_options.dup.merge(args.extract_options! || {}).assert_valid_keys(default_options.keys)
+
+        offenders = options[:ignore_legal_status] ? unfiltered_offenders : filtered_offenders(unfiltered_offenders)
         return [] if offenders.empty?
 
-        # Get additional data from other APIs
-        offender_nos = offenders.map { |o| o.fetch('prisonerNumber') }
-        offender_categories = get_offender_categories(offender_nos)
-        complexities = complexities_for(offender_nos, prison)
-        temp_movements = latest_temp_movement_for(offenders)
-        movements = HmppsApi::PrisonApi::MovementApi.admissions_for(offender_nos)
+        offender_nos = offenders.pluck('prisonerNumber')
 
-        # Create Offender objects
+        # Get additional data from other APIs
+        offender_categories = options[:fetch_categories] ? get_offender_categories(offender_nos) : {}
+        complexities = options[:fetch_complexities] ? complexities_for(offender_nos, prison_id) : {}
+        temp_movements = options[:fetch_movements] ? latest_temp_movement_for(offenders) : {}
+        movements = options[:fetch_movements] ? HmppsApi::PrisonApi::MovementApi.admissions_for(offender_nos) : {}
+
         offenders.map do |offender|
           offender_no = offender.fetch('prisonerNumber')
 
@@ -37,36 +65,6 @@ module HmppsApi
             movements: movements[offender_no]
           )
         end
-      end
-
-      # Get a single offender
-      #
-      # Returns nil if the offender's legal status is not in the list ALLOWED_LEGAL_STATUSES
-      # To ignore the ALLOWED_LEGAL_STATUSES list and return the offender anyway, set `ignore_legal_status` to true.
-      # Warning: when you ignore the offender's legal status, you could potentially receive an offender who wouldn't
-      # normally appear within the service. This should only be done under certain circumstances –
-      # e.g. when deallocating an offender who has since left the service due to a change in legal status
-      def self.get_offender(offender_no, ignore_legal_status: false)
-        unfiltered = get_search_api_offenders([offender_no])
-        offender = (ignore_legal_status ? unfiltered : filtered_offenders(unfiltered)).first
-        return nil if offender.blank?
-
-        # Restricted Patients use supportingPrisonId, since the offender is currently in hospital
-        prison_id = offender.fetch(offender['restrictedPatient'] ? 'supportingPrisonId' : 'prisonId')
-
-        # Get additional data from other APIs
-        complexity_level = complexity_for(offender_no, prison_id)
-        offender_categories = get_offender_categories([offender_no])
-        temp_movements = latest_temp_movement_for([offender])
-        movements = HmppsApi::PrisonApi::MovementApi.admissions_for([offender_no])
-
-        HmppsApi::Offender.new(
-          offender:,
-          category: offender_categories[offender_no],
-          latest_temp_movement: temp_movements[offender_no],
-          complexity_level:,
-          movements: movements[offender_no]
-        )
       end
 
       def self.get_offender_categories(offender_nos)
@@ -139,12 +137,6 @@ module HmppsApi
         HmppsApi::ComplexityApi.get_complexities(offender_nos)
       end
 
-      def self.complexity_for(offender_no, prison_id)
-        return {} unless Prison.womens.exists?(prison_id)
-
-        HmppsApi::ComplexityApi.get_complexity(offender_no)
-      end
-
     private
 
       def self.get_search_api_offenders_in_prison(prison_code)
@@ -170,7 +162,7 @@ module HmppsApi
 
       def self.get_search_api_offenders(offender_nos)
         search_route = '/prisoner-search/prisoner-numbers'
-        search_client.post(search_route, { prisonerNumbers: offender_nos }, queryparams: { 'include-restricted-patients': true }, cache: true)
+        search_client.post(search_route, { prisonerNumbers: Array(offender_nos) }, queryparams: { 'include-restricted-patients': true }, cache: true)
       end
 
       def self.default_image

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -131,10 +131,19 @@ module HmppsApi
         offender['inOutStatus'] == 'OUT' && offender['lastMovementTypeCode'] == HmppsApi::MovementType::TEMPORARY
       end
 
+      # Technically we could use the same API endpoint (POST `/complexity-of-need/multiple/offender-no`)
+      # whether it is 1 offender, or many, but to keep the amount of tests that would need to change low, this
+      # if-else will maintain backward compatibility (so 1 offender uses GET, more than 1 uses POST).
+      #
       def self.complexities_for(offender_nos, prison_id)
         return {} unless Prison.womens.exists?(prison_id)
 
-        HmppsApi::ComplexityApi.get_complexities(offender_nos)
+        if offender_nos.many?
+          HmppsApi::ComplexityApi.get_complexities(offender_nos)
+        else
+          offender_no = offender_nos.first
+          { offender_no => HmppsApi::ComplexityApi.get_complexity(offender_no) }
+        end
       end
 
     private

--- a/helm_deploy/offender-management-allocation-manager/values.yaml
+++ b/helm_deploy/offender-management-allocation-manager/values.yaml
@@ -35,6 +35,9 @@ cronjobs:
   community_api_import:
     enabled: false
     schedule: 0 7 * * *
+  deactivate_cnls:
+    enabled: false
+    schedule: 45 7 * * *
   parole_data_import:
     enabled: false
     schedule: 0 8 * * *
@@ -42,8 +45,6 @@ cronjobs:
     enabled: false
     schedule: 0 9 * * *
   # Below cronjobs are currently only enabled in production
-  deactivate_cnls:
-    enabled: false
   early_allocation_suitability_email:
     enabled: false
   handover_email:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -6,6 +6,8 @@ cronjobs:
     enabled: true
   community_api_import:
     enabled: true
+  deactivate_cnls:
+    enabled: true
   mailbox_register_import:
     enabled: true
   parole_data_import:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -12,6 +12,8 @@ cronjobs:
     enabled: true
   community_api_import:
     enabled: true
+  deactivate_cnls:
+    enabled: true
   mailbox_register_import:
     enabled: true
   parole_data_import:

--- a/lib/deactivate_cnls.rb
+++ b/lib/deactivate_cnls.rb
@@ -27,8 +27,13 @@ class DeactivateCnls
   end
 
   def process_offender(offender_id, offender_index, offender_count)
-    nomis_offender = with_retries { HmppsApi::PrisonApi::OffenderApi.get_offender(offender_id, ignore_legal_status: true) }
+    nomis_offender = with_retries do
+      HmppsApi::PrisonApi::OffenderApi.get_offender(
+        offender_id, ignore_legal_status: true, fetch_categories: false, fetch_movements: false
+      )
+    end
 
+    return if nomis_offender.complexity_level.blank?
     return if nomis_offender.sentenced?
     return if nomis_offender.immigration_case?
 

--- a/lib/deactivate_cnls.rb
+++ b/lib/deactivate_cnls.rb
@@ -14,29 +14,26 @@ class DeactivateCnls
     report_info "Processing #{womens_prisons_count} women's prisons. Dry run: #{dry_run}"
 
     womens_prisons.each_with_index do |prison, i|
-      offenders = OffenderService.get_offenders_in_prison(prison, ignore_legal_status: true)
+      offenders = HmppsApi::PrisonApi::OffenderApi.get_offenders_in_prison(
+        prison.code, ignore_legal_status: true, fetch_complexities: false, fetch_categories: false, fetch_movements: false
+      )
+
       offender_count = offenders.size
       report_info "Prison #{i + 1}/#{womens_prisons_count}: #{prison.name}: processing #{offender_count} offenders"
 
       offenders.each_with_index do |offender, j|
-        process_offender(offender.offender_no, j + 1, offender_count)
+        process_offender(offender, j + 1, offender_count)
       end
     end
 
     report_info "Done. Complexity of need level de-activated for #{inactivated_count} offenders"
   end
 
-  def process_offender(offender_id, offender_index, offender_count)
-    nomis_offender = with_retries do
-      HmppsApi::PrisonApi::OffenderApi.get_offender(
-        offender_id, ignore_legal_status: true, fetch_categories: false, fetch_movements: false
-      )
-    end
-
-    return if nomis_offender.complexity_level.blank?
+  def process_offender(nomis_offender, offender_index, offender_count)
     return if nomis_offender.sentenced?
     return if nomis_offender.immigration_case?
 
+    offender_id = nomis_offender.offender_no
     output = ["- #{offender_index}/#{offender_count}: #{offender_id} is un-sentenced"]
 
     unless dry_run


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1687

Initial work to be able to selectively decide which additional API calls to perform in the `get_offender` and `get_offenders_in_prison` methods.

So for instance we can disable certain API calls, like movements or complexities, that are not necessary in some places in the app, and this will in turn reduce the number of API calls per offender increasing performance / reducing latency and load in other services.

This should also have the advantage that eventually we will not need to stub so many API calls if these are not needed and thus not performed. Maybe even allow for removal of some additional VCR cassettes!

For now only using this in one place, the rake task to inactivate CNL, but in follow up PRs we can use it in other places if we don't need all the details (movements, complexities, categories).

As part of this PR the `DeactivateCnls` task has been enabled in staging and preprod for consistency with other tasks.