### PR TITLE
MO-1690 Deactivate CNLs from released offenders

### DIFF
--- a/app/jobs/deactivate_released_cnls_job.rb
+++ b/app/jobs/deactivate_released_cnls_job.rb
@@ -1,0 +1,53 @@
+class DeactivateReleasedCnlsJob < ApplicationJob
+  queue_as :default
+
+  attr_reader :prison, :inactivated_count, :errors_count
+
+  def perform(prison)
+    @prison = prison
+    @inactivated_count = 0
+    @errors_count = 0
+
+    offenders = HmppsApi::PrisonApi::OffenderApi.get_offenders_out_of_prison(prison.code)
+    offender_count = offenders.size
+    log("Processing #{offender_count} released offenders...")
+
+    offenders.each do |offender|
+      process_offender(offender)
+    end
+
+    log("Done. Inactivated: #{inactivated_count}/#{offender_count}. Errors: #{errors_count}.")
+  end
+
+private
+
+  def process_offender(nomis_offender)
+    with_retries { HmppsApi::ComplexityApi.inactivate(nomis_offender.offender_no) }
+    @inactivated_count += 1
+  rescue StandardError => e
+    log("Offender ID #{nomis_offender.offender_no} produced an error: #{e.message}")
+    @errors_count += 1
+  end
+
+  def with_retries(pause_secs: 5, retry_limit: 3)
+    retry_limit.times do |i|
+      return yield
+    rescue Faraday::ServerError
+      if (i + 1) == retry_limit
+        log("API error: #{retry_limit} re-try limit reached")
+        raise
+      end
+
+      log("API error. Pausing #{pause_secs}s before re-trying")
+      sleep pause_secs
+    end
+  end
+
+  def log(msg)
+    logger.info("[#{self.class.name}] [#{prison.code}] #{msg}")
+  end
+
+  def logger
+    @logger ||= Logger.new($stdout)
+  end
+end

--- a/helm_deploy/offender-management-allocation-manager/templates/cron-deactivate-unsentenced-cnls.yaml
+++ b/helm_deploy/offender-management-allocation-manager/templates/cron-deactivate-unsentenced-cnls.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cronjobs.deactivate_unsentenced_cnls.enabled }}
-{{- $cronjobName := "deactivate-cnls" }}
+{{- $cronjobName := "deactivate-unsentenced-cnls" }}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/lib/tasks/deactivate_released_cnls.rake
+++ b/lib/tasks/deactivate_released_cnls.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :deactivate_released_cnls do
+  desc 'Deactivate complexity of need levels for released offenders'
+  task process: :environment do
+    women_prisons = Prison.where(code: PrisonService::WOMENS_PRISON_CODES)
+    women_prisons_count = women_prisons.size
+
+    women_prisons.each_with_index do |prison, i|
+      puts "Enqueuing prison #{i + 1}/#{women_prisons_count}: #{prison.code} - #{prison.name}"
+      DeactivateReleasedCnlsJob.perform_later(prison)
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1690

Task to deactivate CNLs from released offenders, mostly very old records that were created before we handled OUT movements and events.

Task is a one-off run thus is not scheduled (no cronjob) but can be run again in the future if needed, so keeping it in the repo for reference.

It has been run against staging and preprod successfully.