### PR TITLE
MO-1690 Deactivate CNLs over API limit (BZI)

### DIFF
--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -178,6 +178,8 @@ module HmppsApi
         results
       end
 
+      # NOTE: this API endpoint has a total hardcoded limit of 10_000 offenders returned
+      # in total, even if using a lower page size and looping. `BZI` will go over this limit.
       def self.get_search_api_offenders_out_in_last_prison(prison_code)
         route = '/attribute-search'
         page_num = 0


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1690

Second pass on the deactivation of CNLs, to overcome the limitation of 10_000 returned offenders in the `attribute-search` API.

BZI is the only prison going over the limit. We are now using our own `AllocationHistory` DB table to identify released offenders and deactivate anyone missed from the API call.