### PR TITLE
MO-1697 Handle allocations legal status changes

### DIFF
--- a/app/jobs/process_prisoner_status_job.rb
+++ b/app/jobs/process_prisoner_status_job.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ProcessPrisonerStatusJob < ApplicationJob
+  queue_as :default
+
+  # HTTP 404 Not Found: Not much point retrying a missing offender
+  discard_on Faraday::ResourceNotFound
+
+  def perform(nomis_offender_id, trigger_method: :event)
+    ApplicationRecord.transaction do
+      logger.info("nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_prisoner_status_job,event=started")
+      process_status_change(nomis_offender_id)
+      logger.info("nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_prisoner_status_job,event=finished")
+    end
+  end
+
+private
+
+  def process_status_change(nomis_offender_id)
+    allocation = AllocationHistory.active.find_by(nomis_offender_id:)
+    return if allocation.nil?
+
+    offender = HmppsApi::PrisonApi::OffenderApi.get_offender(
+      nomis_offender_id,
+      ignore_legal_status: true,
+      fetch_complexities: false,
+      fetch_categories: false,
+      fetch_movements: false,
+    )
+
+    if offender.nil? || offender.legal_status.blank?
+      logger.error(
+        "nomis_offender_id=#{nomis_offender_id},job=process_prisoner_status_job,event=missing_offender_record|" \
+          'Failed to retrieve NOMIS offender record'
+      )
+      return
+    end
+
+    if HmppsApi::PrisonApi::OffenderApi::ALLOWED_LEGAL_STATUSES.exclude?(offender.legal_status)
+      logger.info(
+        "nomis_offender_id=#{nomis_offender_id},job=process_prisoner_status_job,event=legal_status_changed|" \
+          "Legal status #{offender.legal_status} is not allowed. Deallocating."
+      )
+
+      allocation.deallocate_primary_pom(
+        event_trigger: AllocationHistory::LEGAL_STATUS_CHANGED
+      )
+      allocation.deallocate_secondary_pom(
+        event_trigger: AllocationHistory::LEGAL_STATUS_CHANGED
+      )
+    end
+  end
+end

--- a/app/lib/domain_events/handlers/prisoner_updated_handler.rb
+++ b/app/lib/domain_events/handlers/prisoner_updated_handler.rb
@@ -2,13 +2,15 @@ class DomainEvents::Handlers::PrisonerUpdatedHandler
   def handle(event)
     nomis_offender_id = event.additional_information.fetch('nomsNumber')
 
-    if CaseInformation.find_by_nomis_offender_id(nomis_offender_id).nil?
-      Shoryuken::Logging.logger.info("event=domain_event_handle_skip,domain_event_type=#{event.event_type}," \
-                                     "nomis_offender_id=#{nomis_offender_id},reason=missing_probation_case_information")
-      return
+    Shoryuken::Logging.logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},nomis_offender_id=#{nomis_offender_id}"
+
+    changes = event.additional_information.fetch('categoriesChanged')
+    if changes.include?('STATUS')
+      # The status of the prisoner has changed, so one of: status, inOutStatus, csra,
+      # category, legalStatus, imprisonmentStatus, imprisonmentStatusDescription, recall
+      ProcessPrisonerStatusJob.perform_later(nomis_offender_id)
     end
 
-    Shoryuken::Logging.logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},nomis_offender_id=#{nomis_offender_id},noop"
     Shoryuken::Logging.logger.info "event=domain_event_handle_success,domain_event_type=#{event.event_type},nomis_offender_id=#{nomis_offender_id}"
   end
 end

--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -19,6 +19,7 @@ class AllocationHistory < ApplicationRecord
   OFFENDER_TRANSFERRED = 1
   OFFENDER_RELEASED = 2
   MANUAL_CHANGE = 3
+  LEGAL_STATUS_CHANGED = 4
 
   after_commit :publish_allocation_changed_event
 
@@ -41,7 +42,8 @@ class AllocationHistory < ApplicationRecord
     user: USER,
     offender_transferred: OFFENDER_TRANSFERRED,
     offender_released: OFFENDER_RELEASED,
-    manual_change: MANUAL_CHANGE
+    manual_change: MANUAL_CHANGE,
+    legal_status_changed: LEGAL_STATUS_CHANGED,
   }
 
   scope :active, -> { where.not(primary_pom_nomis_id: nil) }

--- a/spec/jobs/process_delius_data_job_spec.rb
+++ b/spec/jobs/process_delius_data_job_spec.rb
@@ -13,7 +13,6 @@
 # section should replace API mocks with dependency mocks as has been described above.
 RSpec.describe ProcessDeliusDataJob, :disable_push_to_delius, type: :job do
   let(:nomis_offender_id) { 'G4281GV' }
-  let(:remand_nomis_offender_id) { 'G3716UD' }
   let(:crn) { 'X362207' }
   let(:ldu) {  create(:local_delivery_unit) }
   let(:prison) { create(:prison) }

--- a/spec/jobs/process_prisoner_status_job_spec.rb
+++ b/spec/jobs/process_prisoner_status_job_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe ProcessPrisonerStatusJob, type: :job do
+  let(:nomis_offender_id) { 'A1234BC' }
+  let(:allocation) { instance_double(AllocationHistory, deallocate_primary_pom: true, deallocate_secondary_pom: true) }
+  let(:active_allocations) { double('active_allocations') }
+  let(:offender) { double('Offender', legal_status:) }
+  let(:legal_status) { 'SENTENCED' }
+
+  before do
+    allow(AllocationHistory).to receive(:active).and_return(active_allocations)
+    allow(active_allocations).to receive(:find_by).with(nomis_offender_id:).and_return(allocation)
+
+    allow(HmppsApi::PrisonApi::OffenderApi).to receive(:get_offender).with(
+      nomis_offender_id,
+      ignore_legal_status: true,
+      fetch_complexities: false,
+      fetch_categories: false,
+      fetch_movements: false
+    ).and_return(offender)
+  end
+
+  context 'when allocation is not found' do
+    let(:allocation) { nil }
+
+    it 'does nothing' do
+      expect(HmppsApi::PrisonApi::OffenderApi).not_to receive(:get_offender)
+      described_class.perform_now(nomis_offender_id)
+    end
+  end
+
+  context 'when offender is not found' do
+    let(:offender) { nil }
+
+    it 'logs an error and does not deallocate' do
+      expect(Rails.logger).to receive(:error)
+      expect(allocation).not_to receive(:deallocate_primary_pom)
+      described_class.perform_now(nomis_offender_id)
+    end
+  end
+
+  context 'when offender legal_status is blank' do
+    let(:legal_status) { '' }
+
+    it 'logs an error and does not deallocate' do
+      expect(Rails.logger).to receive(:error)
+      expect(allocation).not_to receive(:deallocate_primary_pom)
+      described_class.perform_now(nomis_offender_id)
+    end
+  end
+
+  context 'when offender legal_status is not allowed' do
+    let(:legal_status) { 'REMAND' }
+
+    it 'deallocates POMs' do
+      expect(allocation).to receive(:deallocate_primary_pom).with(event_trigger: AllocationHistory::LEGAL_STATUS_CHANGED)
+      expect(allocation).to receive(:deallocate_secondary_pom).with(event_trigger: AllocationHistory::LEGAL_STATUS_CHANGED)
+
+      described_class.perform_now(nomis_offender_id)
+    end
+  end
+
+  context 'when offender legal_status is allowed' do
+    let(:legal_status) { 'SENTENCED' }
+
+    it 'does not deallocate POMs' do
+      expect(allocation).not_to receive(:deallocate_primary_pom)
+      expect(allocation).not_to receive(:deallocate_secondary_pom)
+
+      described_class.perform_now(nomis_offender_id)
+    end
+  end
+end

--- a/spec/lib/domain_events/handlers/prisoner_updated_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/prisoner_updated_handler_spec.rb
@@ -2,51 +2,11 @@ RSpec.describe DomainEvents::Handlers::PrisonerUpdatedHandler do
   subject!(:handler) { described_class.new }
 
   before do
-    allow(RecalculateHandoverDateJob).to receive(:perform_now)
-    allow(RecalculateHandoverDateJob).to receive(:perform_later)
-
+    allow(ProcessPrisonerStatusJob).to receive(:perform_later)
     allow(CaseInformation).to receive(:find_by_nomis_offender_id).and_return(double(:case_information))
   end
 
-  it 'does not recalculate handover for cases whose categoriesChanged includes SENTENCE' do
-    event = DomainEvents::Event.new(
-      event_type: 'prisoner-offender-search.prisoner.updated',
-      version: 1,
-      description: 'A prisoner record has been updated',
-      detail_url: 'https://example.org/irrelevant',
-      additional_information: {
-        'nomsNumber' => 'T1111XX',
-        'categoriesChanged' => %w[STATUS SENTENCE],
-      },
-      external_event: true,
-    )
-    handler.handle(event)
-
-    expect(RecalculateHandoverDateJob).not_to have_received(:perform_now)
-    expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
-  end
-
-  it 'does not recalculate handover for cases whose categoriesChanged does not SENTENCE' do
-    event = DomainEvents::Event.new(
-      event_type: 'prisoner-offender-search.prisoner.updated',
-      version: 1,
-      description: 'A prisoner record has been updated',
-      detail_url: 'https://example.org/irrelevant',
-      additional_information: {
-        'nomsNumber' => 'T1111XX',
-        'categoriesChanged' => %w[PERSONAL_DETAILS STATUS],
-      },
-      external_event: true,
-    )
-    handler.handle(event)
-
-    expect(RecalculateHandoverDateJob).not_to have_received(:perform_now)
-    expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
-  end
-
-  it 'does NOT proceed for cases that have no Delius probation case information' do
-    allow(CaseInformation).to receive(:find_by_nomis_offender_id).and_return(nil)
-
+  it 'does not process legal status changes unless categoriesChanged includes STATUS' do
     event = DomainEvents::Event.new(
       event_type: 'prisoner-offender-search.prisoner.updated',
       version: 1,
@@ -60,7 +20,23 @@ RSpec.describe DomainEvents::Handlers::PrisonerUpdatedHandler do
     )
     handler.handle(event)
 
-    expect(RecalculateHandoverDateJob).not_to have_received(:perform_now)
-    expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
+    expect(ProcessPrisonerStatusJob).not_to have_received(:perform_later)
+  end
+
+  it 'process legal status changes when categoriesChanged includes STATUS' do
+    event = DomainEvents::Event.new(
+      event_type: 'prisoner-offender-search.prisoner.updated',
+      version: 1,
+      description: 'A prisoner record has been updated',
+      detail_url: 'https://example.org/irrelevant',
+      additional_information: {
+        'nomsNumber' => 'T1111XX',
+        'categoriesChanged' => %w[PERSONAL_DETAILS STATUS],
+      },
+      external_event: true,
+    )
+    handler.handle(event)
+
+    expect(ProcessPrisonerStatusJob).to have_received(:perform_later)
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1697

Will automatically deallocate offenders whose legal status has changed to one we don't manage in MPC, for instance `remand`.

Listens to existing `prisoner-offender-search.prisoner.updated` events (previously noop) to fetch the updated offender details and check their current `legalStatus` is allowed or not.