### PR TITLE
Ensure deallocation publishes the event

### DIFF
--- a/app/jobs/process_prisoner_status_job.rb
+++ b/app/jobs/process_prisoner_status_job.rb
@@ -7,11 +7,9 @@ class ProcessPrisonerStatusJob < ApplicationJob
   discard_on Faraday::ResourceNotFound
 
   def perform(nomis_offender_id, trigger_method: :event)
-    ApplicationRecord.transaction do
-      logger.info("nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_prisoner_status_job,event=started")
-      process_status_change(nomis_offender_id)
-      logger.info("nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_prisoner_status_job,event=finished")
-    end
+    logger.info("nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_prisoner_status_job,event=started")
+    process_status_change(nomis_offender_id)
+    logger.info("nomis_offender_id=#{nomis_offender_id},trigger_method=#{trigger_method},job=process_prisoner_status_job,event=finished")
   end
 
 private

--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -21,6 +21,9 @@ class AllocationHistory < ApplicationRecord
   MANUAL_CHANGE = 3
   LEGAL_STATUS_CHANGED = 4
 
+  # IMPORTANT:
+  # Dirty changes are reset every time the model saves, not just when a transaction is closed.
+  # When the `after_commit` callback is executed, we can only enquiry about the most recent saved attributes.
   after_commit :publish_allocation_changed_event
 
   # When adding a new 'event' or 'event trigger'


### PR DESCRIPTION
Follow-up to PR #2625.

The publishing of the allocation events rely on dirty changes to know which attributes were changed, but these will not play nice when the same allocation instance is modified several times as part of the same transaction.

We were getting no changes and thus not publishing the event.