### PR TITLE
MO-1697 Do not deallocate on unknown legal status

### DIFF
--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -217,7 +217,8 @@ private
       noms_number: nomis_offender_id,
       additional_information: {
         'staffCode' => primary_pom_nomis_id,
-        'prisonId' => prison
+        'prisonId' => prison,
+        'eventTrigger' => event_trigger_before_type_cast,
       }
     ).publish
   end

--- a/spec/jobs/process_prisoner_status_job_spec.rb
+++ b/spec/jobs/process_prisoner_status_job_spec.rb
@@ -70,4 +70,15 @@ RSpec.describe ProcessPrisonerStatusJob, type: :job do
       described_class.perform_now(nomis_offender_id)
     end
   end
+
+  context 'when offender legal_status is unknown' do
+    let(:legal_status) { 'UNKNOWN' }
+
+    it 'does not deallocate POMs' do
+      expect(allocation).not_to receive(:deallocate_primary_pom)
+      expect(allocation).not_to receive(:deallocate_secondary_pom)
+
+      described_class.perform_now(nomis_offender_id)
+    end
+  end
 end

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -344,7 +344,8 @@ RSpec.describe AllocationHistory, :enable_allocation_change_publish, type: :mode
           noms_number: nomis_offender_id,
           additional_information: {
             'staffCode' => anything,
-            'prisonId' => prison_code
+            'prisonId' => prison_code,
+            'eventTrigger' => described_class::USER,
           }
         )
 


### PR DESCRIPTION
Follow-up to PR #2625.

Upon checking with PM we are going to ignore `unknown` legal statuses out of precaution. All other statuses have been checked and working as expected.

Added the event trigger to the published event, to improve traceability.