### PR TITLE
MO-1714 Remove reliance on CircleCI (part 1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           name: Run tests
           command: |
             export SPEC_STATUS_PATH=~/spec_status
-            bundle exec parallel_test -t rspec -- -t ~flaky -t ~local_only --format progress -- spec || \
+            bundle exec parallel_test -t rspec -- -t ~flaky -t ~local_only --format progress -- spec/{features,services}/**/* || \
               (echo "Flaky tests detected, trying again..." && sleep 30 && bundle exec parallel_test -t rspec -- -t ~flaky -t ~local_only --format progress --only-failures -- spec)
           environment:
             MOZ_HEADLESS: 1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -93,9 +93,9 @@ jobs:
           DISABLE_COVERAGE: 1
         run: |
           export SPEC_STATUS_PATH=~/spec_status
-          bundle exec rspec -t ~@flaky -t ~@local_only -t ~@ci_fixme \
+          bundle exec rspec -t ~@flaky -t ~@local_only \
             --exclude-pattern "spec/{features,services}/**/*" --format progress spec || \
-            (echo "Flaky tests detected, trying again..." && sleep 15 && bundle exec rspec -t ~@flaky -t ~@local_only -t ~@ci_fixme --only-failures spec)
+            (echo "Flaky tests detected, trying again..." && sleep 15 && bundle exec rspec --only-failures spec)
 
   verify_docker_image:
     name: Verify docker image

--- a/spec/api/offender_api_spec.rb
+++ b/spec/api/offender_api_spec.rb
@@ -2,8 +2,15 @@
 
 require 'swagger_helper'
 
-describe 'Offender Early Allocation API', vcr: { cassette_name: 'prison_api/offender_api' }, ci_fixme: true do
+describe 'Offender Early Allocation API' do
   let(:Authorization) { "Bearer TEST_TOKEN" }
+  let(:prison) { Prison.find_by(code: "LEI") || create(:prison, code: "LEI") }
+
+  before do
+    stub_auth_token
+    stub_offender(build(:nomis_offender, prisonerNumber: 'G7266VD', prisonId: prison.code))
+    stub_non_existent_offender('A1111AA')
+  end
 
   path '/api/offenders/{nomsNumber}' do
     get 'Retrieves information for a prisoner including early allocation status' do

--- a/spec/jobs/handover_follow_up_job_spec.rb
+++ b/spec/jobs/handover_follow_up_job_spec.rb
@@ -1,21 +1,17 @@
 require "rails_helper"
 
-describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_up_email" }, ci_fixme: true do
-  around do |example|
-    cassettes = [
-      { name: 'prison_api/offender_api' },
-      { name: 'prison_api/pom_api_list_spec' },
-      { name: 'prison_api/elite2_staff_api_get_email' }
-    ]
-    VCR.use_cassettes(cassettes) do
-      example.run
-    end
-  end
-
+describe HandoverFollowUpJob do
+  let(:prison) { Prison.find_by(code: "LEI") || create(:prison, code: "LEI") }
   let(:local_delivery_unit) { FactoryBot.create(:local_delivery_unit, email_address: "ldu@email.com") }
   let(:mailer_double) { double("CommunityMailer", deliver_later: true) }
 
   before do
+    stub_auth_token
+    stub_offenders_for_prison(prison.code, [build(:nomis_offender, prisonerNumber: nomis_offender_id)])
+    stub_poms(prison.code, [
+      build(:pom, :prison_officer, emails: []),
+    ])
+
     allow(CommunityMailer).to receive(:with).and_return(
       double("CommunityMailer", urgent_pipeline_to_community: mailer_double)
     )
@@ -31,8 +27,10 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
   end
 
   context "when the offender is at an active prison and handover date was a week ago" do
+    let(:nomis_offender_id) { 'G7266VD' }
+
     it "sends the follow up email to that offender" do
-      valid_offender = FactoryBot.create(:offender, nomis_offender_id: "G7266VD")
+      valid_offender = FactoryBot.create(:offender, nomis_offender_id:)
       FactoryBot.create(:calculated_handover_date, start_date: Time.zone.today - 1.week, offender: valid_offender)
       FactoryBot.create(:case_information, local_delivery_unit:, offender: valid_offender)
       FactoryBot.create(:allocation_history, nomis_offender_id: valid_offender.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "486154")
@@ -44,8 +42,10 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
   end
 
   context "when the offender has no handover date" do
+    let(:nomis_offender_id) { 'G7260UD' }
+
     it "does not send the follow up email to that offender" do
-      offender_without_a_handover_date = FactoryBot.create(:offender, nomis_offender_id: "G7260UD")
+      offender_without_a_handover_date = FactoryBot.create(:offender, nomis_offender_id:)
       FactoryBot.create(:case_information, local_delivery_unit:, offender: offender_without_a_handover_date)
       FactoryBot.create(:allocation_history, nomis_offender_id: offender_without_a_handover_date.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "486154")
 
@@ -56,8 +56,10 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
   end
 
   context "when the offender has a handover date in the future" do
+    let(:nomis_offender_id) { 'G5241UH' }
+
     it "does not send the follow up email to that offender" do
-      offender_with_a_handover_in_future = FactoryBot.create(:offender, nomis_offender_id: "G5241UH")
+      offender_with_a_handover_in_future = FactoryBot.create(:offender, nomis_offender_id:)
       FactoryBot.create(:calculated_handover_date, start_date: 1.week.from_now, offender: offender_with_a_handover_in_future)
       FactoryBot.create(:case_information, local_delivery_unit:, offender: offender_with_a_handover_in_future)
       FactoryBot.create(:allocation_history, nomis_offender_id: offender_with_a_handover_in_future.nomis_offender_id, prison: "LEI", primary_pom_nomis_id: "486154")
@@ -69,8 +71,10 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
   end
 
   context "when the offender is at a prison that is not active" do
+    let(:nomis_offender_id) { 'G0918GN' }
+
     it "does not send the follow up email to that offender" do
-      offender_without_an_active_prison = FactoryBot.create(:offender, nomis_offender_id: "G0918GN")
+      offender_without_an_active_prison = FactoryBot.create(:offender, nomis_offender_id:)
       FactoryBot.create(:calculated_handover_date, start_date: 1.week.from_now, offender: offender_without_an_active_prison)
       FactoryBot.create(:case_information, local_delivery_unit:, offender: offender_without_an_active_prison)
 
@@ -81,9 +85,11 @@ describe HandoverFollowUpJob, vcr: { cassette_name: "prison_api/handover_follow_
   end
 
   context "when the offender is at another LDU" do
+    let(:nomis_offender_id) { 'G0918GN' }
+
     it "does not send the follow up email to that offender" do
       a_different_ldu = FactoryBot.create(:local_delivery_unit, email_address: "a-different-ldu@email.com")
-      offender_at_a_different_ldu = FactoryBot.create(:offender, nomis_offender_id: "G0918GN")
+      offender_at_a_different_ldu = FactoryBot.create(:offender, nomis_offender_id:)
       FactoryBot.create(:calculated_handover_date, start_date: 1.week.from_now, offender: offender_at_a_different_ldu)
       FactoryBot.create(:case_information, local_delivery_unit: a_different_ldu, offender: offender_at_a_different_ldu)
 

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -37,26 +37,23 @@ RSpec.describe Prison do
   describe '#unfiltered_offenders' do
     subject { described_class.new(code: 'LEI').unfiltered_offenders }
 
-    it "get first page of offenders for a specific prison",
-       vcr: { cassette_name: 'prison_api/offender_service_offenders_by_prison_first_page_spec' }, ci_fixme: true do
-      offender_array = subject.first(9)
-      expect(offender_array).to be_a(Array)
-      expect(offender_array.length).to eq(9)
+    let(:offenders) { build_list(:nomis_offender, 3) }
+
+    before do
+      stub_auth_token
+      stub_offenders_for_prison('LEI', offenders)
     end
 
-    it "get last page of offenders for a specific prison",
-       vcr: { cassette_name: 'prison_api/offender_service_offenders_by_prison_last_page_spec' }, ci_fixme: true do
+    it "get offenders for a specific prison" do
       offender_array = subject.to_a
       expect(offender_array).to be_a(Array)
-      expect(offender_array.length).to be > 800
+      expect(offender_array.length).to eq(3)
     end
 
     context 'when recall flag set' do
       let(:offenders) { build_list(:nomis_offender, 2, sentence: attributes_for(:sentence_detail, recall: true)) }
 
       before do
-        stub_auth_token
-        stub_offenders_for_prison('LEI', offenders)
         create(:offender, nomis_offender_id: offenders.first.fetch(:prisonerNumber))
       end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1714

Refactor tests that previously couldn't run on GH actions (those tagged as `@ci_fixme`).

This is a first step on a wider piece of work to ultimately run 100% of the tests on GH actions and remove CircleCI.