### PR TITLE
MO-1717 Wrap main offence in details component

### DIFF
--- a/app/views/debugging/_sentence.html.erb
+++ b/app/views/debugging/_sentence.html.erb
@@ -6,7 +6,18 @@
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Main offence</dt>
-        <dd class="govuk-summary-list__value"><%= @offender.main_offence %></dd>
+        <dd class="govuk-summary-list__value">
+          <details class="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Display main offence
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <%= @offender.main_offence %>
+            </div>
+          </details>
+        </dd>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Category</dt>


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1717

Trauma-informed ways of working.

In the debugging page, the main offence is now hidden inside a GOV.UK details component, allowing to expand and view the offence details on demand only if necessary.