### PR TITLE
Get working pattern from POM API response

### DIFF
--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -3,6 +3,8 @@
 class PomDetail < ApplicationRecord
   has_paper_trail
 
+  FULL_TIME_HOURS_PER_WEEK = 37.5
+
   validates :nomis_staff_id, presence: true, uniqueness: { scope: :prison_code }
   validates :status, presence: true
   validates :working_pattern, presence: {

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -17,7 +17,7 @@ class Prison < ApplicationRecord
 
     details = pom_details.where(nomis_staff_id: poms.map(&:staff_id))
 
-    poms.map { |pom| PomWrapper.new(pom, get_pom_detail(details,  pom.staff_id.to_i)) }
+    poms.map { |pom| PomWrapper.new(pom, get_pom_detail(details,  pom)) }
   end
 
   def get_single_pom(nomis_staff_id)
@@ -84,11 +84,11 @@ private
     @summary ||= AllocationsSummary.new(self)
   end
 
-  def get_pom_detail(details, nomis_staff_id)
-    details.detect { |pd| pd.nomis_staff_id == nomis_staff_id } ||
-      PomDetail.find_or_create_by!(prison_code: code, nomis_staff_id: nomis_staff_id) do |pom|
-        pom.working_pattern = 0.0
-        pom.status = 'active'
+  def get_pom_detail(details, pom)
+    details.detect { |d| d.nomis_staff_id == pom.staff_id } ||
+      PomDetail.find_or_create_by!(prison_code: code, nomis_staff_id: pom.staff_id) do |pd|
+        pd.working_pattern = pom.hours_per_week / PomDetail::FULL_TIME_HOURS_PER_WEEK
+        pd.status = 'active'
       end
   end
 end

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -23,7 +23,9 @@ FactoryBot.define do
   end
 
   class Elite2POM
-    attr_accessor :position, :staffId, :emails, :firstName, :lastName, :positionDescription, :status, :primaryEmail
+    attr_accessor :position, :staffId, :emails, :firstName, :lastName, :positionDescription, :status, :primaryEmail,
+                  :fromDate, :toDate, :scheduleType, :hoursPerWeek
+
     attr_writer :agencyId
 
     def first_name
@@ -49,6 +51,11 @@ FactoryBot.define do
     def email_address
       emails.present? ? emails.first : primaryEmail
     end
+
+    def from_date = fromDate
+    def to_date = toDate
+    def schedule_type = scheduleType
+    def hours_per_week = hoursPerWeek
   end
 
   factory :pom, class: 'Elite2POM' do
@@ -64,6 +71,9 @@ FactoryBot.define do
     # So we also .titleize the last name here to avoid breaking tests
     lastName { Faker::Name.last_name.titleize }
     positionDescription { Faker::Company.type }
+
+    scheduleType { 'FT' }
+    hoursPerWeek { PomDetail::FULL_TIME_HOURS_PER_WEEK }
 
     trait :probation_officer do
       position { 'PO' }


### PR DESCRIPTION
Instead of hardcoding to 0.0 we get it from the POM as we already have this information coming through the API response. This will make more sense soon with the POM onboarding.

Updated PomDetails factory with these attributes (were added to the model in previous PR but factory was not committed back then).