### PR TITLE
MO-1443 Change handover completion due copy

### DIFF
--- a/app/jobs/automatic_handover_email_job.rb
+++ b/app/jobs/automatic_handover_email_job.rb
@@ -3,7 +3,7 @@
 class AutomaticHandoverEmailJob < ApplicationJob
   queue_as :mailers
 
-  HEADERS = ['Prisoner', 'CRN', 'Prisoner number', 'Handover completion due', 'Release/Parole Date', 'Prison', 'Current POM', 'POM email', 'COM'].freeze
+  HEADERS = ['Prisoner', 'CRN', 'Prisoner number', 'COM responsible', 'Release/Parole Date', 'Prison', 'Current POM', 'POM email', 'COM'].freeze
   # Turns out that between? is inclusive at both ends, so a 45-day gap needs a 44-day threshold
   SEND_THRESHOLD = 44.days.freeze
 

--- a/app/views/allocations/_allocated_details.html.erb
+++ b/app/views/allocations/_allocated_details.html.erb
@@ -19,7 +19,7 @@
   <li class="govuk-!-margin-top-4">Active alerts: <%= active_alerts %></li>
 
   <li class="govuk-!-margin-top-4">Last OASys completed: <%= last_oasys_completed %></li>
-  <li>Handover completion due: <%= handover_completion_date %></li>
+  <li>COM responsible: <%= handover_completion_date %></li>
 
   <li class="govuk-!-margin-top-4">LDU: <%= ldu_name %></li>
   <li>LDU email: <%= ldu_email %></li>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -105,7 +105,7 @@
       </td>
     </tr>
     <tr class="govuk-table__row" id="responsibility-handover-date-row">
-      <td class="govuk-table__cell govuk-!-width-one-half">Handover completion due</td>
+      <td class="govuk-table__cell govuk-!-width-one-half">COM responsible</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
         <%= format_date(@prisoner.handover_date) %>
         <span class="handover-reason">(<%= @prisoner.handover_reason %>)</span>

--- a/app/views/prisoners/_prisoner_information.html.erb
+++ b/app/views/prisoners/_prisoner_information.html.erb
@@ -11,7 +11,7 @@
       </td>
     </tr>
     <tr class="govuk-table__row" id="responsibility-handover">
-      <td class="govuk-table__cell govuk-!-width-one-half">Handover completion due</td>
+      <td class="govuk-table__cell govuk-!-width-one-half">COM responsible</td>
       <td class="govuk-table__cell table_cell__left_align  govuk-!-width-one-half">
         <%= format_date(probation_field(@prisoner, :handover_date), replacement: 'N/A') %>
         <span class="handover-reason">(<%= probation_field(@prisoner, :handover_reason) %>)</span>

--- a/app/views/prisoners/review_case_details.html.erb
+++ b/app/views/prisoners/review_case_details.html.erb
@@ -156,7 +156,7 @@
               <td class="govuk-table__cell"></td>
             </tr>
             <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Handover completion due</th>
+              <th scope="row" class="govuk-table__header govuk-!-width-one-third">COM responsible</th>
               <td class="govuk-table__cell"><%= format_date(@prisoner.responsibility_handover_date, replacement: 'Unknown') %></td>
               <td class="govuk-table__cell"></td>
             </tr>


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1443

There is confusion because we still use ‘handover completion due’ on some places whereas on the handover pages we talk about COM responsible date.

Copy changed, as per content designer.