### PR TITLE
Improve handling of working pattern hours

### DIFF
--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -57,7 +57,7 @@ private
 
   def load_staff_member
     @staff_id = current_staff_id
-    @current_user = StaffMember.new(@prison, @staff_id)
+    @current_user = StaffMember.new(@prison, @staff_id, _pom_detail = nil) # No need for POM detail here
   end
 
   def service_notifications

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -87,7 +87,7 @@ private
   def get_pom_detail(details, pom)
     details.detect { |d| d.nomis_staff_id == pom.staff_id } ||
       PomDetail.find_or_create_by!(prison_code: code, nomis_staff_id: pom.staff_id) do |pd|
-        pd.working_pattern = pom.hours_per_week / PomDetail::FULL_TIME_HOURS_PER_WEEK
+        pd.hours_per_week = pom.hours_per_week
         pd.status = 'active'
       end
   end

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -9,4 +9,33 @@ RSpec.describe PomDetail, type: :model do
   it { expect(create(:pom_detail, prison: prison)).to validate_uniqueness_of(:nomis_staff_id).scoped_to(:prison_code) }
   it { is_expected.to validate_presence_of(:working_pattern).with_message('Select number of days worked') }
   it { is_expected.to validate_presence_of(:status) }
+
+  describe '#hours_per_week=' do
+    it 'converts hours to working pattern ratio' do
+      subject.hours_per_week = 30
+      expect(subject.working_pattern).to eq(0.8)
+    end
+
+    it 'converts full time hours to 1.0' do
+      subject.hours_per_week = 37.5
+      expect(subject.working_pattern).to eq(1.0)
+    end
+
+    it 'caps working pattern to 1.0 for hours greater than full time' do
+      subject.hours_per_week = 40
+      expect(subject.working_pattern).to eq(1.0)
+    end
+  end
+
+  describe '#hours_per_week' do
+    it 'converts working pattern to hours' do
+      subject.working_pattern = 0.8
+      expect(subject.hours_per_week).to eq(30.0)
+    end
+
+    it 'returns full time hours for full time pattern' do
+      subject.working_pattern = 1.0
+      expect(subject.hours_per_week).to eq(37.5)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #2643.

Handle different values for existing working patterns retrieved from NOMIS, where it may not directly map to one of our ratios.

Also some performance improvements to cut down unnecessary API requests.