### PR TITLE
Revert to previous 0.0 default for working pattern

### DIFF
--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -87,7 +87,7 @@ private
   def get_pom_detail(details, pom)
     details.detect { |d| d.nomis_staff_id == pom.staff_id } ||
       PomDetail.find_or_create_by!(prison_code: code, nomis_staff_id: pom.staff_id) do |pd|
-        pd.hours_per_week = pom.hours_per_week
+        pd.hours_per_week = 0 # TODO: decide if we want to use `pom.hours_per_week` (NOMIS hours)
         pd.status = 'active'
       end
   end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -201,8 +201,8 @@ RSpec.describe Prison do
       result = prison.get_list_of_poms
 
       expect(result.map(&:status)).to all(eq('active'))
-      expect(result[0].working_pattern).to eq(0.5)
-      expect(result[1].working_pattern).to eq(0.3)
+      expect(result[0].working_pattern).to eq(0.0)
+      expect(result[1].working_pattern).to eq(0.0)
     end
 
     context 'when fetching a specific POM' do


### PR DESCRIPTION
We need more information and ask around to decide if we want to use the hours we receive from NOMIS and assign a working pattern derived from it in our service.

Currently we default to 0.0 but given we receive the hours from NOMIS we could improve this. However there is a bit of variance in the data coming from NOMIS, with 35 hours being used in a majority of cases as FT, but others like 37 and even 39 are also used. And some in between.

To be safe and to be able to deploy to production other unrelated stuff, put this back as it was and we will decide later.