### PR TITLE
MO-1727 Retrospectively deallocate remand cases

### DIFF
--- a/lib/tasks/deallocate_unsentenced_offenders.rake
+++ b/lib/tasks/deallocate_unsentenced_offenders.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :deallocate_unsentenced_offenders do
+  desc 'De-allocate cases for offenders that have a non-allowed legal status, like unsentenced, remand, dead, etc.'
+  task process: :environment do
+    # Older than 2 months ago because after that date we started handling
+    # deallocations via events, upon receiving legal status updates.
+    AllocationHistory.active.where('updated_at <= ?', 2.months.ago).pluck(:nomis_offender_id).each do |nomis_offender_id|
+      ProcessPrisonerStatusJob.perform_later(nomis_offender_id)
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1727

Note, this will also deallocate any other non-allowed legal status, like unsentenced, dead, etc.

It is just a quick rake task that reuses the job already created for handling the events, given it will be a one-off run.