### PR TITLE
MpcOffender spring clean

### DIFF
--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -162,18 +162,12 @@ class MpcOffender
     end
   end
 
-  # Separate from next_parole_date as parole case index view sorts by next_parole_date, so it seemed sensible to avoid changing default rails behaviour
-  # for the sake of saving a couple of simple, albeit slightly inefficient, comparisons.
   def next_parole_date_type
-    return nil if next_parole_date.nil?
-
     case next_parole_date
-    when tariff_date
-      'TED'
-    when parole_eligibility_date
-      'PED'
-    when target_hearing_date
-      'Target hearing date'
+    when nil                     then nil
+    when tariff_date             then 'TED'
+    when parole_eligibility_date then 'PED'
+    when target_hearing_date     then 'Target hearing date'
     end
   end
 

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -1,32 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/AccessModifierDeclarations
+
 class MpcOffender
-  delegate :get_image,
-           :recalled?, :immigration_case?, :indeterminate_sentence?,
-           :sentenced?, :over_18?, :describe_sentence, :legal_status, :civil_sentence?,
-           :sentence_start_date, :conditional_release_date, :automatic_release_date, :parole_eligibility_date,
-           :tariff_date, :post_recall_release_date, :licence_expiry_date,
-           :home_detention_curfew_actual_date, :home_detention_curfew_eligibility_date,
-           :prison_arrival_date, :earliest_release_date, :earliest_release, :latest_temp_movement_date, :release_date,
-           :date_of_birth, :main_offence, :awaiting_allocation_for, :location,
-           :category_label, :complexity_level, :category_code, :category_active_since,
-           :first_name, :last_name, :full_name_ordered, :full_name,
-           :inside_omic_policy?, :offender_no, :prison_id, :restricted_patient?, :age, :booking_id, to: :@api_offender
-
-  delegate :crn, :manual_entry?, :tier, :mappa_level, to: :case_information
-  # These fields make sense to be nil when the case information is nil - the others dont
-  delegate :ldu_email_address, :team_name, :ldu_name, :active_vlo?, :welsh_offender, to: :case_information, allow_nil: true
-
-  delegate :victim_liaison_officers,
-           :handover_progress_task_completion_data, :handover_progress_complete?, :handover_type, :enhanced_handover?,
-           :current_parole_review, :previous_parole_reviews, :most_recent_parole_review, :parole_reviews,
-           :case_information, to: :offender
-
-  attr_reader :prison, :offender
-
-  alias_method :nomis_offender_id, :offender_no
-  alias_method :probation_record, :case_information
-  alias_method :model, :offender
 
   def initialize(prison:, offender:, prison_record:)
     @prison = prison
@@ -34,7 +10,112 @@ class MpcOffender
     @api_offender = prison_record # @type HmppsApi::Offender
   end
 
-  # TODO: - view method in model needs to be removed
+  #
+  # Responsibility
+  #
+
+  def pom_responsible? = responsibility.try(:pom_responsible?)
+
+  def pom_supporting? = responsibility.try(:pom_supporting?)
+
+  def com_responsible? = responsibility.try(:com_responsible?)
+
+  def com_supporting? = responsibility.try(:com_supporting?)
+
+  def responsibility_override? = @offender.responsibility.present?
+
+  private def responsibility
+    # Take user-overridden responsbility if it exists
+    # otherwise most common to use the pre-calculated one
+    # or calculate now if neither are present - could be a brand new case
+    @responsibility ||=
+      @offender.responsibility ||
+      @offender.calculated_handover_date ||
+      HandoverDateService.handover(self)
+  end
+
+
+  #
+  # Handover
+  #
+
+  def handover_start_date = @offender.calculated_handover_date&.start_date
+
+  def handover_date = @offender.calculated_handover_date&.handover_date
+
+  # TODO: investigate the purpose of this
+  def responsibility_handover_date = handover.handover_date
+
+  def handover_last_calculated_at = @offender.calculated_handover_date&.last_calculated_at
+
+  def handover_reason = handover.reason_text
+
+  def needs_a_com? = case_information.present? && (com_responsible? || com_supporting?) && allocated_com_name.blank?
+
+  def has_com? = allocated_com_name.present? || allocated_com_email.present?
+
+  def allocated_com_name = case_information.com_name
+
+  def allocated_com_email = case_information.com_email
+
+  def com_allocation_days_overdue(relative_to_date: Time.zone.now.to_date)
+    raise ArgumentError, 'Handover date not set' unless handover_date
+
+    (relative_to_date - handover_date).to_i
+  end
+
+  def should_send_handover_follow_up_email? = sentenced? && prison.active? && handover_start_date == Time.zone.today - 1.week
+
+  def earliest_release_for_handover
+    Handover::HandoverCalculation.calculate_earliest_release(
+      is_indeterminate: indeterminate_sentence?,
+      tariff_date: tariff_date,
+      target_hearing_date: target_hearing_date,
+      parole_eligibility_date: parole_eligibility_date,
+      automatic_release_date: automatic_release_date,
+      conditional_release_date: conditional_release_date,
+    )
+  end
+
+  # TODO: might not sit under handover
+  def pom_tasks
+    @pom_tasks ||= begin
+      tasks = []
+
+      # We don't want the task to be created if there's no parole review, if the
+      # most recent parole review is yet to have a hearing outcome, or if there is
+      # already a date that the hearing outcome was received.
+      if most_recent_parole_review.present? &&
+        !most_recent_parole_review.no_hearing_outcome? &&
+        most_recent_parole_review.hearing_outcome_received_on.blank?
+        tasks << PomTask.new(self, :parole_outcome_date, most_recent_parole_review.review_id)
+      end
+
+      if early_allocations.present?
+        tasks << PomTask.new(self, :early_allocation_decision)
+      end
+
+      tasks
+    end
+  end
+
+  private def handover
+    # TODO: calls on responsibility which could in turn call HandoverDateService.handover - does it need this check?
+    @handover ||= pom_responsible? ? HandoverDateService.handover(self) : OffenderHandover::COM_NO_HANDOVER_DATE
+  end
+
+
+  #
+  # Allocations
+  #
+
+  def recommended_pom_type = RecommendationService.recommended_pom_type(self)
+
+  def active_allocation
+    @active_allocation ||= AllocationHistory.active_allocations_for_prison(prison.code).find_by(nomis_offender_id: offender_no)
+  end
+
+  # TODO: this seems to only exist in attributes_to_archive
   def case_owner
     if pom_responsible?
       'Custody'
@@ -43,56 +124,40 @@ class MpcOffender
     end
   end
 
-  def com_allocation_days_overdue(relative_to_date: Time.zone.now.to_date)
-    raise ArgumentError, 'Handover date not set' unless handover_date
-
-    (relative_to_date - handover_date).to_i
+  # TODO: doesn't seem to be used
+  def to_allocated_offender
+    if active_allocation
+      AllocatedOffender.new(active_allocation.primary_pom_nomis_id, active_allocation, self)
+    else
+      nil
+    end
   end
 
-  def needs_a_com?
-    case_information.present? && (com_responsible? || com_supporting?) && allocated_com_name.blank?
-  end
 
-  def pom_responsible?
-    responsibility.try(:pom_responsible?)
-  end
+  #
+  # Early allocations
+  #
 
-  def pom_supporting?
-    responsibility.try(:pom_supporting?)
-  end
-
-  def com_responsible?
-    responsibility.try(:com_responsible?)
-  end
-
-  def com_supporting?
-    responsibility.try(:com_supporting?)
-  end
-
-  def allocated_com_name
-    case_information.com_name
-  end
-
-  def allocated_com_email
-    case_information.com_email
-  end
-
-  def responsibility_override?
-    @offender.responsibility.present?
-  end
-
-  # Early allocation methods
-  def early_allocation?
-    latest_early_allocation.present? && !licence_expiry_date&.before?(Time.zone.today)
-  end
+  def early_allocations = @offender.early_allocations.where('created_at::date >= ?', sentence_start_date)
 
   def latest_early_allocation
     allocation = early_allocations&.last
     allocation if allocation.present? && allocation.created_within_referral_window? && (allocation.eligible? || allocation.community_decision?)
   end
 
-  def early_allocations
-    @offender.early_allocations.where('created_at::date >= ?', sentence_start_date)
+  def early_allocation? = latest_early_allocation.present? && !licence_expiry_date&.before?(Time.zone.today)
+
+  def early_allocation_state
+    if early_allocation?
+      :eligible
+    elsif early_allocation_active?
+      :decision_pending
+    elsif within_early_allocation_window? &&
+      early_allocations.reject(&:created_within_referral_window?).select { |ea| %w[eligible discretionary].include?(ea.outcome) }.any?
+      :call_to_action # need to complete a new assessment
+    elsif early_allocation_notes?
+      :assessment_saved
+    end
   end
 
   def needs_early_allocation_notify?
@@ -114,47 +179,20 @@ class MpcOffender
     earliest_date.present? && earliest_date <= Time.zone.today + 18.months
   end
 
-  # handover methods
+  private def early_allocation_active? = early_allocations.present? && early_allocations.last.awaiting_community_decision?
 
-  def handover_start_date
-    model.calculated_handover_date&.start_date
+  private def early_allocation_notes?
+    if early_allocations.present?
+      !early_allocations.last.created_within_referral_window? || !early_allocations.last.community_decision_eligible_or_automatically_eligible?
+    end
   end
 
-  def handover_date
-    model.calculated_handover_date&.handover_date
-  end
 
-  def handover_last_calculated_at
-    model.calculated_handover_date&.last_calculated_at
-  end
+  #
+  # Parole
+  #
 
-  def handover_reason
-    handover.reason_text
-  end
-
-  def should_send_handover_follow_up_email?
-    sentenced? && prison.active? && handover_start_date == Time.zone.today - 1.week
-  end
-
-  # LEGACY - does processing when called to blank out handover date if responsibility is COM. Use #handover_date
-  # which returns the actual handover date on the CalculatedHandoverDate model
-  def responsibility_handover_date
-    handover.handover_date
-  end
-
-  # parole methods
-
-  def target_hearing_date
-    @target_hearing_date ||= parole_reviews
-      .ordered_by_sortable_date
-      .for_sentences_starting(sentence_start_date)
-      .pluck(:target_hearing_date)
-      .last
-  end
-
-  def approaching_parole?
-    next_parole_date.present?
-  end
+  def approaching_parole? = next_parole_date.present?
 
   def next_parole_date
     [target_hearing_date, tariff_date, parole_eligibility_date].compact.sort.find do |date|
@@ -171,6 +209,14 @@ class MpcOffender
     end
   end
 
+  def target_hearing_date
+    @target_hearing_date ||= parole_reviews
+      .ordered_by_sortable_date
+      .for_sentences_starting(sentence_start_date)
+      .pluck(:target_hearing_date)
+      .last
+  end
+
   def most_recent_completed_parole_review_for_sentence
     @most_recent_completed_parole_review_for_sentence ||= parole_reviews
       .ordered_by_sortable_date
@@ -179,79 +225,22 @@ class MpcOffender
       .last
   end
 
-  def no_parole_outcome?
-    most_recent_completed_parole_review_for_sentence&.no_hearing_outcome?
-  end
+  def no_parole_outcome? = most_recent_completed_parole_review_for_sentence&.no_hearing_outcome?
 
-  def parole_outcome_not_release?
-    most_recent_completed_parole_review_for_sentence&.outcome_is_not_release?
-  end
+  def parole_outcome_not_release? = most_recent_completed_parole_review_for_sentence&.outcome_is_not_release?
 
-  def thd_12_or_more_months_from_now?
-    target_hearing_date && target_hearing_date >= 12.months.from_now
-  end
+  def thd_12_or_more_months_from_now? = target_hearing_date && target_hearing_date >= 12.months.from_now
 
-  def display_current_parole_info?
-    tariff_date.present? || parole_eligibility_date.present? || current_parole_review.present?
-  end
+  def display_current_parole_info? = [tariff_date, parole_eligibility_date, current_parole_review].any?(&:present?)
 
-  def sentences
-    @sentences ||= Offenders::Sentences.new(booking_id:)
-  end
+  def determinate_parole? = parole_eligibility_date.present?
 
-  def pom_tasks
-    @pom_tasks ||= build_pom_tasks
-  end
 
-  # early allocation methods
+  #
+  # MAPPA / RoSH / Alerts
+  #
 
-  def early_allocation_state
-    if early_allocation?
-      :eligible
-    elsif early_allocation_active?
-      :decision_pending
-    elsif within_early_allocation_window? &&
-      early_allocations.reject(&:created_within_referral_window?).select { |ea| %w[eligible discretionary].include?(ea.outcome) }.any?
-      :call_to_action # need to complete a new assessment
-    elsif early_allocation_notes?
-      :assessment_saved
-    end
-  end
-
-  def prison_timeline
-    @prison_timeline ||= HmppsApi::PrisonTimelineApi.get_prison_timeline(offender_no)
-
-  # Temp fix while Prison API prison timeline sometimes returns 500 and 404
-  # for some offenders
-  rescue Faraday::ServerError, Faraday::ResourceNotFound
-    nil
-  end
-
-  def additional_information
-    return [] if prison_timeline.nil?
-
-    attended_prisons = prison_timeline['prisonPeriod'].map { |p| p['prisons'] }.flatten
-
-    # Remove only ONE of any prison codes that match the current prison
-    previously_attended_prisons = (attended_prisons.reject { |p| p == prison.code }) +
-      attended_prisons.select { |p| p == prison.code }.drop(1)
-
-    [].tap do |output|
-      output << 'Recall' if recalled? && previously_attended_prisons.any?
-
-      output << if previously_attended_prisons.empty?
-                  'New to custody'
-                elsif previously_attended_prisons.include?(prison.code)
-                  'Returning to this prison'
-                else
-                  'New to this prison'
-                end
-    end
-  end
-
-  def mappa_details
-    OffenderService.get_mappa_details(crn)
-  end
+  def mappa_details = OffenderService.get_mappa_details(crn)
 
   def rosh_summary
     return { status: :unable } if case_information.blank?
@@ -311,15 +300,149 @@ class MpcOffender
   end
 
   def active_alert_labels
-    active_alerts = HmppsApi::PrisonAlertsApi.alerts_for(offender_no)
+    HmppsApi::PrisonAlertsApi.alerts_for(offender_no)
       .select { |alert| alert['isActive'] }
       .sort_by { |alert| alert['createdAt'] }
-    active_alerts.map { |alert| alert.dig('alertCode', 'description') }
+      .map { |alert| alert.dig('alertCode', 'description') }
   end
 
-  def recommended_pom_type
-    RecommendationService.recommended_pom_type(self)
+
+  #
+  # Sentencing / Movements
+  #
+
+  def sentences = @sentences ||= Offenders::Sentences.new(booking_id:)
+
+  def prison_timeline
+    @prison_timeline ||= HmppsApi::PrisonTimelineApi.get_prison_timeline(offender_no)
+
+  # Temp fix while Prison API prison timeline sometimes returns 500 and 404
+  # for some offenders
+  rescue Faraday::ServerError, Faraday::ResourceNotFound
+    nil
   end
+
+  def additional_information
+    return [] if prison_timeline.nil?
+
+    attended_prisons = prison_timeline['prisonPeriod'].map { |p| p['prisons'] }.flatten
+
+    # Remove only ONE of any prison codes that match the current prison
+    previously_attended_prisons = (attended_prisons.reject { |p| p == prison.code }) +
+      attended_prisons.select { |p| p == prison.code }.drop(1)
+
+    [].tap do |output|
+      output << 'Recall' if recalled? && previously_attended_prisons.any?
+
+      output << if previously_attended_prisons.empty?
+                  'New to custody'
+                elsif previously_attended_prisons.include?(prison.code)
+                  'Returning to this prison'
+                else
+                  'New to this prison'
+                end
+    end
+  end
+
+  def released?(relative_to_date: Time.zone.now.utc.to_date)
+    return false if earliest_release_date.nil?
+
+    earliest_release_date <= relative_to_date
+  end
+
+  def policy_case? = Offenders::PrisonPolicies.new(self).policy_case?
+
+  def open_prison_rules_apply? = Offenders::PrisonPolicies.new(self).open_prison_rules_apply?
+
+  def in_womens_prison? = Offenders::PrisonPolicies.new(self).in_womens_prison?
+
+  def in_open_conditions? = Offenders::PrisonPolicies.new(self).in_open_conditions?
+
+
+  #
+  # Unsorted delegations
+  # TODO: sort these
+  #
+
+  delegate :get_image,
+           :recalled?,
+           :immigration_case?,
+           :indeterminate_sentence?,
+           :sentenced?,
+           :over_18?,
+           :describe_sentence,
+           :legal_status,
+           :civil_sentence?,
+           :sentence_start_date,
+           :conditional_release_date,
+           :automatic_release_date,
+           :parole_eligibility_date,
+           :tariff_date,
+           :post_recall_release_date,
+           :licence_expiry_date,
+           :home_detention_curfew_actual_date,
+           :home_detention_curfew_eligibility_date,
+           :prison_arrival_date,
+           :earliest_release_date,
+           :earliest_release,
+           :latest_temp_movement_date,
+           :release_date,
+           :date_of_birth,
+           :main_offence,
+           :awaiting_allocation_for,
+           :location,
+           :category_label,
+           :complexity_level,
+           :category_code,
+           :category_active_since,
+           :first_name,
+           :last_name,
+           :full_name_ordered,
+           :full_name,
+           :inside_omic_policy?,
+           :offender_no,
+           :prison_id,
+           :restricted_patient?,
+           :age,
+           :booking_id,
+           to: :@api_offender
+
+  delegate :crn,
+           :manual_entry?,
+           :tier,
+           :mappa_level,
+           to: :case_information
+
+  # These fields make sense to be nil when the case information is nil - the others dont
+  delegate :ldu_email_address,
+           :team_name,
+           :ldu_name,
+           :active_vlo?,
+           :welsh_offender,
+           to: :case_information, allow_nil: true
+
+  delegate :victim_liaison_officers,
+           :handover_progress_task_completion_data,
+           :handover_progress_complete?,
+           :handover_type,
+           :enhanced_handover?,
+           :current_parole_review,
+           :previous_parole_reviews,
+           :most_recent_parole_review,
+           :parole_reviews,
+           :case_information,
+           to: :offender
+
+  attr_reader :prison, :offender
+
+  alias_method :nomis_offender_id, :offender_no
+  alias_method :probation_record, :case_information
+  alias_method :model, :offender
+
+
+  #
+  # Misc / Audit
+  #
 
   def attributes_to_archive
     attr_names = %w[
@@ -379,101 +502,5 @@ class MpcOffender
     attr_names.index_with { |attr_name| send(attr_name) }
   end
 
-  def released?(relative_to_date: Time.zone.now.utc.to_date)
-    return false if earliest_release_date.nil?
-
-    earliest_release_date <= relative_to_date
-  end
-
-  def has_com?
-    allocated_com_name.present? || allocated_com_email.present?
-  end
-
-  def earliest_release_for_handover
-    Handover::HandoverCalculation.calculate_earliest_release(
-      is_indeterminate: indeterminate_sentence?,
-      tariff_date: tariff_date,
-      target_hearing_date: target_hearing_date,
-      parole_eligibility_date: parole_eligibility_date,
-      automatic_release_date: automatic_release_date,
-      conditional_release_date: conditional_release_date,
-    )
-  end
-
-  def determinate_parole?
-    parole_eligibility_date.present?
-  end
-
-  def active_allocation
-    @active_allocation ||= AllocationHistory.active_allocations_for_prison(prison.code).find_by(nomis_offender_id: offender_no)
-  end
-
-  def to_allocated_offender
-    if active_allocation
-      AllocatedOffender.new(active_allocation.primary_pom_nomis_id, active_allocation, self)
-    else
-      nil
-    end
-  end
-
-  def policy_case?
-    Offenders::PrisonPolicies.new(self).policy_case?
-  end
-
-  def open_prison_rules_apply?
-    Offenders::PrisonPolicies.new(self).open_prison_rules_apply?
-  end
-
-  def in_womens_prison?
-    Offenders::PrisonPolicies.new(self).in_womens_prison?
-  end
-
-  def in_open_conditions?
-    Offenders::PrisonPolicies.new(self).in_open_conditions?
-  end
-
-private
-
-  def early_allocation_notes?
-    if early_allocations.present?
-      !early_allocations.last.created_within_referral_window? || !early_allocations.last.community_decision_eligible_or_automatically_eligible?
-    end
-  end
-
-  def early_allocation_active?
-    early_allocations.present? && early_allocations.last.awaiting_community_decision?
-  end
-
-  def handover
-    @handover ||= if pom_responsible?
-                    HandoverDateService.handover(self)
-                  else
-                    OffenderHandover::COM_NO_HANDOVER_DATE
-                  end
-  end
-
-  def responsibility
-    @responsibility ||= @offender.responsibility || \
-      @offender.calculated_handover_date || \
-      HandoverDateService.handover(self)
-  end
-
-  def build_pom_tasks
-    tasks = []
-
-    # We don't want the task to be created if there's no parole review, if the
-    # most recent parole review is yet to have a hearing outcome, or if there is
-    # already a date that the hearing outcome was received.
-    if most_recent_parole_review.present? &&
-      !most_recent_parole_review.no_hearing_outcome? &&
-      most_recent_parole_review.hearing_outcome_received_on.blank?
-      tasks << PomTask.new(self, :parole_outcome_date, most_recent_parole_review.review_id)
-    end
-
-    if early_allocations.present?
-      tasks << PomTask.new(self, :early_allocation_decision)
-    end
-
-    tasks
-  end
 end
+# rubocop:enable Style/AccessModifierDeclarations

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -3,7 +3,6 @@
 # rubocop:disable Style/AccessModifierDeclarations
 
 class MpcOffender
-
   def initialize(prison:, offender:, prison_record:)
     @prison = prison
     @offender = offender
@@ -33,7 +32,6 @@ class MpcOffender
       @offender.calculated_handover_date ||
       HandoverDateService.handover(self)
   end
-
 
   #
   # Handover
@@ -115,7 +113,6 @@ class MpcOffender
     @handover ||= pom_responsible? ? HandoverDateService.handover(self) : OffenderHandover::COM_NO_HANDOVER_DATE
   end
 
-
   #
   # Allocations
   #
@@ -143,7 +140,6 @@ class MpcOffender
       nil
     end
   end
-
 
   #
   # Early allocations
@@ -198,7 +194,6 @@ class MpcOffender
     end
   end
 
-
   #
   # Parole
   #
@@ -251,7 +246,6 @@ class MpcOffender
   def display_current_parole_info? = [tariff_date, parole_eligibility_date, current_parole_review].any?(&:present?)
 
   def determinate_parole? = parole_eligibility_date.present?
-
 
   #
   # MAPPA / RoSH / Alerts
@@ -327,7 +321,6 @@ class MpcOffender
       .map { |alert| alert.dig('alertCode', 'description') }
   end
 
-
   #
   # Sentencing / Movements
   #
@@ -379,13 +372,11 @@ class MpcOffender
 
   def in_open_conditions? = Offenders::PrisonPolicies.new(self).in_open_conditions?
 
-
   #
   # Delegating data from the API
   #
 
   delegate :offender_no,
-
            # Personal / Basic Details
            :first_name,
            :last_name,
@@ -395,7 +386,6 @@ class MpcOffender
            :age,
            :over_18?,
            :get_image,
-
            # Sentencing
            :recalled?,
            :immigration_case?,
@@ -409,7 +399,6 @@ class MpcOffender
            :complexity_level,
            :awaiting_allocation_for,
            :inside_omic_policy?,
-
            # Special Dates
            :sentence_start_date,
            :conditional_release_date,
@@ -425,7 +414,6 @@ class MpcOffender
            :earliest_release,
            :latest_temp_movement_date,
            :release_date,
-
            # Prison
            :prison_id,
            :location,
@@ -433,7 +421,6 @@ class MpcOffender
            :category_code,
            :category_active_since,
            :restricted_patient?,
-
            to: :@api_offender
 
   delegate :crn,
@@ -455,7 +442,6 @@ class MpcOffender
   alias_method :nomis_offender_id, :offender_no
   alias_method :probation_record, :case_information
   alias_method :model, :offender
-
 
   #
   # Misc / Audit
@@ -518,6 +504,5 @@ class MpcOffender
 
     attr_names.index_with { |attr_name| send(attr_name) }
   end
-
 end
 # rubocop:enable Style/AccessModifierDeclarations

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -39,6 +39,17 @@ class MpcOffender
   # Handover
   #
 
+  delegate :handover_progress_task_completion_data,
+           :handover_progress_complete?,
+           :handover_type,
+           :enhanced_handover?,
+           to: :offender
+
+  delegate :ldu_email_address,
+           :team_name,
+           :ldu_name,
+           to: :case_information, allow_nil: true
+
   def handover_start_date = @offender.calculated_handover_date&.start_date
 
   def handover_date = @offender.calculated_handover_date&.handover_date
@@ -192,6 +203,12 @@ class MpcOffender
   # Parole
   #
 
+  delegate :current_parole_review,
+           :previous_parole_reviews,
+           :most_recent_parole_review,
+           :parole_reviews,
+           to: :offender
+
   def approaching_parole? = next_parole_date.present?
 
   def next_parole_date
@@ -239,6 +256,10 @@ class MpcOffender
   #
   # MAPPA / RoSH / Alerts
   #
+
+  delegate :tier,
+           :mappa_level,
+           to: :case_information
 
   def mappa_details = OffenderService.get_mappa_details(crn)
 
@@ -360,19 +381,36 @@ class MpcOffender
 
 
   #
-  # Unsorted delegations
-  # TODO: sort these
+  # Delegating data from the API
   #
 
-  delegate :get_image,
+  delegate :offender_no,
+
+           # Personal / Basic Details
+           :first_name,
+           :last_name,
+           :full_name_ordered,
+           :full_name,
+           :date_of_birth,
+           :age,
+           :over_18?,
+           :get_image,
+
+           # Sentencing
            :recalled?,
            :immigration_case?,
            :indeterminate_sentence?,
            :sentenced?,
-           :over_18?,
            :describe_sentence,
            :legal_status,
            :civil_sentence?,
+           :main_offence,
+           :booking_id,
+           :complexity_level,
+           :awaiting_allocation_for,
+           :inside_omic_policy?,
+
+           # Special Dates
            :sentence_start_date,
            :conditional_release_date,
            :automatic_release_date,
@@ -387,52 +425,31 @@ class MpcOffender
            :earliest_release,
            :latest_temp_movement_date,
            :release_date,
-           :date_of_birth,
-           :main_offence,
-           :awaiting_allocation_for,
+
+           # Prison
+           :prison_id,
            :location,
            :category_label,
-           :complexity_level,
            :category_code,
            :category_active_since,
-           :first_name,
-           :last_name,
-           :full_name_ordered,
-           :full_name,
-           :inside_omic_policy?,
-           :offender_no,
-           :prison_id,
            :restricted_patient?,
-           :age,
-           :booking_id,
+
            to: :@api_offender
 
   delegate :crn,
            :manual_entry?,
-           :tier,
-           :mappa_level,
            to: :case_information
 
-  # These fields make sense to be nil when the case information is nil - the others dont
-  delegate :ldu_email_address,
-           :team_name,
-           :ldu_name,
-           :active_vlo?,
+  delegate :active_vlo?,
            :welsh_offender,
            to: :case_information, allow_nil: true
 
+  # TODO: find out why we directly access these
   delegate :victim_liaison_officers,
-           :handover_progress_task_completion_data,
-           :handover_progress_complete?,
-           :handover_type,
-           :enhanced_handover?,
-           :current_parole_review,
-           :previous_parole_reviews,
-           :most_recent_parole_review,
-           :parole_reviews,
            :case_information,
            to: :offender
 
+  # TODO: find out why we directly access these
   attr_reader :prison, :offender
 
   alias_method :nomis_offender_id, :offender_no


### PR DESCRIPTION
Grouped methods into the following sections
- Responsibility
- Handover
- Allocations
- Early Allocations
- Parole
- MAPPA / RoSH / Alerts
- Sentencing / Movements
- Basic details delegations
- Misc / Audit

Not changed any of the behaviour at all.
Inlined methods where they were only 1 liners.
Mixed in some delegates into the groups where I could.

