### PR TITLE
MO-1759 Ensure cache is expired after add/rm POM

### DIFF
--- a/app/services/hmpps_api/client.rb
+++ b/app/services/hmpps_api/client.rb
@@ -77,6 +77,11 @@ module HmppsApi
       )
     end
 
+    def expire_cache_key(method, route, queryparams: {}, extra_headers: {}, body: nil)
+      key = cache_key(method, route, queryparams:, extra_headers:, body:)
+      Rails.cache.delete(key)
+    end
+
   private
 
     def request(method, route, queryparams: {}, extra_headers: {}, body: nil, cache: false)

--- a/app/services/hmpps_api/prison_api/prison_offender_manager_api.rb
+++ b/app/services/hmpps_api/prison_api/prison_offender_manager_api.rb
@@ -6,18 +6,26 @@ module HmppsApi
       extend PrisonApiClient
 
       def self.list(prison, staff_id: nil)
-        route = "/staff/roles/#{prison}/role/POM"
-        data = client.get(route, queryparams: { staffId: staff_id }.compact_blank, extra_headers: paging_options)
+        route, args = request_config(prison, staff_id:)
+        data = client.get(route, **args)
         api_deserialiser.deserialise_many(HmppsApi::PrisonOffenderManager, data)
+      end
+
+      def self.expire_list_cache(prison)
+        route, args = request_config(prison)
+        client.expire_cache_key(:get, route, **args)
       end
 
     private
 
-      def self.paging_options
-        {
-          'Page-Limit' => '100',
-          'Page-Offset' => '0'
-        }
+      def self.request_config(prison, staff_id: nil)
+        [
+          "/staff/roles/#{prison}/role/POM",
+          {
+            queryparams: { staffId: staff_id }.compact_blank,
+            extra_headers: { 'Page-Limit' => '100', 'Page-Offset' => '0' }
+          }
+        ]
       end
     end
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -72,7 +72,7 @@
 
     <%= render 'dashboard_partition',
                title: "Add a POM",
-               link: search_prison_onboarding_index_path(@prison.code),
+               link: search_prison_onboarding_index_path(@prison.code, from: :home),
                content: "Add a POM so you can allocate to them." if FeatureFlags.pom_onboarding.enabled?
     %>
   </div>

--- a/app/views/onboarding/search.html.erb
+++ b/app/views/onboarding/search.html.erb
@@ -15,7 +15,7 @@
 
 <% content_for :title, "#{page_title} – Digital Prison Services" %>
 
-<%= link_to 'Back', prison_poms_path,
+<%= link_to 'Back', params[:from] == 'home' ? root_path : prison_poms_path,
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">
@@ -23,6 +23,8 @@
     <div class="moj-search govuk-!-margin-bottom-8">
       <%= form_for(@onboarding_form, url: search_prison_onboarding_index_path, method: :post,
                    builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+
+        <%= hidden_field_tag :from, params[:from] %>
 
         <%= f.govuk_text_field :search_query, type: :search, class: 'moj-search__input',
                                autocomplete: 'off', autocorrect: 'off',

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -9,7 +9,7 @@
 
   <% if FeatureFlags.pom_onboarding.enabled? %>
   <div class="moj-page-header-actions__actions">
-    <%= link_to 'Add a POM', search_prison_onboarding_index_path(@prison.code), role: 'button',
+    <%= link_to 'Add a POM', search_prison_onboarding_index_path(@prison.code, from: :staff), role: 'button',
                 class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
                 data: { module: 'govuk-button--secondary' } %>
   </div>

--- a/spec/features/pom_onboarding_feature_spec.rb
+++ b/spec/features/pom_onboarding_feature_spec.rb
@@ -93,6 +93,7 @@ feature 'POM onboarding' do
 
           it 'shows the results table' do
             expect(page).to have_link('Joe Bloggs', href: position_prison_onboarding_path(prison.code, staff_id))
+            expect(page).to have_css('td.govuk-table__cell[data-sort-value="Joe Bloggs"]')
             expect(page).to have_text('joe.bloggs@example.com')
             expect(page).to have_text('TEST_USER')
           end

--- a/spec/services/hmpps_api/prison_api/prison_offender_manager_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/prison_offender_manager_api_spec.rb
@@ -47,4 +47,15 @@ describe HmppsApi::PrisonApi::PrisonOffenderManagerApi do
       expect(response).to all(be_an HmppsApi::PrisonOffenderManager)
     end
   end
+
+  context 'when expiring cache' do
+    let(:route) { '/staff/roles/LEI/role/POM' }
+    let(:args) { { queryparams: {}, extra_headers: { 'Page-Limit' => '100', 'Page-Offset' => '0' } } }
+
+    it 'expires the cache for the prison' do
+      allow(described_class).to receive(:client).and_return(described_class.client)
+      expect(described_class.client).to receive(:expire_cache_key).with(:get, route, **args)
+      described_class.expire_list_cache('LEI')
+    end
+  end
 end

--- a/spec/services/nomis_user_roles_service_spec.rb
+++ b/spec/services/nomis_user_roles_service_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe NomisUserRolesService do
 
     before do
       allow(HmppsApi::NomisUserRolesApi).to receive(:set_staff_role)
+      allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:expire_list_cache)
       allow(prison.pom_details).to receive(:create!)
     end
 
@@ -67,6 +68,10 @@ RSpec.describe NomisUserRolesService do
       expect(HmppsApi::NomisUserRolesApi).to have_received(:set_staff_role).with(
         prison.code, nomis_staff_id, config
       )
+
+      expect(
+        HmppsApi::PrisonApi::PrisonOffenderManagerApi
+      ).to have_received(:expire_list_cache).with(prison.code)
 
       expect(prison.pom_details).to have_received(:create!).with(
         nomis_staff_id: nomis_staff_id,
@@ -84,6 +89,7 @@ RSpec.describe NomisUserRolesService do
       allow(AllocationHistory).to receive(:deallocate_secondary_pom)
 
       allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:list).and_return(pom_list)
+      allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:expire_list_cache)
       allow(HmppsApi::NomisUserRolesApi).to receive(:expire_staff_role)
     end
 
@@ -104,6 +110,10 @@ RSpec.describe NomisUserRolesService do
       described_class.remove_pom(prison, nomis_staff_id)
 
       expect(HmppsApi::NomisUserRolesApi).to have_received(:expire_staff_role).with(pom)
+
+      expect(
+        HmppsApi::PrisonApi::PrisonOffenderManagerApi
+      ).to have_received(:expire_list_cache).with(prison.code)
     end
 
     context 'when POM is not found' do
@@ -113,6 +123,7 @@ RSpec.describe NomisUserRolesService do
         described_class.remove_pom(prison, nomis_staff_id)
 
         expect(HmppsApi::NomisUserRolesApi).not_to have_received(:expire_staff_role)
+        expect(HmppsApi::PrisonApi::PrisonOffenderManagerApi).not_to have_received(:expire_list_cache)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1759

This came up after some testing on staging/preprod. After adding a POM, if going straight to the POM list, some times the new POM will not be there, as the list request could have been cached from before the onboarding. The POM would appear after the cache expired.

With this PR we force a cache expire upon adding or removing POMs so the list always return most up to date POMs.

Also, improved the back link on the onboarding search page.