### PR TITLE
Improve deallocation of primary/secondary POMs

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -48,8 +48,12 @@ class PomsController < PrisonStaffApplicationController
 
     if pom_detail.save
       if pom_detail.status == 'inactive'
-        AllocationHistory.deallocate_primary_pom(nomis_staff_id, active_prison_id)
-        AllocationHistory.deallocate_secondary_pom(nomis_staff_id, active_prison_id)
+        AllocationHistory.deallocate_primary_pom(
+          nomis_staff_id, active_prison_id, event_trigger: AllocationHistory::INACTIVE_POM
+        )
+        AllocationHistory.deallocate_secondary_pom(
+          nomis_staff_id, active_prison_id, event_trigger: AllocationHistory::INACTIVE_POM
+        )
       end
       redirect_to prison_pom_path(active_prison_id, id: nomis_staff_id),
                   notice: "Profile updated for #{helpers.full_name_ordered(@pom)}"

--- a/app/models/concerns/sortable_allocation.rb
+++ b/app/models/concerns/sortable_allocation.rb
@@ -10,9 +10,7 @@ module SortableAllocation
   # 'Doe, John' -> 'John Doe'
   # 'JOHN DOE'  -> 'John Doe'
   def formatted_pom_name
-    return unless allocation
-
-    allocation.primary_pom_name.split(',').reverse.map(&:strip).join(' ').titleize
+    allocation&.formatted_primary_pom_name
   end
 
   def allocated_pom_role

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -20,6 +20,10 @@ class PomDetail < ApplicationRecord
     end
   end
 
+  def has_allocations?
+    allocations.any?
+  end
+
   # 37.5 -> 1.0, 33.75 -> 0.9, etc.
   # If for any reason hours are greater than 37.5 we convert to 1.0 (full-time)
   def hours_per_week=(hours)

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -56,10 +56,11 @@ class StaffMember
 
   def allocations
     @allocations ||= begin
-      alloc_hash = @prison.allocations_for_pom(@staff_id).index_by(&:nomis_offender_id)
+      alloc_hash = prison.allocations_for_pom(staff_id).index_by(&:nomis_offender_id)
+      return [] if alloc_hash.empty?
 
-      @prison.allocated.select { |a| alloc_hash.key?(a.offender_no) }.map do |offender|
-        AllocatedOffender.new(@staff_id, alloc_hash.fetch(offender.offender_no), offender)
+      prison.allocated.select { |a| alloc_hash.key?(a.offender_no) }.map do |offender|
+        AllocatedOffender.new(staff_id, alloc_hash.fetch(offender.offender_no), offender)
       end
     end
   end
@@ -71,7 +72,7 @@ class StaffMember
   end
 
   def has_allocation?(nomis_offender_id)
-    @prison.allocations_for_pom(@staff_id).detect { |a| a.nomis_offender_id == nomis_offender_id }.present?
+    prison.allocations_for_pom(staff_id).detect { |a| a.nomis_offender_id == nomis_offender_id }.present?
   end
 
   # Counts for ordering
@@ -102,8 +103,8 @@ private
   end
 
   def fetch_pom
-    poms = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(@prison.code)
-    poms.detect { |pom| pom.staff_id == @staff_id }
+    poms = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(prison.code)
+    poms.detect { |pom| pom.staff_id == staff_id }
   end
 
   # Attempt to forward-populate the PomDetail table for new records
@@ -112,6 +113,6 @@ private
   end
 
   def staff_detail
-    @staff_detail ||= HmppsApi::NomisUserRolesApi.staff_details(@staff_id)
+    @staff_detail ||= HmppsApi::NomisUserRolesApi.staff_details(staff_id)
   end
 end

--- a/app/services/nomis_user_roles_service.rb
+++ b/app/services/nomis_user_roles_service.rb
@@ -43,8 +43,12 @@ class NomisUserRolesService
   # @param [Prison] prison
   # @param [Integer] nomis_staff_id
   def self.remove_pom(prison, nomis_staff_id)
-    AllocationHistory.deallocate_primary_pom(nomis_staff_id, prison.code)
-    AllocationHistory.deallocate_secondary_pom(nomis_staff_id, prison.code)
+    AllocationHistory.deallocate_primary_pom(
+      nomis_staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
+    )
+    AllocationHistory.deallocate_secondary_pom(
+      nomis_staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
+    )
 
     prison.pom_details.destroy_by(nomis_staff_id:)
 
@@ -59,5 +63,7 @@ class NomisUserRolesService
       # list endpoint until any previous cached request expires (which could take 1h)
       HmppsApi::PrisonApi::PrisonOffenderManagerApi.expire_list_cache(prison.code)
     end
+
+    true
   end
 end

--- a/spec/models/allocated_offender_spec.rb
+++ b/spec/models/allocated_offender_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AllocatedOffender do
     subject { described_class.new(staff_id, allocation, offender) }
 
     let(:staff_id) { 123 }
-    let(:allocation) { instance_double(AllocationHistory, primary_pom_name:) }
+    let(:allocation) { AllocationHistory.new(primary_pom_name:) }
     let(:offender) { instance_double(Offender) }
 
     let(:primary_pom_name) { 'DOE, JOHN' }

--- a/spec/services/nomis_user_roles_service_spec.rb
+++ b/spec/services/nomis_user_roles_service_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe NomisUserRolesService do
   end
 
   describe '.remove_pom' do
+    let(:event_trigger) { AllocationHistory::INACTIVE_POM }
+
     before do
       allow(prison.pom_details).to receive(:destroy_by)
 
@@ -96,8 +98,12 @@ RSpec.describe NomisUserRolesService do
     it 'deallocates both primary and secondary POMs' do
       described_class.remove_pom(prison, nomis_staff_id)
 
-      expect(AllocationHistory).to have_received(:deallocate_primary_pom).with(nomis_staff_id, prison.code)
-      expect(AllocationHistory).to have_received(:deallocate_secondary_pom).with(nomis_staff_id, prison.code)
+      expect(AllocationHistory).to have_received(:deallocate_primary_pom).with(
+        nomis_staff_id, prison.code, event_trigger:
+      )
+      expect(AllocationHistory).to have_received(:deallocate_secondary_pom).with(
+        nomis_staff_id, prison.code, event_trigger:
+      )
     end
 
     it 'removes the POM details' do


### PR DESCRIPTION
Some groundwork related to the limbo cases / remove POMs (MO-1758)

Improved the handling of deallocations for primary/secondary POMs, some other minor refactors, and some preparation needed for follow-up PRs.