### PR TITLE
MO-1764 Enable onboarding feature

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -89,7 +89,7 @@
                title: "Add a POM",
                new_badge: FeatureFlags.pom_onboarding_callout.enabled?,
                link: search_prison_onboarding_index_path(@prison.code, from: :home),
-               content: "Add a POM so you can allocate to them." if FeatureFlags.pom_onboarding.enabled?
+               content: "Add a POM so you can allocate to them."
     %>
   </div>
 <% end %>

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -7,13 +7,11 @@
     <h1 class="govuk-heading-xl">Manage your staff</h1>
   </div>
 
-  <% if FeatureFlags.pom_onboarding.enabled? %>
   <div class="moj-page-header-actions__actions">
     <%= link_to 'Add a POM', search_prison_onboarding_index_path(@prison.code, from: :staff), role: 'button',
                 class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
                 data: { module: 'govuk-button--secondary' } %>
   </div>
-  <% end %>
 </div>
 
 <div class="govuk-tabs" data-module="govuk-tabs">

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -4,9 +4,7 @@
 feature_flags:
   example_feature:
     staging: true
-  pom_onboarding:
-    staging: true
-    preprod: true
   pom_onboarding_callout:
     staging: true
-    preprod: false
+    preprod: true
+    production: true


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1764

Removes the feature flag code around the two entry points and also enabled the banner/badge callout.

Intended to be deployed to prod to make the onboarding journey visible (previously only in staging/preprod).