### PR TITLE
MO-1765 Previously allocated additional info

### DIFF
--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -107,11 +107,6 @@ class AllocationHistory < ApplicationRecord
     get_old_versions.map { |h| [h.primary_pom_nomis_id, h.secondary_pom_nomis_id] }.flatten.compact.uniq
   end
 
-  # Versions are sorted oldest to newest, thus the reverse
-  def previously_allocated_primary_pom_name
-    get_old_versions.reverse.detect(&:primary_pom_name)&.formatted_primary_pom_name
-  end
-
   # 'Doe, John' -> 'John Doe'
   # 'JOHN DOE'  -> 'John Doe'
   def formatted_primary_pom_name

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -337,6 +337,9 @@ class MpcOffender
   end
 
   def additional_information
+    previous_pom_name = AllocationService.previous_pom_name(prison, nomis_offender_id)
+    return ["Previously allocated to #{previous_pom_name}"] if previous_pom_name
+
     return [] if prison_timeline.nil?
 
     attended_prisons = prison_timeline['prisonPeriod'].map { |p| p['prisons'] }.flatten

--- a/app/services/allocation_service.rb
+++ b/app/services/allocation_service.rb
@@ -95,4 +95,12 @@ class AllocationService
       end
     end
   end
+
+  def self.previous_pom_name(prison, nomis_offender_id)
+    allocation = AllocationHistory.inactive.at_prison(prison).find_by(nomis_offender_id:)
+    return if allocation.nil?
+
+    # Versions are sorted oldest to newest, thus the reverse
+    allocation.get_old_versions.reverse.detect(&:primary_pom_name)&.formatted_primary_pom_name
+  end
 end

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -413,37 +413,6 @@ RSpec.describe AllocationHistory, :enable_allocation_change_publish, type: :mode
         expect(staff_ids.first).to eq(previous_primary_pom_nomis_id)
       end
     end
-
-    describe '#previously_allocated_primary_pom_name' do
-      it 'returns the formatted name of the previous primary POM if available' do
-        nomis_offender_id = 'GHF5678'
-        previous_primary_pom_nomis_id = 345_567
-        previous_primary_pom_name = 'DOE, JOHN'
-        updated_primary_pom_nomis_id = 485_926
-        updated_primary_pom_name = 'SMITH, JANE'
-
-        allocation = create(
-          :allocation_history,
-          prison: build(:prison).code,
-          nomis_offender_id: nomis_offender_id,
-          primary_pom_nomis_id: previous_primary_pom_nomis_id,
-          primary_pom_name: previous_primary_pom_name
-        )
-
-        allocation.update!(
-          primary_pom_nomis_id: updated_primary_pom_nomis_id,
-          primary_pom_name: updated_primary_pom_name,
-          event: AllocationHistory::REALLOCATE_PRIMARY_POM
-        )
-
-        expect(allocation.previously_allocated_primary_pom_name).to eq('John Doe')
-      end
-
-      it 'returns nil if there is no previous primary POM name' do
-        allocation = create(:allocation_history, prison: build(:prison).code)
-        expect(allocation.previously_allocated_primary_pom_name).to be_nil
-      end
-    end
   end
 
   describe 'publishing a domain event', :push_pom_to_delius do

--- a/spec/services/allocation_service_spec.rb
+++ b/spec/services/allocation_service_spec.rb
@@ -232,4 +232,38 @@ describe AllocationService do
       ])
     end
   end
+
+  describe '.previous_pom_name' do
+    let(:nomis_offender_id) { 'GHF5678' }
+    let(:previous_primary_pom_nomis_id) { 345_567 }
+    let(:previous_primary_pom_name) { 'DOE, JOHN' }
+
+    let!(:allocation) do
+      create(
+        :allocation_history,
+        prison: prison_code,
+        nomis_offender_id: nomis_offender_id,
+        primary_pom_nomis_id: previous_primary_pom_nomis_id,
+        primary_pom_name: previous_primary_pom_name
+      )
+    end
+
+    context 'when there is not a previous allocation' do
+      it 'returns nil' do
+        expect(
+          described_class.previous_pom_name(prison, nomis_offender_id)
+        ).to be_nil
+      end
+    end
+
+    context 'when there is a previous allocation' do
+      it 'returns the formatted name of the previous primary POM if available' do
+        allocation.deallocate_primary_pom
+
+        expect(
+          described_class.previous_pom_name(prison, nomis_offender_id)
+        ).to eq('John Doe')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1765

Move the code from `AllocationHistory` to `AllocationService`.

Add the additional info for unallocated cases, previously allocated to another POM.