### PR TITLE
MO-1758 Remove POM functionality

### DIFF
--- a/app/assets/javascripts/init_header.js
+++ b/app/assets/javascripts/init_header.js
@@ -1,9 +1,11 @@
 // DPS common header initialisation
 
-$(document).on('turbolinks:load', function() {
-  window.initHeader();
-});
-
-$(document).ready(function() {
-  window.initHeader();
-});
+// TODO: check if this is still neccessary, apparently not in my localhost?
+//
+// $(document).on('turbolinks:load', function() {
+//   window.initHeader();
+// });
+//
+// $(document).ready(function() {
+//   window.initHeader();
+// });

--- a/app/assets/javascripts/scroll_to_anchor.js
+++ b/app/assets/javascripts/scroll_to_anchor.js
@@ -1,0 +1,11 @@
+$(document).on('turbolinks:load', function() {
+  if (window.location.hash && window.location.hash.includes('!top')) {
+    window.location.hash = window.location.hash.replace('!top', '');
+
+    // Let the browser handle the hash first (important for tabs),
+    // then we take over and scroll to the top (so any banner is seen)
+    setTimeout(function() {
+      window.scrollTo({top: 0, behavior: 'instant'});
+    }, 10);
+  }
+});

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -3,7 +3,7 @@
 class PomsController < PrisonStaffApplicationController
   before_action :ensure_spo_user
 
-  before_action :load_pom_staff_member, only: [:show, :edit, :update]
+  before_action :load_pom_staff_member, only: [:show, :edit, :update, :destroy]
   before_action :store_referrer_in_session, only: [:edit]
   before_action :set_referrer
 
@@ -61,6 +61,12 @@ class PomsController < PrisonStaffApplicationController
       @errors = pom_detail.errors
       render :edit
     end
+  end
+
+  def destroy
+    NomisUserRolesService.remove_pom(@prison, nomis_staff_id)
+    redirect_to prison_poms_path(anchor: "#{params[:from]}!top"),
+                notice: "#{@pom.full_name_or_staff_id} removed. Their cases have been moved to @unallocated_link@."
   end
 
 private

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -67,4 +67,8 @@ module PomHelper
   def inactive_poms(poms)
     poms.reject { |pom| %w[active unavailable].include? pom.status }
   end
+
+  def removed_poms(poms, prison)
+    @removed_poms ||= prison.get_removed_poms(existing_poms: poms)
+  end
 end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -31,6 +31,14 @@ class Prison < ApplicationRecord
     pom
   end
 
+  def get_removed_poms(existing_poms:)
+    removed_poms = pom_details.where.not(nomis_staff_id: existing_poms.map(&:staff_id))
+
+    removed_poms.filter(&:has_allocations?).map do |pom_detail|
+      StaffMember.new(self, pom_detail.nomis_staff_id, pom_detail)
+    end
+  end
+
   def active?
     self.class.active.pluck(:code).include?(code)
   end

--- a/app/views/layouts/_notice.html.erb
+++ b/app/views/layouts/_notice.html.erb
@@ -1,5 +1,5 @@
 <% if notice.present? %>
-  <div class="moj-banner moj-banner--success">
+  <div class="moj-banner moj-banner--success govuk-!-margin-bottom-8">
     <svg class="moj-banner__icon" fill="currentColor" role="img" focusable="false"
          xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
       <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path>
@@ -7,7 +7,11 @@
 
     <div class="moj-banner__message">
       <span class="moj-banner__assistive">Success</span>
-      <%= notice %>
+      <%=
+        notice.tap do |msg|
+          msg.gsub!('@unallocated_link@', link_to('the allocations list', unallocated_prison_prisoners_path))
+        end.html_safe
+      %>
     </div>
   </div>
 <% end %>

--- a/app/views/poms/_removed_poms.html.erb
+++ b/app/views/poms/_removed_poms.html.erb
@@ -1,0 +1,31 @@
+<table class="govuk-table responsive">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">POM</th>
+      <th class="govuk-table__header" scope="col">Last case allocated</th>
+      <th class="govuk-table__header" scope="col">Total cases</th>
+      <th class="govuk-table__header" scope="col">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% poms.each_with_index do |pom, i| %>
+      <tr class="govuk-table__row pom_row_<%= i %>">
+        <td aria-label="POM" class="govuk-table__cell">
+          <%= pom.full_name_or_staff_id %>
+        </td>
+        <td aria-label="Last case allocated" class="govuk-table__cell">
+          <%= I18n.l(pom.last_allocated_date, format: '%-d %B %Y', default: 'N/A') %>
+        </td>
+        <td aria-label="Total cases" class="govuk-table__cell govuk-!-font-weight-bold">
+          <%= pom.total_allocations_count %>
+        </td>
+        <td aria-label="Action" class="govuk-table__cell">
+          <%= form_for(:remove_pom, url: prison_pom_path(@prison.code, pom.staff_id), method: :delete) do |f| %>
+            <%= hidden_field_tag :from, :attention_needed %>
+            <%= f.button 'Remove POM', type: 'submit', class: 'app-button--link govuk-link govuk-!-font-size-19' %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -31,6 +31,16 @@
         Inactive staff (<%= inactive_poms(@poms).count %>)
       </a>
     </li>
+    <% if FeatureFlags.limbo_cases.enabled? && (count = removed_poms(@poms, @prison).count).positive? %>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#attention_needed">
+        Attention needed
+      </a>
+      <span id="attention-needed-badge" class="moj-notification-badge govuk-!-margin-left-1">
+        <%= count %>
+      </span>
+    </li>
+    <% end %>
   </ul>
 
   <section class="govuk-tabs__panel" id="active_probation_poms">
@@ -63,4 +73,15 @@
     <h2 class="govuk-heading-l">Inactive staff</h2>
     <%= render "inactive_poms", poms: inactive_poms(@poms) %>
   </section>
+
+  <% if FeatureFlags.limbo_cases.enabled? && (removed_poms = removed_poms(@poms, @prison)).any? %>
+  <section class="govuk-tabs__panel" id="attention_needed">
+    <h2 class="govuk-heading-l">Attention needed</h2>
+    <p>
+      These people are no longer recorded as POMs on NOMIS or Digital Prison Services.<br/>
+      You must remove them from this service and then reallocate their cases.
+    </p>
+    <%= render "removed_poms", poms: removed_poms %>
+  </section>
+  <% end %>
 </div>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -8,3 +8,7 @@ feature_flags:
     staging: true
     preprod: true
     production: true
+  limbo_cases:
+    staging: true
+    preprod: true
+    production: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
     resources :case_information, only: %i[new create edit update show], param: :prisoner_id, controller: 'case_information',
                                  path_names: { new: 'new/:prisoner_id' }
 
-    resources :poms, only: %i[index show edit update], param: :nomis_staff_id
+    resources :poms, only: %i[index show edit update destroy], param: :nomis_staff_id
     # routes to show the 2 tabs on PomsController#show
     get 'poms/:nomis_staff_id/tabs/:tab', to: 'poms#show', as: :show_pom_tab
 

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature "remove a POM no longer present in NOMIS" do
+  let!(:prison) { Prison.find_by(code: "LEI") || create(:prison, code: "LEI") }
+  let(:spo) { build(:pom) }
+  let(:probation_poms) do
+    [
+      build(:pom, :probation_officer),
+      build(:pom, :probation_officer)
+    ]
+  end
+
+  before do
+    stub_pom(spo)
+    stub_signin_spo(spo, [prison.code])
+    stub_poms(prison.code, probation_poms)
+  end
+
+  context 'when there are no POMs with cases in limbo' do
+    before do
+      # Goes to the Manage your staff page
+      visit prison_poms_path(prison_id: prison.code)
+    end
+
+    it 'does not show the attention needed tab' do
+      expect(page).not_to have_css('a.govuk-tabs__tab', text: 'Attention needed')
+    end
+  end
+
+  context 'when there are POMs with cases in limbo' do
+    let(:removed_pom_staff_id) { 123_456 }
+    let(:removed_pom) { build(:pom, staffId: removed_pom_staff_id, firstName: 'JOHN', lastName: 'DOE') }
+    let(:offenders_in_prison) { build_list(:nomis_offender, 1, prisonId: prison.code) }
+
+    before do
+      # Create a POM that is present locally but not remotely
+      PomDetail.find_or_create_by!(
+        prison_code: prison.code, nomis_staff_id: removed_pom_staff_id, status: 'active', working_pattern: 1.0
+      )
+
+      stub_pom(removed_pom)
+      stub_inexistent_filtered_pom(prison.code, removed_pom_staff_id)
+      stub_offenders_for_prison(prison.code, offenders_in_prison)
+
+      offenders_in_prison.each do |offender|
+        nomis_offender_id = offender[:prisonerNumber]
+        offender = create(:offender, nomis_offender_id:)
+
+        Timecop.travel Date.new(2025, 6, 22) do
+          create(:allocation_history, :primary, prison: prison.code, nomis_offender_id:, primary_pom_nomis_id: removed_pom_staff_id)
+          create(:case_information, offender:)
+        end
+      end
+
+      # Goes to the Manage your staff page
+      visit prison_poms_path(prison_id: prison.code)
+    end
+
+    it 'shows the attention needed tab' do
+      expect(page).to have_css('a.govuk-tabs__tab', text: 'Attention needed')
+      expect(page).to have_css('#attention-needed-badge', text: '1')
+    end
+
+    it 'shows the removed POMs with details' do
+      click_link 'Attention needed'
+      expect(page).to have_css('h2.govuk-heading-l', text: 'Attention needed')
+
+      within('section#attention_needed') do
+        expect(page).to have_css('td.govuk-table__cell[aria-label="POM"]', text: 'John Doe')
+        expect(page).to have_css('td.govuk-table__cell[aria-label="Last case allocated"]', text: '22 June 2025')
+        expect(page).to have_css('td.govuk-table__cell[aria-label="Total cases"]', text: '1')
+        expect(page).to have_css('td.govuk-table__cell[aria-label="Action"]', text: 'Remove POM')
+      end
+    end
+
+    it 'removes the POM' do
+      within('section#attention_needed') do
+        click_button 'Remove POM'
+      end
+
+      expect(page).to have_css('.moj-banner--success',
+                               text: 'John Doe removed. Their cases have been moved to the allocations list.')
+
+      expect(page).to have_link('the allocations list',
+                                href: unallocated_prison_prisoners_path(prison))
+
+      pom_details = PomDetail.find_by(prison_code: prison.code, nomis_staff_id: removed_pom_staff_id)
+      expect(pom_details).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1758

Remove POMs that are no longer registered as such in NOMIS but they were left with allocated cases in our service.

These, if any, will show up in a new tab `Attention needed` along with the number of cases they have, so the POM can be deleted and their cases free to allocate again.

Part of the backend for this to work has been done over past PRs so this is mostly just the final frontend/controller work.

It is behind a feature flag so it is safe if a deploy to prod happens.