### PR TITLE
MO-1766 Copy/sorting tweaks to limbo cases

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -66,7 +66,7 @@ class PomsController < PrisonStaffApplicationController
   def destroy
     NomisUserRolesService.remove_pom(@prison, nomis_staff_id)
     redirect_to prison_poms_path(anchor: "#{params[:from]}!top"),
-                notice: "#{@pom.full_name_or_staff_id} removed. Their cases have been moved to @unallocated_link@."
+                notice: "#{@pom.full_name_or_staff_id} removed. If necessary, their cases have been moved to @unallocated_link@."
   end
 
 private

--- a/app/views/poms/_removed_poms.html.erb
+++ b/app/views/poms/_removed_poms.html.erb
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% poms.each_with_index do |pom, i| %>
+    <% poms.sort_by(&:full_name_ordered).each_with_index do |pom, i| %>
       <tr class="govuk-table__row pom_row_<%= i %>">
         <td aria-label="POM" class="govuk-table__cell">
           <%= pom.full_name_or_staff_id %>

--- a/lib/tasks/reports/limbo_cases.rake
+++ b/lib/tasks/reports/limbo_cases.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+namespace :reports do
+  desc 'List all prisons having removed POMs with cases in limbo'
+  task removed_poms_limbo_cases: :environment do
+    puts 'Report started'
+
+    # avoid lots of log traces from the API calls
+    Rails.logger.level = :warn
+
+    total = 0
+
+    Prison.active.order(:name).each do |prison|
+      poms = prison.get_list_of_poms
+      removed_poms = prison.get_removed_poms(existing_poms: poms)
+      next if removed_poms.empty?
+
+      limbo_cases = removed_poms.map do |pom|
+        [
+          pom.allocations.sum { |a| a.allocation.primary_pom_nomis_id == pom.staff_id ? 1 : 0 },
+          pom.allocations.sum { |a| a.allocation.secondary_pom_nomis_id == pom.staff_id ? 1 : 0 },
+        ]
+      end
+
+      puts "==> #{prison.name}: #{limbo_cases} allocations for #{removed_poms.size} removed POMs"
+      total += 1
+    end
+
+    puts "Report complete. Total prisons with deleted POMS having limbo cases: #{total} out of #{Prison.active.count}"
+  end
+end

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -81,7 +81,7 @@ feature "remove a POM no longer present in NOMIS" do
       end
 
       expect(page).to have_css('.moj-banner--success',
-                               text: 'John Doe removed. Their cases have been moved to the allocations list.')
+                               text: 'John Doe removed. If necessary, their cases have been moved to the allocations list.')
 
       expect(page).to have_link('the allocations list',
                                 href: unallocated_prison_prisoners_path(prison))


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1766

Just some minor tweaks agreed after doing the demo of the feature. Also, a rake task to produce an output of all the prisons with removed POMs having limbo cases, to help us evaluate the numbers.

Awaiting some further potential changes but that will come as a separate PR if neccessary.