### PR TITLE
MO-1768 Only consider active primary limbo cases

### DIFF
--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -40,11 +40,15 @@ class AllocatedOffender
   end
 
   def pom_responsible?
-    @offender.pom_responsible? if @allocation.primary_pom_nomis_id == @staff_id
+    primary_pom? && @offender.pom_responsible?
   end
 
   def pom_supporting?
-    @offender.pom_supporting? if @allocation.primary_pom_nomis_id == @staff_id
+    primary_pom? && @offender.pom_supporting?
+  end
+
+  def primary_pom?
+    @allocation.primary_pom_nomis_id == @staff_id
   end
 
   def coworking?

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -132,15 +132,6 @@ class MpcOffender
     end
   end
 
-  # TODO: doesn't seem to be used
-  def to_allocated_offender
-    if active_allocation
-      AllocatedOffender.new(active_allocation.primary_pom_nomis_id, active_allocation, self)
-    else
-      nil
-    end
-  end
-
   #
   # Early allocations
   #

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -13,6 +13,7 @@ class PomDetail < ApplicationRecord
 
   belongs_to :prison, foreign_key: :prison_code, inverse_of: :pom_details
 
+  # @return [Array<MpcOffender>] Allocated offenders for this POM
   def allocations
     @allocations ||= begin
       allocations = AllocationHistory.active_pom_allocations(nomis_staff_id, prison_code).pluck(:nomis_offender_id)
@@ -20,8 +21,10 @@ class PomDetail < ApplicationRecord
     end
   end
 
-  def has_allocations?
-    allocations.any?
+  def has_primary_allocations?
+    allocations.filter_map(&:active_allocation).any? do |alloc|
+      alloc.primary_pom_nomis_id == nomis_staff_id
+    end
   end
 
   # 37.5 -> 1.0, 33.75 -> 0.9, etc.

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -34,7 +34,7 @@ class Prison < ApplicationRecord
   def get_removed_poms(existing_poms:)
     removed_poms = pom_details.where.not(nomis_staff_id: existing_poms.map(&:staff_id))
 
-    removed_poms.filter(&:has_allocations?).map do |pom_detail|
+    removed_poms.filter(&:has_primary_allocations?).map do |pom_detail|
       StaffMember.new(self, pom_detail.nomis_staff_id, pom_detail)
     end
   end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -92,6 +92,10 @@ class StaffMember
     allocations.count(&:pom_responsible?)
   end
 
+  def primary_allocations_count
+    allocations.count(&:primary_pom?)
+  end
+
   def coworking_allocations_count
     allocations.count(&:coworking?)
   end

--- a/app/presenters/offender_with_allocation_presenter.rb
+++ b/app/presenters/offender_with_allocation_presenter.rb
@@ -10,8 +10,8 @@ class OffenderWithAllocationPresenter
            :next_parole_date, :next_parole_date_type,
            # used in the allocated page
            :last_name, :location, :restricted_patient?, :earliest_release, :earliest_release_date, :tier, :latest_temp_movement_date,
-           # needed in the caseload global page
-           :pom_responsible?, :pom_supporting?, :coworking?,
+           # needed in the caseload global page and limbo cases page
+           :pom_responsible?, :pom_supporting?, :primary_pom?, :coworking?,
            # needed for search
            :active_allocation, :probation_record, to: :@offender
 

--- a/app/views/poms/_removed_poms.html.erb
+++ b/app/views/poms/_removed_poms.html.erb
@@ -17,7 +17,7 @@
           <%= I18n.l(pom.last_allocated_date, format: '%-d %B %Y', default: 'N/A') %>
         </td>
         <td aria-label="Total cases" class="govuk-table__cell govuk-!-font-weight-bold">
-          <%= pom.total_allocations_count %>
+          <%= pom.primary_allocations_count %>
         </td>
         <td aria-label="Action" class="govuk-table__cell">
           <%= form_for(:remove_pom, url: prison_pom_path(@prison.code, pom.staff_id), method: :delete) do |f| %>

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -29,7 +29,7 @@ feature "remove a POM no longer present in NOMIS" do
     end
   end
 
-  context 'when there are POMs with cases in limbo' do
+  context 'when there are POMs with primary cases in limbo' do
     let(:removed_pom_staff_id) { 123_456 }
     let(:removed_pom) { build(:pom, staffId: removed_pom_staff_id, firstName: 'JOHN', lastName: 'DOE') }
     let(:offenders_in_prison) { build_list(:nomis_offender, 1, prisonId: prison.code) }

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -445,30 +445,6 @@ RSpec.describe MpcOffender, type: :model do
     end
   end
 
-  describe '#to_allocated_offender' do
-    describe 'when allocation history exists' do
-      it 'build an AllocatedOffender' do
-        alloc_history = FactoryBot.create :allocation_history, :primary, nomis_offender_id: offender.offender_no,
-                                                                         prison: offender.prison.code
-        alloc_offender = instance_double AllocatedOffender
-        allow(AllocatedOffender).to receive(:new).with(alloc_history.primary_pom_nomis_id, alloc_history, offender)
-                                                 .and_return(alloc_offender)
-        expect(offender.to_allocated_offender).to eq alloc_offender
-      end
-    end
-
-    describe 'when allocation history is not there' do
-      it 'returns nil' do
-        allow(AllocatedOffender).to receive(:new)
-
-        aggregate_failures do
-          expect(offender.to_allocated_offender).to eq nil
-          expect(AllocatedOffender).not_to have_received(:new)
-        end
-      end
-    end
-  end
-
   describe '#earliest_release_for_handover' do
     it 'uses official calculations correctly' do
       expected = double :expected

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -224,26 +224,31 @@ RSpec.describe Prison do
 
     let(:pom1) { build(:pom) }
     let(:pom2) { build(:pom) }
-    let(:existing_poms) { [pom1] }
+
     let(:offender_no) { 'T0000A' }
+    let(:offender) { double(offender_no:) }
+    let(:prison_record) { double(offender_no:) }
 
     let!(:pom_detail1) { create(:pom_detail, prison: prison, nomis_staff_id: pom1.staff_id) }
     let!(:pom_detail2) { create(:pom_detail, prison: prison, nomis_staff_id: pom2.staff_id) }
 
-    before do
-      allow(prison).to receive(:allocated).and_return([double(offender_no:)])
-    end
-
-    context 'when removed POM has allocations' do
-      before do
+    context 'when removed POM has active primary allocations' do
+      let!(:allocation) do
         create(:allocation_history,
                prison: prison.code,
                primary_pom_nomis_id: pom2.staff_id,
+               secondary_pom_nomis_id: pom1.staff_id,
                nomis_offender_id: offender_no)
       end
 
-      it 'returns removed POMs with allocations' do
-        removed = prison.get_removed_poms(existing_poms:)
+      before do
+        allow(prison).to receive(:allocated).and_return(
+          [MpcOffender.new(prison:, offender:, prison_record:)]
+        )
+      end
+
+      it 'returns removed POMs with active primary allocations' do
+        removed = prison.get_removed_poms(existing_poms: [pom1])
 
         expect(removed.size).to eq(1)
         expect(removed.first).to be_a(StaffMember)
@@ -251,9 +256,23 @@ RSpec.describe Prison do
       end
     end
 
-    context 'when removed POM has no allocations' do
-      it 'does not return POMs without allocations' do
-        removed = prison.get_removed_poms(existing_poms:)
+    context 'when removed POM has no active primary allocations' do
+      let!(:allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               primary_pom_nomis_id: pom1.staff_id,
+               secondary_pom_nomis_id: pom2.staff_id,
+               nomis_offender_id: offender_no)
+      end
+
+      before do
+        allow(prison).to receive(:allocated).and_return(
+          [MpcOffender.new(prison:, offender:, prison_record:)]
+        )
+      end
+
+      it 'does not return POMs without active primary allocations' do
+        removed = prison.get_removed_poms(existing_poms: [pom1])
         expect(removed).to be_empty
       end
     end

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -223,28 +223,46 @@ RSpec.describe StaffMember, type: :model do
     end
   end
 
-  describe '#coworking_allocations_count' do
-    let(:coworking_allocations) do
+  describe '#primary_allocations_count' do
+    let(:allocations) do
       [
-        create(:allocation_history, primary_pom_nomis_id: other_staff_id, nomis_offender_id: 'G1234AB', prison: prison.code, secondary_pom_nomis_id: staff_id),
+        create(:allocation_history, primary_pom_nomis_id: staff_id, nomis_offender_id: 'G1234AB', prison: prison.code),
+        create(:allocation_history, primary_pom_nomis_id: staff_id, nomis_offender_id: 'G1234GG', prison: prison.code),
+        create(:allocation_history, primary_pom_nomis_id: other_staff_id, nomis_offender_id: 'G1234VV', prison: prison.code, secondary_pom_nomis_id: staff_id)
+      ]
+    end
+
+    before do
+      allocations
+    end
+
+    it 'returns the count of primary allocations' do
+      expect(user.primary_allocations_count).to eq(2)
+    end
+  end
+
+  describe '#coworking_allocations_count' do
+    let(:allocations) do
+      [
+        create(:allocation_history, primary_pom_nomis_id: staff_id, nomis_offender_id: 'G1234AB', prison: prison.code, secondary_pom_nomis_id: other_staff_id),
         create(:allocation_history, primary_pom_nomis_id: other_staff_id, nomis_offender_id: 'G1234GG', prison: prison.code, secondary_pom_nomis_id: staff_id)
       ]
     end
 
     before do
-      coworking_allocations
+      allocations
     end
 
     it 'returns the count of coworking allocations' do
-      expect(user.coworking_allocations_count).to eq(2)
+      expect(user.coworking_allocations_count).to eq(1)
     end
   end
 
   describe '#total_allocations_count' do
     let(:allocations) do
       [
-        create(:allocation_history, primary_pom_nomis_id: staff_id, nomis_offender_id: 'G1234AB', prison: prison.code),
-        create(:allocation_history, primary_pom_nomis_id: staff_id, nomis_offender_id: 'G1234GG', prison: prison.code)
+        create(:allocation_history, primary_pom_nomis_id: staff_id, nomis_offender_id: 'G1234AB', prison: prison.code, secondary_pom_nomis_id: other_staff_id),
+        create(:allocation_history, primary_pom_nomis_id: other_staff_id, nomis_offender_id: 'G1234GG', prison: prison.code, secondary_pom_nomis_id: staff_id)
       ]
     end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1768

For the removed POMs with limbo cases we previously counted all cases, primary and coworking.

It has been decided to only consider active primary cases, thus reducing greatly the number of prisons that will show the "attention needed" tab, given the coworking cases, even when assigned to a removed POM, are not causing major problems and can be reassigned easily.