### PR TITLE
Requests for RoSH summary are within the last 3 years

### DIFF
--- a/app/services/hmpps_api/assess_risks_and_needs_api.rb
+++ b/app/services/hmpps_api/assess_risks_and_needs_api.rb
@@ -1,6 +1,7 @@
 module HmppsApi
   class AssessRisksAndNeedsApi
     VALID_ASSESSMENT_TYPES = %w[LAYER_1 LAYER1 LAYER_3 LAYER3].freeze
+    TIMEFRAME_IN_WEEKS = 156
 
     def self.client
       host = Rails.configuration.assess_risks_and_needs_api_host
@@ -9,7 +10,7 @@ module HmppsApi
 
     def self.get_rosh_summary(crn)
       safe_crn = URI.encode_www_form_component(crn)
-      route = "/risks/crn/#{safe_crn}"
+      route = "/risks/crn/#{safe_crn}/#{TIMEFRAME_IN_WEEKS}"
       client.get(route)
     end
 

--- a/spec/services/hmpps_api/assess_risks_and_needs_api_spec.rb
+++ b/spec/services/hmpps_api/assess_risks_and_needs_api_spec.rb
@@ -201,4 +201,17 @@ describe HmppsApi::AssessRisksAndNeedsApi do
       end
     end
   end
+
+  describe '.get_rosh_summary' do
+    it 'requests the rosh summary from within the last 3 years' do
+      response = double(:response)
+      client = double(:client, get: response)
+      allow(described_class).to receive(:client).and_return(client)
+
+      result = described_class.get_rosh_summary('CRN123')
+
+      expect(result).to eq(response)
+      expect(client).to have_received(:get).with("/risks/crn/CRN123/156")
+    end
+  end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -37,10 +37,6 @@ module ApiHelper
     stub_request(:get, "#{Rails.configuration.complexity_api_host}/v1/complexity-of-need/offender-no/#{offender_no}")
       .to_return(body: { level: offender.fetch(:complexityLevel) }.to_json)
 
-    # RoSH summary
-    stub_request(:get, Addressable::Template.new("#{Rails.configuration.assess_risks_and_needs_api_host}/risks/crn/{crn}/summary"))
-      .to_return(body: {}.to_json)
-
     # Alerts
     stub_request(:get, "#{Rails.configuration.prison_alerts_api_host}/prisoners/#{offender_no}/alerts")
       .to_return(body: { content: [] }.to_json)
@@ -194,7 +190,7 @@ module ApiHelper
   end
 
   def stub_risk_and_needs(crn, response_body = '{"summary": {}}')
-    stub_request(:get, "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/risks/crn/#{crn}")
+    stub_request(:get, "https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/risks/crn/#{crn}/156")
       .to_return(status: 200, body: response_body, headers: {})
   end
 


### PR DESCRIPTION
- Make use of new timeframe param from the ARNS api (swagger: https://assess-risks-and-needs.hmpps.service.justice.gov.uk/swagger-ui/index.html#/integration-controller/getCriminogenicNeedsByCrnWithinTimeframe)