### PR TITLE
Prevent SAR failing due to comparing nil dates

### DIFF
--- a/app/services/sar_offender_data_service.rb
+++ b/app/services/sar_offender_data_service.rb
@@ -53,12 +53,12 @@ private
     end_time = (end_date + 1.day).to_time
 
     last_before_range = if algorithm == :state
-                          [items.select { |i| i.created_at < start_time }.max_by(&:created_at)]
+                          [items.select { |i| i.created_at.present? && i.created_at < start_time }.max_by(&:created_at)]
                         else
                           []
                         end
 
-    within_range = items.select { |i| i.created_at >= start_time && i.created_at <= end_time }.sort_by(&:created_at)
+    within_range = items.select { |i| i.created_at.present? && i.created_at >= start_time && i.created_at <= end_time }.sort_by(&:created_at)
 
     (last_before_range + within_range).compact
   end


### PR DESCRIPTION
Stopping a bug in live where some data has no created_at and is failing due to comparison with null