### PR TITLE
MO-1936 Fix caseload switch in non-root routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,11 +60,7 @@ class ApplicationController < ActionController::Base
     return @dps_header_footer if @dps_header_footer
 
     begin
-      @dps_header_footer ||= {
-        'header' => HmppsApi::DpsFrontendComponentsApi.header(identity.token),
-        'footer' => HmppsApi::DpsFrontendComponentsApi.footer(identity.token),
-        'status' => 'ok',
-      }
+      @dps_header_footer ||= HmppsApi::DpsFrontendComponentsApi.components(identity.token).merge('status' => 'ok')
     rescue StandardError => e
       logger.error "event=dps_header_footer_retrieval_error|#{e.message}"
       @dps_header_footer ||= { 'status' => 'fallback' }

--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -5,8 +5,8 @@
 class PrisonsApplicationController < ApplicationController
   include Sorting
 
-  before_action :authenticate_user, :check_prison_access, :load_staff_member, :service_notifications, :load_roles,
-                :check_active_caseload
+  before_action :authenticate_user, :check_active_caseload, :check_prison_access,
+                :load_staff_member, :load_roles, :service_notifications
 
 protected
 
@@ -95,10 +95,14 @@ private
     prison_id = params[:prison_id]
     return if prison_id.blank?
 
-    if default_prison_code != prison_id
-      flash[:notice] = t('views.navigation.enforce_active_caseload', name: Prison.find_by_code(default_prison_code).name)
-      session.delete(:sso_data)
-      redirect_to prison_dashboard_index_path(prison_id: default_prison_code)
-    end
+    # Do not rely only on `default_prison_code` from the session here.
+    # When a user switches active caseload outside this app, the session can be stale
+    # until we force a refresh, so we must compare against a live upstream value.
+    active_caseload_id = dps_header_footer.dig('meta', 'activeCaseLoad', 'caseLoadId') || default_prison_code
+    return if active_caseload_id.blank? || active_caseload_id == prison_id
+
+    flash[:notice] = t('views.navigation.enforce_active_caseload', name: Prison.find_by_code(active_caseload_id).name)
+    session.delete(:sso_data)
+    redirect_to prison_dashboard_index_path(prison_id: active_caseload_id)
   end
 end

--- a/app/services/hmpps_api/dps_frontend_components_api.rb
+++ b/app/services/hmpps_api/dps_frontend_components_api.rb
@@ -6,23 +6,20 @@ require 'typhoeus/adapters/faraday'
 module HmppsApi
   class DpsFrontendComponentsApi
     class << self
-      def header(token)
-        get_component('header', token)
-      end
-
-      def footer(token)
-        get_component('footer', token)
-      end
-
-    private
-
-      def get_component(type, token)
+      # See: https://frontend-components-dev.hmpps.service.justice.gov.uk/api-docs/#/default/get_components
+      def components(token, component: %w[header footer])
         raw_response = connection.get do |req|
-          req.url("#{root}/#{type}")
+          req.url("#{root}/components?#{components_query(Array(component))}")
           req.headers['X-User-Token'] = token
         end
 
         ActiveSupport::JSON.decode(raw_response.body)
+      end
+
+    private
+
+      def components_query(component)
+        URI.encode_www_form(component.map { ['component', it] })
       end
 
       def connection

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe DashboardController, type: :controller do
   end
 
   describe '#index' do
+    context 'when the live active caseload differs from the prison in the URL', skip_active_caseload_check_stubbing: true do
+      let(:prison) { create(:prison, code: 'RSI').code }
+
+      before do
+        create(:prison, code: 'LEI')
+        stub_sso_data('RSI', caseloads: %w[LEI RSI])
+        stub_dps_header_footer
+      end
+
+      it 'redirects to the live active caseload prison dashboard' do
+        get :index, params: { prison_id: prison }
+
+        expect(response).to redirect_to(prison_dashboard_index_path(prison_id: 'LEI'))
+        expect(flash[:notice]).to eq(I18n.t('views.navigation.enforce_active_caseload', name: 'Leeds (HMP)'))
+        expect(session[:sso_data]).to be_nil
+      end
+    end
+
     context 'when logged in as POM' do
       render_views
 

--- a/spec/controllers/prisons_application_controller_spec.rb
+++ b/spec/controllers/prisons_application_controller_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe PrisonsApplicationController, type: :controller do
+  describe 'before_actions' do
+    it 'checks the active caseload before prison-specific setup' do
+      callbacks = described_class._process_action_callbacks.select { |callback| callback.kind == :before }.map(&:filter)
+
+      expect(callbacks.index(:authenticate_user)).to be < callbacks.index(:check_active_caseload)
+      expect(callbacks.index(:check_active_caseload)).to be < callbacks.index(:check_prison_access)
+      expect(callbacks.index(:check_active_caseload)).to be < callbacks.index(:load_staff_member)
+    end
+  end
+
   describe 'referrer' do
     context 'when referrer is set to null' do
       it 'redirects to the root_path of /' do

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RootController, type: :controller do
+  describe '#index' do
+    before do
+      stub_sso_data('RSI', caseloads: %w[LEI RSI])
+    end
+
+    it 'clears the cached SSO data and redirects to the current prison dashboard path' do
+      get :index
+
+      expect(response).to redirect_to(prison_dashboard_index_path('RSI'))
+      expect(session[:sso_data]).to be_nil
+    end
+  end
+end

--- a/spec/features/active_caseload_enforcement_feature_spec.rb
+++ b/spec/features/active_caseload_enforcement_feature_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Active caseload enforcement' do
+  let(:pom) do
+    build(
+      :pom,
+      firstName: 'Alice',
+      lastName: 'Example',
+      position: RecommendationService::PRISON_POM,
+      staffId: 485_926
+    )
+  end
+
+  before do
+    create(:prison, code: 'LEI')
+    create(:prison, code: 'RSI')
+
+    signin_spo_user(%w[LEI RSI])
+    stub_poms('LEI', [pom])
+    stub_poms('RSI', [pom])
+    stub_offenders_for_prison('LEI', [])
+
+    stub_dps_header_footer
+  end
+
+  it 'redirects a different prison URL to the live active caseload dashboard', skip_active_caseload_check_stubbing: true do
+    visit prison_dashboard_index_path('RSI')
+
+    expect(page).to have_current_path(prison_dashboard_index_path('LEI'))
+    expect(page).to have_content('Leeds (HMP) selected')
+  end
+end

--- a/spec/features/dps_header_footer_feature_spec.rb
+++ b/spec/features/dps_header_footer_feature_spec.rb
@@ -2,22 +2,26 @@
 # but it seems prudent to test the actual API responses at most once and stub them everywhere else
 feature 'DPS standard header and footer:', :aggregate_failures, :skip_dps_header_footer_stubbing do
   let(:api_host) { Rails.configuration.dps_frontend_components_api_host }
-  let(:header_endpoint) { "#{api_host}/header" }
-  let(:footer_endpoint) { "#{api_host}/footer" }
+  let(:components_endpoint) { "#{api_host}/components" }
 
-  let(:header_body) do
+  let(:components_body) do
     {
-      html: '<header class="connect-dps-common-header govuk-!-display-none-print" role="banner">...</header>',
-      css: ['https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/header.css'],
-      javascript: ['https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/js/header.js']
-    }.to_json
-  end
-
-  let(:footer_body) do
-    {
-      html: '<footer class="connect-dps-common-footer govuk-!-display-none-print" role="contentinfo">...</footer>',
-      css: ['https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/footer.css'],
-      javascript: []
+      header: {
+        html: '<header class="connect-dps-common-header govuk-!-display-none-print" role="banner">...</header>',
+        css: ['https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/header.css'],
+        javascript: ['https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/js/header.js']
+      },
+      footer: {
+        html: '<footer class="connect-dps-common-footer govuk-!-display-none-print" role="contentinfo">...</footer>',
+        css: ['https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/footer.css'],
+        javascript: []
+      },
+      meta: {
+        activeCaseLoad: {
+          caseLoadId: 'LEI',
+          description: 'Leeds (HMP)',
+        },
+      },
     }.to_json
   end
 
@@ -31,16 +35,15 @@ feature 'DPS standard header and footer:', :aggregate_failures, :skip_dps_header
   end
 
   before :each, :mock_api_error do
-    stub_request(:get, header_endpoint).to_return(status: 503)
-    stub_request(:get, footer_endpoint).to_return(status: 503)
+    stub_request(:get, "#{components_endpoint}?component=header&component=footer").to_return(status: 503)
   end
 
   before :each, :mock_api_success do
-    stub_request(:get, header_endpoint).to_return(status: 200, body: header_body)
-    stub_request(:get, footer_endpoint).to_return(status: 200, body: footer_body)
+    stub_request(:get, "#{components_endpoint}?component=header&component=footer")
+      .to_return(status: 200, body: components_body)
   end
 
-  scenario 'standard DPS header is used', :mock_api_success do
+  it 'uses the standard DPS header', :mock_api_success do
     signin_pom_user
     visit '/'
 
@@ -49,14 +52,14 @@ feature 'DPS standard header and footer:', :aggregate_failures, :skip_dps_header
     expect(page).to have_css('script[src="https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/js/header.js"]', visible: :all)
   end
 
-  scenario 'fallback DPS header is used when DPS components API is not available', :mock_api_error do
+  it 'uses the fallback DPS header when the DPS components API is not available', :mock_api_error do
     signin_pom_user
     visit '/'
 
     expect(page).to have_css('header.fallback-dps-header')
   end
 
-  scenario 'standard DPS footer is used', :mock_api_success do
+  it 'uses the standard DPS footer', :mock_api_success do
     signin_pom_user
     visit '/'
 
@@ -64,7 +67,7 @@ feature 'DPS standard header and footer:', :aggregate_failures, :skip_dps_header
     expect(page).to have_css('link[rel=stylesheet][href="https://frontend-components-dev.hmpps.service.justice.gov.uk/assets/stylesheets/footer.css"]', visible: :all)
   end
 
-  scenario 'fallback DPS footer is used when DPS components API is not available', :mock_api_error do
+  it 'uses the fallback DPS footer when the DPS components API is not available', :mock_api_error do
     signin_pom_user
     visit '/'
 

--- a/spec/services/hmpps_api/dps_frontend_components_api_spec.rb
+++ b/spec/services/hmpps_api/dps_frontend_components_api_spec.rb
@@ -1,44 +1,50 @@
 RSpec.describe HmppsApi::DpsFrontendComponentsApi, :skip_dps_header_footer_stubbing do
   let(:access_token) { 'TESTING_ACCESS_TOKEN' }
   let(:invalid_access_token) { 'INVALID_TESTING_ACCESS_TOKEN' }
+  let(:components_response) do
+    {
+      header: { html: '<h>', css: ['https://example.org/h.css'], javascript: ['h.js'] },
+      footer: { html: '<f>', css: ['https://example.org/f.css'], javascript: ['f.js'] },
+      meta: {
+        activeCaseLoad: {
+          caseLoadId: 'LEI',
+          description: 'Leeds (HMP)',
+        },
+      },
+    }.to_json
+  end
 
   before do
     allow(Rails.configuration).to receive(:dps_frontend_components_api_host).and_return('https://example.org')
-
-    stub_request(:get, 'https://example.org/footer')
-      .with(headers: { 'X-User-Token' => access_token })
-      .to_return(body: '{"html": "<f>", "css": ["https://example.org/f.css"], "javascript": ["f.js"]}')
-
-    stub_request(:get, 'https://example.org/header')
-      .with(headers: { 'X-User-Token' => access_token })
-      .to_return(body: '{"html": "<h>", "css": ["https://example.org/h.css"], "javascript": ["h.js"]}')
   end
 
-  describe '#footer' do
-    it 'with valid access token, gets the footer HTML and CSS from the API' do
-      expect(described_class.footer(access_token))
-        .to eq({ 'html' => '<f>', 'css' => ['https://example.org/f.css'], 'javascript' => ['f.js'] })
+  describe '#components' do
+    before do
+      stub_request(:get, 'https://example.org/components?component=header&component=footer')
+        .with(headers: { 'X-User-Token' => access_token })
+        .to_return(body: components_response)
+    end
+
+    it 'gets the requested DPS components and metadata from the API' do
+      expect(described_class.components(access_token)).to eq(
+        {
+          'header' => { 'html' => '<h>', 'css' => ['https://example.org/h.css'], 'javascript' => ['h.js'] },
+          'footer' => { 'html' => '<f>', 'css' => ['https://example.org/f.css'], 'javascript' => ['f.js'] },
+          'meta' => {
+            'activeCaseLoad' => {
+              'caseLoadId' => 'LEI',
+              'description' => 'Leeds (HMP)',
+            },
+          },
+        }
+      )
     end
 
     it 'raises exceptions for unsuccessful responses' do
-      stub_request(:get, 'https://example.org/footer')
+      stub_request(:get, 'https://example.org/components?component=header&component=footer')
         .with(headers: { 'X-User-Token' => invalid_access_token })
         .to_return(status: 401)
-      expect { described_class.footer(invalid_access_token) }.to raise_error(Faraday::UnauthorizedError)
-    end
-  end
-
-  describe '#header' do
-    it 'with valid access token, gets the header HTML and CSS from the API' do
-      expect(described_class.header(access_token))
-        .to eq({ 'html' => '<h>', 'css' => ['https://example.org/h.css'], 'javascript' => ['h.js'] })
-    end
-
-    it 'raises exceptions for unsuccessful responses' do
-      stub_request(:get, 'https://example.org/header')
-        .with(headers: { 'X-User-Token' => invalid_access_token })
-        .to_return(status: 401)
-      expect { described_class.header(invalid_access_token) }.to raise_error(Faraday::UnauthorizedError)
+      expect { described_class.components(invalid_access_token) }.to raise_error(Faraday::UnauthorizedError)
     end
   end
 end

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -29,7 +29,8 @@ module AuthHelper
       }.to_json)
   end
 
-  def stub_sso_data(prison, username: 'user', staff_id: 754_732, roles: [SsoIdentity::SPO_ROLE], email: '754732@example.com')
+  def stub_sso_data(prison, username: 'user', staff_id: 754_732, roles: [SsoIdentity::SPO_ROLE], email: '754732@example.com',
+                    active_caseload: prison, caseloads: [prison], token: USER_ACCESS_TOKEN)
     allow(HmppsApi::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
 
     stub_pom(
@@ -40,11 +41,11 @@ module AuthHelper
       session[:sso_data] = {
         'expiry' => Time.zone.now + 1.day,
         'roles' => roles,
-        'active_caseload' => prison,
-        'caseloads' => [prison],
+        'active_caseload' => active_caseload,
+        'caseloads' => caseloads,
         'username' => username,
         'staff_id' => staff_id,
-        'token' => USER_ACCESS_TOKEN,
+        'token' => token,
       }
     end
   end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -43,12 +43,23 @@ module FeaturesHelper
     OmniAuth.config.add_mock(:hmpps_sso, hmpps_sso_response)
   end
 
-  def stub_dps_header_footer
-    allow_any_instance_of(SsoIdentity).to receive(:token).and_return('fake-user-access-token')
-    allow(HmppsApi::DpsFrontendComponentsApi).to receive_messages(
-      header: { 'html' => '<header>', 'css' => [], 'javascript' => [] },
-      footer: { 'html' => '<footer>', 'css' => [], 'javascript' => [] },
-    )
+  def stub_dps_header_footer(token: 'fake-user-access-token', header: {}, footer: {}, active_case_load_id: 'LEI', active_case_load_description: 'Leeds (HMP)', meta: {})
+    allow_any_instance_of(SsoIdentity).to receive(:token).and_return(token)
+
+    payload = {
+      'header' => { 'html' => '<header>', 'css' => [], 'javascript' => [] }.merge(header),
+      'footer' => { 'html' => '<footer>', 'css' => [], 'javascript' => [] }.merge(footer),
+      'meta' => {
+        'activeCaseLoad' => {
+          'caseLoadId' => active_case_load_id,
+          'description' => active_case_load_description,
+        },
+      },
+    }
+
+    payload['meta'] = payload['meta'].deep_merge(meta)
+
+    allow(HmppsApi::DpsFrontendComponentsApi).to receive(:components).with(token, any_args).and_return(payload)
   end
 
   def stub_active_caseload_check


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1936
Slack: https://mojdt.slack.com/archives/C05SDFXAVSP/p1775747103734939

The DPS header component caseload switch recently started redirecting back to the URL where the user was before changing prison. Previously it always redirected back to the root (`/`) of the service where we would reset the session and fetch again the new caseload.

This session reset was only on the root of the service so other routes would not know of the caseload change and keep the stale session with the previous caseload/prison in the URL.

This PR updates the DPS frontend components API to use the new endpoint as previous ones are deprecated. The new endpoint returns a `meta` object that includes the active caseload that we can now use to do the check and restore previous behaviour in any landing page, not just in the root.