### PR TITLE
Better handling of retryable handover email errors

### DIFF
--- a/app/jobs/handover_reminder_batch_job.rb
+++ b/app/jobs/handover_reminder_batch_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class HandoverReminderBatchJob < ApplicationJob
+  queue_as :mailers
+
+  # Email content can become stale; avoid retrying for days
+  sidekiq_options retry: 10
+
+  def perform(for_date = Time.zone.today)
+    Handover::HandoverEmailBatchRun.send_all(for_date:)
+  end
+end

--- a/app/lib/handover/handover_email.rb
+++ b/app/lib/handover/handover_email.rb
@@ -6,7 +6,7 @@ class Handover::HandoverEmail
       OffenderEmailSent.find_by(offender_email_type: handover_email_type,
                                 nomis_offender_id: nomis_offender_id,
                                 staff_member_id: staff_member_id).present?
-      return
+      return false
     end
 
     mailer = HandoverMailer.with(**mailer_args.merge(nomis_offender_id: nomis_offender_id))
@@ -18,5 +18,7 @@ class Handover::HandoverEmail
                                 staff_member_id: staff_member_id)
       deliver_now ? mailer.deliver_now : mailer.deliver_later
     end
+
+    true
   end
 end

--- a/app/lib/handover/handover_email_batch_run.rb
+++ b/app/lib/handover/handover_email_batch_run.rb
@@ -1,10 +1,17 @@
 class Handover::HandoverEmailBatchRun
+  RETRYABLE_BATCH_ERRORS = [
+    HandoverMailer::InvalidRecipientEmailError,
+    ActiveJob::EnqueueError,
+    ActiveRecord::ConnectionTimeoutError,
+    ActiveRecord::Deadlocked,
+  ].freeze
+
   class << self
     def send_one_upcoming_handover_window(offender, deliver_now: false, for_date: Time.zone.now.to_date)
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
       return unless chd&.handover_date && chd.handover_date == for_date + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
 
-      Handover::HandoverEmail.deliver_if_deliverable(
+      sent = Handover::HandoverEmail.deliver_if_deliverable(
         :upcoming_handover_window,
         offender.offender_no,
         offender.staff_member.staff_id,
@@ -16,6 +23,8 @@ class Handover::HandoverEmailBatchRun
         release_date: format_date(offender.earliest_release_for_handover&.date),
         deliver_now: deliver_now,
       )
+      return unless sent
+
       Rails.logger.info("event=handover_email_delivered,nomis_offender_id=#{offender.offender_no},email=upcoming_handover_window,for_date=#{for_date.iso8601}")
     end
 
@@ -23,7 +32,7 @@ class Handover::HandoverEmailBatchRun
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
       return unless chd&.handover_date && chd.handover_date == for_date && offender.has_com?
 
-      Handover::HandoverEmail.deliver_if_deliverable(
+      sent = Handover::HandoverEmail.deliver_if_deliverable(
         :handover_date,
         offender.offender_no,
         offender.staff_member.staff_id,
@@ -36,6 +45,8 @@ class Handover::HandoverEmailBatchRun
         enhanced_handover: offender.enhanced_handover?,
         deliver_now: deliver_now,
       )
+      return unless sent
+
       Rails.logger.info("event=handover_email_delivered,nomis_offender_id=#{offender.offender_no},email=handover_date,for_date=#{for_date.iso8601}")
     end
 
@@ -43,7 +54,7 @@ class Handover::HandoverEmailBatchRun
       chd = CalculatedHandoverDate.find_by(nomis_offender_id: offender.offender_no)
       return unless chd&.handover_date && chd.handover_date == for_date - 14.days && !offender.has_com?
 
-      Handover::HandoverEmail.deliver_if_deliverable(
+      sent = Handover::HandoverEmail.deliver_if_deliverable(
         :com_allocation_overdue,
         offender.offender_no,
         offender.staff_member.staff_id,
@@ -56,6 +67,8 @@ class Handover::HandoverEmailBatchRun
         enhanced_handover: offender.enhanced_handover?,
         deliver_now: deliver_now,
       )
+      return unless sent
+
       Rails.logger.info("event=handover_email_delivered,nomis_offender_id=#{offender.offender_no},email=com_allocation_overdue,for_date=#{for_date.iso8601}")
     end
 
@@ -87,9 +100,9 @@ class Handover::HandoverEmailBatchRun
     def with_error_handling(nomis_offender_id, email_type)
       yield
     rescue StandardError => e
-      raise unless Rails.env.production?
+      Rails.logger.error("event=handover_email_batch_run_error,email=#{email_type},nomis_offender_id=#{nomis_offender_id}|#{e.message}")
 
-      Rails.logger.error("event=handover_email_batch_run_error,email=#{email_type},nomis_offender_id=#{nomis_offender_id}|#{e.inspect},#{e.backtrace.join(',')}")
+      raise if RETRYABLE_BATCH_ERRORS.any? { |error_class| e.is_a?(error_class) }
     end
   end
 end

--- a/app/mailers/handover_mailer.rb
+++ b/app/mailers/handover_mailer.rb
@@ -1,5 +1,18 @@
 class HandoverMailer < ApplicationMailer
+  class InvalidRecipientEmailError < ArgumentError; end
+
   set_mailer_tag 'handover_reminder'
+
+  def self.with(params = nil, **kwargs)
+    mail_params = params.respond_to?(:to_h) ? params.to_h : {}
+    mail_params = mail_params.merge(kwargs) if kwargs.any?
+
+    if mail_params[:email].blank?
+      raise InvalidRecipientEmailError, 'Missing recipient email'
+    end
+
+    super(mail_params)
+  end
 
   def upcoming_handover_window
     set_template('7114ad9e-e71a-4424-a884-bcc72bd1a569')

--- a/lib/tasks/handover/handover_emails.rake
+++ b/lib/tasks/handover/handover_emails.rake
@@ -2,6 +2,6 @@ namespace :handover do
   desc 'Send all handover reminder emails for today'
   task send_all_handover_reminders: :environment do
     Rails.logger = Logger.new($stdout) if Rails.env.production?
-    Handover::HandoverEmailBatchRun.send_all
+    HandoverReminderBatchJob.perform_later(Time.zone.today)
   end
 end

--- a/spec/jobs/handover_reminder_batch_job_spec.rb
+++ b/spec/jobs/handover_reminder_batch_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe HandoverReminderBatchJob, type: :job do
+  describe '#perform' do
+    it 'runs the handover reminder batch for the given date' do
+      for_date = Date.new(2026, 4, 13)
+      allow(Handover::HandoverEmailBatchRun).to receive(:send_all)
+
+      described_class.perform_now(for_date)
+
+      expect(Handover::HandoverEmailBatchRun).to have_received(:send_all).with(for_date: for_date)
+    end
+  end
+end

--- a/spec/lib/handover/handover_email_batch_run_spec.rb
+++ b/spec/lib/handover/handover_email_batch_run_spec.rb
@@ -188,8 +188,7 @@ RSpec.describe Handover::HandoverEmailBatchRun do
     end
   end
 
-  describe 'production error handling' do
-    let(:production_env) { ActiveSupport::StringInquirer.new('production') }
+  describe 'error handling' do
     let(:retryable_error_classes) do
       [
         HandoverMailer::InvalidRecipientEmailError,
@@ -214,7 +213,6 @@ RSpec.describe Handover::HandoverEmailBatchRun do
     end
 
     before do
-      allow(Rails).to receive(:env).and_return(production_env)
       o = FactoryBot.create :offender, id: offender.offender_no
       FactoryBot.create :calculated_handover_date, offender: o, handover_date: today + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
       allow(AllocatedOffender).to receive(:all).and_return([offender])
@@ -237,7 +235,7 @@ RSpec.describe Handover::HandoverEmailBatchRun do
         .exactly(retryable_error_classes.size).times
     end
 
-    it 'logs and continues for unrelated errors in production' do
+    it 'logs and continues for unrelated errors' do
       allow(Handover::HandoverEmail).to receive(:deliver_if_deliverable).and_raise(StandardError, 'boom')
       allow(Rails.logger).to receive(:error)
 

--- a/spec/lib/handover/handover_email_batch_run_spec.rb
+++ b/spec/lib/handover/handover_email_batch_run_spec.rb
@@ -187,4 +187,106 @@ RSpec.describe Handover::HandoverEmailBatchRun do
       end
     end
   end
+
+  describe 'production error handling' do
+    let(:production_env) { ActiveSupport::StringInquirer.new('production') }
+    let(:retryable_error_classes) do
+      [
+        HandoverMailer::InvalidRecipientEmailError,
+        ActiveJob::EnqueueError,
+        ActiveRecord::ConnectionTimeoutError,
+        ActiveRecord::Deadlocked,
+      ]
+    end
+    let(:offender) do
+      instance_double(AllocatedOffender,
+                      offender_no: FactoryBot.generate(:nomis_offender_id),
+                      first_name: 'ALI',
+                      full_name_ordered: 'Ali Bloggs',
+                      enhanced_handover?: true,
+                      staff_member: double(staff_id: 'STAFF1', email_address: nil),
+                      has_com?: true,
+                      allocated_com_name: 'COM 0',
+                      allocated_com_email: 'com0@example.com',
+                      ldu_name: 'LDU 0',
+                      ldu_email_address: 'ldu0@example.com',
+                      earliest_release_for_handover: NamedDate[Date.new(2100, 11, 12), 'UNUSED'])
+    end
+
+    before do
+      allow(Rails).to receive(:env).and_return(production_env)
+      o = FactoryBot.create :offender, id: offender.offender_no
+      FactoryBot.create :calculated_handover_date, offender: o, handover_date: today + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
+      allow(AllocatedOffender).to receive(:all).and_return([offender])
+    end
+
+    it 're-raises allowlisted retryable errors so the batch can be retried' do
+      allow(Rails.logger).to receive(:error)
+
+      retryable_error_classes.each do |error_class|
+        allow(Handover::HandoverEmail).to receive(:deliver_if_deliverable)
+          .and_raise(error_class, 'retry me')
+
+        expect {
+          described_class.send_all(for_date: today)
+        }.to raise_error(error_class)
+      end
+
+      expect(Rails.logger).to have_received(:error)
+        .with(include('event=handover_email_batch_run_error'))
+        .exactly(retryable_error_classes.size).times
+    end
+
+    it 'logs and continues for unrelated errors in production' do
+      allow(Handover::HandoverEmail).to receive(:deliver_if_deliverable).and_raise(StandardError, 'boom')
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        described_class.send_all(for_date: today)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(include('event=handover_email_batch_run_error'))
+    end
+  end
+
+  describe 'when a reminder was already sent in an earlier attempt' do
+    let(:offender) do
+      instance_double(AllocatedOffender,
+                      offender_no: FactoryBot.generate(:nomis_offender_id),
+                      first_name: 'ALI',
+                      full_name_ordered: 'Ali Bloggs',
+                      enhanced_handover?: true,
+                      staff_member: double(staff_id: 'STAFF1', email_address: 'staff1@example.org'),
+                      has_com?: true,
+                      allocated_com_name: 'COM 0',
+                      allocated_com_email: 'com0@example.com',
+                      ldu_name: 'LDU 0',
+                      ldu_email_address: 'ldu0@example.com',
+                      earliest_release_for_handover: NamedDate[Date.new(2100, 11, 12), 'UNUSED'])
+    end
+
+    before do
+      o = FactoryBot.create :offender, id: offender.offender_no
+      FactoryBot.create :calculated_handover_date, offender: o, handover_date: today + DEFAULT_UPCOMING_HANDOVER_WINDOW_DURATION
+      allow(AllocatedOffender).to receive(:all).and_return([offender])
+      allow(Handover::HandoverEmail).to receive(:deliver_if_deliverable).and_return(false)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it 'does not log the reminder as delivered again' do
+      described_class.send_all(for_date: today)
+
+      expect(Handover::HandoverEmail).to have_received(:deliver_if_deliverable).with(
+        :upcoming_handover_window, offender.offender_no, 'STAFF1',
+        email: 'staff1@example.org',
+        full_name_ordered: 'Ali Bloggs',
+        first_name: 'Ali',
+        handover_date: '9 April 2021',
+        enhanced_handover: true,
+        release_date: '12 November 2100',
+        deliver_now: false,
+      )
+      expect(Rails.logger).not_to have_received(:info).with(include('event=handover_email_delivered'))
+    end
+  end
 end

--- a/spec/lib/handover/handover_email_spec.rb
+++ b/spec/lib/handover/handover_email_spec.rb
@@ -16,8 +16,12 @@ RSpec.describe Handover::HandoverEmail do
 
   describe "::deliver_if_deliverable" do
     describe "when not opted out and not already sent" do
-      before do
+      let(:result) do
         described_class.deliver_if_deliverable(handover_email_type, nomis_offender_id, pom_id, **default_args)
+      end
+
+      before do
+        result
       end
 
       it "sends the email" do
@@ -32,14 +36,22 @@ RSpec.describe Handover::HandoverEmail do
                                                                   staff_member_id: pom_id,
                                                                   offender_email_type: handover_email_type)
       end
+
+      it 'returns true' do
+        expect(result).to be(true)
+      end
     end
 
     describe "when opted out" do
+      let(:result) do
+        described_class.deliver_if_deliverable(handover_email_type, nomis_offender_id, pom_id, **default_args)
+      end
+
       before do
         allow(OffenderEmailOptOut).to receive(:find_by).with(staff_member_id: pom_id,
                                                              offender_email_type: handover_email_type)
                                                        .and_return([anything])
-        described_class.deliver_if_deliverable(handover_email_type, nomis_offender_id, pom_id, **default_args)
+        result
       end
 
       it "does not send the email" do
@@ -49,15 +61,23 @@ RSpec.describe Handover::HandoverEmail do
       it "does not create sent record" do
         expect(OffenderEmailSent).not_to have_received(:create!)
       end
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
     end
 
     describe "when already sent" do
+      let(:result) do
+        described_class.deliver_if_deliverable(handover_email_type, nomis_offender_id, pom_id, **default_args)
+      end
+
       before do
         allow(OffenderEmailSent).to receive(:find_by).with(nomis_offender_id: nomis_offender_id,
                                                            staff_member_id: pom_id,
                                                            offender_email_type: handover_email_type)
                                                        .and_return([anything])
-        described_class.deliver_if_deliverable(handover_email_type, nomis_offender_id, pom_id, **default_args)
+        result
       end
 
       it "does not send the email" do
@@ -66,6 +86,10 @@ RSpec.describe Handover::HandoverEmail do
 
       it "does not create sent record" do
         expect(OffenderEmailSent).not_to have_received(:create!)
+      end
+
+      it 'returns false' do
+        expect(result).to be(false)
       end
     end
 

--- a/spec/mailers/handover_mailer_spec.rb
+++ b/spec/mailers/handover_mailer_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe HandoverMailer, type: :mailer do
+  describe '.with' do
+    it 'raises when recipient email is blank' do
+      expect {
+        described_class.with(email: nil, nomis_offender_id: 'A1234BC')
+      }.to raise_error(HandoverMailer::InvalidRecipientEmailError, 'Missing recipient email')
+    end
+  end
+
+  describe '#upcoming_handover_window' do
+    subject(:mail) { described_class.with(**params).upcoming_handover_window }
+
+    let(:params) do
+      {
+        email: 'pom@example.com',
+        nomis_offender_id: 'A1234BC',
+        full_name_ordered: 'Doe, Jane',
+        first_name: 'Jane',
+        handover_date: '13 April 2026',
+        enhanced_handover: false,
+        release_date: '20 April 2026'
+      }
+    end
+
+    it 'sets the recipient' do
+      expect(mail.to).to eq(['pom@example.com'])
+    end
+
+    it 'sets the correct template and personalisation' do
+      expect(mail.govuk_notify_template).to eq('7114ad9e-e71a-4424-a884-bcc72bd1a569')
+      expect(mail.govuk_notify_personalisation).to include(
+        nomis_offender_id: 'A1234BC',
+        full_name_ordered: 'Doe, Jane',
+        first_name: 'Jane',
+        handover_date: '13 April 2026',
+        is_standard: 'yes',
+        is_enhanced: 'no',
+        release_date: '20 April 2026'
+      )
+    end
+  end
+
+  describe '#handover_date' do
+    subject(:mail) { described_class.with(**params).handover_date }
+
+    let(:params) do
+      {
+        email: 'pom@example.com',
+        nomis_offender_id: 'A1234BC',
+        full_name_ordered: 'Doe, Jane',
+        first_name: 'Jane',
+        com_name: 'Alex Smith',
+        com_email: 'com@example.com',
+        enhanced_handover: true,
+        release_date: '20 April 2026'
+      }
+    end
+
+    it 'sets the recipient' do
+      expect(mail.to).to eq(['pom@example.com'])
+    end
+
+    it 'sets the correct template and personalisation' do
+      expect(mail.govuk_notify_template).to eq('95ddd96c-23f9-4066-b033-d4a1d83b702e')
+      expect(mail.govuk_notify_personalisation).to include(
+        nomis_offender_id: 'A1234BC',
+        full_name_ordered: 'Doe, Jane',
+        first_name: 'Jane',
+        com_name: 'Alex Smith',
+        com_email: 'com@example.com',
+        is_standard: 'no',
+        is_enhanced: 'yes',
+        release_date: '20 April 2026'
+      )
+    end
+  end
+
+  describe '#com_allocation_overdue' do
+    subject(:mail) { described_class.with(**params).com_allocation_overdue }
+
+    let(:params) do
+      {
+        email: 'pom@example.com',
+        nomis_offender_id: 'A1234BC',
+        full_name_ordered: 'Doe, Jane',
+        handover_date: '13 April 2026',
+        release_date: '20 April 2026',
+        ldu_name: 'Leeds',
+        ldu_email: 'ldu@example.com',
+        enhanced_handover: false
+      }
+    end
+
+    it 'sets the recipient' do
+      expect(mail.to).to eq(['pom@example.com'])
+    end
+
+    it 'sets the correct template and personalisation' do
+      expect(mail.govuk_notify_template).to eq('21d34a34-f2ec-42c2-82b3-720899b58a3b')
+      expect(mail.govuk_notify_personalisation).to include(
+        nomis_offender_id: 'A1234BC',
+        full_name_ordered: 'Doe, Jane',
+        handover_date: '13 April 2026',
+        release_date: '20 April 2026',
+        is_standard: 'yes',
+        is_enhanced: 'no',
+        ldu_information: "LDU: Leeds\nLDU email: ldu@example.com\n",
+        has_ldu_email: true,
+        missing_ldu_email: false
+      )
+    end
+  end
+end


### PR DESCRIPTION
There may be situations where the recipient email is `nil` if we've not been able to obtain the staff details (which is an API request) due to timeout / upstream issues.

However the previous retry mechanism would retry the actual email delivery, which already had the stale recipient and will not refresh it.

Observed in a sentry error:
https://ministryofjustice.sentry.io/issues/7406737924/?project=5584139

Bit of refactor to actually retry the job instead (we have dedup already so successful emails will not be re-sent) that should refresh the stale recipient.