### PR TITLE
MO-1941 Add rosh level input to missing info page

### DIFF
--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -73,8 +73,7 @@ private
   end
 
   def redirect_to_female_missing_info?
-    PrisonService.womens_prison?(active_prison_id) && @prisoner.complexity_level.blank? &&
-      (@case_info.persisted? || !complexity_recently_saved?)
+    PrisonService.womens_prison?(active_prison_id) && @prisoner.complexity_level.blank? && !complexity_recently_saved?
   end
 
   def complexity_recently_saved?

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -3,13 +3,12 @@
 class CaseInformationController < PrisonsApplicationController
   include PrisonerPageNavigation
 
-  before_action :set_prisoner
-  before_action :set_case_info_or_redirect
+  before_action :set_prisoner, :set_case_info_or_redirect
   before_action :ensure_new_case_allowed, only: [:new, :create]
-  before_action :ensure_editable_manual_entry, only: [:edit, :update]
-  before_action :set_back_path, only: [:edit, :update]
+  before_action :ensure_editable_manual_entry, :set_back_path, only: [:edit, :update]
 
   def new
+    editable_case_information_fields
     return unless redirect_to_female_missing_info?
 
     redirect_to(
@@ -22,7 +21,7 @@ class CaseInformationController < PrisonsApplicationController
   def edit; end
 
   def create
-    @case_info.assign_attributes(case_information_params.merge(manual_entry: true))
+    @case_info.assign_attributes(case_information_params_for_create.merge(manual_entry: true))
 
     if @case_info.save(context: :manual_entry)
       session.delete(complexity_saved_session_key)
@@ -66,7 +65,11 @@ private
   end
 
   def case_information_params
-    params.require(:case_information).permit(:tier, :enhanced_resourcing)
+    params.require(:case_information).permit(:tier, :rosh_level, :enhanced_resourcing).slice(*manual_entry_case_information_fields)
+  end
+
+  def case_information_params_for_create
+    case_information_params.slice(*editable_case_information_fields)
   end
 
   def redirect_to_female_missing_info?
@@ -84,7 +87,7 @@ private
 
   def ensure_new_case_allowed
     return if action_name == 'new' && redirect_to_female_missing_info?
-    return unless @case_info.persisted?
+    return unless @case_info.persisted? && @case_info.complete_for_allocation?
 
     Rails.logger.warn("[#{self.class}] Prisoner #{@prisoner.nomis_offender_id} already has case information, refusing #{action_name}")
     redirect_to('/404')
@@ -100,5 +103,27 @@ private
   def set_back_path
     @back_path = prisoner_page_path(prison_id: active_prison_id, prisoner_id:)
     @source_page = prisoner_page_source
+  end
+
+  def editable_case_information_fields
+    @editable_case_information_fields ||= if @case_info.persisted?
+                                            [].tap do |fields|
+                                              fields << :tier if @case_info.tier.blank?
+                                              fields << :rosh_level if rosh_level_feature_enabled? && @case_info.rosh_level.blank?
+                                              fields << :enhanced_resourcing if @case_info.enhanced_resourcing.nil?
+                                            end
+                                          else
+                                            manual_entry_case_information_fields
+                                          end
+  end
+
+  def manual_entry_case_information_fields
+    @manual_entry_case_information_fields ||= %i[tier enhanced_resourcing].tap do |fields|
+      fields.insert(1, :rosh_level) if rosh_level_feature_enabled?
+    end
+  end
+
+  def rosh_level_feature_enabled?
+    FeatureFlags.rosh_level.enabled?
   end
 end

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -26,7 +26,7 @@ class CaseInformationController < PrisonsApplicationController
     if @case_info.save(context: :manual_entry)
       session.delete(complexity_saved_session_key)
 
-      if params.fetch(:commit) == 'Save'
+      if save_and_return?
         redirect_to missing_information_prison_prisoners_path(active_prison_id, sort: params[:sort], page: params[:page])
       else
         redirect_to prison_prisoner_review_case_details_path(prison_id: active_prison_id, prisoner_id:)
@@ -82,6 +82,10 @@ private
 
   def complexity_saved_session_key
     "female_missing_info_complexity_saved_#{prisoner_id}"
+  end
+
+  def save_and_return?
+    params[:save_and_allocate].blank? && params.fetch(:commit, 'Save') == 'Save'
   end
 
   def ensure_new_case_allowed

--- a/app/controllers/female_missing_infos_controller.rb
+++ b/app/controllers/female_missing_infos_controller.rb
@@ -35,7 +35,7 @@ class FemaleMissingInfosController < PrisonsApplicationController
 private
 
   def has_case_information?
-    @has_case_information ||= CaseInformation.exists?(nomis_offender_id: @missing_info.nomis_offender_id)
+    !!CaseInformation.find_by(nomis_offender_id: @missing_info.nomis_offender_id)&.complete_for_allocation?
   end
 
   def next_step_path

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -5,7 +5,7 @@ class CaseInformation < ApplicationRecord
 
   MAPPA_LEVELS = [0, 1, 2, 3].freeze
   TIER_LEVELS = %w[A B C D].freeze
-  ROSH_LEVELS = %w[LOW MEDIUM HIGH VERY_HIGH].freeze
+  ROSH_LEVELS = %w[VERY_HIGH HIGH MEDIUM LOW].freeze
 
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
 
@@ -14,11 +14,13 @@ class CaseInformation < ApplicationRecord
   belongs_to :local_delivery_unit, -> { enabled }, optional: true, inverse_of: :case_information
   delegate :name, :email_address, to: :local_delivery_unit, prefix: :ldu, allow_nil: true
 
-  validates :manual_entry, inclusion: { in: [true, false], allow_nil: false }
+  validates :manual_entry, inclusion: { in: [true, false] }
   validates :nomis_offender_id, presence: true, uniqueness: true
 
   validates :tier, inclusion: { in: TIER_LEVELS, message: 'Select tier' }
-  validates :rosh_level, inclusion: { in: ROSH_LEVELS, allow_nil: true }
+
+  validates :rosh_level, inclusion: { in: ROSH_LEVELS, allow_blank: true }
+  validates :rosh_level, presence: { message: 'Select ROSH' }, on: :manual_entry, if: :rosh_level_feature_enabled?
 
   validates :enhanced_resourcing,
             inclusion: { in: [true, false], message: 'Select case allocation decision' },
@@ -30,7 +32,17 @@ class CaseInformation < ApplicationRecord
 
   scope :without_com, -> { where(com_name: nil) }
 
+  def complete_for_allocation?
+    tier.present? && (!rosh_level_feature_enabled? || rosh_level.present?)
+  end
+
   def welsh_offender
     probation_service == 'Wales'
+  end
+
+private
+
+  def rosh_level_feature_enabled?
+    FeatureFlags.rosh_level.enabled?
   end
 end

--- a/app/models/delius_import_error.rb
+++ b/app/models/delius_import_error.rb
@@ -8,6 +8,7 @@ class DeliusImportError < ApplicationRecord
   MISSING_TEAM = 4
   MISSING_LDU = 5
   MISMATCHED_DOB = 6
+  INVALID_ROSH_LEVEL = 7
 
   validates :nomis_offender_id, presence: true
 
@@ -18,6 +19,7 @@ class DeliusImportError < ApplicationRecord
          INVALID_CASE_ALLOCATION,
          MISSING_TEAM,
          MISSING_LDU,
-         MISMATCHED_DOB]
+         MISMATCHED_DOB,
+         INVALID_ROSH_LEVEL]
   }
 end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -74,7 +74,7 @@ class Prison < ApplicationRecord
   end
 
   def offender_allocatable?(offender)
-    offender.case_information.present? && (womens? ? offender.complexity_level.present? : true)
+    offender.case_information&.complete_for_allocation? && (womens? ? offender.complexity_level.present? : true)
   end
 
   def offender_allocated?(offender)

--- a/app/models/prison/allocations_summary.rb
+++ b/app/models/prison/allocations_summary.rb
@@ -15,7 +15,7 @@ private
     @summary = @prison.unfiltered_offenders.group_by do |offender|
       if !offender.inside_omic_policy?
         :outside_omic_policy
-      elsif @prison.offender_allocatable?(offender) && @prison.offender_allocated?(offender)
+      elsif @prison.offender_allocated?(offender)
         :allocated
       elsif @prison.offender_allocatable?(offender)
         :unallocated

--- a/app/services/delius_data_import_service.rb
+++ b/app/services/delius_data_import_service.rb
@@ -159,11 +159,11 @@ private
         local_delivery_unit: ldu_record,
         ldu_code: ldu_code,
         team_name: probation_record.dig(:manager, :team, :description),
-        enhanced_resourcing: enhanced_resourcing(probation_record.fetch(:resourcing)),
+        enhanced_resourcing: enhanced_resourcing(probation_record.fetch(:resourcing), case_info.enhanced_resourcing),
         probation_service: ldu_record&.country || 'England',
         active_vlo: probation_record.fetch(:vlo_assigned),
         mappa_level: probation_record.fetch(:mappa_level),
-        rosh_level: probation_record.dig(:rosh, :level),
+        rosh_level: probation_record.dig(:rosh, :level).presence || case_info.rosh_level,
         rosh_start_date: probation_record.dig(:rosh, :start_date),
       )
     end
@@ -184,18 +184,19 @@ private
     tier[0] if tier.present?
   end
 
+  def enhanced_resourcing(probation_value, case_value)
+    return case_value if probation_value.blank?
+
+    probation_value.upcase == 'ENHANCED'
+  end
+
   def error_type(field)
     {
       tier: DeliusImportError::INVALID_TIER,
+      rosh_level: DeliusImportError::INVALID_ROSH_LEVEL,
       case_allocation: DeliusImportError::INVALID_CASE_ALLOCATION,
       local_delivery_unit: DeliusImportError::MISSING_LDU,
       team: DeliusImportError::MISSING_TEAM,
     }.fetch(field)
-  end
-
-  def enhanced_resourcing(value)
-    return nil if value.blank?
-
-    value.upcase == 'ENHANCED'
   end
 end

--- a/app/views/allocations/_female_complexity_level.html.erb
+++ b/app/views/allocations/_female_complexity_level.html.erb
@@ -1,9 +1,0 @@
-<% if @prison.womens? %>
-  <tr class="govuk-table__row" id="complexity-level-row">
-    <td class="govuk-table__cell">Complexity of need level</td>
-    <td id=complexity-level class="govuk-table__cell table_cell__left_align">
-      <%= @prisoner.complexity_level&.capitalize %>
-      <%= link_to 'Change', url, class: 'govuk-link pull-right' %>
-    </td>
-  </tr>
-<% end %>

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -50,7 +50,27 @@
       </td>
     </tr>
 
-    <%= render 'female_complexity_level', url: edit_prison_prisoner_complexity_level_path(@prison.code, @prisoner.offender_no, from: :allocation) %>
+    <tr class="govuk-table__row" id="rosh-row">
+      <td class="govuk-table__cell">ROSH</td>
+      <td class="govuk-table__cell table_cell__left_align">
+        <%= @prisoner.rosh_level.present? ? @prisoner.rosh_level.humanize : 'No ROSH found' %>
+        <%= link_to 'Change',
+                    edit_prison_prisoner_case_information_path(@prison.code, @prisoner.offender_no, from: :allocation),
+                    class: 'govuk-link pull-right' if @prisoner.manual_entry? && FeatureFlags.rosh_level.enabled? %>
+      </td>
+    </tr>
+
+    <% if @prison.womens? %>
+      <tr class="govuk-table__row" id="complexity-level-row">
+        <td class="govuk-table__cell">Complexity of need level</td>
+        <td id="complexity-level" class="govuk-table__cell table_cell__left_align">
+          <%= @prisoner.complexity_level&.capitalize %>
+          <%= link_to 'Change',
+                      edit_prison_prisoner_complexity_level_path(@prison.code, @prisoner.offender_no, from: :allocation),
+                      class: 'govuk-link pull-right' %>
+        </td>
+      </tr>
+    <% end %>
 
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -3,31 +3,50 @@
              method: method,
              builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <%= form.govuk_error_summary %>
+
   <%= render 'heading', heading: heading %>
+
   <%= hidden_field_tag('from', @source_page) %>
   <%= hidden_field_tag("sort", params[:sort]) %>
   <%= hidden_field_tag("page", params[:page]) %>
 
-  <%= form.govuk_collection_radio_buttons(
-        :tier,
-        [OpenStruct.new(name: 'A', value: 'A'),
-         OpenStruct.new(name: 'B', value: 'B'),
-         OpenStruct.new(name: 'C', value: 'C'),
-         OpenStruct.new(name: 'D', value: 'D')],
-        :value,
-        :name,
-        legend: { text: t('.tier.legend') }
-      ) %>
+  <% show_all_fields = action_name.in?(%w[edit update]) %>
+  <% editable_fields = @editable_case_information_fields || [] %>
+  <% show_tier = show_all_fields || editable_fields.include?(:tier) %>
+  <% show_rosh_level = (show_all_fields && FeatureFlags.rosh_level.enabled?) || editable_fields.include?(:rosh_level) %>
+  <% show_enhanced_resourcing = show_all_fields || editable_fields.include?(:enhanced_resourcing) %>
 
-  <%= form.govuk_collection_radio_buttons(
-        :enhanced_resourcing,
-        [OpenStruct.new(name: t('.resourcing.labels.enhanced'), value: 'true'),
-         OpenStruct.new(name: t('.resourcing.labels.standard'), value: 'false')],
-        :value,
-        :name,
-        legend: { text: t('.resourcing.legend') },
-        hint: { text: t('.resourcing.hint') },
-      ) %>
+  <% if show_tier %>
+    <%= form.govuk_collection_radio_buttons(
+          :tier,
+          CaseInformation::TIER_LEVELS.map { OpenStruct.new(name: it, value: it) },
+          :value,
+          :name,
+          legend: { text: t('case_information.form.tier.legend') }
+        ) %>
+  <% end %>
+
+  <% if show_rosh_level %>
+    <%= form.govuk_collection_radio_buttons(
+          :rosh_level,
+          CaseInformation::ROSH_LEVELS.map { OpenStruct.new(name: it.humanize, value: it) },
+          :value,
+          :name,
+          legend: { text: t('case_information.form.rosh.legend') }
+        ) %>
+  <% end %>
+
+  <% if show_enhanced_resourcing %>
+    <%= form.govuk_collection_radio_buttons(
+          :enhanced_resourcing,
+          [OpenStruct.new(name: t('case_information.form.resourcing.labels.enhanced'), value: 'true'),
+           OpenStruct.new(name: t('case_information.form.resourcing.labels.standard'), value: 'false')],
+          :value,
+          :name,
+          legend: { text: t('case_information.form.resourcing.legend') },
+          hint: { text: t('case_information.form.resourcing.hint') },
+        ) %>
+  <% end %>
 
   <div class="govuk-button-group govuk-!-margin-top-7">
     <% buttons.each do |button| %>

--- a/app/views/case_information/_form.html.erb
+++ b/app/views/case_information/_form.html.erb
@@ -50,11 +50,13 @@
 
   <div class="govuk-button-group govuk-!-margin-top-7">
     <% buttons.each do |button| %>
-      <%= form.submit button.fetch(:text),
-                      role: "button",
-                      draggable: "false",
-                      class: "govuk-button #{button.fetch(:class, '')}".strip,
-                      data: { module: 'govuk-button' } %>
+      <% submit_options = {
+           class: "govuk-button #{button.fetch(:class, '')}".strip,
+           data: { module: 'govuk-button' },
+           name: button[:name]
+         }.compact %>
+      <% submit_options[:value] = button[:value] if button.key?(:value) %>
+      <%= form.submit button.fetch(:text), submit_options %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/case_information/edit.html.erb
+++ b/app/views/case_information/edit.html.erb
@@ -9,7 +9,9 @@
           heading: t('.heading', name: @prisoner.full_name_ordered),
           action: prison_prisoner_case_information_path(@prison.code, @prisoner.offender_no),
           method: :put,
-          buttons: [{class:'' , text: 'Update'}]
+          buttons: [
+            { text: 'Update' }
+          ]
     } %>
   </div>
 </div>

--- a/app/views/case_information/new.html.erb
+++ b/app/views/case_information/new.html.erb
@@ -9,7 +9,10 @@
           heading: t('.heading', name: @prisoner.full_name_ordered),
           action: prison_prisoner_case_information_path(@prison.code, @prisoner.offender_no),
           method: :post,
-          buttons: [{class: '', text: 'Save'}, {class: 'govuk-button--secondary', text: 'Save and allocate' }]
+          buttons: [
+            { text: 'Save' },
+            { text: 'Save and allocate', name: 'save_and_allocate', class: 'govuk-button--secondary' }
+          ]
     } %>
   </div>
 </div>

--- a/app/views/prisoners/review_case_details.html.erb
+++ b/app/views/prisoners/review_case_details.html.erb
@@ -45,125 +45,94 @@
       </div>
       <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading"></p>
-        <p class="govuk-!-margin-bottom-0">
+        <p>
           <span class="govuk-tag govuk-tag--blue"><%= sentence_type_label(@prisoner) %></span>
           <%= vlo_tag(@prisoner) %>
         </p>
 
-        <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m"></caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header"></th>
-              <th scope="col" class="govuk-table__header"></th>
-              <th scope="col" class="govuk-table__header"></th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Main offence</th>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= @prisoner.main_offence %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third"></td>
-            </tr>
-            <tr class="govuk-table__row" id="tier">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Tier</th>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= @prisoner.tier.presence || 'No tier found' %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third">
-                <%= link_to('Change', edit_prison_prisoner_case_information_path(@prison, @prisoner.offender_no, from: :review_case), class: 'govuk-link govuk-link--no-visited-state') if @prisoner.manual_entry? %>
-              </td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Category</th>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= @prisoner.category_code.presence || 'No category found
-' %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third"></td>
-            </tr>
-            <% if @prison.womens? %>
-              <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header govuk-!-width-one-third">Complexity of need level</th>
-                <td class="govuk-table__cell govuk-!-width-one-third"><%= @prisoner.complexity_level&.capitalize %></td>
-                <td class="govuk-table__cell govuk-!-width-one-third">
-                  <%= link_to 'Change', edit_prison_prisoner_complexity_level_path(@prison.code, @prisoner.offender_no, from: :review_case), class: 'govuk-link govuk-link--no-visited-state' %>
-                </td>
-              </tr>
-            <% end %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Sentence start date</th>
-              <td class="govuk-table__cell govuk-!-width-one-third">
-                <%= format_date(@prisoner.sentence_start_date, replacement: 'N/A') %>
-              </td>
-              <td class="govuk-table__cell govuk-!-width-one-third"></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Earliest release date</th>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= format_earliest_release_date(@prisoner.earliest_release) %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third"></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Handover type</th>
-              <td class="govuk-table__cell govuk-!-width-one-third">
-                <%= handover_type_label(@prisoner) %>
-              </td>
-              <td class="govuk-table__cell govuk-!-width-one-third">
-                <%= link_to 'Change', edit_prison_prisoner_case_information_path(@prison.code, @prisoner.offender_no, from: :review_case), class: 'govuk-link govuk-link--no-visited-state' if @prisoner.manual_entry? %>
-              </td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Location</th>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= @prisoner.location %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third"></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">POM role needed</th>
-              <td class="govuk-table__cell govuk-!-width-one-third"><%= pom_responsibility_label(@prisoner) %></td>
-              <td class="govuk-table__cell govuk-!-width-one-third"></td>
-            </tr>
-            <% if @pom.present? %>
-              <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header govuk-!-width-one-third">POM</th>
-                <td class="govuk-table__cell govuk-!-width-one-third"><%= @pom.full_name_ordered %></td>
-                <td class="govuk-table__cell govuk-!-width-one-third"></td>
-              </tr>
-              <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header govuk-!-width-one-third">POM email</th>
-                <td class="govuk-table__cell govuk-!-width-one-third"><%= @pom.email_address %></td>
-                <td class="govuk-table__cell govuk-!-width-one-third"></td>
-              </tr>
-              <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header govuk-!-width-one-third">POM role</th>
-                <td class="govuk-table__cell govuk-!-width-one-third"><%= @pom.position_description %></td>
-                <td class="govuk-table__cell govuk-!-width-one-third"></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">Main offence</dt>
+            <dd class="govuk-summary-list__value"><%= @prisoner.main_offence %></dd>
+          </div>
+          <div class="govuk-summary-list__row" id="tier">
+            <dt class="govuk-summary-list__key">Tier</dt>
+            <dd class="govuk-summary-list__value"><%= @prisoner.tier.presence || 'No tier found' %></dd>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to('Change', edit_prison_prisoner_case_information_path(@prison, @prisoner.offender_no, from: :review_case), class: 'govuk-link govuk-link--no-visited-state') if @prisoner.manual_entry? %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">Category</dt>
+            <dd class="govuk-summary-list__value"><%= @prisoner.category_code.presence || 'No category found' %></dd>
+          </div>
+          <div class="govuk-summary-list__row" id="rosh-row">
+            <dt class="govuk-summary-list__key">ROSH</dt>
+            <dd class="govuk-summary-list__value"><%= @prisoner.rosh_level.present? ? @prisoner.rosh_level.humanize : 'No ROSH found' %></dd>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to('Change', edit_prison_prisoner_case_information_path(@prison, @prisoner.offender_no, from: :review_case),
+                          class: 'govuk-link govuk-link--no-visited-state') if @prisoner.manual_entry? && FeatureFlags.rosh_level.enabled? %>
+            </dd>
+          </div>
+          <% if @prison.womens? %>
+            <div class="govuk-summary-list__row" id="complexity-level-row">
+              <dt class="govuk-summary-list__key">Complexity of need level</dt>
+              <dd class="govuk-summary-list__value"><%= @prisoner.complexity_level&.capitalize %></dd>
+              <dd class="govuk-summary-list__actions">
+                <%= link_to 'Change', edit_prison_prisoner_complexity_level_path(@prison.code, @prisoner.offender_no, from: :review_case), class: 'govuk-link govuk-link--no-visited-state' %>
+              </dd>
+            </div>
+          <% end %>
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">Sentence start date</dt>
+            <dd class="govuk-summary-list__value"><%= format_date(@prisoner.sentence_start_date, replacement: 'N/A') %></dd>
+          </div>
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">Earliest release date</dt>
+            <dd class="govuk-summary-list__value"><%= format_earliest_release_date(@prisoner.earliest_release) %></dd>
+          </div>
+          <div class="govuk-summary-list__row" id="service-provider-row">
+            <dt class="govuk-summary-list__key">Handover type</dt>
+            <dd class="govuk-summary-list__value"><%= handover_type_label(@prisoner) %></dd>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to 'Change', edit_prison_prisoner_case_information_path(@prison.code, @prisoner.offender_no, from: :review_case), class: 'govuk-link govuk-link--no-visited-state' if @prisoner.manual_entry? %>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">Location</dt>
+            <dd class="govuk-summary-list__value"><%= @prisoner.location %></dd>
+          </div>
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">POM role needed</dt>
+            <dd class="govuk-summary-list__value"><%= pom_responsibility_label(@prisoner) %></dd>
+          </div>
+          <% if @pom.present? %>
+            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+              <dt class="govuk-summary-list__key">POM</dt>
+              <dd class="govuk-summary-list__value"><%= @pom.full_name_ordered %></dd>
+            </div>
+            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+              <dt class="govuk-summary-list__key">POM email</dt>
+              <dd class="govuk-summary-list__value"><%= @pom.email_address %></dd>
+            </div>
+            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+              <dt class="govuk-summary-list__key">POM role</dt>
+              <dd class="govuk-summary-list__value"><%= @pom.position_description %></dd>
+            </div>
+          <% end %>
+        </dl>
 
-        <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Key dates</caption>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header"></th>
-              <th scope="col" class="govuk-table__header"></th>
-              <th scope="col" class="govuk-table__header"></th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <tr class="govuk-table__row">
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">Last OASys completed</th>
-              <td class="govuk-table__cell govuk-!-width-one-third">
-                <%= render 'oasys_assessment', assessment: @oasys_assessment %>
-              </td>
-              <td class="govuk-table__cell"></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header govuk-!-width-one-third">COM responsible</th>
-              <td class="govuk-table__cell"><%= format_date(@prisoner.responsibility_handover_date, replacement: 'Unknown') %></td>
-              <td class="govuk-table__cell"></td>
-            </tr>
-          </tbody>
-        </table>
+        <h3 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-4">Key dates</h3>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">Last OASys completed</dt>
+            <dd class="govuk-summary-list__value"><%= render 'oasys_assessment', assessment: @oasys_assessment %></dd>
+          </div>
+          <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+            <dt class="govuk-summary-list__key">COM responsible</dt>
+            <dd class="govuk-summary-list__value"><%= format_date(@prisoner.responsibility_handover_date, replacement: 'Unknown') %></dd>
+          </div>
+        </dl>
 
         <% if @coworking %>
           <%= link_to 'Choose a co-working POM to allocate to now', prison_prisoner_staff_index_path(@prison, @prisoner.offender_no, coworking: true) %>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -6,3 +6,5 @@ feature_flags:
     staging: true
   limbo_bulk_reallocation:
     staging: false
+  rosh_level:
+    staging: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,8 @@ en:
     form:
       tier:
         legend: "What is this person’s tier?"
+      rosh:
+        legend: "What is this person’s ROSH?"
       resourcing:
         labels:
           enhanced: 'Retained/Enhanced Resourcing'

--- a/spec/controllers/case_information_controller_spec.rb
+++ b/spec/controllers/case_information_controller_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe CaseInformationController, type: :controller do
   let(:offender) { build(:nomis_offender, prisonId: prison.code) }
   let(:offender_no) { offender.fetch(:prisonerNumber) }
   let(:pom) { build(:pom) }
+  let(:rosh_level_feature_enabled) { true }
   let!(:offender_record) { create(:offender, nomis_offender_id: offender_no) }
 
   before do
     stub_offender(offender)
     stub_sso_data(prison.code)
     stub_poms(prison.code, [pom])
+    stub_rosh_level_feature(enabled: rosh_level_feature_enabled)
   end
 
   describe '#create' do
@@ -23,6 +25,7 @@ RSpec.describe CaseInformationController, type: :controller do
         commit: 'Save',
         case_information: {
           tier: 'A',
+          rosh_level: 'HIGH',
           enhanced_resourcing: 'true'
         }
       }
@@ -33,6 +36,7 @@ RSpec.describe CaseInformationController, type: :controller do
         expect(response).to redirect_to(missing_information_prison_prisoners_path(prison.code, sort: nil, page: nil))
         expect(case_information.manual_entry?).to be(true)
         expect(case_information.tier).to eq('A')
+        expect(case_information.rosh_level).to eq('HIGH')
         expect(case_information.enhanced_resourcing).to be(true)
       end
     end
@@ -44,6 +48,7 @@ RSpec.describe CaseInformationController, type: :controller do
         commit: 'Save and allocate',
         case_information: {
           tier: 'A',
+          rosh_level: 'HIGH',
           enhanced_resourcing: 'true'
         }
       }
@@ -60,16 +65,18 @@ RSpec.describe CaseInformationController, type: :controller do
                offender: offender_record,
                manual_entry: false,
                tier: 'B',
+               rosh_level: 'LOW',
                enhanced_resourcing: false)
       end
 
-      it 'refuses direct create requests and leaves the record unchanged' do
+      it 'refuses direct create requests and leaves the record unchanged when no fields are missing' do
         post :create, params: {
           prison_id: prison.code,
           prisoner_id: offender_no,
           commit: 'Save',
           case_information: {
             tier: 'A',
+            rosh_level: 'HIGH',
             enhanced_resourcing: 'true'
           }
         }
@@ -78,7 +85,134 @@ RSpec.describe CaseInformationController, type: :controller do
           expect(response).to redirect_to('/404')
           expect(case_information.reload.manual_entry?).to be(false)
           expect(case_information.tier).to eq('B')
+          expect(case_information.rosh_level).to eq('LOW')
           expect(case_information.enhanced_resourcing).to be(false)
+        end
+      end
+
+      context 'when some fields are still missing' do
+        let!(:case_information) do
+          create(:case_information,
+                 offender: offender_record,
+                 manual_entry: false,
+                 tier: 'B',
+                 rosh_level: nil,
+                 enhanced_resourcing: false)
+        end
+
+        it 'updates only the missing fields and marks the record as manual entry' do
+          post :create, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            commit: 'Save',
+            case_information: {
+              tier: 'A',
+              rosh_level: 'HIGH',
+              enhanced_resourcing: 'true'
+            }
+          }
+
+          aggregate_failures do
+            expect(response).to redirect_to(missing_information_prison_prisoners_path(prison.code, sort: nil, page: nil))
+            expect(case_information.reload.manual_entry?).to be(true)
+            expect(case_information.tier).to eq('B')
+            expect(case_information.rosh_level).to eq('HIGH')
+            expect(case_information.enhanced_resourcing).to be(false)
+          end
+        end
+
+        context 'when enhanced resourcing is the only missing field' do
+          let!(:case_information) do
+            create(:case_information,
+                   offender: offender_record,
+                   manual_entry: false,
+                   tier: 'B',
+                   rosh_level: 'HIGH',
+                   enhanced_resourcing: nil)
+          end
+
+          it 'refuses direct create requests because the case is already complete for allocation' do
+            post :create, params: {
+              prison_id: prison.code,
+              prisoner_id: offender_no,
+              commit: 'Save',
+              case_information: {
+                tier: 'A',
+                rosh_level: 'LOW',
+                enhanced_resourcing: 'true'
+              }
+            }
+
+            aggregate_failures do
+              expect(response).to redirect_to('/404')
+              expect(case_information.reload.manual_entry?).to be(false)
+              expect(case_information.tier).to eq('B')
+              expect(case_information.rosh_level).to eq('HIGH')
+              expect(case_information.enhanced_resourcing).to be_nil
+            end
+          end
+        end
+
+        context 'when rosh level and enhanced resourcing are missing' do
+          let!(:case_information) do
+            create(:case_information,
+                   offender: offender_record,
+                   manual_entry: false,
+                   tier: 'B',
+                   rosh_level: nil,
+                   enhanced_resourcing: nil)
+          end
+
+          it 'still requires enhanced resourcing on manual entry' do
+            post :create, params: {
+              prison_id: prison.code,
+              prisoner_id: offender_no,
+              commit: 'Save',
+              case_information: {
+                rosh_level: 'HIGH'
+              }
+            }
+
+            aggregate_failures do
+              expect(response).to have_http_status(:ok)
+              expect(case_information.reload.manual_entry?).to be(false)
+              expect(case_information.rosh_level).to be_nil
+              expect(case_information.enhanced_resourcing).to be_nil
+              expect(assigns(:case_info).errors.messages).to include(enhanced_resourcing: ['Select case allocation decision'])
+            end
+          end
+        end
+      end
+
+      context 'when some fields are still missing on a manual entry record' do
+        let!(:case_information) do
+          create(:case_information,
+                 offender: offender_record,
+                 manual_entry: true,
+                 tier: 'B',
+                 rosh_level: nil,
+                 enhanced_resourcing: false)
+        end
+
+        it 'updates only the missing fields' do
+          post :create, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            commit: 'Save',
+            case_information: {
+              tier: 'A',
+              rosh_level: 'HIGH',
+              enhanced_resourcing: 'true'
+            }
+          }
+
+          aggregate_failures do
+            expect(response).to redirect_to(missing_information_prison_prisoners_path(prison.code, sort: nil, page: nil))
+            expect(case_information.reload.manual_entry?).to be(true)
+            expect(case_information.tier).to eq('B')
+            expect(case_information.rosh_level).to eq('HIGH')
+            expect(case_information.enhanced_resourcing).to be(false)
+          end
         end
       end
     end
@@ -99,13 +233,64 @@ RSpec.describe CaseInformationController, type: :controller do
 
     context 'when case information already exists and is not manual entry' do
       before do
-        create(:case_information, offender: offender_record, manual_entry: false)
+        create(:case_information,
+               offender: offender_record,
+               manual_entry: false,
+               tier: 'A',
+               rosh_level: 'HIGH',
+               enhanced_resourcing: false)
       end
 
-      it 'refuses direct access to the new page' do
+      it 'refuses direct access to the new page when no fields are missing' do
         get :new, params: { prison_id: prison.code, prisoner_id: offender_no }
 
         expect(response).to redirect_to('/404')
+      end
+
+      context 'when some fields are still missing' do
+        before do
+          CaseInformation.find_by!(nomis_offender_id: offender_no).update!(rosh_level: nil, enhanced_resourcing: false, tier: 'B')
+        end
+
+        it 'allows access to the new page' do
+          get :new, params: { prison_id: prison.code, prisoner_id: offender_no }
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        context 'when the rosh feature flag is disabled' do
+          let(:rosh_level_feature_enabled) { false }
+
+          it 'refuses access because the case is complete for allocation' do
+            get :new, params: { prison_id: prison.code, prisoner_id: offender_no }
+
+            expect(response).to redirect_to('/404')
+          end
+        end
+      end
+
+      context 'when enhanced resourcing is the only missing field' do
+        before do
+          CaseInformation.find_by!(nomis_offender_id: offender_no).update!(rosh_level: 'HIGH', enhanced_resourcing: nil, tier: 'B')
+        end
+
+        it 'refuses access to the new page' do
+          get :new, params: { prison_id: prison.code, prisoner_id: offender_no }
+
+          expect(response).to redirect_to('/404')
+        end
+      end
+
+      context 'when some fields are still missing on a manual entry record' do
+        before do
+          CaseInformation.find_by!(nomis_offender_id: offender_no).update!(manual_entry: true, rosh_level: nil, enhanced_resourcing: false, tier: 'B')
+        end
+
+        it 'allows access to the new page' do
+          get :new, params: { prison_id: prison.code, prisoner_id: offender_no }
+
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
   end
@@ -117,6 +302,7 @@ RSpec.describe CaseInformationController, type: :controller do
                offender: offender_record,
                manual_entry: true,
                tier: 'B',
+               rosh_level: 'LOW',
                enhanced_resourcing: false)
       end
 
@@ -127,11 +313,15 @@ RSpec.describe CaseInformationController, type: :controller do
           from: 'review_case',
           case_information: {
             tier: 'A',
+            rosh_level: 'HIGH',
             enhanced_resourcing: 'true'
           }
         }
 
-        expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+        aggregate_failures do
+          expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+          expect(case_information.reload.rosh_level).to eq('HIGH')
+        end
       end
 
       it 'redirects back to allocation information when from is allocation' do
@@ -141,11 +331,34 @@ RSpec.describe CaseInformationController, type: :controller do
           from: 'allocation',
           case_information: {
             tier: 'A',
+            rosh_level: 'HIGH',
             enhanced_resourcing: 'true'
           }
         }
 
         expect(response).to redirect_to(prison_prisoner_allocation_path(prison.code, prisoner_id: offender_no))
+      end
+
+      context 'when the rosh feature flag is disabled' do
+        let(:rosh_level_feature_enabled) { false }
+
+        it 'does not update the rosh level' do
+          put :update, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            from: 'review_case',
+            case_information: {
+              tier: 'A',
+              rosh_level: 'HIGH',
+              enhanced_resourcing: 'true'
+            }
+          }
+
+          aggregate_failures do
+            expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+            expect(case_information.reload.rosh_level).to eq('LOW')
+          end
+        end
       end
     end
 
@@ -155,6 +368,7 @@ RSpec.describe CaseInformationController, type: :controller do
                offender: offender_record,
                manual_entry: false,
                tier: 'B',
+               rosh_level: 'LOW',
                enhanced_resourcing: false)
       end
 
@@ -164,6 +378,7 @@ RSpec.describe CaseInformationController, type: :controller do
           prisoner_id: offender_no,
           case_information: {
             tier: 'A',
+            rosh_level: 'HIGH',
             enhanced_resourcing: 'true'
           }
         }
@@ -172,6 +387,7 @@ RSpec.describe CaseInformationController, type: :controller do
           expect(response).to redirect_to('/404')
           expect(case_information.reload.manual_entry?).to be(false)
           expect(case_information.tier).to eq('B')
+          expect(case_information.rosh_level).to eq('LOW')
           expect(case_information.enhanced_resourcing).to be(false)
         end
       end
@@ -184,6 +400,7 @@ RSpec.describe CaseInformationController, type: :controller do
           prisoner_id: offender_no,
           case_information: {
             tier: 'A',
+            rosh_level: 'HIGH',
             enhanced_resourcing: 'true'
           }
         }

--- a/spec/controllers/female_missing_infos_controller_spec.rb
+++ b/spec/controllers/female_missing_infos_controller_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe FemaleMissingInfosController, type: :controller do
   let(:offender) { build(:nomis_offender, prisonId: prison.code, complexityLevel: complexity_level) }
   let(:offender_no) { offender.fetch(:prisonerNumber) }
   let(:pom) { build(:pom) }
+  let(:rosh_level_feature_enabled) { true }
 
   before do
     stub_offender(offender)
     stub_sso_data(prison.code)
     stub_poms(prison.code, [pom])
+    stub_rosh_level_feature(enabled: rosh_level_feature_enabled)
   end
 
   describe '#new' do
@@ -78,6 +80,58 @@ RSpec.describe FemaleMissingInfosController, type: :controller do
             reason: nil
           )
           expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+        end
+      end
+    end
+
+    context 'when case information already exists but is incomplete' do
+      let(:complexity_level) { nil }
+
+      before do
+        create(:case_information,
+               offender: build(:offender, nomis_offender_id: offender_no),
+               rosh_level: nil,
+               enhanced_resourcing: false)
+      end
+
+      it 'redirects to case information after saving complexity' do
+        put :update, params: {
+          prison_id: prison.code,
+          prisoner_id: offender_no,
+          complexity_form: { complexity_level: 'medium' }
+        }
+
+        aggregate_failures do
+          expect(HmppsApi::ComplexityApi).to have_received(:save).with(
+            offender_no,
+            level: 'medium',
+            username: 'user',
+            reason: nil
+          )
+          expect(session["female_missing_info_complexity_saved_#{offender_no}"]).to eq(true)
+          expect(response).to redirect_to(new_prison_prisoner_case_information_path(prison.code, prisoner_id: offender_no, sort: nil, page: nil))
+        end
+      end
+
+      context 'when the rosh feature flag is disabled' do
+        let(:rosh_level_feature_enabled) { false }
+
+        it 'redirects to review case details after saving complexity' do
+          put :update, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            complexity_form: { complexity_level: 'medium' }
+          }
+
+          aggregate_failures do
+            expect(HmppsApi::ComplexityApi).to have_received(:save).with(
+              offender_no,
+              level: 'medium',
+              username: 'user',
+              reason: nil
+            )
+            expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+          end
         end
       end
     end

--- a/spec/controllers/prisoners_controller_spec.rb
+++ b/spec/controllers/prisoners_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PrisonersController, type: :controller do
 
         create(:case_information, offender: build(:offender, nomis_offender_id: allocated_offender_one.fetch(:prisonerNumber)))
         create(:allocation_history, nomis_offender_id: allocated_offender_one.fetch(:prisonerNumber), prison: prison.code)
-        create(:case_information, offender: build(:offender, nomis_offender_id: allocated_offender_two.fetch(:prisonerNumber)))
+        create(:case_information, :without_rosh, offender: build(:offender, nomis_offender_id: allocated_offender_two.fetch(:prisonerNumber)))
         create(:allocation_history, nomis_offender_id: allocated_offender_two.fetch(:prisonerNumber), prison: prison.code)
       end
 

--- a/spec/controllers/reallocations/selection_controller_spec.rb
+++ b/spec/controllers/reallocations/selection_controller_spec.rb
@@ -151,34 +151,12 @@ RSpec.describe Reallocations::SelectionController, type: :controller do
 
     context "when reallocating cases in the women's estate" do
       let(:prison) { create(:womens_prison) }
-      let(:offenders_in_prison) { [offender, missing_complexity_offender] }
-      let(:missing_complexity_offender) do
-        build(
-          :nomis_offender,
-          :inside_omic_policy,
-          prisonId: prison.code,
-          prisonerNumber: 'G9999ZZ',
-          firstName: 'Casey',
-          lastName: 'NoComplexity',
-          complexityLevel: nil,
-          sentence: attributes_for(:sentence_detail,
-                                   conditionalReleaseDate: '2028-06-01',
-                                   releaseDate: '2029-06-01')
-        )
-      end
 
-      before do
-        create_reallocation_case(missing_complexity_offender.fetch(:prisonerNumber), tier: 'B')
-      end
-
-      it 'shows the complexity column and only includes allocatable cases' do
+      it 'shows the complexity column' do
         perform_request
 
         expect(response).to be_successful
-        expect(assigns(:allocations).map(&:nomis_offender_id)).to eq([offender_no])
         expect(response.body).to include('Complexity level')
-        expect(response.body).to include('Medium')
-        expect(response.body).not_to include(missing_complexity_offender.fetch(:prisonerNumber))
       end
     end
   end

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
 
     tier { 'A' }
 
+    rosh_level { 'HIGH' }
+    rosh_start_date { Date.new(2025, 6, 1) }
+
     manual_entry { true }
 
     crn { Faker::Alphanumeric.alpha(number: 10) }
@@ -27,6 +30,11 @@ FactoryBot.define do
 
     trait :with_active_vlo do
       active_vlo { true }
+    end
+
+    trait :without_rosh do
+      rosh_level { nil }
+      rosh_start_date { nil }
     end
   end
 end

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -4,26 +4,33 @@ describe 'case information feature' do
     let(:offender) { build(:nomis_offender, prisonId: prison.code) }
     let(:offenders) { [offender] }
     let(:user) { build(:pom) }
+    let(:rosh_level_feature_enabled) { true }
 
     include_context 'with missing information feature defaults'
+
+    before do
+      stub_rosh_level_feature(enabled: rosh_level_feature_enabled)
+    end
 
     context 'when add missing details the first time (create journey)' do
       before do
         start_missing_information_journey(prison_code: prison.code, prisoner_id: offender.fetch(:prisonerNumber))
         expect_case_information_page(prison_code: prison.code, prisoner_id: offender.fetch(:prisonerNumber))
-        fill_in_case_information(resourcing: 'true', tier: 'A')
+        fill_in_case_information(resourcing: 'true', tier: 'A', rosh_level: 'HIGH')
       end
 
       it 'allows spo to save case information and then returns to add missing info page' do
         click_button 'Save'
         expect(page).to have_current_path(missing_information_prison_prisoners_path(prison.code), ignore_query: true)
         expect(CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber)).tier).to eq('A')
+        expect(CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber)).rosh_level).to eq('HIGH')
       end
 
       it 'allows spo to review the case after adding missing information' do
         click_button 'Save and allocate'
         expect(page).to have_current_path prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender.fetch(:prisonerNumber))
         expect(CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber)).tier).to eq('A')
+        expect(CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber)).rosh_level).to eq('HIGH')
       end
     end
 
@@ -44,6 +51,87 @@ describe 'case information feature' do
         expect(page).to have_content('There is a problem')
         expect(page).to have_content('Select case allocation decision')
       end
+
+      it 'shows all fields when editing a manual case' do
+        visit edit_prison_prisoner_case_information_path(prison.code, offender.fetch(:prisonerNumber))
+
+        expect(page).to have_content('What is this person’s tier?')
+        expect(page).to have_content('What is this person’s ROSH?')
+        expect(page).to have_content('What case allocation decision has been made for this person?')
+      end
+
+      context 'when the rosh feature flag is disabled' do
+        let(:rosh_level_feature_enabled) { false }
+
+        it 'does not show the rosh field when editing a manual case' do
+          visit edit_prison_prisoner_case_information_path(prison.code, offender.fetch(:prisonerNumber))
+
+          expect(page).to have_content('What is this person’s tier?')
+          expect(page).to have_no_content('What is this person’s ROSH?')
+          expect(page).to have_content('What case allocation decision has been made for this person?')
+        end
+      end
+    end
+
+    context 'when adding missing details to an imported case with some existing values' do
+      before do
+        create(:case_information,
+               offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)),
+               manual_entry: false,
+               tier: 'A',
+               rosh_level: nil,
+               enhanced_resourcing: false)
+      end
+
+      it 'shows only the missing fields' do
+        visit new_prison_prisoner_case_information_path(prison.code, offender.fetch(:prisonerNumber))
+
+        expect_case_information_page(
+          prison_code: prison.code,
+          prisoner_id: offender.fetch(:prisonerNumber),
+          show_tier: false,
+          show_rosh_level: true,
+          show_enhanced_resourcing: false
+        )
+      end
+
+      it 'fills only the missing fields and preserves existing values' do
+        visit new_prison_prisoner_case_information_path(prison.code, offender.fetch(:prisonerNumber))
+
+        fill_in_case_information(rosh_level: 'HIGH')
+        click_button 'Save'
+
+        case_information = CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber))
+
+        aggregate_failures do
+          expect(page).to have_current_path(missing_information_prison_prisoners_path(prison.code), ignore_query: true)
+          expect(case_information.manual_entry?).to be(true)
+          expect(case_information.tier).to eq('A')
+          expect(case_information.rosh_level).to eq('HIGH')
+          expect(case_information.enhanced_resourcing).to be(false)
+        end
+      end
+
+      context 'when more than one field is missing and validation fails' do
+        before do
+          CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber)).update_columns(tier: nil, rosh_level: nil)
+        end
+
+        it 'keeps the previously selected value visible on rerender' do
+          visit new_prison_prisoner_case_information_path(prison.code, offender.fetch(:prisonerNumber))
+
+          fill_in_case_information(tier: 'A')
+          click_button 'Save'
+
+          aggregate_failures do
+            expect(page).to have_content('There is a problem')
+            expect(page).to have_content('Select ROSH')
+            expect(page).to have_content('What is this person’s tier?')
+            expect(page).to have_content('What is this person’s ROSH?')
+            expect(page).to have_checked_field('case-information-tier-a-field', visible: :all)
+          end
+        end
+      end
     end
 
     context 'when trying to edit a non manual entry' do
@@ -54,6 +142,32 @@ describe 'case information feature' do
       it 'does not allow the user to edit the case information' do
         visit edit_prison_prisoner_case_information_path(prison.code, offender.fetch(:prisonerNumber))
         expect(page).to have_current_path('/404')
+      end
+    end
+
+    context 'when the rosh feature flag is disabled' do
+      let(:rosh_level_feature_enabled) { false }
+
+      it 'allows adding missing details without showing rosh' do
+        start_missing_information_journey(prison_code: prison.code, prisoner_id: offender.fetch(:prisonerNumber))
+
+        expect_case_information_page(
+          prison_code: prison.code,
+          prisoner_id: offender.fetch(:prisonerNumber),
+          show_rosh_level: false
+        )
+
+        fill_in_case_information(resourcing: 'true', tier: 'A')
+        click_button 'Save'
+
+        case_information = CaseInformation.find_by!(nomis_offender_id: offender.fetch(:prisonerNumber))
+
+        aggregate_failures do
+          expect(page).to have_current_path(missing_information_prison_prisoners_path(prison.code), ignore_query: true)
+          expect(case_information.tier).to eq('A')
+          expect(case_information.rosh_level).to be_nil
+          expect(case_information.enhanced_resourcing).to be(true)
+        end
       end
     end
   end

--- a/spec/features/complexity_level_feature_spec.rb
+++ b/spec/features/complexity_level_feature_spec.rb
@@ -100,7 +100,7 @@ feature 'complexity level feature' do
 
       visit prison_prisoner_review_case_details_path(prison_id: womens_prison.code, prisoner_id: offender_no)
 
-      find('tr', text: 'Complexity of need level').click_link('Change')
+      find('#complexity-level-row').click_link('Change')
 
       expect(page).to have_text 'Update complexity of need level'
 
@@ -115,14 +115,14 @@ feature 'complexity level feature' do
       click_on('Return to prisoner page')
 
       expect(page).to have_current_path(prison_prisoner_review_case_details_path(prison_id: womens_prison.code, prisoner_id: offender_no), ignore_query: true)
-      expect(page).to have_css('tr', text: 'Complexity of need level')
+      expect(page).to have_css('#complexity-level-row', text: 'Complexity of need level')
       expect(page).to have_text('Low')
     end
 
     it 'keeps the review case details back link after a validation error' do
       visit prison_prisoner_review_case_details_path(prison_id: womens_prison.code, prisoner_id: offender_no)
 
-      find('tr', text: 'Complexity of need level').click_link('Change')
+      find('#complexity-level-row').click_link('Change')
 
       find('label[for=complexity-level-low-field]').click
       click_on('Update')

--- a/spec/features/delius_import_feature_spec.rb
+++ b/spec/features/delius_import_feature_spec.rb
@@ -45,15 +45,11 @@ RSpec.feature "Delius import feature", :disable_push_to_delius do
     it "imports from Delius and creates case information" do
       visit missing_information_prison_prisoners_path(prison_code)
       expect(page).to have_content("Add missing details")
-      expect(page).to have_content(offender_no)
+      expect(page).not_to have_content(offender_no)
 
       ProcessDeliusDataJob.perform_now offender_no
 
       expect(DeliusImportError.all).to eq []
-
-      reload_page
-      expect(page).to have_content("Add missing details")
-      expect(page).not_to have_content(offender_no)
 
       visit allocated_prison_prisoners_path(prison_code)
       expect(page).to have_content("See allocations")

--- a/spec/features/female_missing_info_feature_spec.rb
+++ b/spec/features/female_missing_info_feature_spec.rb
@@ -48,10 +48,11 @@ feature "womens missing info journey" do
         click_button 'Save'
         within '.govuk-error-summary' do
           expect(page).to have_content('Select tier')
+          expect(page).to have_content('Select ROSH')
           expect(page).to have_content('Select case allocation decision')
         end
 
-        fill_in_case_information(resourcing: 'false', tier: 'B')
+        fill_in_case_information(resourcing: 'false', tier: 'B', rosh_level: 'MEDIUM')
         click_button 'Save'
         wait_for { page.current_path == missing_information_prison_prisoners_path(prison.code) }
       }.to change(CaseInformation, :count).by(1)
@@ -95,7 +96,7 @@ feature "womens missing info journey" do
 
       expect_case_information_page(prison_code: prison.code, prisoner_id: prisoner_id)
 
-      fill_in_case_information(resourcing: 'true', tier: 'A')
+      fill_in_case_information(resourcing: 'true', tier: 'A', rosh_level: 'HIGH')
       click_button 'Save'
       wait_for { page.current_path == missing_information_prison_prisoners_path(prison.code) }
     end
@@ -131,7 +132,7 @@ feature "womens missing info journey" do
     end
 
     def fill_in_missing_case_information
-      fill_in_case_information(resourcing: 'true', tier: 'A')
+      fill_in_case_information(resourcing: 'true', tier: 'A', rosh_level: 'LOW')
       click_button 'Save'
     end
   end

--- a/spec/features/female_missing_info_feature_spec.rb
+++ b/spec/features/female_missing_info_feature_spec.rb
@@ -88,6 +88,34 @@ feature "womens missing info journey" do
     end
   end
 
+  context 'when case information is present but still incomplete' do
+    let(:complexity) { nil }
+
+    before do
+      create(:case_information,
+             offender: build(:offender, nomis_offender_id: prisoner_id),
+             rosh_level: nil,
+             enhanced_resourcing: false)
+
+      start_missing_information_journey(prison_code: prison.code, prisoner_id: prisoner_id)
+
+      find('label[for=complexity-form-complexity-level-medium-field]').click
+    end
+
+    it 'shows save and continue because case information is still needed' do
+      expect(page).to have_button('Save and continue')
+      expect(page).to have_no_button('Save and allocate')
+    end
+
+    it 'continues to the case information step after saving complexity' do
+      expect(HmppsApi::ComplexityApi).to receive(:save).with(prisoner_id, level: 'medium', username: username, reason: nil)
+
+      click_button 'Save and continue'
+
+      expect(page).to have_current_path(new_prison_prisoner_case_information_path(prison.code, prisoner_id), ignore_query: true)
+    end
+  end
+
   context 'when complexity level is present' do
     let(:complexity) { 'medium' }
 

--- a/spec/features/update_case_information_spec.rb
+++ b/spec/features/update_case_information_spec.rb
@@ -19,13 +19,13 @@ RSpec.feature "Update case information", type: :feature do
 
   context 'when there is a new allocation' do
     before do
-      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no), rosh_level: 'HIGH')
     end
 
     it 'returns to review case details after updating from review case details' do
       visit prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no)
 
-      within('tr#tier') do
+      within('#tier') do
         click_link('Change')
       end
 
@@ -38,7 +38,7 @@ RSpec.feature "Update case information", type: :feature do
   context 'when there is an existing allocation' do
     before do
       create(:allocation_history, nomis_offender_id: offender_no, primary_pom_nomis_id: pom.staff_id,  prison: prison.code)
-      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no), rosh_level: 'HIGH')
     end
 
     it 'returns to allocation information after updating from allocation information' do
@@ -60,6 +60,7 @@ RSpec.feature "Update case information", type: :feature do
       create(:case_information,
              offender: build(:offender, nomis_offender_id: offender_no),
              tier: 'B',
+             rosh_level: 'HIGH',
              enhanced_resourcing: nil)
     end
 

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -1,5 +1,10 @@
 describe CaseInformation do
   let(:case_info) { create(:case_information) }
+  let(:rosh_level_feature_enabled) { true }
+
+  before do
+    stub_rosh_level_feature(enabled: rosh_level_feature_enabled)
+  end
 
   context 'with mappa level' do
     subject { build(:case_information) }
@@ -31,6 +36,30 @@ describe CaseInformation do
       subject.rosh_level = 'UNKNOWN'
 
       expect(subject).not_to be_valid
+    end
+
+    it 'requires a rosh level for manual entry' do
+      subject.rosh_level = nil
+
+      expect(subject.valid?(:manual_entry)).to be(false)
+      expect(subject.errors.messages).to include(rosh_level: ['Select ROSH'])
+    end
+
+    context 'when the rosh feature flag is disabled' do
+      let(:rosh_level_feature_enabled) { false }
+
+      it 'does not require a rosh level for manual entry' do
+        subject.rosh_level = nil
+
+        expect(subject.valid?(:manual_entry)).to be(true)
+      end
+    end
+
+    it 'treats a blank rosh level as missing for manual entry' do
+      subject.rosh_level = ''
+
+      expect(subject.valid?(:manual_entry)).to be(false)
+      expect(subject.errors.messages).to include(rosh_level: ['Select ROSH'])
     end
   end
 
@@ -101,16 +130,42 @@ describe CaseInformation do
 
     context 'when manually entering values from the missing details form' do
       it 'can be true' do
-        expect(build(:case_information, enhanced_resourcing: true).valid?(:manual_entry)).to be(true)
+        expect(build(:case_information, enhanced_resourcing: true, rosh_level: 'HIGH').valid?(:manual_entry)).to be(true)
       end
 
       it 'can be false' do
-        expect(build(:case_information, enhanced_resourcing: false).valid?(:manual_entry)).to be(true)
+        expect(build(:case_information, enhanced_resourcing: false, rosh_level: 'HIGH').valid?(:manual_entry)).to be(true)
       end
 
       it 'cannot be nil' do
-        expect(build(:case_information, enhanced_resourcing: nil).valid?(:manual_entry)).to be(false)
+        expect(build(:case_information, enhanced_resourcing: nil, rosh_level: 'HIGH').valid?(:manual_entry)).to be(false)
       end
+    end
+  end
+
+  describe '#complete_for_allocation?' do
+    it 'is true when tier and rosh level are present' do
+      expect(build(:case_information, tier: 'A', rosh_level: 'HIGH', enhanced_resourcing: false).complete_for_allocation?).to be(true)
+    end
+
+    it 'is true when enhanced resourcing is missing' do
+      expect(build(:case_information, tier: 'A', rosh_level: 'HIGH', enhanced_resourcing: nil).complete_for_allocation?).to be(true)
+    end
+
+    it 'is false when rosh level is missing' do
+      expect(build(:case_information, rosh_level: nil).complete_for_allocation?).to be(false)
+    end
+
+    context 'when the rosh feature flag is disabled' do
+      let(:rosh_level_feature_enabled) { false }
+
+      it 'is true when rosh level is missing' do
+        expect(build(:case_information, tier: 'A', rosh_level: nil).complete_for_allocation?).to be(true)
+      end
+    end
+
+    it 'is false when tier is missing' do
+      expect(build(:case_information, tier: nil, rosh_level: 'HIGH').complete_for_allocation?).to be(false)
     end
   end
 end

--- a/spec/models/delius_import_error_spec.rb
+++ b/spec/models/delius_import_error_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe DeliusImportError, type: :model do
   it {
     expect(subject).to validate_presence_of :nomis_offender_id
-    expect(subject).to validate_inclusion_of(:error_type).in_array([0, 1, 2, 4, 5, 6])
+    expect(subject).to validate_inclusion_of(:error_type).in_array([0, 1, 2, 4, 5, 6, 7])
   }
 end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Prison do
         instance_double MpcOffender, "mpc_offender-#{nomis_offender_id}", offender_no: nomis_offender_id,
                                                                           nomis_offender_id:,
                                                                           inside_omic_policy?: true,
-                                                                          case_information: double,
+                                                                          case_information: double(complete_for_allocation?: true),
                                                                           released?: false
       end
     end

--- a/spec/services/delius_data_import_service_spec.rb
+++ b/spec/services/delius_data_import_service_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   let(:com_forename) { 'Arnold' }
   let(:com_surname) { 'Aardvark' }
   let(:com_email) { 'arnie@aardvark.me' }
+  let(:resourcing) { 'ENHANCED' }
   let(:tier) { 'A_2' }
   let(:rosh_level) { 'HIGH' }
   let(:rosh_start_date) { Date.new(2026, 3, 14) }
@@ -20,6 +21,7 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
     build :probation_record, offender_no: nomis_offender_id,
                              crn: crn,
                              tier: tier,
+                             resourcing: resourcing,
                              team_description: team_name,
                              ldu_code: ldu.code,
                              ldu_description: ldu.name,
@@ -61,29 +63,18 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   shared_examples 'audit event' do
     let(:audit_event) { AuditEvent.last }
 
-    it 'creates an audit event' do
+    it 'creates an audit event with the expected data and tags' do
       expect {
         service.process(nomis_offender_id)
       }.to change(AuditEvent, :count).by(1)
-    end
 
-    it 'includes the CaseInformation attribute diffs in the audit event data' do
-      service.process(nomis_offender_id)
       expect(audit_event.data['before']).to eq(expected_data['before'])
       expect(audit_event.data['after']).to eq(expected_data['after'])
-    end
-
-    it 'includes the word batch in the tags' do
-      service.process(nomis_offender_id)
       expect(audit_event.tags).to include('batch')
     end
   end
 
   context 'when case_information not present' do
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-    end
-
     it 'creates case information' do
       expect {
         service.process(nomis_offender_id)
@@ -137,20 +128,6 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
     let(:offender_id) { 'A1111AA' }
     let(:nomis_offender_id) { offender_id }
 
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: offender_id))
-    end
-
-    context 'with a normal COM name' do
-      it 'shows com name' do
-        expect {
-          service.process(offender_id)
-        }.to change(CaseInformation, :count).by(1)
-
-        expect(case_info.com_name).to eq("#{com_surname}, #{com_forename}")
-      end
-    end
-
     context 'with no COM details' do
       let(:mock_probation_record) do
         build :probation_record, :no_com, offender_no: nomis_offender_id,
@@ -177,10 +154,6 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   context 'when tier contains extra characters' do
     let(:tier) { 'B1' }
 
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-    end
-
     it 'creates case information' do
       expect {
         service.process(nomis_offender_id)
@@ -192,10 +165,6 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   context 'when tier is invalid' do
     let(:tier) { 'X' }
 
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-    end
-
     it 'does not create case information' do
       expect {
         service.process(nomis_offender_id)
@@ -203,20 +172,20 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
     end
   end
 
-  describe '#probation_service' do
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-    end
+  context 'when rosh level is invalid' do
+    let(:rosh_level) { 'UNKNOWN' }
 
-    context 'with an English LDU' do
-      let(:ldu) { create(:local_delivery_unit, country: 'England') }
-
-      it 'maps to England' do
+    it 'does not create case information and stores a rosh import error' do
+      expect {
         service.process(nomis_offender_id)
-        expect(case_info.probation_service).to eq('England')
-      end
-    end
+      }.not_to change(CaseInformation, :count)
 
+      expect(DeliusImportError.where(nomis_offender_id: nomis_offender_id).pluck(:error_type))
+        .to eq([DeliusImportError::INVALID_ROSH_LEVEL])
+    end
+  end
+
+  describe '#probation_service' do
     context 'with a Welsh LDU' do
       let(:ldu) { create(:local_delivery_unit, country: 'Wales') }
 
@@ -228,25 +197,12 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   end
 
   describe 'Local Delivery Unit' do
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-      service.process(nomis_offender_id)
-    end
-
-    context 'when the LDU code exists in our lookup table' do
-      let(:ldu_code) { ldu.code }
-
-      it 'associates it with that LDU' do
-        expect(case_info.local_delivery_unit).to eq ldu
-      end
-
-      it 'records the LDU code' do
-        expect(case_info.ldu_code).to eq ldu_code
-      end
-    end
-
     context 'when the LDU code is not in our lookup table' do
       let(:ldu) { OpenStruct.new(code: 'ABC123', name: 'Captain Underpants') }
+
+      before do
+        service.process(nomis_offender_id)
+      end
 
       it 'imports the record, but without an LDU association' do
         expect(case_info.local_delivery_unit).to be_nil
@@ -259,10 +215,6 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   end
 
   context 'when case information already present' do
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-    end
-
     let!(:c1) { create(:case_information, tier: 'B', offender: build(:offender, nomis_offender_id: nomis_offender_id)) }
     let(:tier) { 'C' }
 
@@ -287,12 +239,66 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
     end
 
     include_examples 'audit event' do
-      let(:attrs_not_changing) { %w[id created_at updated_at active_vlo nomis_offender_id tier] }
+      let(:attrs_not_changing) { %w[id created_at updated_at active_vlo nomis_offender_id tier rosh_level] }
       let(:expected_data) do
         {
-          'before' => c1.attributes.except(*attrs_not_changing),
-          'after' => audit_case_information_attributes.except('nomis_offender_id', 'tier')
+          'before' => c1.attributes.except(*attrs_not_changing).merge('rosh_start_date' => c1.rosh_start_date&.to_s),
+          'after' => audit_case_information_attributes.except('nomis_offender_id', 'tier', 'rosh_level')
         }
+      end
+    end
+
+    context 'when the existing rosh level is already present' do
+      let!(:c1) do
+        create(:case_information,
+               offender: build(:offender, nomis_offender_id: nomis_offender_id),
+               manual_entry: true,
+               tier: 'B',
+               rosh_level: 'LOW')
+      end
+
+      context 'when probation rosh is nil' do
+        let(:rosh_level) { nil }
+
+        it 'preserves the existing rosh level' do
+          service.process(nomis_offender_id)
+
+          expect(c1.reload.rosh_level).to eq('LOW')
+        end
+      end
+
+      context 'when probation rosh is present' do
+        let(:rosh_level) { 'HIGH' }
+
+        it 'overwrites the existing rosh level' do
+          service.process(nomis_offender_id)
+
+          expect(c1.reload.rosh_level).to eq('HIGH')
+        end
+      end
+    end
+
+    context 'when probation resourcing is missing' do
+      let(:resourcing) { nil }
+
+      it 'preserves the existing enhanced resourcing value if any' do
+        c1.update!(enhanced_resourcing: false)
+
+        service.process(nomis_offender_id)
+
+        expect(c1.reload.enhanced_resourcing).to be(false)
+      end
+    end
+
+    context 'when probation resourcing is present' do
+      let(:resourcing) { 'STANDARD' }
+
+      it 'overwrites the existing enhanced resourcing value' do
+        c1.update!(enhanced_resourcing: true)
+
+        service.process(nomis_offender_id)
+
+        expect(c1.reload.enhanced_resourcing).to be(false)
       end
     end
   end
@@ -301,16 +307,9 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
     let(:service) { described_class.new(identifier_type: :crn) }
 
     before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
       allow(OffenderService).to receive(:get_probation_record).with(crn).and_return(mock_probation_record)
       allow(service.logger).to receive(:error)
       service.process(crn)
-    end
-
-    context 'when the probation record has a NOMIS offender ID' do
-      it 'does not log an error' do
-        expect(service.logger).not_to have_received(:error)
-      end
     end
 
     context 'when the probation record does not have a NOMIS offender ID' do
@@ -323,10 +322,6 @@ RSpec.describe DeliusDataImportService, :disable_push_to_delius do
   end
 
   context 'with error handling' do
-    before do
-      stub_offender(build(:nomis_offender, prisonId: prison.code, prisonerNumber: nomis_offender_id))
-    end
-
     context 'with non-retriable client errors' do
       [
         Faraday::ResourceNotFound,

--- a/spec/support/helpers/feature_flags_helper.rb
+++ b/spec/support/helpers/feature_flags_helper.rb
@@ -1,0 +1,11 @@
+module FeatureFlagsHelper
+  def stub_rosh_level_feature(enabled: true)
+    allow(FeatureFlags).to receive(:rosh_level).and_return(
+      instance_double(FeatureFlags::EnabledFeature, enabled?: enabled)
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include(FeatureFlagsHelper)
+end

--- a/spec/support/shared_contexts/missing_information_feature_setup.rb
+++ b/spec/support/shared_contexts/missing_information_feature_setup.rb
@@ -19,14 +19,18 @@ RSpec.shared_context 'with missing information feature defaults' do
     end
   end
 
-  def expect_case_information_page(prison_code:, prisoner_id:, expected_path: new_prison_prisoner_case_information_path(prison_code, prisoner_id))
+  def expect_case_information_page(prison_code:, prisoner_id:, expected_path: new_prison_prisoner_case_information_path(prison_code, prisoner_id),
+                                   show_tier: true, show_rosh_level: true, show_enhanced_resourcing: true)
     expect(page).to have_current_path(expected_path, ignore_query: true)
     expect(page).to have_content('Add missing details for')
-    expect(page).to have_content('What is this person’s tier?')
+    expect(page).to(show_tier ? have_content('What is this person’s tier?') : have_no_content('What is this person’s tier?'))
+    expect(page).to(show_rosh_level ? have_content('What is this person’s ROSH?') : have_no_content('What is this person’s ROSH?'))
+    expect(page).to(show_enhanced_resourcing ? have_content('What case allocation decision has been made for this person?') : have_no_content('What case allocation decision has been made for this person?'))
   end
 
-  def fill_in_case_information(resourcing:, tier:)
-    find("label[for=case-information-enhanced-resourcing-#{resourcing}-field]").click
-    find("label[for=case-information-tier-#{tier.downcase}-field]").click
+  def fill_in_case_information(resourcing: nil, tier: nil, rosh_level: nil)
+    find("label[for=case-information-tier-#{tier.downcase}-field]", visible: :all).click if tier.present?
+    find("label[for=case-information-rosh-level-#{rosh_level.downcase.tr('_', '-')}-field]", visible: :all).click if rosh_level.present?
+    find("label[for=case-information-enhanced-resourcing-#{resourcing}-field]", visible: :all).click if resourcing.present?
   end
 end

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "allocations/show", type: :view do
                     date_of_birth: Faker::Date.backward,
                     category_label: 'X',
                     tier: 'A',
+                    rosh_level: 'HIGH',
                     manual_entry?: false,
                     handover_start_date: nil,
                     handover_date: nil,
@@ -27,6 +28,7 @@ RSpec.describe "allocations/show", type: :view do
   end
 
   let(:page) { Nokogiri::HTML(rendered) }
+  let(:rosh_level_feature_enabled) { true }
 
   before do
     assign(:prison, prison)
@@ -41,6 +43,7 @@ RSpec.describe "allocations/show", type: :view do
 
     allow(view).to receive(:vlo_tag).and_return('')
     allow(view).to receive(:prisoner_location).and_return('')
+    stub_rosh_level_feature(enabled: rosh_level_feature_enabled)
     assign(:prisoner, offender)
   end
 
@@ -75,6 +78,39 @@ RSpec.describe "allocations/show", type: :view do
 
     it 'shows Previous Parole section' do
       expect(page).to have_css('.govuk-table__header', text: 'Previous parole applications')
+    end
+  end
+
+  describe 'At a glance rows' do
+    before do
+      stub_template 'shared/_vlo_information.html.erb' => ''
+    end
+
+    it 'shows the rosh row' do
+      render
+
+      expect(page.at_css('tr#rosh-row')).to have_text('ROSH')
+      expect(page.at_css('tr#rosh-row')).to have_text('High')
+    end
+
+    it 'links the rosh change action to missing details when the feature flag is enabled and case information is editable' do
+      allow(offender).to receive(:manual_entry?).and_return(true)
+
+      render
+
+      expect(page.at_css('tr#rosh-row')).to have_css("a[href='#{edit_prison_prisoner_case_information_path(prison.code, offender.offender_no, from: :allocation)}']", text: 'Change')
+    end
+
+    context 'when the rosh feature flag is disabled' do
+      let(:rosh_level_feature_enabled) { false }
+
+      it 'does not show the rosh change link' do
+        allow(offender).to receive(:manual_entry?).and_return(true)
+
+        render
+
+        expect(page.at_css('tr#rosh-row')).not_to have_css("a[href='#{edit_prison_prisoner_case_information_path(prison.code, offender.offender_no, from: :allocation)}']")
+      end
     end
   end
 

--- a/spec/views/prisoners/review_case_details.html.erb_spec.rb
+++ b/spec/views/prisoners/review_case_details.html.erb_spec.rb
@@ -15,10 +15,16 @@ RSpec.describe "prisoners/review_case_details", type: :view do
   let(:contacts_table) { page.all('table.govuk-table').last }
   let(:vlo_row) { contacts_table.find('tr', text: 'Victim liaison officer (VLO)') }
   let(:vlo_cells) { vlo_row.all('td') }
-  let(:case_info) { build(:case_information) }
+  let(:at_a_glance_summary) { page.all('dl.govuk-summary-list').first }
+  let(:case_info) { build(:case_information, rosh_level: 'HIGH') }
   let(:prison) { build(:prison) }
   let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
   let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_a)) }
+  let(:rosh_level_feature_enabled) { true }
+
+  before do
+    stub_rosh_level_feature(enabled: rosh_level_feature_enabled)
+  end
 
   describe 'Sentence and offence section' do
     before { render }
@@ -31,6 +37,33 @@ RSpec.describe "prisoners/review_case_details", type: :view do
 
         expect(row).to have_css('td', count: 2)
         expect(row).to have_css('td[colspan="2"]', count: 1)
+      end
+    end
+  end
+
+  describe 'At a glance section' do
+    before { render }
+
+    it 'shows the rosh row' do
+      row = at_a_glance_summary.find('#rosh-row')
+
+      expect(row).to have_text('ROSH')
+      expect(row).to have_text('High')
+    end
+
+    it 'shows the rosh change link when the feature flag is enabled and the case information is editable' do
+      row = at_a_glance_summary.find('#rosh-row')
+
+      expect(row).to have_link('Change', href: edit_prison_prisoner_case_information_path(prison, offender.offender_no, from: :review_case))
+    end
+
+    context 'when the rosh feature flag is disabled' do
+      let(:rosh_level_feature_enabled) { false }
+
+      it 'does not show the rosh change link' do
+        row = at_a_glance_summary.find('#rosh-row')
+
+        expect(row).not_to have_link('Change', href: edit_prison_prisoner_case_information_path(prison, offender.offender_no, from: :review_case))
       end
     end
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1941

Continuation of the previous PR #2798.

Adds the rosh level radio buttons to the missing info page, to add rosh if missing, or to edit a manually entered previous one (through links added to the review case and allocation page).

Changed logic so a case is considered allocatable only when having tier and rosh present.

The rosh radios/links and case completeness are behind feature flag for now, which makes some code annoying.