### PR TITLE
Remove noisy tier handler log trace

### DIFF
--- a/app/lib/domain_events/handlers/tier_change_handler.rb
+++ b/app/lib/domain_events/handlers/tier_change_handler.rb
@@ -3,14 +3,9 @@ module DomainEvents
     class TierChangeHandler
       def handle(event, logger: Shoryuken::Logging.logger)
         logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},crn=#{event.crn_number}"
-        case_info = CaseInformation.find_by_crn(event.crn_number)
 
-        if case_info.nil?
-          logger.error "event=domain_event_handle_failure,domain_event_type=#{event.event_type}," \
-            "crn=#{event.crn_number}|Case information not found for this CRN"
-
-          return
-        end
+        case_info = CaseInformation.find_by(crn: event.crn_number)
+        return if case_info.nil?
 
         api_tier_info = HmppsApi::TieringApi.get_calculation(
           event.crn_number, event.additional_information['calculationId']

--- a/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
@@ -72,14 +72,6 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
     end
   end
 
-  context 'when local case information not found' do
-    before { handler.handle(event) }
-
-    it 'emits a log error message' do
-      expect(Shoryuken::Logging.logger).to have_received(:error).once
-    end
-  end
-
   context 'when tiering API returns an error' do
     let!(:case_information) { create(:case_information, crn: crn, tier: 'A') }
     let(:tier_from_api) { nil }


### PR DESCRIPTION
As part of the normal day to day we receive many tiering calculation events for cases that are not in our system (i.e. not OMiC eligible, etc.).

An error level trace was polluting the logs for something we don't have control or care about. Removed this logging.