### PR TITLE
Cleanup legacy code / small refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@
 - Background processing is separate locally: start Sidekiq with `bundle exec sidekiq -C config/sidekiq.yml` and Shoryuken with `bin/rake shoryuken:start` when testing domain events.
 - Local AWS/event testing uses Localstack and the SNS/SQS setup documented in `README.md`; the important env vars are `LOCALSTACK_URL`, `DOMAIN_EVENTS_TOPIC_ARN`, and `DOMAIN_EVENTS_SQS_QUEUE_NAME`.
 - For Delius/LDU work, `bundle exec rake import:local_delivery_units:dry_run` previews the Mailbox Register sync and `bundle exec rake import:local_delivery_units:process` persists it (`lib/tasks/import_local_delivery_units.rake`).
-- Main test command is `bundle exec rspec`. Feature specs expect Firefox + geckodriver. Tests run jobs inline, block external HTTP with WebMock, stub DPS header/footer by default, and commonly stub event publication unless metadata opts back in; check `spec/rails_helper.rb` for useful metadata hooks like `:queueing`, `:enable_allocation_change_publish`, `:skip_dps_header_footer_stubbing`, and `:skip_active_caseload_check_stubbing`.
+- Main test command is `bundle exec rspec`. Feature specs expect Firefox + geckodriver. Tests run jobs inline, block external HTTP with WebMock, stub DPS header/footer by default, and commonly stub event publication unless metadata opts back in; check `spec/rails_helper.rb` for useful metadata hooks like `:queueing`, `:enable_domain_event_publish`, `:skip_dps_header_footer_stubbing`, and `:skip_active_caseload_check_stubbing`.
 - For local linting, prefer `bin/rubocop` over `bundle exec rubocop`; the wrapper uses RuboCop server mode to reduce repeated startup time.
 - API docs are generated with rswag; see request/API specs under `spec/api` and browse locally at `/api-docs`.
 

--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -45,7 +45,6 @@ private
           tags: %w[job recalculate_handover_date handover changed],
           system_event: true,
           data: {
-            'case_info_manual_entry' => case_info.manual_entry?,
             'before' => handover_before,
             'after' => handover_after,
             'nomis_offender_state' => nomis_offender.attributes_to_archive,
@@ -53,15 +52,13 @@ private
         )
       end
 
-      # Don't push if the CaseInformation record is a manual entry (meaning it didn't match against nDelius)
-      # This avoids 404 Not Found errors for offenders who don't exist in nDelius (they could be Scottish, etc.)
-      push_to_delius record unless case_info.manual_entry?
+      publish_event(record)
 
       request_supporting_com record, nomis_offender
     end
   end
 
-  def push_to_delius(record)
+  def publish_event(record)
     # Don't push if the dates haven't changed
     if record.saved_change_to_start_date? || record.saved_change_to_handover_date?
       event = DomainEvents::EventFactory.build_handover_event(host: Rails.configuration.allocation_manager_host,

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe AllocationsController, type: :controller do
         end
       end
 
-      context 'when COM name has been updated by nDelius', :disable_push_to_delius do
+      context 'when COM name has been updated by nDelius' do
         let(:create_time) { 3.days.ago }
         let(:create_date) { create_time.to_date }
         let(:yesterday) { 1.day.ago.to_date }

--- a/spec/controllers/case_information_controller_spec.rb
+++ b/spec/controllers/case_information_controller_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe CaseInformationController, type: :controller do
       let!(:case_information) do
         create(:case_information,
                offender: offender_record,
-               manual_entry: false,
                tier: 'B',
                rosh_level: 'LOW',
                enhanced_resourcing: false)
@@ -94,7 +93,6 @@ RSpec.describe CaseInformationController, type: :controller do
         let!(:case_information) do
           create(:case_information,
                  offender: offender_record,
-                 manual_entry: false,
                  tier: 'B',
                  rosh_level: nil,
                  enhanced_resourcing: false)
@@ -125,7 +123,6 @@ RSpec.describe CaseInformationController, type: :controller do
           let!(:case_information) do
             create(:case_information,
                    offender: offender_record,
-                   manual_entry: false,
                    tier: 'B',
                    rosh_level: 'HIGH',
                    enhanced_resourcing: nil)
@@ -157,7 +154,6 @@ RSpec.describe CaseInformationController, type: :controller do
           let!(:case_information) do
             create(:case_information,
                    offender: offender_record,
-                   manual_entry: false,
                    tier: 'B',
                    rosh_level: nil,
                    enhanced_resourcing: nil)
@@ -186,9 +182,8 @@ RSpec.describe CaseInformationController, type: :controller do
 
       context 'when some fields are still missing on a manual entry record' do
         let!(:case_information) do
-          create(:case_information,
+          create(:case_information, :manual_entry,
                  offender: offender_record,
-                 manual_entry: true,
                  tier: 'B',
                  rosh_level: nil,
                  enhanced_resourcing: false)
@@ -235,7 +230,6 @@ RSpec.describe CaseInformationController, type: :controller do
       before do
         create(:case_information,
                offender: offender_record,
-               manual_entry: false,
                tier: 'A',
                rosh_level: 'HIGH',
                enhanced_resourcing: false)
@@ -298,9 +292,8 @@ RSpec.describe CaseInformationController, type: :controller do
   describe '#update' do
     context 'when case information is a manual entry' do
       let!(:case_information) do
-        create(:case_information,
+        create(:case_information, :manual_entry,
                offender: offender_record,
-               manual_entry: true,
                tier: 'B',
                rosh_level: 'LOW',
                enhanced_resourcing: false)
@@ -366,7 +359,6 @@ RSpec.describe CaseInformationController, type: :controller do
       let!(:case_information) do
         create(:case_information,
                offender: offender_record,
-               manual_entry: false,
                tier: 'B',
                rosh_level: 'LOW',
                enhanced_resourcing: false)

--- a/spec/factories/case_information.rb
+++ b/spec/factories/case_information.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     rosh_level { 'HIGH' }
     rosh_start_date { Date.new(2025, 6, 1) }
 
-    manual_entry { true }
+    manual_entry { false }
 
     crn { Faker::Alphanumeric.alpha(number: 10) }
 
@@ -22,6 +22,10 @@ FactoryBot.define do
 
     trait :english do
       probation_service { 'England' }
+    end
+
+    trait :manual_entry do
+      manual_entry { true }
     end
 
     trait :with_com do

--- a/spec/features/case_information_feature_spec.rb
+++ b/spec/features/case_information_feature_spec.rb
@@ -36,7 +36,7 @@ describe 'case information feature' do
 
     context 'when updating missing information (edit journey)' do
       before do
-        create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)))
+        create(:case_information, :manual_entry, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)))
       end
 
       it 'no longer displays the save and allocate button' do
@@ -77,7 +77,6 @@ describe 'case information feature' do
       before do
         create(:case_information,
                offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)),
-               manual_entry: false,
                tier: 'A',
                rosh_level: nil,
                enhanced_resourcing: false)
@@ -136,7 +135,7 @@ describe 'case information feature' do
 
     context 'when trying to edit a non manual entry' do
       before do
-        create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)), manual_entry: false)
+        create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)))
       end
 
       it 'does not allow the user to edit the case information' do

--- a/spec/features/delius_import_feature_spec.rb
+++ b/spec/features/delius_import_feature_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Delius import feature", :disable_push_to_delius do
+RSpec.feature "Delius import feature" do
   let(:offender_no) {  offender.fetch(:prisonerNumber) }
   let(:prison) { create(:prison) }
   let(:prison_code) { prison.code }

--- a/spec/features/update_case_information_spec.rb
+++ b/spec/features/update_case_information_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Update case information", type: :feature do
 
   context 'when there is a new allocation' do
     before do
-      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no), rosh_level: 'HIGH')
+      create(:case_information, :manual_entry, offender: build(:offender, nomis_offender_id: offender_no), rosh_level: 'HIGH')
     end
 
     it 'returns to review case details after updating from review case details' do
@@ -38,7 +38,7 @@ RSpec.feature "Update case information", type: :feature do
   context 'when there is an existing allocation' do
     before do
       create(:allocation_history, nomis_offender_id: offender_no, primary_pom_nomis_id: pom.staff_id,  prison: prison.code)
-      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no), rosh_level: 'HIGH')
+      create(:case_information, :manual_entry, offender: build(:offender, nomis_offender_id: offender_no), rosh_level: 'HIGH')
     end
 
     it 'returns to allocation information after updating from allocation information' do
@@ -57,7 +57,7 @@ RSpec.feature "Update case information", type: :feature do
   context 'when the update is invalid' do
     before do
       create(:allocation_history, nomis_offender_id: offender_no, primary_pom_nomis_id: pom.staff_id,  prison: prison.code)
-      create(:case_information,
+      create(:case_information, :manual_entry,
              offender: build(:offender, nomis_offender_id: offender_no),
              tier: 'B',
              rosh_level: 'HIGH',

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -117,7 +117,6 @@ describe RecalculateHandoverDateJob do
     end
   end
 
-
   context 'when responsibility changes from POM only to POM with COM support (ISPs)' do
     before do
       the_responsibility_is_recorded_as(CalculatedHandoverDate.pom_only(reason: :indeterminate))

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -1,7 +1,7 @@
 describe RecalculateHandoverDateJob do
   subject(:offender) { new_mpc_offender 'G1234AB' }
 
-  let(:ndelius_event) { double(:ndelius_event) }
+  let(:handover_event) { double(:handover_event) }
   let(:handover_change_event) { double(:handover_change_event) }
   let(:request_supporting_com_email) { double(:request_supporting_com_email).as_null_object }
   let(:assign_com_email) { double(:assign_com_email).as_null_object }
@@ -47,9 +47,9 @@ describe RecalculateHandoverDateJob do
       expect(handover_change_event).not_to have_received(:publish)
     end
 
-    it 'does not emit an event to NDelius' do
+    it 'does not emit a handover event' do
       recalculate_handover_dates
-      expect(ndelius_event).not_to have_received(:publish)
+      expect(handover_event).not_to have_received(:publish)
     end
   end
 
@@ -97,7 +97,6 @@ describe RecalculateHandoverDateJob do
               'last_calculated_at' => be_within(1.second).of(Time.zone.now),
               'nomis_offender_id' => offender.nomis_offender_id,
             },
-            'case_info_manual_entry' => false,
             'nomis_offender_state' => offender.attributes_to_archive
           }
         }
@@ -112,24 +111,12 @@ describe RecalculateHandoverDateJob do
       the_responsibility_will_be_calculated_as(CalculatedHandoverDate.pom_with_com(reason: :determinate_short, handover_date: 2.days.from_now))
     end
 
-    context 'when the case information comes from nDelius' do
-      before { the_case_information_is manual_entry: false }
-
-      it 'emits an event to nDelius to inform it of a new handover date' do
-        expect(ndelius_event).to receive(:publish).with(job: 'recalculate_handover_date')
-        recalculate_handover_dates
-      end
-    end
-
-    context 'when the case information is manually entered' do
-      before { the_case_information_is manual_entry: true }
-
-      it 'does not emit an event to nDelius' do
-        recalculate_handover_dates
-        expect(ndelius_event).not_to have_received(:publish)
-      end
+    it 'emits a handover event' do
+      expect(handover_event).to receive(:publish).with(job: 'recalculate_handover_date')
+      recalculate_handover_dates
     end
   end
+
 
   context 'when responsibility changes from POM only to POM with COM support (ISPs)' do
     before do
@@ -223,7 +210,7 @@ describe RecalculateHandoverDateJob do
 
     it 'does not emit any events' do
       recalculate_handover_dates
-      expect(ndelius_event).not_to have_received(:publish)
+      expect(handover_event).not_to have_received(:publish)
       expect(handover_change_event).not_to have_received(:publish)
     end
 
@@ -275,10 +262,10 @@ describe RecalculateHandoverDateJob do
       .with(offender.nomis_offender_id)
       .and_return(offender)
 
-    # Publish to NDelius event
-    allow(ndelius_event).to receive(:publish)
+    # Handover event
+    allow(handover_event).to receive(:publish)
     allow(DomainEvents::EventFactory).to receive(:build_handover_event)
-      .and_return(ndelius_event)
+      .and_return(handover_event)
 
     # Audit Event
     stub_const('AuditEvent', handover_change_event)

--- a/spec/lib/domain_events/event_spec.rb
+++ b/spec/lib/domain_events/event_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DomainEvents::Event do
+RSpec.describe DomainEvents::Event, :enable_domain_event_publish do
   subject(:basic_event) { described_class.new(event_type: 'test-domain.changed', version: 77) }
 
   let(:full_event) do

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe AllocationHistory, :enable_allocation_change_publish, type: :model do
+RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
   let(:nomis_staff_id) { 456_789 }
   let(:nomis_offender_id) { 'A3434LK' }
   let(:another_nomis_offender_id) { 654_321 }

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CalculatedHandoverDate, :disable_push_to_delius do
+RSpec.describe CalculatedHandoverDate do
   subject { build(:calculated_handover_date) }
 
   let(:today) { Time.zone.today }

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -101,7 +101,7 @@ describe CaseInformation do
 
   context 'without manual flag' do
     it 'will be valid' do
-      expect(build(:case_information, manual_entry: false)).to be_valid
+      expect(build(:case_information)).to be_valid
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,11 +50,6 @@ RSpec.configure do |config|
     page.driver.browser.manage.window.resize_to(1280,3072)
   end
 
-  config.before(:each, :disable_push_to_delius) do
-    # Stub the publishing handover.changed domain events. Useful when running ProcessDeliusDataJob, which attempts
-    # to push to the Community API when it recalculates handover dates
-    allow_any_instance_of(DomainEvents::Event).to receive(:publish)
-  end
 
   config.before(:each, :disable_early_allocation_event) do
     allow(EarlyAllocationService).to receive(:send_early_allocation)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,7 +50,6 @@ RSpec.configure do |config|
     page.driver.browser.manage.window.resize_to(1280,3072)
   end
 
-
   config.before(:each, :disable_early_allocation_event) do
     allow(EarlyAllocationService).to receive(:send_early_allocation)
   end
@@ -109,8 +108,8 @@ RSpec.configure do |config|
       stub_dps_header_footer
     end
 
-    if example.metadata[:enable_allocation_change_publish].blank?
-      allow_any_instance_of(AllocationHistory).to receive(:publish_allocation_changed_event)
+    if example.metadata[:enable_domain_event_publish].blank?
+      allow_any_instance_of(DomainEvents::Event).to receive(:publish)
     end
 
     if example.metadata[:skip_active_caseload_check_stubbing].blank?

--- a/spec/services/delius_data_import_service_spec.rb
+++ b/spec/services/delius_data_import_service_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe DeliusDataImportService do
   end
 
   context 'when case information already present' do
-    let!(:c1) { create(:case_information, tier: 'B', offender: build(:offender, nomis_offender_id: nomis_offender_id)) }
+    let!(:c1) { create(:case_information, :manual_entry, tier: 'B', offender: build(:offender, nomis_offender_id: nomis_offender_id)) }
     let(:tier) { 'C' }
 
     it 'does not create case information' do
@@ -250,9 +250,8 @@ RSpec.describe DeliusDataImportService do
 
     context 'when the existing rosh level is already present' do
       let!(:c1) do
-        create(:case_information,
+        create(:case_information, :manual_entry,
                offender: build(:offender, nomis_offender_id: nomis_offender_id),
-               manual_entry: true,
                tier: 'B',
                rosh_level: 'LOW')
       end

--- a/spec/services/delius_data_import_service_spec.rb
+++ b/spec/services/delius_data_import_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe DeliusDataImportService, :disable_push_to_delius do
+RSpec.describe DeliusDataImportService do
   subject(:service) { described_class.new }
 
   let(:nomis_offender_id) { 'G4281GV' }

--- a/spec/services/sar_offender_data_service_spec.rb
+++ b/spec/services/sar_offender_data_service_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe SarOffenderDataService do
           end
 
           it 'returns booleans' do
-            expect(case_information['manualEntry']).to eq(true)
+            expect(case_information['manualEntry']).to eq(false)
             expect(case_information['enhancedResourcing']).to eq(false)
           end
 

--- a/spec/support/helpers/scenario_setup_helper/mpc_offender_setup.rb
+++ b/spec/support/helpers/scenario_setup_helper/mpc_offender_setup.rb
@@ -5,7 +5,7 @@ module ScenarioSetupHelper
         .new(offender: create(:offender, nomis_offender_id:),
              prison: create(:prison, code: prison_code),
              prison_record: build(:hmpps_api_offender, prisonerNumber: nomis_offender_id))
-        .tap { create(:case_information, nomis_offender_id:, manual_entry: false) }
+        .tap { create(:case_information, nomis_offender_id:) }
     end
   end
 end

--- a/spec/views/prisoners/review_case_details.html.erb_spec.rb
+++ b/spec/views/prisoners/review_case_details.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "prisoners/review_case_details", type: :view do
   let(:vlo_row) { contacts_table.find('tr', text: 'Victim liaison officer (VLO)') }
   let(:vlo_cells) { vlo_row.all('td') }
   let(:at_a_glance_summary) { page.all('dl.govuk-summary-list').first }
-  let(:case_info) { build(:case_information, rosh_level: 'HIGH') }
+  let(:case_info) { build(:case_information, :manual_entry, rosh_level: 'HIGH') }
   let(:prison) { build(:prison) }
   let(:offender) { build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender) }
   let(:api_offender) { build(:hmpps_api_offender, category: build(:offender_category, :cat_a)) }


### PR DESCRIPTION
Cleanup or rename code related to legacy push to Delius (service used to have an API to directly write to nDelius handover dates). We don't do that anymore and instead we publish an event for consumers to deal with.

Changed default value for "manual entry" in the case information factory and update tests accordingly.