### PR TITLE
Improve missing complexity level action buttons

### DIFF
--- a/app/controllers/female_missing_infos_controller.rb
+++ b/app/controllers/female_missing_infos_controller.rb
@@ -21,7 +21,9 @@ class FemaleMissingInfosController < PrisonsApplicationController
         @missing_info.nomis_offender_id, level: @missing_info.complexity_level, username: current_user, reason: nil
       )
 
-      if @next_step_required
+      if save_and_return?
+        redirect_to missing_information_prison_prisoners_path(active_prison_id, sort: params[:sort], page: params[:page])
+      elsif @next_step_required
         session[complexity_saved_session_key] = true
         redirect_to next_step_path
       else
@@ -60,6 +62,10 @@ private
 
   def step_params
     params.fetch(:complexity_form, {}).permit(:complexity_level)
+  end
+
+  def save_and_return?
+    params[:save_and_continue].blank? && params[:save_and_allocate].blank?
   end
 
   def ensure_womens_prison

--- a/app/views/female_missing_infos/_complexity_level_form.html.erb
+++ b/app/views/female_missing_infos/_complexity_level_form.html.erb
@@ -25,10 +25,11 @@
       ) %>
 
   <div class="govuk-button-group">
-    <%= form.submit @next_step_required ? "Save and continue" : "Save and allocate",
-                    role: "button",
-                    draggable: "false",
-                    class: "govuk-button",
-                    data: { module: 'govuk-button' } %>
+    <% if @next_step_required %>
+      <%= form.submit "Save and continue", class: "govuk-button", name: "save_and_continue", data: { module: 'govuk-button' } %>
+    <% else %>
+      <%= form.submit "Save", class: "govuk-button", data: { module: 'govuk-button' } %>
+      <%= form.submit "Save and allocate", class: "govuk-button govuk-button--secondary", name: "save_and_allocate", data: { module: 'govuk-button' } %>
+    <% end %>
   </div>
 <% end %>

--- a/spec/controllers/female_missing_infos_controller_spec.rb
+++ b/spec/controllers/female_missing_infos_controller_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe FemaleMissingInfosController, type: :controller do
           prison_id: prison.code,
           prisoner_id: offender_no,
           complexity_form: { complexity_level: 'low' },
+          save_and_continue: 'Save and continue',
           sort: 'last_name',
           page: '2'
         }
@@ -65,21 +66,46 @@ RSpec.describe FemaleMissingInfosController, type: :controller do
         create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
       end
 
-      it 'redirects to review case details after saving complexity' do
-        put :update, params: {
-          prison_id: prison.code,
-          prisoner_id: offender_no,
-          complexity_form: { complexity_level: 'medium' }
-        }
+      context 'when save and allocate is clicked' do
+        it 'redirects to review case details after saving complexity' do
+          put :update, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            complexity_form: { complexity_level: 'medium' },
+            save_and_allocate: 'Save and allocate'
+          }
 
-        aggregate_failures do
-          expect(HmppsApi::ComplexityApi).to have_received(:save).with(
-            offender_no,
-            level: 'medium',
-            username: 'user',
-            reason: nil
-          )
-          expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+          aggregate_failures do
+            expect(HmppsApi::ComplexityApi).to have_received(:save).with(
+              offender_no,
+              level: 'medium',
+              username: 'user',
+              reason: nil
+            )
+            expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+          end
+        end
+      end
+
+      context 'when save is clicked' do
+        it 'saves complexity and redirects to missing information list' do
+          put :update, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            complexity_form: { complexity_level: 'medium' },
+            sort: 'last_name',
+            page: '2'
+          }
+
+          aggregate_failures do
+            expect(HmppsApi::ComplexityApi).to have_received(:save).with(
+              offender_no,
+              level: 'medium',
+              username: 'user',
+              reason: nil
+            )
+            expect(response).to redirect_to(missing_information_prison_prisoners_path(prison.code, sort: 'last_name', page: '2'))
+          end
         end
       end
     end
@@ -94,33 +120,13 @@ RSpec.describe FemaleMissingInfosController, type: :controller do
                enhanced_resourcing: false)
       end
 
-      it 'redirects to case information after saving complexity' do
-        put :update, params: {
-          prison_id: prison.code,
-          prisoner_id: offender_no,
-          complexity_form: { complexity_level: 'medium' }
-        }
-
-        aggregate_failures do
-          expect(HmppsApi::ComplexityApi).to have_received(:save).with(
-            offender_no,
-            level: 'medium',
-            username: 'user',
-            reason: nil
-          )
-          expect(session["female_missing_info_complexity_saved_#{offender_no}"]).to eq(true)
-          expect(response).to redirect_to(new_prison_prisoner_case_information_path(prison.code, prisoner_id: offender_no, sort: nil, page: nil))
-        end
-      end
-
-      context 'when the rosh feature flag is disabled' do
-        let(:rosh_level_feature_enabled) { false }
-
-        it 'redirects to review case details after saving complexity' do
+      context 'when save and continue is clicked' do
+        it 'redirects to case information after saving complexity' do
           put :update, params: {
             prison_id: prison.code,
             prisoner_id: offender_no,
-            complexity_form: { complexity_level: 'medium' }
+            complexity_form: { complexity_level: 'medium' },
+            save_and_continue: 'Save and continue'
           }
 
           aggregate_failures do
@@ -130,7 +136,53 @@ RSpec.describe FemaleMissingInfosController, type: :controller do
               username: 'user',
               reason: nil
             )
-            expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+            expect(session["female_missing_info_complexity_saved_#{offender_no}"]).to eq(true)
+            expect(response).to redirect_to(new_prison_prisoner_case_information_path(prison.code, prisoner_id: offender_no, sort: nil, page: nil))
+          end
+        end
+      end
+
+      context 'when the rosh feature flag is disabled' do
+        let(:rosh_level_feature_enabled) { false }
+
+        context 'when save and allocate is clicked' do
+          it 'redirects to review case details after saving complexity' do
+            put :update, params: {
+              prison_id: prison.code,
+              prisoner_id: offender_no,
+              complexity_form: { complexity_level: 'medium' },
+              save_and_allocate: 'Save and allocate'
+            }
+
+            aggregate_failures do
+              expect(HmppsApi::ComplexityApi).to have_received(:save).with(
+                offender_no,
+                level: 'medium',
+                username: 'user',
+                reason: nil
+              )
+              expect(response).to redirect_to(prison_prisoner_review_case_details_path(prison_id: prison.code, prisoner_id: offender_no))
+            end
+          end
+        end
+
+        context 'when save is clicked' do
+          it 'saves complexity and redirects to missing information list' do
+            put :update, params: {
+              prison_id: prison.code,
+              prisoner_id: offender_no,
+              complexity_form: { complexity_level: 'medium' }
+            }
+
+            aggregate_failures do
+              expect(HmppsApi::ComplexityApi).to have_received(:save).with(
+                offender_no,
+                level: 'medium',
+                username: 'user',
+                reason: nil
+              )
+              expect(response).to redirect_to(missing_information_prison_prisoners_path(prison.code, sort: nil, page: nil))
+            end
           end
         end
       end


### PR DESCRIPTION
Some improvements to the buttons:

- when case info is incomplete: single primary button "Save and continue".

- when case info is complete: two buttons. Primary "Save" (returns to missing information list) and secondary "Save and allocate" (goes to review/allocation page).