### PR TITLE
Guard against nil allocated complexity levels

### DIFF
--- a/app/models/concerns/sortable_allocation.rb
+++ b/app/models/concerns/sortable_allocation.rb
@@ -18,7 +18,7 @@ module SortableAllocation
   end
 
   def complexity_level_number
-    ComplexityLevelHelper::COMPLEXITIES.fetch(complexity_level)
+    ComplexityLevelHelper::COMPLEXITIES.fetch(complexity_level, 0)
   end
 
   def high_complexity?

--- a/app/views/caseload_global/_caseload.html.erb
+++ b/app/views/caseload_global/_caseload.html.erb
@@ -15,7 +15,7 @@
   </td>
   <% if @prison.womens? %>
     <td aria-label="Complexity Level" class="govuk-table__cell">
-      <%= caseload.complexity_level.titleize %>
+      <%= caseload.complexity_level&.titleize %>
     </td>
   <% end %>
   <td aria-label="Earliest release date" class="govuk-table__cell ">

--- a/app/views/shared/_caseload_homd.html.erb
+++ b/app/views/shared/_caseload_homd.html.erb
@@ -14,7 +14,7 @@
   </td>
   <% if @prison.womens? %>
     <td aria-label="Complexity Level" class="govuk-table__cell">
-      <%= caseload_homd.complexity_level.titleize %>
+      <%= caseload_homd.complexity_level&.titleize %>
     </td>
   <% end %>
   <td aria-label="Earliest release date" class="govuk-table__cell ">

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -26,7 +26,13 @@ if sentry_dsn
 
     config.before_send = lambda do |event, hint|
       return nil if hint[:exception]&.full_message&.match?(/ApplicationInsights::TelemetryClient/)
-      return nil unless SentryCircuitBreakerService.check_within_quota
+
+      begin
+        return nil unless SentryCircuitBreakerService.check_within_quota
+      rescue StandardError => e
+        Rails.logger.warn("event=sentry_circuit_breaker_error|#{e.message}")
+        # Allow the event through if the circuit breaker check fails
+      end
 
       # Sanitize extra data
       if event.extra

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,10 +8,20 @@ if sentry_dsn
     config.dsn = sentry_dsn
     config.release = ENV['BUILD_NUMBER']
     config.enable_metrics = false
+    config.rails.report_rescued_exceptions = true
 
     config.excluded_exceptions += %w[
       JWT::ExpiredSignature
+      JWT::VerificationError
+      HmppsApi::Error::Unauthorized
       ProcessDeliusDataJob::ImportTransientError
+      ActiveRecord::RecordNotFound
+      ActionController::RoutingError
+      ActionController::UnknownFormat
+      ActionController::InvalidAuthenticityToken
+      ActionController::BadRequest
+      Faraday::ConnectionFailed
+      Faraday::TimeoutError
     ]
 
     config.before_send = lambda do |event, hint|

--- a/spec/models/concerns/sortable_allocation_spec.rb
+++ b/spec/models/concerns/sortable_allocation_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SortableAllocation do
+  let(:test_class) do
+    Class.new do
+      include SortableAllocation
+
+      def initialize(offender)
+        @offender = offender
+      end
+    end
+  end
+
+  let(:offender) { double(:offender, complexity_level:) }
+  let(:instance) { test_class.new(offender) }
+
+  describe '#complexity_level_number' do
+    context 'when complexity_level is nil' do
+      let(:complexity_level) { nil }
+
+      it 'returns 0' do
+        expect(instance.complexity_level_number).to eq(0)
+      end
+    end
+
+    context 'when complexity_level is low' do
+      let(:complexity_level) { 'low' }
+
+      it 'returns 1' do
+        expect(instance.complexity_level_number).to eq(1)
+      end
+    end
+
+    context 'when complexity_level is medium' do
+      let(:complexity_level) { 'medium' }
+
+      it 'returns 2' do
+        expect(instance.complexity_level_number).to eq(2)
+      end
+    end
+
+    context 'when complexity_level is high' do
+      let(:complexity_level) { 'high' }
+
+      it 'returns 3' do
+        expect(instance.complexity_level_number).to eq(3)
+      end
+    end
+  end
+
+  describe '#high_complexity?' do
+    context 'when complexity_level is nil' do
+      let(:complexity_level) { nil }
+
+      it 'returns false' do
+        expect(instance.high_complexity?).to be(false)
+      end
+    end
+
+    context 'when complexity_level is high' do
+      let(:complexity_level) { 'high' }
+
+      it 'returns true' do
+        expect(instance.high_complexity?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This came out a few times in the logs but was being swallowed by the exception handler and not pushed to Sentry.

There are genuine occasions where an allocated case inactivates their CNL at a later point, so we guard against this, allowing sorting, and not blowing up the view.

I've made the sentry config more strict and should report more exceptions than before but updated the filter to not be overwhelming, we need to observe and iterate if needed.