### PR TITLE
Further sentry error handling tweaks

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -34,19 +34,25 @@ if sentry_dsn
         # Allow the event through if the circuit breaker check fails
       end
 
-      # Sanitize extra data
-      if event.extra
-        event.extra = param_filter.filter(event.extra)
-      end
+      begin
+        # Sanitize extra data
+        if event.extra
+          event.extra = param_filter.filter(event.extra)
+        end
 
-      # Sanitize user data
-      if event.user
-        event.user = param_filter.filter(event.user)
-      end
+        # Sanitize user data
+        if event.user
+          event.user = param_filter.filter(event.user)
+        end
 
-      # Sanitize context data
-      if event.contexts
-        event.contexts = param_filter.filter(event.contexts)
+        # Sanitize context data
+        if event.contexts
+          event.contexts = param_filter.filter(event.contexts)
+        end
+      rescue StandardError => e
+        Rails.logger.warn(
+          "event=sentry_sanitization_error|original_exception_class=#{hint[:exception]&.class}|#{e.message}"
+        )
       end
 
       # Return the sanitized event object

--- a/spec/initializers/sentry_initializer_spec.rb
+++ b/spec/initializers/sentry_initializer_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'Sentry initializer' do
+  let(:initializer_path) { Rails.root.join('config/initializers/sentry.rb') }
+  let(:fake_sentry_config_class) do
+    Struct.new(:dsn, :release, :enable_metrics, :before_send, :excluded_exceptions, :rails, keyword_init: true)
+  end
+  let(:fake_event_class) { Struct.new(:extra, :user, :contexts) }
+  let(:rails_config) { double('rails_config', report_rescued_exceptions: nil) }
+  let(:config) { fake_sentry_config_class.new(excluded_exceptions: [], rails: rails_config) }
+  let(:event) do
+    fake_event_class.new(
+      { system_admin_note: 'secret', visible: 'keep me' },
+      { system_admin_note: 'secret', username: 'alice' },
+      { request: { system_admin_note: 'secret', visible: 'keep me' } },
+    )
+  end
+  let(:exception) { StandardError.new("undefined method 'titleize' for nil") }
+
+  before do
+    allow(Rails.configuration).to receive(:sentry_dsn).and_return('https://public@example.com/1')
+    allow(rails_config).to receive(:report_rescued_exceptions=)
+    allow(Sentry).to receive(:init).and_yield(config)
+    allow(SentryCircuitBreakerService).to receive(:check_within_quota).and_return(true)
+  end
+
+  def load_initializer
+    load initializer_path
+  end
+
+  it 'sanitises event payloads before sending them to Sentry' do
+    load_initializer
+
+    expect(config.before_send.call(event, { exception: exception })).to eq(
+      fake_event_class.new(
+        { system_admin_note: '[FILTERED]', visible: 'keep me' },
+        { system_admin_note: '[FILTERED]', username: 'alice' },
+        { request: { system_admin_note: '[FILTERED]', visible: 'keep me' } },
+      )
+    )
+  end
+
+  it 'fails open when payload sanitisation raises an error' do
+    param_filter = instance_double(ActiveSupport::ParameterFilter)
+    allow(param_filter).to receive(:filter).with(event.extra).and_return({ password: '[FILTERED]' })
+    allow(param_filter).to receive(:filter).with(event.user).and_return({ password: '[FILTERED]' })
+    allow(param_filter).to receive(:filter).with(event.contexts).and_raise(NoMethodError, "undefined method 'dig' for Sentry context")
+    allow(ActiveSupport::ParameterFilter).to receive(:new).and_return(param_filter)
+    allow(Rails.logger).to receive(:warn)
+
+    load_initializer
+
+    expect(config.before_send.call(event, { exception: exception })).to be(event)
+    expect(Rails.logger).to have_received(:warn).with(
+      a_string_including(
+        'event=sentry_sanitization_error',
+        'original_exception_class=StandardError',
+        "undefined method 'dig' for Sentry context"
+      )
+    )
+  end
+end


### PR DESCRIPTION
There is a bit of a mystery as some exceptions show up on logs but are not sent to Sentry, so this is for some extra guard in case is dropping events.