### PR TITLE
Further error reporting refactor/modernisation

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  before_action :report_exception, only: :internal_server_error
+
   def not_found
     respond_with_status(:not_found)
   end
@@ -12,6 +14,13 @@ class ErrorsController < ApplicationController
   end
 
 private
+
+  def report_exception
+    exception = request.env['action_dispatch.exception']
+    return unless exception
+
+    Rails.error.report(exception, handled: false, source: 'exceptions_app')
+  end
 
   def respond_with_status(status)
     respond_to do |format|

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -10,8 +10,7 @@ class OnboardingController < PrisonsApplicationController
   before_action :set_pom_details, only: [:position, :working_pattern, :check_answers]
 
   rescue_from StandardError do |e|
-    Rails.logger.error(e)
-    Sentry.capture_exception(e)
+    Rails.error.report(e, severity: :error, source: 'onboarding')
     render :error
   end
 

--- a/app/controllers/reallocations/base_controller.rb
+++ b/app/controllers/reallocations/base_controller.rb
@@ -83,7 +83,7 @@ module Reallocations
         "event=bulk_reallocation_error,prison_id=#{@prison.code},source_pom_id=#{@pom&.staff_id}," \
         "target_pom_id=#{@new_pom&.staff_id},path=#{request.fullpath}|#{error.message}"
       )
-      Sentry.capture_exception(error)
+      Rails.error.report(error, severity: :error, source: 'bulk_reallocation')
       render 'reallocations/error', status: :internal_server_error
     end
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,9 +9,9 @@ class ApplicationMailer < GovukNotifyRails::Mailer
   # are not recoverable so it is not useful to retry failed jobs
   # :nocov:
   rescue_from 'Notifications::Client::BadRequestError' do |ex|
-    Rails.logger.warn("[#{self.class}] #{ex} - #{message.to}")
-    Sentry.capture_exception(
-      ex, contexts: { recipient: { emails: message.to.join(',') } }
+    Rails.logger.error("[#{self.class}] #{ex} - #{message.to}")
+    Rails.error.report(
+      ex, severity: :error, source: 'mailer', context: { recipient: { emails: message.to.join(',') } }
     )
   end
   # :nocov:

--- a/app/services/hmpps_api/oauth/token.rb
+++ b/app/services/hmpps_api/oauth/token.rb
@@ -52,7 +52,6 @@ module HmppsApi
         true
       rescue JWT::DecodeError => e
         Rails.logger.error("event=api_access_blocked|#{e.message}")
-        Sentry.capture_exception(e)
         false
       end
 

--- a/app/services/prison_service.rb
+++ b/app/services/prison_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-PrisonInfo = Struct.new(:code, :name, :country, :gender)
-
 class PrisonService
+  PrisonInfo = Struct.new(:code, :name, :country, :gender)
+
   PRISONS = [
     PrisonInfo.new('ACI', 'Altcourse (HMP)', :england, :male),
     PrisonInfo.new('AGI', 'Askham Grange (HMP/YOI)', :england, :female),

--- a/app/workers/domain_events_consumer.rb
+++ b/app/workers/domain_events_consumer.rb
@@ -37,11 +37,9 @@ class DomainEventsConsumer
       log sqs_msg, 'success', append: "sns_message_id=#{sns_msg['MessageId']},event_type=#{event_type}"
     rescue StandardError => e
       log sqs_msg, 'error', append: "reason=exception|#{e.inspect},#{e.backtrace.join(',')}", brief: true
-      Sentry.capture_exception(e,
-                               tags: {
-                                 domain_event: true,
-                                 domain_event_type: event_type,
-                               })
+      Rails.error.report(
+        e, handled: false, source: 'domain_events_consumer', context: { tags: { domain_event: true, domain_event_type: event_type } }
+      )
       raise
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,13 +89,11 @@ Rails.application.configure do
                            write_timeout: 1.0,
 
                            error_handler: lambda { |method:, returning:, exception:|
-                                            # Report errors to Sentry as warnings
-                                            Sentry.capture_exception exception, level: 'warning',
-                                                                                tags: {
-                                                                                  method: method,
-                                                                                  returning: returning
-                                                                                }
-                                          }
+                             # Report errors to Sentry as warnings
+                             Rails.error.report(
+                               exception, source: 'cache_store', context: { tags: { method:, returning: } }
+                             )
+                           }
                          }
 
     # Store user sessions in the Redis cache

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,7 +8,10 @@ if sentry_dsn
     config.dsn = sentry_dsn
     config.release = ENV['BUILD_NUMBER']
     config.enable_metrics = false
-    config.rails.report_rescued_exceptions = true
+
+    # Opt in to new Rails error reporting API
+    # https://edgeguides.rubyonrails.org/error_reporting.html
+    config.rails.register_error_subscriber = true
 
     config.excluded_exceptions += %w[
       JWT::ExpiredSignature
@@ -61,4 +64,8 @@ if sentry_dsn
   end
 else
   Rails.logger.warn '[WARN] Sentry is not configured (SENTRY_DSN)'
+end
+
+Rails.application.config.after_initialize do
+  Rails.error.subscribe(LoggerErrorSubscriber.new)
 end

--- a/lib/logger_error_subscriber.rb
+++ b/lib/logger_error_subscriber.rb
@@ -1,0 +1,22 @@
+# This subscriber will log exceptions to stdout, when using
+# new Rails error reporting API (i.e. `Rails.error.handle`, etc.)
+#
+class LoggerErrorSubscriber
+  LOG_METHODS = { info: :info, warning: :warn, error: :error }.freeze
+
+  def report(error, handled:, severity:, source:, **)
+    Rails.logger.public_send(
+      LOG_METHODS.fetch(severity, :error),
+      [
+        'event=rails_error_reported',
+        "source=#{source}",
+        "handled=#{handled}",
+        "error_class=#{error.class}",
+        "message=#{error.message}",
+        "first_frame=#{error.backtrace&.first}",
+      ].join(',')
+    )
+  rescue StandardError => e
+    Rails.logger.error("event=rails_error_subscriber_failure|#{e.class}: #{e.message}")
+  end
+end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ErrorsController, type: :controller do
+  describe '#internal_server_error' do
+    let(:exception) { NoMethodError.new("undefined method 'titleize' for nil") }
+
+    before do
+      allow(Rails.error).to receive(:report)
+    end
+
+    it 'captures the original exception from the Rack env' do
+      request.env['action_dispatch.exception'] = exception
+
+      get :internal_server_error
+
+      expect(Rails.error).to have_received(:report).with(
+        exception,
+        handled: false,
+        source: 'exceptions_app'
+      )
+      expect(response).to have_http_status(:internal_server_error)
+    end
+
+    it 'does not capture when there is no original exception in the Rack env' do
+      get :internal_server_error
+
+      expect(Rails.error).not_to have_received(:report)
+      expect(response).to have_http_status(:internal_server_error)
+    end
+  end
+end

--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  CLOSED_MALE_PRISON_CODES = PrisonService.prison_codes.reject { |x|
-    PrisonService::OPEN_PRISON_CODES.include?(x) ||
-      PrisonService::ENGLISH_HUB_PRISON_CODES.include?(x) ||
-      PrisonService::WOMENS_PRISON_CODES.include?(x) ||
-      ['LEI', 'PVI'].include?(x)
-  }
-
   factory :prison do
     # rotate around every male closed prison - open and womens prisons have different rules
     sequence(:code) do |c|
-      CLOSED_MALE_PRISON_CODES[c % CLOSED_MALE_PRISON_CODES.size]
+      prison_codes = PrisonService.prison_codes.reject { |x|
+        PrisonService::OPEN_PRISON_CODES.include?(x) ||
+          PrisonService::ENGLISH_HUB_PRISON_CODES.include?(x) ||
+          PrisonService::WOMENS_PRISON_CODES.include?(x) ||
+          %w[LEI PVI].include?(x)
+      }
+
+      prison_codes[c % prison_codes.size]
     end
 
     trait :open do

--- a/spec/initializers/sentry_initializer_spec.rb
+++ b/spec/initializers/sentry_initializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Sentry initializer' do
     Struct.new(:dsn, :release, :enable_metrics, :before_send, :excluded_exceptions, :rails, keyword_init: true)
   end
   let(:fake_event_class) { Struct.new(:extra, :user, :contexts) }
-  let(:rails_config) { double('rails_config', report_rescued_exceptions: nil) }
+  let(:rails_config) { double('rails_config', register_error_subscriber: nil) }
   let(:config) { fake_sentry_config_class.new(excluded_exceptions: [], rails: rails_config) }
   let(:event) do
     fake_event_class.new(
@@ -19,7 +19,9 @@ RSpec.describe 'Sentry initializer' do
 
   before do
     allow(Rails.configuration).to receive(:sentry_dsn).and_return('https://public@example.com/1')
-    allow(rails_config).to receive(:report_rescued_exceptions=)
+    allow(Rails.application.config).to receive(:after_initialize).and_yield
+    allow(Rails.error).to receive(:subscribe)
+    allow(rails_config).to receive(:register_error_subscriber=)
     allow(Sentry).to receive(:init).and_yield(config)
     allow(SentryCircuitBreakerService).to receive(:check_within_quota).and_return(true)
   end
@@ -30,6 +32,9 @@ RSpec.describe 'Sentry initializer' do
 
   it 'sanitises event payloads before sending them to Sentry' do
     load_initializer
+
+    expect(rails_config).to have_received(:register_error_subscriber=).with(true)
+    expect(Rails.error).to have_received(:subscribe).with(an_instance_of(LoggerErrorSubscriber))
 
     expect(config.before_send.call(event, { exception: exception })).to eq(
       fake_event_class.new(

--- a/spec/lib/logger_error_subscriber_spec.rb
+++ b/spec/lib/logger_error_subscriber_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe LoggerErrorSubscriber do
+  subject(:subscriber) { described_class.new }
+
+  let(:error_reporter) { ActiveSupport::ErrorReporter.new(subscriber) }
+  let(:exception) do
+    StandardError.new('boom').tap do |error|
+      error.set_backtrace(['/app/app/services/example.rb:12:in `call`'])
+    end
+  end
+
+  before do
+    allow(Rails.logger).to receive(:error)
+    allow(Rails.logger).to receive(:warn)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  it 'logs reported errors with structured metadata' do
+    subscriber.report(
+      exception,
+      handled: true,
+      severity: :error,
+      context: { tags: { domain_event: true }, request_id: 'abc123' },
+      source: 'domain_events_consumer'
+    )
+
+    expect(Rails.logger).to have_received(:error).with(
+      a_string_including(
+        'event=rails_error_reported',
+        'source=domain_events_consumer',
+        'handled=true',
+        'error_class=StandardError',
+        'message=boom',
+        'first_frame=/app/app/services/example.rb:12:in `call`'
+      )
+    )
+  end
+
+  it 'uses warn for warning severity' do
+    subscriber.report(exception, handled: true, severity: :warning, context: {}, source: 'cache_store')
+
+    expect(Rails.logger).to have_received(:warn).with(
+      a_string_including('source=cache_store')
+    )
+  end
+
+  it 'logs default handled and severity values without subscriber changes' do
+    error_reporter.report(exception, source: 'cache_store')
+
+    expect(Rails.logger).to have_received(:warn).with(
+      a_string_including(
+        'source=cache_store',
+        'handled=true'
+      )
+    )
+  end
+
+  it 'logs default severity for unhandled errors' do
+    error_reporter.report(exception, handled: false, source: 'exceptions_app')
+
+    expect(Rails.logger).to have_received(:error).with(
+      a_string_including(
+        'source=exceptions_app',
+        'handled=false'
+      )
+    )
+  end
+end

--- a/spec/workers/domain_events_consumer_spec.rb
+++ b/spec/workers/domain_events_consumer_spec.rb
@@ -161,4 +161,39 @@ RSpec.describe DomainEventsConsumer do
     expect { consumer.perform(sqs_msg, sns_msg_raw) }.not_to raise_error
     expect(DomainEventTestHandler.handled_events).to eq []
   end
+
+  it 'reports and re-raises unexpected errors' do
+    sns_msg_raw = {
+      'Type' => 'Notification',
+      'MessageId' => 'sns_msg_id',
+      'TopicArn' => 'arn:::::',
+      'Message' => {
+        'eventType' => 'testapp.domain.action',
+        'version' => 1,
+      }.to_json,
+      'MessageAttributes' => {
+        'eventType' => {
+          'Type' => 'String',
+          'Value' => 'testapp.domain.action',
+        },
+      },
+    }.to_json
+    error = StandardError.new('boom')
+
+    allow(consumer).to receive(:consume).and_raise(error)
+    allow(Rails.error).to receive(:report)
+
+    expect { consumer.perform(sqs_msg, sns_msg_raw) }.to raise_error(error)
+    expect(Rails.error).to have_received(:report).with(
+      error,
+      handled: false,
+      source: 'domain_events_consumer',
+      context: {
+        tags: {
+          domain_event: true,
+          domain_event_type: 'testapp.domain.action',
+        },
+      }
+    )
+  end
 end


### PR DESCRIPTION
Follow-up to previous PR #2808.

Move to use Rails error reporting API, with sentry as the backend.

Additional error reporting in the /500 route.