### PR TITLE
Guard against nil offenders

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -99,8 +99,7 @@ private
   end
 
   def load_prisoner_via_prisoner_id
-    @prisoner = OffenderService.get_offender(prisoner_id_from_url)
-    redirect_to('/404') if @prisoner.nil?
+    @prisoner = get_offender_or_404(prisoner_id_from_url)
   end
 
   def coworking?

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -62,6 +62,6 @@ private
   end
 
   def load_prisoner
-    @prisoner = OffenderService.get_offender(nomis_offender_id_from_url)
+    @prisoner = get_offender_or_404(nomis_offender_id_from_url)
   end
 end

--- a/app/controllers/build_allocations_controller.rb
+++ b/app/controllers/build_allocations_controller.rb
@@ -95,7 +95,7 @@ private
   end
 
   def load_prisoner
-    @prisoner = OffenderService.get_offender(nomis_offender_id_from_url)
+    @prisoner = get_offender_or_404(nomis_offender_id_from_url)
   end
 
   def load_pom

--- a/app/controllers/case_information_controller.rb
+++ b/app/controllers/case_information_controller.rb
@@ -49,8 +49,7 @@ class CaseInformationController < PrisonsApplicationController
 private
 
   def set_prisoner
-    @prisoner = OffenderService.get_offender(prisoner_id)
-    redirect_to('/404') if @prisoner.nil?
+    @prisoner = get_offender_or_404(prisoner_id)
   end
 
   def set_case_info_or_redirect

--- a/app/controllers/early_allocations_controller.rb
+++ b/app/controllers/early_allocations_controller.rb
@@ -114,7 +114,7 @@ class EarlyAllocationsController < PrisonsApplicationController
 private
 
   def load_prisoner
-    @prisoner = OffenderService.get_offender(params[:prisoner_id])
+    @prisoner = get_offender_or_404(params[:prisoner_id])
   end
 
   def pdf_as_string

--- a/app/controllers/female_missing_infos_controller.rb
+++ b/app/controllers/female_missing_infos_controller.rb
@@ -45,8 +45,7 @@ private
   end
 
   def load_prisoner
-    @prisoner = OffenderService.get_offender(prisoner_id)
-    redirect_to('/404') if @prisoner.nil?
+    @prisoner = get_offender_or_404(prisoner_id)
   end
 
   def load_missing_info

--- a/app/controllers/parole_reviews_controller.rb
+++ b/app/controllers/parole_reviews_controller.rb
@@ -19,7 +19,7 @@ class ParoleReviewsController < PrisonsApplicationController
 private
 
   def load_offender
-    @offender = OffenderService.get_offender(params[:prisoner_id])
+    @offender = get_offender_or_404(params[:prisoner_id])
   end
 
   def load_parole_review_record

--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -14,6 +14,14 @@ protected
     params.fetch(:prison_id, default_prison_code)
   end
 
+  def get_offender_or_404(offender_no, *args)
+    offender = OffenderService.get_offender(offender_no, *args)
+    return offender if offender.present?
+
+    redirect_to '/404'
+    nil
+  end
+
   def ensure_pom
     unless current_user_is_pom?
       redirect_to '/401'

--- a/app/controllers/responsibilities_controller.rb
+++ b/app/controllers/responsibilities_controller.rb
@@ -89,12 +89,12 @@ private
   end
 
   def load_offender_from_url
-    @offender = OffenderService.get_offender(nomis_offender_id_from_url)
+    @offender = get_offender_or_404(nomis_offender_id_from_url)
   end
 
   def load_offender_from_responsibility_params
     offender_id = responsibility_params.fetch(:nomis_offender_id)
-    @offender = OffenderService.get_offender(offender_id)
+    @offender = get_offender_or_404(offender_id)
   end
 
   def responsibility_params

--- a/app/controllers/victim_liaison_officers_controller.rb
+++ b/app/controllers/victim_liaison_officers_controller.rb
@@ -65,6 +65,6 @@ private
   end
 
   def load_offender
-    @offender = OffenderService.get_offender(params[:prisoner_id])
+    @offender = get_offender_or_404(params[:prisoner_id])
   end
 end

--- a/app/views/shared/_caseload.html.erb
+++ b/app/views/shared/_caseload.html.erb
@@ -14,7 +14,7 @@
   </td>
   <% if @prison.womens? %>
     <td aria-label="Complexity Level" class="govuk-table__cell">
-      <%= caseload.complexity_level.titleize %>
+      <%= caseload.complexity_level&.titleize %>
     </td>
   <% end %>
   <td aria-label="Earliest release date" class="govuk-table__cell ">

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe AllocationsController, type: :controller do
         stub_keyworker(offender_no)
       end
 
+      context 'when the prisoner cannot be loaded' do
+        before do
+          stub_non_existent_offender(offender_no)
+        end
+
+        it 'redirects to 404' do
+          get :show, params: { prison_id: prison_code, prisoner_id: offender_no }
+
+          expect(response).to redirect_to('/404')
+        end
+      end
+
       context 'when POM has left' do
         before do
           create(:allocation_history, prison: prison_code, nomis_offender_id: offender_no, primary_pom_nomis_id: inactive_pom_staff_id)
@@ -149,7 +161,7 @@ RSpec.describe AllocationsController, type: :controller do
         before do
           case_info = create(:case_information, offender: build(:offender, victim_liaison_officers: [build(:victim_liaison_officer)]))
           create(:allocation_history, prison: prison_code, nomis_offender_id: case_info.nomis_offender_id)
-          stub_offender(build(:nomis_offender, prisonerNumber: case_info.nomis_offender_id))
+          stub_offender(build(:nomis_offender, prisonerNumber: case_info.nomis_offender_id, prisonId: prison_code))
           stub_movements_for case_info.nomis_offender_id, [attributes_for(:movement)]
           stub_pom_emails(485_926, [])
         end

--- a/spec/controllers/build_allocations_controller_spec.rb
+++ b/spec/controllers/build_allocations_controller_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe BuildAllocationsController, type: :controller do
   end
 
   describe '#new' do
+    context 'when the prisoner cannot be loaded' do
+      before do
+        stub_non_existent_offender(offender_no)
+
+        get :new, params: {
+          prison_id: prison.code,
+          prisoner_id: offender_no,
+          staff_id: pom.staffId
+        }
+      end
+
+      it 'redirects to 404' do
+        expect(response).to redirect_to('/404')
+      end
+    end
+
     context 'when the selected POM is no longer eligible' do
       before do
         create(:allocation_history, prison: prison.code, nomis_offender_id: offender_no,


### PR DESCRIPTION
Additional guard against invalid offender URLs or offenders no longer returned by the API, etc. so it gives an early 404 instead of blowing up somewhere down the line and ending on a 500.