### PR TITLE
MO-1950 Improve Alerts API error handling

### DIFF
--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -88,9 +88,16 @@ module OffenderHelper
       handover_start_date: view_context.format_date(offender.handover_start_date).presence || 'Unknown',
       handover_completion_date: view_context.format_date(offender.responsibility_handover_date).presence || 'Unknown',
       last_oasys_completed: view_context.format_date(last_oasys_completed(offender.offender_no)).presence || 'No OASys information',
-      active_alerts: offender.active_alert_labels.join(', '),
+      active_alerts: format_active_alerts(offender),
       additional_notes: nil
     }
+  end
+
+  def format_active_alerts(offender)
+    active_alert_labels = offender.active_alert_labels
+    return 'This information is currently unavailable' if active_alert_labels.nil?
+
+    active_alert_labels.join(', ')
   end
 
   def last_oasys_completed(offender_no)

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -260,8 +260,10 @@ class MpcOffender
   def rosh_summary = RoshSummary.for(crn)
 
   def active_alert_labels
-    HmppsApi::PrisonAlertsApi.alerts_for(offender_no)
-      .select { |alert| alert['isActive'] }
+    alerts = HmppsApi::PrisonAlertsApi.alerts_for(offender_no)
+    return nil if alerts.nil?
+
+    alerts.select { |alert| alert['isActive'] }
       .sort_by { |alert| alert['createdAt'] }
       .map { |alert| alert.dig('alertCode', 'description') }
   end

--- a/app/services/hmpps_api/prison_alerts_api.rb
+++ b/app/services/hmpps_api/prison_alerts_api.rb
@@ -10,7 +10,13 @@ module HmppsApi
       safe_offender_no = URI.encode_www_form_component(nomis_offender_id)
       route = "/prisoners/#{safe_offender_no}/alerts"
       data, = client.get(route)
+
+      raise TypeError, 'unexpected response body' unless data.is_a?(Hash)
+
       data.fetch('content', [])
+    rescue Faraday::Error, JSON::ParserError, TypeError => e
+      Rails.logger.error("event=prison_alerts_api_error,nomis_offender_id=#{nomis_offender_id}|#{e.message}")
+      nil
     end
   end
 end

--- a/app/services/reallocation/email_context_builder.rb
+++ b/app/services/reallocation/email_context_builder.rb
@@ -21,7 +21,7 @@ module Reallocation
         handover_start_date: format_date(offender.handover_start_date).presence || 'Unknown',
         handover_completion_date: format_date(offender.responsibility_handover_date).presence || 'Unknown',
         last_oasys_completed: format_date(last_oasys_completed(offender.offender_no)).presence || 'No OASys information',
-        active_alerts: offender.active_alert_labels.join(', '),
+        active_alerts: format_active_alerts(offender),
         additional_notes: nil,
       }
     end

--- a/app/views/shared/_active_alerts.html.erb
+++ b/app/views/shared/_active_alerts.html.erb
@@ -2,7 +2,9 @@
   Active alerts
 </h3>
 
-<% if alerts.none? %>
+<% if alerts.nil? %>
+  <p>This information is currently unavailable. Try again later.</p>
+<% elsif alerts.none? %>
   <p>None</p>
 <% else %>
   <ul class="govuk-list govuk-list--bullet">

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -166,6 +166,16 @@ RSpec.describe OffenderHelper do
       end
     end
 
+    context 'when prison alerts are unavailable' do
+      before do
+        allow(offender).to receive(:active_alert_labels).and_return(nil)
+      end
+
+      it 'displays the unavailable message' do
+        expect(subject[:active_alerts]).to eq('This information is currently unavailable')
+      end
+    end
+
     context 'when no COM name' do
       before do
         allow(offender).to receive(:allocated_com_name).and_return(nil)

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -224,6 +224,12 @@ RSpec.describe MpcOffender, type: :model do
 
       expect(subject.active_alert_labels).to eq(["Alert B", "Alert D"])
     end
+
+    it 'returns nil when prison alerts are unavailable' do
+      allow(HmppsApi::PrisonAlertsApi).to receive(:alerts_for).and_return(nil)
+
+      expect(subject.active_alert_labels).to be_nil
+    end
   end
 
   describe '#model' do

--- a/spec/services/hmpps_api/prison_alerts_api_spec.rb
+++ b/spec/services/hmpps_api/prison_alerts_api_spec.rb
@@ -16,5 +16,32 @@ describe HmppsApi::PrisonAlertsApi do
 
       expect(described_class.alerts_for("ABC123")).to eq(response["content"])
     end
+
+    context 'when the alerts API is unavailable' do
+      it 'returns nil' do
+        stub_request(:get, "#{Rails.configuration.prison_alerts_api_host}/prisoners/ABC123/alerts")
+          .to_return(status: 503, body: { status: 503 }.to_json)
+
+        expect(described_class.alerts_for('ABC123')).to be_nil
+      end
+    end
+
+    context 'when the alerts API returns no content' do
+      it 'returns nil' do
+        stub_request(:get, "#{Rails.configuration.prison_alerts_api_host}/prisoners/ABC123/alerts")
+          .to_return(status: 204, body: '')
+
+        expect(described_class.alerts_for('ABC123')).to be_nil
+      end
+    end
+
+    context 'when the alerts API returns malformed data' do
+      it 'returns nil' do
+        stub_request(:get, "#{Rails.configuration.prison_alerts_api_host}/prisoners/ABC123/alerts")
+          .to_return(body: 'not json')
+
+        expect(described_class.alerts_for('ABC123')).to be_nil
+      end
+    end
   end
 end

--- a/spec/views/shared/active_alerts.html.erb_spec.rb
+++ b/spec/views/shared/active_alerts.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_active_alerts', type: :view do
+  subject(:page) { Nokogiri::HTML(rendered) }
+
+  context 'when alerts are unavailable' do
+    before do
+      render partial: 'shared/active_alerts', locals: { alerts: nil, offender_no: 'A1234AA' }
+    end
+
+    it 'shows the unavailable message' do
+      expect(page.text).to include('This information is currently unavailable. Try again later.')
+    end
+  end
+
+  context 'when there are no alerts' do
+    before do
+      render partial: 'shared/active_alerts', locals: { alerts: [], offender_no: 'A1234AA' }
+    end
+
+    it 'shows none' do
+      expect(page.text).to include('None')
+    end
+  end
+
+  context 'when alerts are present' do
+    before do
+      render partial: 'shared/active_alerts', locals: { alerts: ['ACCT open', 'Risk to staff'], offender_no: 'A1234AA' }
+    end
+
+    it 'renders each alert as a list item' do
+      expect(page.css('li').map(&:text)).to eq(['ACCT open', 'Risk to staff'])
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1950

Ahead of a scheduled Alerts API downtime next week, we need to ensure our service is not misleading when alerts can't be fetched. Currently we were defaulting to "None".

With this PR we will have more granular messaging.