### PR TITLE
MO-1958 Responsibility override tidy/fixes

### DIFF
--- a/app/controllers/responsibilities_controller.rb
+++ b/app/controllers/responsibilities_controller.rb
@@ -3,19 +3,19 @@
 class ResponsibilitiesController < PrisonsApplicationController
   before_action :load_offender_from_url, only: [:new, :confirm_removal, :destroy]
   before_action :load_offender_from_responsibility_params, only: [:confirm, :create]
-  before_action :store_referrer_in_session, only: [:new, :confirm_removal]
+  before_action :check_existing_responsibility, only: [:new, :confirm]
 
   def new
-    @referrer = referrer
     if @offender.ldu_email_address.present?
-      @responsibility = Responsibility.new nomis_offender_id: nomis_offender_id_from_url
+      @responsibility = Responsibility.new(nomis_offender_id:)
     else
       render 'error'
     end
   end
 
   def confirm
-    @responsibility = Responsibility.new responsibility_params
+    @responsibility = Responsibility.new(responsibility_params)
+
     if @responsibility.valid?
       @ldu_email_address = @offender.ldu_email_address
     else
@@ -24,15 +24,20 @@ class ResponsibilitiesController < PrisonsApplicationController
   end
 
   def create
-    @responsibility = Responsibility.create! responsibility_params
+    emails = [@current_user.email_address, @offender.ldu_email_address].compact_blank
 
-    me = HmppsApi::NomisUserRolesApi.user_details(current_user).email_address
-    emails = [me, @offender.ldu_email_address].compact_blank
+    @responsibility = Responsibility.find_or_initialize_by(nomis_offender_id:)
+
+    # Treat repeated submits as a no-op so we don't create duplicate overrides or emails.
+    return redirect_back_to_allocation unless @responsibility.new_record?
+
+    @responsibility.assign_attributes(responsibility_params.slice(:reason, :reason_text, :value))
+    @responsibility.save!
 
     # GovUk notify can only deliver to 1 address at a time.
     emails.each do |email|
       PomMailer.with(
-        message: params[:message],
+        message: responsibility_params[:message],
         prisoner_number: @responsibility.nomis_offender_id,
         prisoner_name: @offender.full_name,
         prison_name: @prison.name,
@@ -40,11 +45,16 @@ class ResponsibilitiesController < PrisonsApplicationController
       ).responsibility_override.deliver_later
     end
 
-    redirect_to referrer
+    redirect_back_to_allocation
+  rescue ActiveRecord::RecordInvalid
+    @responsibility = Responsibility.find_by(nomis_offender_id:)
+    raise unless @responsibility
+
+    redirect_back_to_allocation
   end
 
   def confirm_removal
-    @responsibility = RemoveResponsibilityForm.new nomis_offender_id: nomis_offender_id_from_url
+    @responsibility = RemoveResponsibilityForm.new(nomis_offender_id:)
     @ldu_email_address = @offender.ldu_email_address
   end
 
@@ -52,37 +62,44 @@ class ResponsibilitiesController < PrisonsApplicationController
     @responsibility = RemoveResponsibilityForm.new(responsibility_params)
     @ldu_email_address = @offender.ldu_email_address
 
-    allocation = AllocationHistory.find_by(nomis_offender_id: nomis_offender_id_from_url)
-
+    allocation = AllocationHistory.find_by(nomis_offender_id:)
     emails = [@current_user.email_address, @ldu_email_address]
 
     if @responsibility.valid?
-      Responsibility.find_by!(nomis_offender_id: nomis_offender_id_from_url).destroy!
+      Responsibility.find_by!(nomis_offender_id:).destroy!
 
       if allocation&.active?
         pom_email = HmppsApi::NomisUserRolesApi.email_address(allocation.primary_pom_nomis_id)
         emails << pom_email
-        ResponsibilityMailer.with(emails: emails.compact,
+        ResponsibilityMailer.with(emails: emails.compact_blank,
                                   pom_name: allocation.primary_pom_name,
                                   pom_email: pom_email,
                                   prisoner_name: @offender.full_name,
-                                  prisoner_number: nomis_offender_id_from_url,
+                                  prisoner_number: nomis_offender_id,
                                   prison_name: @prison.name,
                                   notes: @responsibility.reason_text).responsibility_to_custody_with_pom.deliver_later
       else
-        ResponsibilityMailer.with(emails: emails.compact,
+        ResponsibilityMailer.with(emails: emails.compact_blank,
                                   prisoner_name: @offender.full_name,
-                                  prisoner_number: nomis_offender_id_from_url,
+                                  prisoner_number: nomis_offender_id,
                                   prison_name: @prison.name,
                                   notes: @responsibility.reason_text).responsibility_to_custody.deliver_later
       end
-      redirect_to prison_prisoner_allocation_path(@prison.code, @responsibility.nomis_offender_id)
+      redirect_back_to_allocation
     else
       render :confirm_removal
     end
   end
 
 private
+
+  def check_existing_responsibility
+    render 'responsibilities/presence_error' if Responsibility.exists?(nomis_offender_id:)
+  end
+
+  def redirect_back_to_allocation
+    redirect_to prison_prisoner_allocation_path(@prison.code, nomis_offender_id)
+  end
 
   def nomis_offender_id_from_url
     params.fetch(:nomis_offender_id)
@@ -97,10 +114,14 @@ private
     @offender = get_offender_or_404(offender_id)
   end
 
+  def nomis_offender_id
+    @offender.offender_no
+  end
+
   def responsibility_params
     params
       .require(:responsibility)
-      .permit(:nomis_offender_id, :reason, :reason_text)
+      .permit(:nomis_offender_id, :reason, :reason_text, :message)
       .merge(value: Responsibility::PROBATION)
   end
 end

--- a/app/models/responsibility.rb
+++ b/app/models/responsibility.rb
@@ -3,6 +3,8 @@
 class Responsibility < ApplicationRecord
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
 
+  after_commit :publish_audit_event, on: %i[create destroy]
+
   belongs_to :offender,
              primary_key: :nomis_offender_id,
              foreign_key: :nomis_offender_id,
@@ -11,7 +13,10 @@ class Responsibility < ApplicationRecord
   PRISON = 'Prison'
   PROBATION = 'Probation'
 
-  validates :nomis_offender_id, presence: true
+  # transient attribute used in the email sent, not persisted to the DB
+  attr_accessor :message
+
+  validates :nomis_offender_id, presence: true, uniqueness: true
   validates :reason_text,
             presence: {
               message: 'Please provide reason when Other is selected'
@@ -42,4 +47,16 @@ class Responsibility < ApplicationRecord
   def pom_supporting? = value == PROBATION
   def com_responsible? = value == PROBATION
   def com_supporting? = value == PRISON
+
+private
+
+  def publish_audit_event
+    AuditEvent.publish(
+      nomis_offender_id:,
+      tags: %w[record responsibility override] << (destroyed? ? 'removed' : 'created'),
+      system_event: PaperTrail.request.whodunnit.blank?,
+      username: PaperTrail.request.whodunnit,
+      data: attributes.slice('value', 'reason')
+    )
+  end
 end

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -74,22 +74,22 @@
       </tr>
     <% end %>
 
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
-      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half responsibility_change">
-        <%= case_owner_label(@prisoner) %>
-        <% if @prisoner.pom_responsible? %>
-          <%= link_to 'Change', new_prison_responsibility_path(@prison.code, nomis_offender_id: @prisoner.offender_no), class: 'govuk-link pull-right' %>
-        <% elsif @prisoner.com_responsible? && @prisoner.responsibility_override? %>
-          <%= link_to 'Change', confirm_removal_prison_responsibility_path(@prison.code, nomis_offender_id: @prisoner.offender_no), class: 'govuk-link pull-right' %>
-        <% end %>
-      </td>
-    </tr>
     <tr class="govuk-table__row" id="service-provider-row">
       <td class="govuk-table__cell">Handover type</td>
       <td class="govuk-table__cell table_cell__left_align">
         <%= handover_type_label(@prisoner) %>
         <%= link_to 'Change', edit_prison_prisoner_case_information_path(@prison.code, @prisoner.offender_no, from: :allocation), class: 'govuk-link pull-right' if @prisoner.manual_entry? %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-!-width-one-half">Current responsibility</td>
+      <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half responsibility_change">
+        <%= case_owner_label(@prisoner) %>
+        <% if @prisoner.pom_responsible? %>
+          <%= link_to 'Change', new_prison_responsibility_path(@prison.code, @prisoner.offender_no), class: 'govuk-link pull-right' %>
+        <% elsif @prisoner.com_responsible? && @prisoner.responsibility_override? %>
+          <%= link_to 'Change', confirm_removal_prison_responsibility_path(@prison.code, nomis_offender_id: @prisoner.offender_no), class: 'govuk-link pull-right' %>
+        <% end %>
       </td>
     </tr>
     <tr id="oasys-date" class="govuk-table__row">

--- a/app/views/responsibilities/confirm.html.erb
+++ b/app/views/responsibilities/confirm.html.erb
@@ -1,36 +1,42 @@
-<%= form_for(@responsibility, url: prison_responsibilities_path(@prison.code, @responsibility)) do |f| %>
-  <%= f.hidden_field(:nomis_offender_id) %>
-  <%= f.hidden_field(:reason) %>
-  <%= f.hidden_field(:reason_text) %>
+<% content_for :title, "Confirm change of responsibility – Digital Prison Services" %>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" aria-describedby="how-contacted-conditional-hint">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-          Confirm change of responsibility for this case
-        </h1>
-      </legend>
-    </fieldset>
-    <p class="govuk-body">
-      The community probation team will be responsible for this case
-    </p>
-    <p class="govuk-body">
-      We will email the community probation team at <%= @ldu_email_address %>.
-      They will need to allocate a community offender manager if one has not yet been allocated.
-    </p>
-    <p class="govuk-body">
-      You will also receive a copy of this email for your records.
-    </p>
-    <div class="govuk-form-group">
-      <label class="govuk-label govuk-!-font-weight-bold" for="message">Add a note to the email:</label>
-      <span id="message_hint" class="govuk-hint">For example, you can tell the community team about any special requirements.</span>
-      <textarea class="govuk-textarea" id="message" name="message" rows="3" aria-describedby="message_hint"></textarea>
-    </div>
+<%= link_to 'Back',
+            new_prison_responsibility_path(@prison.code, @offender.offender_no),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@responsibility,
+                 url: prison_responsibilities_path(@prison.code, @responsibility),
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+      <%= f.hidden_field(:nomis_offender_id) %>
+      <%= f.hidden_field(:reason) %>
+      <%= f.hidden_field(:reason_text) %>
+
+      <h1 class="govuk-heading-l">Confirm change of responsibility for this case</h1>
+
+      <p class="govuk-body">
+        The community probation team will be responsible for this case.
+      </p>
+
+      <p class="govuk-body">
+        We will email the community probation team at <strong><%= @ldu_email_address %></strong>.
+        They will need to allocate a community offender manager if one has not yet been allocated.
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        You will also receive a copy of this email for your records.
+      </p>
+
+      <%= f.govuk_text_area :message,
+                            label: { text: 'Add a note to the email (optional)', size: 's' },
+                            hint: { text: 'For example, you can tell the community team about any special requirements.' },
+                            rows: 3 %>
+
+      <div class="govuk-button-group">
+        <%= f.submit 'Confirm', class: 'govuk-button', data: { module: 'govuk-button' } %>
+        <%= link_to 'Cancel', prison_prisoner_allocation_path(@prison.code, @offender.offender_no), class: 'govuk-link' %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="govuk-form-group">
-    <button type="submit" class="govuk-button">Confirm</button>
-    <%= link_to 'Cancel', prison_prisoner_allocation_path(@prison.code, @responsibility.nomis_offender_id), class: 'govuk-link app-cancel-link' %>
-  </div>
-
-<% end %>
+</div>

--- a/app/views/responsibilities/confirm.html.erb
+++ b/app/views/responsibilities/confirm.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@responsibility,
-                 url: prison_responsibilities_path(@prison.code, @responsibility),
+                 url: prison_responsibilities_path(@prison.code),
                  builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
       <%= f.hidden_field(:nomis_offender_id) %>
       <%= f.hidden_field(:reason) %>

--- a/app/views/responsibilities/confirm_removal.html.erb
+++ b/app/views/responsibilities/confirm_removal.html.erb
@@ -1,38 +1,37 @@
-<%= link_to 'Back', :back, class: :back %>
+<% content_for :title, "Confirm change of responsibility – Digital Prison Services" %>
 
-<%= form_for(@responsibility, url: prison_responsibility_path(@prison.code, @responsibility.nomis_offender_id),
-             method: :delete,
-             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
-  <!--  Just so we always submit something in the form -->
-  <%= f.hidden_field :nomis_offender_id %>
+<%= link_to 'Back', prison_prisoner_allocation_path(@prison.code, @offender.offender_no),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
-  <%= f.govuk_error_summary %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@responsibility,
+                 url: prison_responsibility_path(@prison.code, @offender.offender_no),
+                 method: :delete,
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+      <%= f.hidden_field :nomis_offender_id %>
+      <%= f.govuk_error_summary %>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-          Confirm change of responsibility for this case
-        </h1>
-      </legend>
-    </fieldset>
-    <p class="govuk-body">
-      The community probation team will not longer be responsible for this case.
-      We will email the community probation team at <%= @ldu_email_address %>
-    </p>
-    <p class="govuk-body">
-      You will also receive a copy of this email for your records.
-    </p>
-    <%= f.govuk_text_area :reason_text,
-                          label: { text: 'Why are you changing responsibility for this case?' },
-                          hint_text: 'This will be included in the email to the community team',
-                          rows: 3 %>
+      <h1 class="govuk-heading-l">Confirm change of responsibility for this case</h1>
+
+      <p class="govuk-body">
+        The community probation team will no longer be responsible for this case.<br/>
+        We will email the community probation team at <strong><%= @ldu_email_address %></strong>.
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-6">
+        You will also receive a copy of this email for your records.
+      </p>
+
+      <%= f.govuk_text_area :reason_text,
+                            label: { text: 'Why are you changing responsibility for this case?', size: 's' },
+                            hint: { text: 'This will be included in the email to the community team.' },
+                            rows: 3 %>
+
+      <div class="govuk-button-group">
+        <%= f.submit 'Confirm', class: 'govuk-button', data: { module: 'govuk-button' } %>
+        <%= link_to 'Cancel', prison_prisoner_allocation_path(@prison.code, @offender.offender_no), class: 'govuk-link' %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="govuk-form-group">
-    <button type="submit" class="govuk-button">Confirm</button>
-    <%= link_to 'Cancel', prison_prisoner_allocation_path(@prison.code, @responsibility.nomis_offender_id), class: 'govuk-link app-cancel-link' %>
-  </div>
-
-<% end %>
-
+</div>

--- a/app/views/responsibilities/error.html.erb
+++ b/app/views/responsibilities/error.html.erb
@@ -1,17 +1,19 @@
-<fieldset class="govuk-fieldset" aria-describedby="how-contacted-conditional-hint">
-  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-    <h1 class="govuk-fieldset__heading">
-      Responsibility for this case can't be changed
-    </h1>
-  </legend>
-</fieldset>
+<% content_for :title, "Responsibility for this case can’t be changed – Digital Prison Services" %>
 
-<p class="govuk-body">
-  As there is no community LDU information available for this prisoner, it’s not possible to change
-  case responsibility from custody to the community.
-</p>
-<p class="govuk-body">
-  This is something we are currently working on.
-</p>
+<%= link_to 'Back', prison_prisoner_allocation_path(@prison.code, @offender.offender_no),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
-<%= back_link %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Responsibility for this case can’t be changed</h1>
+
+    <p class="govuk-body">
+      As there is no community LDU information available for this prisoner, it’s not possible to change
+      case responsibility from custody to the community.
+    </p>
+
+    <p class="govuk-body">
+      This is something we are currently working on.
+    </p>
+  </div>
+</div>

--- a/app/views/responsibilities/new.html.erb
+++ b/app/views/responsibilities/new.html.erb
@@ -1,23 +1,34 @@
-<%= form_for(@responsibility,
-             url: confirm_prison_responsibilities_path(@prison.code, @responsibility),
-             builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
-  <%= f.hidden_field(:nomis_offender_id) %>
-  <%= f.govuk_error_summary %>
+<% content_for :title, "Why are you changing responsibility for this case? – Digital Prison Services" %>
 
-  <%= f.govuk_radio_buttons_fieldset(
-          :reason, legend: { text: "Why are you changing responsibility for this case?", size: 'xl' }) do %>
-    <%= f.govuk_radio_button :reason, 'less_than_10_months_to_serve',
-                             label: { text: 'The prisoner has less than 10 months less to serve' }, link_errors: true %>
-    <%= f.govuk_radio_button :reason, 'community_team_to_work_with_offender',
-                             label: { text: 'Decision made for the community probation team to work with this prisoner' } %>
-    <%= f.govuk_radio_button :reason, 'prisoner_has_been_recalled',
-                             label: { text: 'Prisoner has been recalled' } %>
-    <%= f.govuk_radio_button :reason, 'other_reason',
-                             label: { text: 'Other' } do %>
-      <%= f.govuk_text_area :reason_text, label: { text: 'Enter Reason' } %>
+<%= link_to 'Back', prison_prisoner_allocation_path(@prison.code, @offender.offender_no),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@responsibility,
+                 url: confirm_prison_responsibilities_path(@prison.code, @responsibility),
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+      <%= f.hidden_field(:nomis_offender_id) %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+              :reason, legend: { text: 'Why are you changing responsibility for this case?', size: 'l', tag: 'h1' }) do %>
+        <%= f.govuk_radio_button :reason, 'less_than_10_months_to_serve',
+                                 label: { text: 'The prisoner has less than 10 months less to serve' }, link_errors: true %>
+        <%= f.govuk_radio_button :reason, 'community_team_to_work_with_offender',
+                                 label: { text: 'Decision made for the community probation team to work with this prisoner' } %>
+        <%= f.govuk_radio_button :reason, 'prisoner_has_been_recalled',
+                                 label: { text: 'Prisoner has been recalled' } %>
+        <%= f.govuk_radio_button :reason, 'other_reason',
+                                 label: { text: 'Other' } do %>
+          <%= f.govuk_text_area :reason_text, label: { text: 'Enter reason' }, rows: 3 %>
+        <% end %>
+      <% end %>
+
+      <div class="govuk-button-group">
+        <%= f.submit 'Continue', class: 'govuk-button', data: { module: 'govuk-button' } %>
+        <%= link_to 'Cancel', prison_prisoner_allocation_path(@prison.code, @offender.offender_no), class: 'govuk-link' %>
+      </div>
     <% end %>
-  <% end %>
-
-  <%= f.submit "Continue", role: "button", draggable: "false", class: "govuk-button" %>
-  <%= link_to 'Cancel', @referrer, class: 'govuk-link app-cancel-link' %>
-<% end %>
+  </div>
+</div>

--- a/app/views/responsibilities/new.html.erb
+++ b/app/views/responsibilities/new.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@responsibility,
-                 url: confirm_prison_responsibilities_path(@prison.code, @responsibility),
+                 url: confirm_prison_responsibilities_path(@prison.code),
                  builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
       <%= f.hidden_field(:nomis_offender_id) %>
       <%= f.govuk_error_summary %>

--- a/app/views/responsibilities/presence_error.html.erb
+++ b/app/views/responsibilities/presence_error.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Changing responsibility for this person – Digital Prison Services" %>
+
+<%= link_to 'Back', prison_prisoner_allocation_path(@prison.code, @offender.offender_no),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Changing responsibility for this person</h1>
+
+    <p class="govuk-body">
+      To change whether custody or community is responsible for this person, go to
+      their <%= link_to 'allocation information', prison_prisoner_allocation_path(@prison.code, @offender.offender_no), class: 'govuk-link' %>
+      and choose to change their current responsibility.
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,8 +164,9 @@ Rails.application.routes.draw do
 
     resources :tasks, only: %i[index]
 
-    resources :responsibilities, only: %i[new create destroy], param: :nomis_offender_id do
+    resources :responsibilities, only: %i[create destroy], param: :nomis_offender_id do
       member do
+        get :new, path: :new, as: :new
         get :confirm_removal
       end
       collection do

--- a/spec/controllers/responsibilities_controller_spec.rb
+++ b/spec/controllers/responsibilities_controller_spec.rb
@@ -4,13 +4,16 @@ require 'rails_helper'
 
 RSpec.describe ResponsibilitiesController, type: :controller do
   before do
-    offender = create(:case_information, local_delivery_unit: build(:local_delivery_unit))
-    create(:responsibility, nomis_offender_id: offender.nomis_offender_id)
+    create(:case_information, local_delivery_unit: build(:local_delivery_unit))
 
     stub_sso_data(prison.code, email: sso_email_address)
 
-    allow(ResponsibilityMailer).to receive(:with).and_return(double(responsibility_to_custody: responsibility_to_custody_mailer,
-                                                                    responsibility_to_custody_with_pom: responsibility_to_custody_with_pom_mailer))
+    allow(ResponsibilityMailer).to receive(:with).and_return(
+      double(
+        responsibility_to_custody: responsibility_to_custody_mailer,
+        responsibility_to_custody_with_pom: responsibility_to_custody_with_pom_mailer
+      )
+    )
   end
 
   let(:case_info) { CaseInformation.last }
@@ -23,9 +26,158 @@ RSpec.describe ResponsibilitiesController, type: :controller do
   let(:offender) { OffenderService.get_offender(offender_no) }
   let(:responsibility_to_custody_mailer) { double(:responsibility_to_custody_mailer, deliver_later: nil) }
   let(:responsibility_to_custody_with_pom_mailer) { double(:responsibility_to_custody_with_pom_mailer, deliver_later: nil) }
+  let(:responsibility_override_mailer) { double(:responsibility_override_mailer, deliver_later: nil) }
+
+  describe '#new' do
+    before do
+      stub_offender(nomis_offender)
+    end
+
+    context 'when a responsibility override already exists' do
+      render_views
+
+      before do
+        create(:responsibility, nomis_offender_id: offender_no)
+      end
+
+      it 'renders an error page explaining the override already exists' do
+        get :new, params: { prison_id: prison.code, nomis_offender_id: offender_no }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template(:presence_error)
+          expect(response.body).to include(prison_prisoner_allocation_path(prison.code, offender_no))
+        end
+      end
+    end
+  end
+
+  describe '#confirm' do
+    before do
+      stub_offender(nomis_offender)
+    end
+
+    context 'when a responsibility override already exists' do
+      render_views
+
+      before do
+        create(:responsibility, nomis_offender_id: offender_no)
+      end
+
+      it 'renders an error page instead of allowing confirmation' do
+        post :confirm, params: {
+          prison_id: prison.code,
+          responsibility: {
+            nomis_offender_id: offender_no,
+            reason: :less_than_10_months_to_serve,
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template(:presence_error)
+          expect(response.body).to include(prison_prisoner_allocation_path(prison.code, offender_no))
+        end
+      end
+    end
+  end
+
+  describe '#create' do
+    let(:message) { 'Useful context for the community team' }
+
+    before do
+      stub_offender(nomis_offender)
+
+      allow(PomMailer).to receive(:with)
+        .and_return(double(responsibility_override: responsibility_override_mailer))
+    end
+
+    it 'creates a responsibility override and sends emails when one does not already exist' do
+      expect {
+        post :create, params: {
+          prison_id: prison.code,
+          responsibility: {
+            nomis_offender_id: offender_no,
+            reason: :less_than_10_months_to_serve,
+            message:,
+          }
+        }
+      }.to change(Responsibility, :count).by(1)
+
+      aggregate_failures do
+        expect(response).to redirect_to(prison_prisoner_allocation_path(prison.code, offender_no))
+        expect(PomMailer).to have_received(:with).with(
+          message:,
+          prisoner_number: offender_no,
+          prisoner_name: "#{nomis_offender.fetch(:lastName)}, #{nomis_offender.fetch(:firstName)}",
+          prison_name: prison.name,
+          email: sso_email_address
+        )
+        expect(PomMailer).to have_received(:with).with(
+          message:,
+          prisoner_number: offender_no,
+          prisoner_name: "#{nomis_offender.fetch(:lastName)}, #{nomis_offender.fetch(:firstName)}",
+          prison_name: prison.name,
+          email: offender.ldu_email_address
+        )
+        expect(responsibility_override_mailer).to have_received(:deliver_later).twice
+      end
+    end
+
+    it 'reuses the existing responsibility override and does not send duplicate emails' do
+      create(:responsibility, nomis_offender_id: offender_no)
+
+      expect {
+        post :create, params: {
+          prison_id: prison.code,
+          responsibility: {
+            nomis_offender_id: offender_no,
+            reason: :less_than_10_months_to_serve,
+            message:,
+          }
+        }
+      }.not_to change(Responsibility, :count)
+
+      aggregate_failures do
+        expect(response).to redirect_to(prison_prisoner_allocation_path(prison.code, offender_no))
+        expect(PomMailer).not_to have_received(:with)
+        expect(responsibility_override_mailer).not_to have_received(:deliver_later)
+      end
+    end
+
+    it 'treats a uniqueness validation failure as an existing override and does not send duplicate emails' do
+      existing_responsibility = create(:responsibility, nomis_offender_id: offender_no)
+      unsaved_responsibility = Responsibility.new(nomis_offender_id: offender_no)
+      unsaved_responsibility.errors.add(:nomis_offender_id, :taken)
+
+      allow(Responsibility).to receive(:find_or_initialize_by)
+        .and_return(unsaved_responsibility)
+      allow(unsaved_responsibility).to receive(:save!)
+        .and_raise(ActiveRecord::RecordInvalid.new(unsaved_responsibility))
+
+      expect {
+        post :create, params: {
+          prison_id: prison.code,
+          responsibility: {
+            nomis_offender_id: offender_no,
+            reason: :less_than_10_months_to_serve,
+            message:,
+          }
+        }
+      }.not_to change(Responsibility, :count)
+
+      aggregate_failures do
+        expect(assigns(:responsibility)).to eq(existing_responsibility)
+        expect(response).to redirect_to(prison_prisoner_allocation_path(prison.code, offender_no))
+        expect(PomMailer).not_to have_received(:with)
+        expect(responsibility_override_mailer).not_to have_received(:deliver_later)
+      end
+    end
+  end
 
   describe '#destroy' do
     before do
+      create(:responsibility, nomis_offender_id: offender_no)
       stub_offender(nomis_offender)
     end
 

--- a/spec/features/responsibility/homd_overrides_responsibilities_spec.rb
+++ b/spec/features/responsibility/homd_overrides_responsibilities_spec.rb
@@ -50,7 +50,7 @@ describe 'HOMD overrides responsibilities' do
     within('tr', text: 'Current responsibility Custody') { click_on 'Change' }
     choose 'The prisoner has less than 10 months less to serve'
     click_on 'Continue'
-    fill_in 'Add a note to the email:', with: 'Reasons are thus'
+    fill_in 'Add a note to the email (optional)', with: 'Reasons are thus'
     click_on 'Confirm'
 
     visit allocated_prison_prisoners_path(prison)

--- a/spec/models/responsibility_spec.rb
+++ b/spec/models/responsibility_spec.rb
@@ -47,4 +47,52 @@ RSpec.describe Responsibility, type: :model do
 
     it { is_expected.to be_valid }
   end
+
+  describe 'audit events' do
+    let(:audit_payloads) { [] }
+
+    before do
+      allow(AuditEvent).to receive(:publish) do |**payload|
+        audit_payloads << payload
+      end
+      PaperTrail.request.whodunnit = 'HOMD_USER'
+    end
+
+    after do
+      PaperTrail.request.whodunnit = nil
+    end
+
+    it 'publishes an audit event when a responsibility override is created' do
+      create(:responsibility, offender: offender)
+
+      expect(AuditEvent).to have_received(:publish).once
+      expect(audit_payloads.last).to include(
+        nomis_offender_id: offender.nomis_offender_id,
+        tags: %w[record responsibility override created],
+        system_event: false,
+        username: 'HOMD_USER',
+        data: {
+          'value' => Responsibility::PROBATION,
+          'reason' => 'less_than_10_months_to_serve',
+        }
+      )
+    end
+
+    it 'publishes an audit event when a responsibility override is removed' do
+      responsibility = create(:responsibility, offender: offender)
+
+      responsibility.destroy!
+
+      expect(audit_payloads.last).to include(
+        nomis_offender_id: offender.nomis_offender_id,
+        tags: %w[record responsibility override removed],
+        system_event: false,
+        username: 'HOMD_USER',
+        data: {
+          'value' => Responsibility::PROBATION,
+          'reason' => 'less_than_10_months_to_serve',
+        }
+      )
+    end
+  end
 end

--- a/spec/views/allocations/show.html.erb_spec.rb
+++ b/spec/views/allocations/show.html.erb_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "allocations/show", type: :view do
 
     it 'allows POM responsible cases to have responsibility overridden' do
       render
-      expect(page).to have_css ".responsibility_change a[href='#{new_prison_responsibility_path(prison.code, nomis_offender_id: offender.offender_no)}']"
+      expect(page).to have_css ".responsibility_change a[href='#{new_prison_responsibility_path(prison.code, offender.offender_no)}']"
     end
 
     it 'allows COM responsible overrides to be deleted' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1958

The responsibility override was a bit of a mess with all their views lacking grid and proper markup, the forms not using new design system, etc.

Also we've had a few instances of duplicated responsibilities because there is no unique validation on the records, and the controller didn't protect against it either.

Some new copy agreed with service/content designers.

Partially started as "let's add an audit event" (MO-1956) and then well I went down the rabbit whole...