### PR TITLE
MO-1956 Add key case info details to timeline

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -28,9 +28,11 @@ class AllocationsController < PrisonsApplicationController
   def history
     @timeline = HmppsApi::PrisonApi::MovementApi.movements_for nomis_offender_id_from_url
 
+    # TODO: refactor this mess following the pattern set in `CaseInformationHistory`
     allocation = AllocationHistory.find_by!(nomis_offender_id: nomis_offender_id_from_url)
     vlo_history = PaperTrail::Version
         .where(item_type: 'VictimLiaisonOfficer', nomis_offender_id: nomis_offender_id_from_url).map { |vlo_version| VloHistory.new(vlo_version) }
+    case_information_history = CaseInformationHistory.timeline_entries_for(nomis_offender_id_from_url)
     responsibility_history = PaperTrail::Version
         .where(item_type: 'Responsibility', nomis_offender_id: nomis_offender_id_from_url)
         .map { |responsibility_version| ResponsibilityHistory.new(responsibility_version) }
@@ -58,6 +60,7 @@ class AllocationsController < PrisonsApplicationController
     @history = [
       AllocationService.history(allocation),
       vlo_history,
+      case_information_history,
       responsibility_history,
       complexity_history,
       email_history,

--- a/app/presenters/case_information_history.rb
+++ b/app/presenters/case_information_history.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class CaseInformationHistory < BaseHistoryPresenter
+  DETAIL_ATTRIBUTES = %w[tier rosh_level enhanced_resourcing].freeze
+  DETAIL_LABELS = { 'tier' => 'Tier', 'rosh_level' => 'ROSH', 'enhanced_resourcing' => 'Resourcing' }.freeze
+
+  Detail = Struct.new(:label, :from_value, :to_value)
+
+  delegate :created_at, :event, to: :@version
+
+  def initialize(version)
+    super()
+    @version = version
+  end
+
+  def self.timeline_entries_for(nomis_offender_id)
+    PaperTrail::Version
+      .where(item_type: 'CaseInformation', nomis_offender_id:)
+      .filter_map do |version|
+        history = new(version)
+        history if history.event == 'destroy' || history.change_details.any?
+      end
+  end
+
+  def to_partial_path
+    "case_history/case_information/#{event}"
+  end
+
+  def created_by_name
+    paper_trail_created_by_name(@version)
+  end
+
+  def change_details
+    return [] if event == 'destroy'
+
+    changeset = @version.changeset || {}
+
+    DETAIL_ATTRIBUTES.filter_map do |attribute|
+      next if attribute == 'rosh_level' && FeatureFlags.rosh_level.disabled?
+      next unless changeset.key?(attribute)
+
+      previous_value, new_value = changeset.fetch(attribute, [nil, nil])
+
+      Detail.new(
+        detail_label_for(attribute),
+        detail_value_for(attribute, previous_value),
+        detail_value_for(attribute, new_value)
+      )
+    end
+  end
+
+private
+
+  def detail_label_for(attribute)
+    DETAIL_LABELS.fetch(attribute)
+  end
+
+  def detail_value_for(attribute, value)
+    return '(unset)' if value.nil?
+
+    case attribute
+    when 'rosh_level'
+      value.to_s.humanize
+    when 'enhanced_resourcing'
+      ActiveModel::Type::Boolean.new.cast(value) ? 'enhanced' : 'standard'
+    else
+      value
+    end
+  end
+end

--- a/app/presenters/case_information_history.rb
+++ b/app/presenters/case_information_history.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class CaseInformationHistory < BaseHistoryPresenter
-  DETAIL_ATTRIBUTES = %w[tier rosh_level enhanced_resourcing].freeze
-  DETAIL_LABELS = { 'tier' => 'Tier', 'rosh_level' => 'ROSH', 'enhanced_resourcing' => 'Resourcing' }.freeze
+  TIMELINE_DETAILS = {
+    'tier' => 'Tier',
+    'rosh_level' => 'ROSH',
+    'enhanced_resourcing' => 'Resourcing',
+  }.freeze
 
   Detail = Struct.new(:label, :from_value, :to_value)
 
@@ -35,14 +38,14 @@ class CaseInformationHistory < BaseHistoryPresenter
 
     changeset = @version.changeset || {}
 
-    DETAIL_ATTRIBUTES.filter_map do |attribute|
+    TIMELINE_DETAILS.filter_map do |attribute, label|
       next if attribute == 'rosh_level' && FeatureFlags.rosh_level.disabled?
       next unless changeset.key?(attribute)
 
       previous_value, new_value = changeset.fetch(attribute, [nil, nil])
 
       Detail.new(
-        detail_label_for(attribute),
+        label,
         detail_value_for(attribute, previous_value),
         detail_value_for(attribute, new_value)
       )
@@ -50,10 +53,6 @@ class CaseInformationHistory < BaseHistoryPresenter
   end
 
 private
-
-  def detail_label_for(attribute)
-    DETAIL_LABELS.fetch(attribute)
-  end
 
   def detail_value_for(attribute, value)
     return '(unset)' if value.nil?

--- a/app/views/allocations/history.html.erb
+++ b/app/views/allocations/history.html.erb
@@ -4,9 +4,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-0">
       <%= @prisoner.full_name %>
     </h1>
+    <span class="govuk-caption-l govuk-!-margin-bottom-8">Prison number: <%= @prisoner.offender_no %></span>
 
     <!-- @history is forward-sorted - having converted to a hash key -> list we need to convert back to a list, reverse and also reverse the list itself  -->
     <% prison_episodes(@timeline, @history).each do |episode, case_histories| %>

--- a/app/views/case_history/case_information/_create.html.erb
+++ b/app/views/case_history/case_information/_create.html.erb
@@ -1,0 +1,12 @@
+<% details = create.change_details %>
+<% description = capture do %>
+  <% details.each do |detail| %>
+    <p class="govuk-body">
+      <%= detail.label %>: <%= detail.to_value %>
+    </p>
+  <% end %>
+<% end %>
+<%= render 'case_history/case_history',
+           title: 'Case information created',
+           description: description,
+           object: create %>

--- a/app/views/case_history/case_information/_destroy.html.erb
+++ b/app/views/case_history/case_information/_destroy.html.erb
@@ -1,0 +1,4 @@
+<%= render 'case_history/case_history',
+           title: 'Case information removed',
+           description: 'Case information removed',
+           object: destroy %>

--- a/app/views/case_history/case_information/_update.html.erb
+++ b/app/views/case_history/case_information/_update.html.erb
@@ -1,0 +1,12 @@
+<% details = update.change_details %>
+<% description = capture do %>
+  <% details.each do |detail| %>
+    <p class="govuk-body">
+      <%= detail.label %>: <%= detail.from_value %> → <%= detail.to_value %>
+    </p>
+  <% end %>
+<% end %>
+<%= render 'case_history/case_history',
+           title: 'Case information updated',
+           description: description,
+           object: update %>

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -173,7 +173,9 @@ RSpec.describe AllocationsController, type: :controller do
 
         it 'has a VLO create record' do
           get :history, params: { prison_id: prison_code, prisoner_id: vlo_offender_no }
-          expect(history.map(&:event)).to eq(['create', 'allocate_primary_pom'])
+          relevant_history = history.select { |entry| entry.is_a?(VloHistory) || entry.is_a?(CaseHistory) }
+
+          expect(relevant_history.map(&:event)).to eq(['create', 'allocate_primary_pom'])
         end
 
         context 'with update and delete VLO events' do
@@ -188,7 +190,9 @@ RSpec.describe AllocationsController, type: :controller do
 
           it 'has VLO and alloocation data sorted by date' do
             get :history, params: { prison_id: prison_code, prisoner_id: vlo_offender_no }
-            expect(history.map(&:event)).to eq(['create', 'allocate_primary_pom', 'update', 'destroy', "reallocate_primary_pom"])
+            relevant_history = history.select { |entry| entry.is_a?(VloHistory) || entry.is_a?(CaseHistory) }
+
+            expect(relevant_history.map(&:event)).to eq(['create', 'allocate_primary_pom', 'update', 'destroy', "reallocate_primary_pom"])
           end
         end
       end
@@ -224,8 +228,10 @@ RSpec.describe AllocationsController, type: :controller do
           it 'doesnt mess up the allocation history updated_at because we surface the value' do
             get :history, params: { prison_id: prison_code, prisoner_id: offender_no }
             history = assigns(:history)
-            expect(history.size).to eq(2)
-            expect(history.map(&:created_at).map(&:to_date)).to eq([create_date, yesterday])
+            allocation_history = history.select { |entry| entry.is_a?(CaseHistory) }
+
+            expect(allocation_history.size).to eq(2)
+            expect(allocation_history.map(&:created_at).map(&:to_date)).to eq([create_date, yesterday])
           end
         end
 
@@ -272,8 +278,9 @@ RSpec.describe AllocationsController, type: :controller do
           it "get the allocation history for an offender" do
             get :history, params: { prison_id: prison_code, prisoner_id: offender_no }
             allocation_list = assigns(:history)
+            allocation_history = allocation_list.select { |entry| entry.is_a?(CaseHistory) }
 
-            expect(allocation_list.map(&:event)).to eq(['allocate_primary_pom', 'allocate_primary_pom'])
+            expect(allocation_history.map(&:event)).to eq(['allocate_primary_pom', 'allocate_primary_pom'])
           end
         end
       end

--- a/spec/features/case_history_spec.rb
+++ b/spec/features/case_history_spec.rb
@@ -214,12 +214,12 @@ feature 'Case History' do
 
       it 'has a section for Prescoed transfer to open conditions' do
         # 1st Prison - Prescoed. This only contains the transfer to open conditions
-        within '.app-case-history__episode:nth-of-type(1)' do
+        within_timeline_section("Prescoed (HMP/YOI)") do
           expect(page).to have_css('.govuk-heading-m', text: "Prescoed (HMP/YOI)")
 
           prescoed_transfer = EmailHistory.where(nomis_offender_id: nomis_offender_id, event: EmailHistory::OPEN_PRISON_COMMUNITY_ALLOCATION).first
 
-          within '.moj-timeline__item:nth-of-type(1)' do
+          within_timeline_item(prescoed_transfer.email) do
             [
               ['.moj-timeline__title', "System generated email sent"],
               ['.moj-timeline__date', "#{prescoed_transfer.created_at.strftime("#{prescoed_transfer.created_at.day.ordinalize} %B %Y")} (#{prescoed_transfer.created_at.strftime('%R')}) email sent automatically"],
@@ -235,53 +235,26 @@ feature 'Case History' do
         expect(page).to have_css('.moj-timeline__title', text: "Prisoner unallocated")
       end
 
-      it 'has a Pentonville section with 6 items' do
-        within '.app-case-history__episode:nth-of-type(2)' do
+      it 'has a Pentonville section with the expected history entries' do
+        within_timeline_section(second_prison.name) do
           expect(page).to have_css('.govuk-heading-m', text: second_prison.name)
-          expect(all('.moj-timeline__item').size).to eq(6)
+
+          aggregate_failures do
+            expect_timeline_titles('Prisoner reallocated', 'Prisoner allocated')
+            expect(page).to have_css('.moj-timeline__header', text: 'Early allocation decision requested')
+            expect(page).to have_css('.moj-timeline__header', text: 'Early allocation assessment form completed')
+            expect(page).to have_css('.moj-timeline__header', text: 'System generated email sent')
+          end
         end
       end
 
       it 'has a Pentonville section', :js do
-        within '.app-case-history__episode:nth-of-type(2)' do
-          within '.moj-timeline__item:nth-of-type(1)' do
-            expect(page).to have_css('.moj-timeline__title', text: 'Prisoner reallocated')
-          end
-
-          within '.moj-timeline__item:nth-of-type(2)' do
-            [
-              ['.moj-timeline__header', "Early allocation decision requested"],
-            ].each do |key, val|
-              expect(page).to have_css(key, text: val)
-            end
-          end
-
-          within '.moj-timeline__item:nth-of-type(3)' do
-            [
-              ['.moj-timeline__header', "Early allocation assessment form completed"],
-            ].each do |key, val|
-              expect(page).to have_css(key, text: val)
-            end
-          end
-
-          within '.moj-timeline__item:nth-of-type(4)' do
-            [
-              ['.moj-timeline__header', "System generated email sent"],
-            ].each do |key, val|
-              expect(page).to have_css(key, text: val)
-            end
-          end
-
-          within '.moj-timeline__item:nth-of-type(5)' do
-            [
-              ['.moj-timeline__header', "Early allocation assessment form completed"],
-            ].each do |key, val|
-              expect(page).to have_css(key, text: val)
-            end
-          end
-
-          within '.moj-timeline__item:nth-of-type(6)' do
-            expect(page).to have_css('.moj-timeline__title', text: 'Prisoner allocated')
+        within_timeline_section(second_prison.name) do
+          aggregate_failures do
+            expect_timeline_titles('Prisoner reallocated', 'Prisoner allocated')
+            expect(page).to have_css('.moj-timeline__header', text: 'Early allocation decision requested')
+            expect(page).to have_css('.moj-timeline__header', text: 'Early allocation assessment form completed')
+            expect(page).to have_css('.moj-timeline__header', text: 'System generated email sent')
           end
         end
       end
@@ -291,11 +264,12 @@ feature 'Case History' do
                                                         updated_at: first_arrival_date + 2.days,
                                                         created_by_name: created_by_name
 
-        within '.app-case-history__episode:nth-of-type(3)' do
+        within_timeline_section(first_prison.name) do
           expect(page).to have_css('.govuk-heading-m', text: first_prison.name)
-          expect(all('.moj-timeline__item').size).to eq(5)
 
-          within '.moj-timeline__item:nth-of-type(1)' do
+          within find_timeline_item("#{formatted_deallocate_date} by System Admin") { |item|
+                   item.has_css?('.moj-timeline__title', text: 'Prisoner unallocated')
+                 } do
             [
               ['.moj-timeline__title', "Prisoner unallocated"],
               ['.moj-timeline__date', "#{formatted_deallocate_date} by System Admin"],
@@ -304,7 +278,7 @@ feature 'Case History' do
             end
           end
 
-          within '.moj-timeline__item:nth-of-type(2)' do
+          within_timeline_item('Co-working unallocated') do
             [
               ['.moj-timeline__title', "Co-working unallocated"],
             ].each do |key, val|
@@ -312,7 +286,7 @@ feature 'Case History' do
             end
           end
 
-          within '.moj-timeline__item:nth-of-type(3)' do
+          within_timeline_item('Co-working allocation') do
             [
               ['.moj-timeline__title', "Co-working allocation"],
               ['.moj-timeline__description', "Prisoner allocated to #{hist_allocate_secondary.secondary_pom_name.titleize} - #{probation_pom[:email]}"],
@@ -322,20 +296,15 @@ feature 'Case History' do
             end
           end
 
-          within '.moj-timeline__item:nth-of-type(4)' do
-            expect(page).to have_css('.moj-timeline__title', text: 'Prisoner reallocated')
-          end
-
-          within '.moj-timeline__item:nth-of-type(5)' do
-            expect(page).to have_css('.moj-timeline__title', text: 'Prisoner allocated')
-          end
+          expect_timeline_titles('Prisoner reallocated', 'Prisoner allocated')
         end
       end
 
       it 'links to previous Early Allocation assessments' do
-        # The 5th history item is an 'eligible' early allocation assessment
-        eligible_assessment = within '.app-case-history__episode:nth-of-type(2)' do
-          page.find('.moj-timeline > .moj-timeline__item:nth-child(5)')
+        eligible_assessment = within_timeline_section(second_prison.name) do
+          find_timeline_item('Early allocation assessment form completed') do |item|
+            item.has_css?('.moj-timeline__description', text: 'Assessment outcome: eligible.')
+          end
         end
 
         within eligible_assessment do
@@ -392,7 +361,15 @@ feature 'Case History' do
 
       it 'displays 3 sections - allocation plus 2 early allocation records' do
         visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
-        expect(all('.moj-timeline__item').size).to eq(3)
+
+        aggregate_failures do
+          expect_timeline_titles(
+            'Prisoner allocated',
+            'Case information created',
+            'Early allocation assessment form completed',
+            'Early allocation decision recorded'
+          )
+        end
       end
     end
 
@@ -412,8 +389,166 @@ feature 'Case History' do
         Timecop.return
       end
 
-      it 'displays all the data and doesnt crash' do
+      it 'displays the timeline without crashing' do
         visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
+      end
+    end
+
+    context 'when case information is removed because the record is destroyed' do
+      let(:tomorrow) { Time.zone.tomorrow }
+
+      before do
+        Timecop.travel tomorrow do
+          MovementService.process_movement build(:movement, :release, offenderNo: nomis_offender_id)
+        end
+      end
+
+      it 'shows a case information removed entry in the case history' do
+        visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
+
+        aggregate_failures do
+          expect_timeline_titles('Case information removed')
+
+          within_timeline_item('Case information removed') do
+            expect(page).to have_css('.moj-timeline__description', text: 'Case information removed')
+            expect(page).to have_css('.moj-timeline__date', text: 'by System Admin')
+          end
+        end
+      end
+    end
+
+    context 'when case information is added and later updated' do
+      let(:tomorrow) { Time.zone.tomorrow }
+      let(:day_after) { tomorrow + 1.day }
+      let(:two_days_after) { day_after + 1.day }
+      let!(:case_info) { nil }
+      let!(:offender_record) { create(:offender, nomis_offender_id: nomis_offender_id) }
+
+      before do
+        Timecop.travel tomorrow do
+          PaperTrail.request(
+            whodunnit: 'legacy.user',
+            controller_info: { user_first_name: 'Legacy', user_last_name: 'User', prison: open_prison.code }
+          ) do
+            create(
+              :case_information,
+              :manual_entry,
+              offender: offender_record,
+              tier: 'B',
+              rosh_level: 'LOW',
+              enhanced_resourcing: true
+            )
+          end
+        end
+
+        Timecop.travel day_after do
+          CaseInformation.find_by!(nomis_offender_id: nomis_offender_id).update!(tier: 'C')
+        end
+
+        Timecop.travel two_days_after do
+          PaperTrail.request(
+            whodunnit: 'current.user',
+            controller_info: { user_first_name: 'MOIC', user_last_name: 'POM', prison: open_prison.code }
+          ) do
+            CaseInformation.find_by!(nomis_offender_id: nomis_offender_id)
+              .update!(rosh_level: 'VERY_HIGH', enhanced_resourcing: false)
+          end
+        end
+      end
+
+      it 'displays both manual and relevant system-generated case information history entries' do
+        visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
+
+        aggregate_failures do
+          expect_timeline_titles('Case information created', 'Case information updated')
+
+          within(find_timeline_item('Case information created') { |item| item.text.include?('by Legacy User') }) do
+            expect(page).to have_css('.moj-timeline__description', text: 'Tier: B')
+            expect(page).to have_css('.moj-timeline__date', text: 'by Legacy User')
+          end
+
+          within(find_timeline_item('Case information updated') { |item| item.text.include?('by System Admin') }) do
+            expect(page).to have_css('.moj-timeline__description', text: 'Tier: B → C')
+            expect(page).to have_css('.moj-timeline__date', text: 'by System Admin')
+          end
+
+          within(find_timeline_item('Case information updated') { |item| item.text.include?('by MOIC POM') }) do
+            expect(page).to have_css('.moj-timeline__description', text: 'Resourcing: enhanced → standard')
+            expect(page).to have_css('.moj-timeline__date', text: 'by MOIC POM')
+          end
+        end
+      end
+    end
+
+    context 'when case information is updated by the system' do
+      let(:tomorrow) { Time.zone.tomorrow }
+
+      before do
+        Timecop.travel tomorrow do
+          PaperTrail.request(whodunnit: nil, controller_info: {}) do
+            case_info.update!(tier: 'B', rosh_level: 'LOW', enhanced_resourcing: true)
+          end
+        end
+      end
+
+      it 'shows the tracked case information changes as a system generated timeline entry' do
+        visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
+
+        within_timeline_item('Case information updated') do
+          aggregate_failures do
+            expect(page).to have_css('.moj-timeline__description', text: 'ROSH: High → Low')
+            expect(page).to have_css('.moj-timeline__date', text: 'by System Admin')
+          end
+        end
+      end
+    end
+
+    context 'when case information is updated by the system and the rosh feature flag is disabled' do
+      let(:tomorrow) { Time.zone.tomorrow }
+
+      before do
+        stub_feature_flag(:rosh_level, enabled: false)
+
+        Timecop.travel tomorrow do
+          PaperTrail.request(whodunnit: nil, controller_info: {}) do
+            case_info.update!(tier: 'B', rosh_level: 'LOW', enhanced_resourcing: true)
+          end
+        end
+      end
+
+      it 'hides the ROSH change from the case history timeline entry' do
+        visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
+
+        within_timeline_item('Case information updated') do
+          aggregate_failures do
+            expect(page).to have_no_css('.moj-timeline__description', text: 'ROSH: High → Low')
+            expect(page).to have_css('.moj-timeline__description', text: 'Resourcing: standard → enhanced')
+          end
+        end
+      end
+    end
+
+    context 'when case allocation decision is cleared by the system' do
+      let(:tomorrow) { Time.zone.tomorrow }
+
+      before do
+        Timecop.travel tomorrow do
+          PaperTrail.request(whodunnit: nil, controller_info: {}) do
+            case_info.update!(enhanced_resourcing: nil)
+          end
+        end
+      end
+
+      it 'shows the tracked case information change to (unset)' do
+        visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
+
+        within_timeline_item('Case information updated') do
+          aggregate_failures do
+            expect(page).to have_css('.moj-timeline__title', text: 'Case information updated')
+            expect(page).to have_css('.moj-timeline__description', text: 'Resourcing: standard → (unset)')
+            expect(page).to have_css('.moj-timeline__date', text: 'by System Admin')
+          end
+        end
       end
     end
 

--- a/spec/features/complexity_level_history_feature_spec.rb
+++ b/spec/features/complexity_level_history_feature_spec.rb
@@ -50,17 +50,18 @@ feature 'Case history with complexity level' do
       expect(all('.govuk-grid-row').size).to eq(1)
     end
 
-    it 'has a section with complexity and allocation' do
-      within '.govuk-grid-row:nth-of-type(1)' do
+    it 'has a section with the expected complexity and allocation entries' do
+      within_timeline_section(prison.name) do
         expect(page).to have_css('.govuk-heading-m', text: prison.name)
-        expect(all('.moj-timeline__item').size).to eq(2)
+
+        expect_timeline_titles('Prisoner allocated', 'Case information created', 'Complexity of need level added')
       end
     end
 
     # have to put :js here as \n is handled differently between Capybara and Rack::Test
     it 'has a section with the allocation in it', :js do
-      within '.govuk-grid-row:nth-of-type(1)' do
-        within '.moj-timeline__item:nth-of-type(1)' do
+      within_timeline_section(prison.name) do
+        within_timeline_item('Prisoner allocated to') do
           [
             ['.moj-timeline__description',
              [
@@ -75,17 +76,11 @@ feature 'Case history with complexity level' do
       end
     end
 
-    it 'has a section with the level in it' do
-      within '.govuk-grid-row:nth-of-type(1)' do
-        within '.moj-timeline__item:nth-of-type(2)' do
-          [
-            ['.moj-timeline__title', 'Complexity of need level added'],
-            ['.moj-timeline__description', 'Level: High'],
-            ['.moj-timeline__date', "#{formatted_date_for(complexity_add_time.getlocal)} by #{pom.first_name} #{pom.last_name}"],
-          ].each do |key, val|
-            expect(page).to have_css(key, text: val)
-          end
-        end
+    it 'shows the complexity level timeline entry' do
+      within_timeline_section(prison.name) do
+        expect(page).to have_css('.moj-timeline__title', text: 'Complexity of need level added')
+        expect(page).to have_css('.moj-timeline__description', text: 'Level: High')
+        expect(page).to have_css('.moj-timeline__date', text: "#{formatted_date_for(complexity_add_time.getlocal)} by #{pom.first_name} #{pom.last_name}")
       end
     end
   end
@@ -106,16 +101,17 @@ feature 'Case history with complexity level' do
       expect(all('.govuk-grid-row').size).to eq(1)
     end
 
-    it 'has 3 detail sections' do
-      within '.govuk-grid-row:nth-of-type(1)' do
+    it 'has the expected complexity history entries' do
+      within_timeline_section(prison.name) do
         expect(page).to have_css('.govuk-heading-m', text: prison.name)
-        expect(all('.moj-timeline__item').size).to eq(3)
+
+        expect_timeline_titles('Prisoner allocated', 'Case information created', 'Complexity of need level added', 'Complexity of need level updated')
       end
     end
 
-    it 'has a complexity change section', :js do
-      within '.govuk-grid-row:nth-of-type(1)' do
-        within '.moj-timeline__item:nth-of-type(1)' do
+    it 'shows the complexity level updated timeline entry', :js do
+      within_timeline_section(prison.name) do
+        within_timeline_item('Complexity of need level updated') do
           expect(page).to have_css('.moj-timeline__title', text: 'Complexity of need level updated')
           expect(page).to have_css('.moj-timeline__description', text: [
             'Changed from: High to Medium',
@@ -134,10 +130,11 @@ feature 'Case history with complexity level' do
       expect(all('.govuk-grid-row').size).to eq(1)
     end
 
-    it 'has 1 detail sections' do
-      within '.govuk-grid-row:nth-of-type(1)' do
+    it 'shows the baseline history entries' do
+      within_timeline_section(prison.name) do
         expect(page).to have_css('.govuk-heading-m', text: prison.name)
-        expect(all('.moj-timeline__item').size).to eq(1)
+
+        expect_timeline_titles('Prisoner allocated', 'Case information created')
       end
     end
   end

--- a/spec/features/early_allocation_18month_feature_spec.rb
+++ b/spec/features/early_allocation_18month_feature_spec.rb
@@ -30,14 +30,18 @@ feature 'early allocation when crossing 18 month threshold' do
       stub_signin_spo user, [prison.code]
     end
 
-    it 'does some funky history record stuff' do
+    it 'shows the early allocation reassessment reminder in case history' do
       visit history_prison_prisoner_allocation_path prison.code, offender_no
       # expect only 1 prison record
       expect(all('.govuk-grid-row').size).to eq(1)
-      # and expect 3 timeline items (the allocation itself, plus 2 emails)
 
-      within '.govuk-grid-row:nth-of-type(1)' do
-        expect(all('.moj-timeline__item').size).to eq(3)
+      within_timeline_section(prison.name) do
+        expect_timeline_titles(
+          'Prisoner allocated',
+          'Case information created',
+          'Early allocation assessment form completed',
+          'Reminder sent to POM for early allocation re-assessment'
+        )
       end
     end
   end

--- a/spec/presenters/case_information_history_spec.rb
+++ b/spec/presenters/case_information_history_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe CaseInformationHistory do
+  let(:event) { 'update' }
+  let(:version) { PaperTrail::Version.new(event:) }
+  let(:presenter) { described_class.new(version) }
+  let(:expected_partial_path) { 'case_history/case_information/update' }
+
+  it_behaves_like 'a paper trail timeline presenter'
+
+  describe '.timeline_entries_for' do
+    let(:nomis_offender_id) { 'A1234BC' }
+    let(:create_version) { PaperTrail::Version.new(event: 'create', object_changes: YAML.dump('tier' => [nil, 'A'])) }
+    let(:tracked_version) { PaperTrail::Version.new(event: 'update', object_changes: YAML.dump('tier' => ['A', 'B'])) }
+    let(:tracked_nil_version) { PaperTrail::Version.new(event: 'update', object_changes: YAML.dump('enhanced_resourcing' => [false, nil])) }
+    let(:destroy_version) { PaperTrail::Version.new(event: 'destroy') }
+    let(:hidden_version) { PaperTrail::Version.new }
+
+    it 'builds presenters for tracked create and update versions, including changes to nil, keeps destroy versions, and filters out hidden entries' do
+      allow(PaperTrail::Version).to receive(:where)
+        .with(item_type: 'CaseInformation', nomis_offender_id: nomis_offender_id)
+        .and_return([create_version, tracked_version, tracked_nil_version, destroy_version, hidden_version])
+
+      entries = described_class.timeline_entries_for(nomis_offender_id)
+
+      expect(entries.map(&:event)).to eq(%w[create update update destroy])
+    end
+  end
+
+  describe '#event' do
+    it 'returns the PaperTrail event for updates even when manual_entry changes' do
+      version = PaperTrail::Version.new(
+        event: 'update',
+        object_changes: YAML.dump('manual_entry' => [false, true], 'tier' => [nil, 'B'])
+      )
+
+      presenter = described_class.new(version)
+
+      aggregate_failures do
+        expect(presenter.event).to eq('update')
+        expect(presenter.to_partial_path).to eq('case_history/case_information/update')
+      end
+    end
+
+    it 'keeps create versions mapped to the create partial' do
+      presenter = described_class.new(PaperTrail::Version.new(event: 'create'))
+
+      aggregate_failures do
+        expect(presenter.event).to eq('create')
+        expect(presenter.to_partial_path).to eq('case_history/case_information/create')
+      end
+    end
+
+    it 'keeps destroy versions mapped to the destroy partial' do
+      presenter = described_class.new(PaperTrail::Version.new(event: 'destroy'))
+
+      aggregate_failures do
+        expect(presenter.event).to eq('destroy')
+        expect(presenter.to_partial_path).to eq('case_history/case_information/destroy')
+      end
+    end
+  end
+
+  describe '#change_details' do
+    it 'returns an empty list when the version has no tracked CaseInformation changes' do
+      expect(described_class.new(PaperTrail::Version.new).change_details).to eq([])
+    end
+
+    it 'returns the tracked details in the timeline order' do
+      version = PaperTrail::Version.new(
+        object_changes: YAML.dump(
+          'tier' => ['A', 'C'],
+          'rosh_level' => ['HIGH', 'VERY_HIGH'],
+          'enhanced_resourcing' => [false, true]
+        )
+      )
+
+      details = described_class.new(version).change_details
+
+      aggregate_failures do
+        expect(details.map(&:label)).to eq(['Tier', 'ROSH', 'Resourcing'])
+        expect(details.map(&:from_value)).to eq(['A', 'High', 'standard'])
+        expect(details.map(&:to_value)).to eq(['C', 'Very high', 'enhanced'])
+      end
+    end
+
+    it 'does not include ROSH details when the rosh_level feature flag is disabled' do
+      stub_feature_flag(:rosh_level, enabled: false)
+
+      version = PaperTrail::Version.new(
+        object_changes: YAML.dump(
+          'tier' => ['A', 'C'],
+          'rosh_level' => ['HIGH', 'VERY_HIGH'],
+          'enhanced_resourcing' => [false, true]
+        )
+      )
+
+      details = described_class.new(version).change_details
+
+      aggregate_failures do
+        expect(details.map(&:label)).to eq(['Tier', 'Resourcing'])
+        expect(details.map(&:from_value)).to eq(['A', 'standard'])
+        expect(details.map(&:to_value)).to eq(['C', 'enhanced'])
+      end
+    end
+
+    it 'ignores non-timeline attributes from the PaperTrail changeset' do
+      version = PaperTrail::Version.new(
+        object_changes: YAML.dump(
+          'manual_entry' => [false, true],
+          'tier' => ['B', 'D']
+        )
+      )
+
+      details = described_class.new(version).change_details
+
+      aggregate_failures do
+        expect(details.size).to eq(1)
+        expect(details.first.label).to eq('Tier')
+        expect(details.first.from_value).to eq('B')
+        expect(details.first.to_value).to eq('D')
+      end
+    end
+
+    it 'keeps tracked updates when the new value is nil' do
+      version = PaperTrail::Version.new(
+        event: 'update',
+        object_changes: YAML.dump(
+          'enhanced_resourcing' => [false, nil]
+        )
+      )
+
+      details = described_class.new(version).change_details
+
+      aggregate_failures do
+        expect(details.size).to eq(1)
+        expect(details.first.label).to eq('Resourcing')
+        expect(details.first.from_value).to eq('standard')
+        expect(details.first.to_value).to eq('(unset)')
+      end
+    end
+
+    it 'returns no tracked details for destroy versions because the timeline uses generic copy' do
+      version = PaperTrail::Version.new(
+        event: 'destroy',
+        object_changes: YAML.dump(
+          'tier' => ['B', nil],
+          'rosh_level' => ['LOW', nil],
+          'enhanced_resourcing' => [false, nil]
+        )
+      )
+
+      details = described_class.new(version).change_details
+
+      expect(details).to eq([])
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :js) do
-    page.driver.browser.manage.window.resize_to(1280,3072)
+    page.driver.browser.manage.window.resize_to(1280, 3072)
   end
 
   config.before(:each, :disable_early_allocation_event) do
@@ -73,7 +73,7 @@ RSpec.configure do |config|
     # We need to use a proper cache store to support the cache-backed session store
     Rails.cache.clear
   end
-  
+
   config.before(:each) do
     stub_bank_holidays
   end
@@ -83,6 +83,8 @@ RSpec.configure do |config|
   config.include AuthHelper
   config.include ApiHelper
   config.include ScenarioSetupHelper
+  config.include CaseHistoryTimelineHelper, type: :feature
+  config.include CaseHistoryTimelineHelper, type: :view
 
   config.before(:each, type: :view) do
     # This is needed for any view test that uses the sort_link and sort_arrow helpers
@@ -102,7 +104,7 @@ RSpec.configure do |config|
     stub_auth_token
     stub_request(:get, %r{#{Rails.configuration.prison_api_host}/api/offender-sentences/booking/\d+/sentenceTerms}).to_return(body: [].to_json)
 
-    if [:feature, :controller].include?(example.metadata[:type]) and
+    if [:feature, :controller].include?(example.metadata[:type]) &&
       example.metadata[:skip_dps_header_footer_stubbing].blank?
 
       stub_dps_header_footer
@@ -139,7 +141,7 @@ Faker::Config.locale = 'en-GB'
 FactoryBot.define do
   sequence :nomis_offender_id do |seq|
     index = seq - 1 # because seq starts at 1, not 0
-    number = "%04d" % (index / 26) # zero-pad to 4 digits, e.g. 0001
+    number = sprintf('%04d', index / 26) # zero-pad to 4 digits, e.g. 0001
     letter = ('A'..'Z').to_a[index % 26]
 
     # Start with "T" to indicate that this is a "test" offender ID
@@ -147,7 +149,7 @@ FactoryBot.define do
     "T#{number}A#{letter}"
   end
 end
-FactoryBot::SyntaxRunner.send(:include, ApiHelper)
+FactoryBot::SyntaxRunner.include(ApiHelper)
 FactoryBot::SyntaxRunner.send(:delegate, :stub_request, to: WebMock)
 
 Shoryuken::Logging.logger = Rails.logger

--- a/spec/support/helpers/case_history_timeline_helper.rb
+++ b/spec/support/helpers/case_history_timeline_helper.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module CaseHistoryTimelineHelper
+  TIMELINE_SECTION_SELECTORS = %w[.app-case-history__episode .govuk-grid-row].freeze
+
+  def timeline_titles
+    timeline_nodes('.moj-timeline__title').map { |node| node.text.strip }
+  end
+
+  def expect_timeline_titles(*titles)
+    aggregate_failures do
+      titles.each do |title|
+        expect(timeline_titles).to include(title)
+      end
+    end
+  end
+
+  def within_timeline_section(heading, &block)
+    within(find_timeline_section(heading), &block)
+  end
+
+  def find_timeline_item(text, &matcher)
+    items = timeline_nodes('.moj-timeline__item').select { |item| item.text.include?(text) }
+    item = matcher ? items.find { |candidate| matcher.call(candidate) } : items.first
+
+    raise "Could not find timeline item matching #{text.inspect}" unless item
+
+    item
+  end
+
+  def within_timeline_item(text, &block)
+    within(find_timeline_item(text), &block)
+  end
+
+  def find_timeline_section(heading)
+    section = TIMELINE_SECTION_SELECTORS
+      .flat_map { |selector| all(selector) }
+      .find { |candidate| candidate.has_css?('.govuk-heading-m', text: heading) }
+
+    raise "Could not find timeline section for #{heading}" unless section
+
+    section
+  end
+
+private
+
+  def timeline_nodes(selector)
+    if page.respond_to?(:all)
+      page.all(selector)
+    else
+      page.css(selector)
+    end
+  end
+end

--- a/spec/views/allocations/allocation_history.html.erb_spec.rb
+++ b/spec/views/allocations/allocation_history.html.erb_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
@@ -54,7 +54,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
@@ -71,7 +71,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
@@ -86,7 +86,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
@@ -103,7 +103,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
@@ -114,12 +114,12 @@ RSpec.describe "allocations/history", type: :view do
       include_examples 'view link'
     end
 
-    context 'with a disretionary early allocation' do
+    context 'with a discretionary early allocation' do
       let(:ea) { create(:early_allocation, :discretionary, created_at: Time.zone.local(2060, 11, 19, 11, 28, 0)) }
       let(:early_allocations) { [ea] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ["Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
 
@@ -136,7 +136,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:history) { [EarlyAllocationHistory.new(ea), EarlyAllocationDecision.new(ea)] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ['Early allocation decision recorded', "Early allocation assessment form completed"]
+        expect_timeline_titles('Early allocation decision recorded', 'Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("21st November 2060 (11:35)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")
@@ -157,7 +157,7 @@ RSpec.describe "allocations/history", type: :view do
       let(:history) { [EarlyAllocationHistory.new(ea), EarlyAllocationDecision.new(ea)] }
 
       it 'shows a single record' do
-        expect(page.css(".moj-timeline__title").map(&:text).map(&:strip)).to eq ['Early allocation decision recorded', "Early allocation assessment form completed",]
+        expect_timeline_titles('Early allocation decision recorded', 'Early allocation assessment form completed')
         expect(page.css('.moj-timeline__date')).to have_text("19th November 2060 (11:28)")
         expect(page.css('.moj-timeline__date')).to have_text("21st November 2060 (11:35)")
         expect(page.css('.moj-timeline__date')).to have_text("by #{ea.created_by_firstname} #{ea.created_by_lastname}")


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1956

Another PR related to case history / timeline, following previous ones #2815 and #2818.

This one adds key information from the case information (currently tier, rosh and resourcing). Rosh is behind feature flag for consistency with the other work we have in flight.

Will produce create/update/destroy entries in the timeline.

Refactor and improvement of timeline related specs so they are not so brittle when adding new events.