### PR TITLE
MO-1956 Skip case destroys in timeline

### DIFF
--- a/app/presenters/case_information_history.rb
+++ b/app/presenters/case_information_history.rb
@@ -21,7 +21,7 @@ class CaseInformationHistory < BaseHistoryPresenter
       .where(item_type: 'CaseInformation', nomis_offender_id:)
       .filter_map do |version|
         history = new(version)
-        history if history.event == 'destroy' || history.change_details.any?
+        history if history.change_details.any?
       end
   end
 

--- a/app/views/case_history/case_information/_destroy.html.erb
+++ b/app/views/case_history/case_information/_destroy.html.erb
@@ -1,4 +1,0 @@
-<%= render 'case_history/case_history',
-           title: 'Case information removed',
-           description: 'Case information removed',
-           object: destroy %>

--- a/spec/features/case_history_spec.rb
+++ b/spec/features/case_history_spec.rb
@@ -394,29 +394,6 @@ feature 'Case History' do
       end
     end
 
-    context 'when case information is removed because the record is destroyed' do
-      let(:tomorrow) { Time.zone.tomorrow }
-
-      before do
-        Timecop.travel tomorrow do
-          MovementService.process_movement build(:movement, :release, offenderNo: nomis_offender_id)
-        end
-      end
-
-      it 'shows a case information removed entry in the case history' do
-        visit history_prison_prisoner_allocation_path(open_prison.code, nomis_offender_id)
-
-        aggregate_failures do
-          expect_timeline_titles('Case information removed')
-
-          within_timeline_item('Case information removed') do
-            expect(page).to have_css('.moj-timeline__description', text: 'Case information removed')
-            expect(page).to have_css('.moj-timeline__date', text: 'by System Admin')
-          end
-        end
-      end
-    end
-
     context 'when case information is added and later updated' do
       let(:tomorrow) { Time.zone.tomorrow }
       let(:day_after) { tomorrow + 1.day }

--- a/spec/presenters/case_information_history_spec.rb
+++ b/spec/presenters/case_information_history_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe CaseInformationHistory do
     let(:destroy_version) { PaperTrail::Version.new(event: 'destroy') }
     let(:hidden_version) { PaperTrail::Version.new }
 
-    it 'builds presenters for tracked create and update versions, including changes to nil, keeps destroy versions, and filters out hidden entries' do
+    it 'builds presenters for tracked create and update versions, including changes to nil, and filters out hidden entries' do
       allow(PaperTrail::Version).to receive(:where)
         .with(item_type: 'CaseInformation', nomis_offender_id: nomis_offender_id)
         .and_return([create_version, tracked_version, tracked_nil_version, destroy_version, hidden_version])
 
       entries = described_class.timeline_entries_for(nomis_offender_id)
 
-      expect(entries.map(&:event)).to eq(%w[create update update destroy])
+      expect(entries.map(&:event)).to eq(%w[create update update])
     end
   end
 
@@ -48,15 +48,6 @@ RSpec.describe CaseInformationHistory do
       aggregate_failures do
         expect(presenter.event).to eq('create')
         expect(presenter.to_partial_path).to eq('case_history/case_information/create')
-      end
-    end
-
-    it 'keeps destroy versions mapped to the destroy partial' do
-      presenter = described_class.new(PaperTrail::Version.new(event: 'destroy'))
-
-      aggregate_failures do
-        expect(presenter.event).to eq('destroy')
-        expect(presenter.to_partial_path).to eq('case_history/case_information/destroy')
       end
     end
   end


### PR DESCRIPTION
Tiny tweak to previous PR #2819.

Case record destroys are not that valuable in the timeline and add noise, because the case destroy is always accompanied by the corresponding event that triggered the destroy in first place, which is "Prisoner unallocated" (either because a transfer, or a release).