### PR TITLE
MO-1965 Cover new recall codes and other hardening

### DIFF
--- a/app/domains/sentences/sentence_term/sentence_type.rb
+++ b/app/domains/sentences/sentence_term/sentence_type.rb
@@ -1,41 +1,37 @@
 class Sentences::SentenceTerm::SentenceType < SimpleDelegator
-  # Available Sentence Types, Sentence Descriptions
-  # DLP           Adult Discretionary Life
-  # MLP           Adult Mandatory Life
-  # ALP           Automatic LIfe
-  # ALP           Automatic Life
-  # ADIMP         CJA03 Standard Determinate Sentence
-  # EDS21         EDS Sec 279 Sentencing Code (21+)
-  # EPP           Extended Sent Public Protection CJA 03
-  # A/FINE        Imprisonment in Default of Fine
-  # IPP           Indeterminate Sentence for the Public Protection
-  # LEGACY        Legacy (pre 1991 Act)
-  # LR            Licence Recall
-  # LR_IPP        Licence recall from IPP Sentence
-  # LIFE          Life Imprisonment or Detention S.53(1) CYPA 1933
-  # LR_EDS21      LR EDS Sec 279 Sentencing Code (21+)
-  # 14FTR_ORA     ORA 14 Day Fixed Term Recall
-  # LR_ORA        ORA Licence Recall
-  # ADIMP_ORA     ORA Sentencing Code Standard Determinate Sentence
-  # LR_ALP        Recall from Automatic Life
-  # LR_ALP_CDE21  Recall from Automatic Life Sec 283 Sentencing Code (21+)
-  # LR_DLP        Recall from Discretionary Life
-  # LR_LIFE       Recall to Custody Indeterminate Sentence
-  # ADIMP         Sentencing Code Standard Determinate Sentence
-
-  INDETERMINATE_SENTENCE_TYPES = [
-    'IPP',
-    'LR_IPP',
-    'ALP',
-    'LR_ALP',
-    'ALP_CDE21',
-    'LR_ALP_CDE21',
-    'LIFE',
-    'LR_LIFE',
-    'DLP',
-    'LR_DLP',
-    'MLP',
-    'LR_MLP'
+  # Source of truth for indeterminate sentence types:
+  # https://github.com/ministryofjustice/prison-api/blob/main/src/main/java/uk/gov/justice/hmpps/prison/api/model/SentenceTypeRecallType.kt
+  # Keep this list aligned for now, we should evaluate using an API to get this info.
+  INDETERMINATE_SENTENCE_TYPES = %w[
+    20
+    ALP
+    ALP_CODE18
+    ALP_CODE21
+    ALP_LASPO
+    DFL
+    DLP
+    DPP
+    HMPL
+    IPP
+    LEGACY
+    LIFE
+    LIFE/IPP
+    LR_ALP
+    LR_ALP_CDE18
+    LR_ALP_CDE21
+    LR_ALP_LASPO
+    LR_DLP
+    LR_DPP
+    LR_IPP
+    LR_LIFE
+    LR_MLP
+    MLP
+    SEC272
+    SEC275
+    SEC93
+    SEC93_03
+    SEC94
+    ZMD
   ].freeze
 
   def indeterminate? = in?(INDETERMINATE_SENTENCE_TYPES)

--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -11,8 +11,7 @@ module HmppsApi
              :automatic_release_date, :licence_expiry_date,
              :post_recall_release_date, :earliest_release_date, :earliest_release,
              :indeterminate_sentence?, :immigration_case?, :civil_sentence?, :describe_sentence,
-             :legal_status,
-             to: :sentence
+             :legal_status, :recalled?, to: :sentence
 
     delegate :code, :label, :active_since, to: :@category, prefix: :category, allow_nil: true
 
@@ -67,10 +66,6 @@ module HmppsApi
         sentence.home_detention_curfew_eligibility_date.present? ||
         sentence.tariff_date.present? ||
         sentence.indeterminate_sentence?
-    end
-
-    def recalled?
-      @sentence.recall
     end
 
     def over_18?

--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -13,7 +13,7 @@ module HmppsApi
                 :tariff_date,
                 :legal_status
 
-    delegate :criminal_sentence?, :immigration_case?, :civil_sentence?, to: :@sentence_type
+    delegate :criminal_sentence?, :immigration_case?, :civil_sentence?, :recall?, to: :@sentence_type
 
     # Note - this is hiding a defect - we never get sentence_expiry_date from NOMIS (but maybe we should?)
     attr_accessor :sentence_expiry_date
@@ -74,6 +74,10 @@ module HmppsApi
       else
         past_dates.max_by { |date| date[:date].to_date }
       end
+    end
+
+    def recalled?
+      @recall || recall?
     end
 
     def initialize(payload)

--- a/app/models/sentence_type.rb
+++ b/app/models/sentence_type.rb
@@ -1,6 +1,63 @@
 # frozen_string_literal: true
 
 class SentenceType
+  # Source of truth for recall sentence types:
+  # https://github.com/ministryofjustice/prison-api/blob/main/src/main/java/uk/gov/justice/hmpps/prison/api/model/SentenceTypeRecallType.kt
+  # Keep this list aligned exactly with the upstream enum until we can rely on upstream `recall` attribute again.
+  RECALL_SENTENCE_TYPES = %w[
+    14FTR_ORA
+    CUR
+    CUR_ORA
+    FTR
+    FTRSCH15_ORA
+    FTRSCH18
+    FTRSCH18_ORA
+    FTR_14_HDC_ORA
+    FTR_56ORA
+    FTR_HDC
+    FTR_HDC_ORA
+    FTR_ORA
+    FTR_SCH15
+    HDR
+    HDR_ORA
+    LR
+    LRSEC250_ORA
+    LR_ALP
+    LR_ALP_CDE18
+    LR_ALP_CDE21
+    LR_ALP_LASPO
+    LR_DLP
+    LR_DPP
+    LR_EDS18
+    LR_EDS21
+    LR_EDSU18
+    LR_EPP
+    LR_ES
+    LR_IPP
+    LR_LASPO_AR
+    LR_LASPO_DR
+    LR_LIFE
+    LR_MLP
+    LR_ORA
+    LR_SEC236A
+    LR_SEC91_ORA
+    LR_SOPC18
+    LR_SOPC21
+    LR_YOI_ORA
+  ].freeze
+
+  CIVIL_SENTENCE_TYPES = %w[
+    A/FINE
+    A_FINE
+    A_CFINE
+    CIVIL
+    CIVIL_CON
+    CIVIL_DT
+    CIV_RMD
+    YOC_CONT
+    YO_CFINE
+  ].freeze
+
   attr_reader :code
 
   def initialize(imprisonment_status)
@@ -16,15 +73,11 @@ class SentenceType
     !civil_sentence?
   end
 
+  def recall?
+    RECALL_SENTENCE_TYPES.include?(@code)
+  end
+
   def civil_sentence?
-    %w[
-      CIVIL
-      CIVIL_CON
-      YOC_CONT
-      CIVIL_DT
-      A_CFINE
-      YO_CFINE
-      CIV_RMD
-    ].include? @code
+    CIVIL_SENTENCE_TYPES.include?(@code)
   end
 end

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -9,10 +9,6 @@ module HmppsApi
       # Used to filter out offenders who are on remand, civil prisoners, unsentenced, etc.
       ALLOWED_LEGAL_STATUSES = %w[SENTENCED INDETERMINATE_SENTENCE RECALL IMMIGRATION_DETAINEE].freeze
 
-      # Despite filtering out civil cases (legal status `CIVIL_PRISONER`) some civil cases
-      # will show up as `SENTENCED` legal status, and we need to filter by their sentence type code.
-      EXCLUDED_IMPRISONMENT_STATUSES = %w[A_FINE].freeze
-
       def self.get_offenders_in_prison(prison, *args)
         offenders = get_search_api_offenders_in_prison(prison)
 
@@ -119,10 +115,12 @@ module HmppsApi
         client.get(path)
       end
 
+      # Despite filtering out civil cases (legal status `CIVIL_PRISONER`) some civil cases
+      # will show up as `SENTENCED` legal status, and we need to filter by their sentence type code.
       def self.filtered_offenders(offenders)
         offenders.select do |o|
           ALLOWED_LEGAL_STATUSES.include?(o['legalStatus']) &&
-            EXCLUDED_IMPRISONMENT_STATUSES.exclude?(o['imprisonmentStatus'])
+            SentenceType::CIVIL_SENTENCE_TYPES.exclude?(o['imprisonmentStatus'])
         end
       end
 

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -257,6 +257,14 @@ describe HmppsApi::Offender do
       end
     end
 
+    context 'when recall flag is false but imprisonment status is an upstream recall code' do
+      let(:sentence) { attributes_for(:sentence_detail, recall: false, imprisonmentStatus: 'FTR_56ORA') }
+
+      it 'is true' do
+        expect(subject.recalled?).to eq(true)
+      end
+    end
+
     context 'when recall flag unset' do
       let(:sentence) { attributes_for(:sentence_detail, recall: false) }
 

--- a/spec/models/hmpps_api/sentence_detail_spec.rb
+++ b/spec/models/hmpps_api/sentence_detail_spec.rb
@@ -129,4 +129,22 @@ describe HmppsApi::SentenceDetail, model: true do
       end
     end
   end
+
+  describe '#recalled?' do
+    it 'is true when the recall flag is present' do
+      expect(build(:sentence_detail, recall: true).recalled?).to be true
+    end
+
+    it 'is true for upstream fixed-term recall sentence codes even without the recall flag' do
+      sentence_detail = build(:sentence_detail, recall: false, imprisonmentStatus: 'FTR_56ORA')
+
+      expect(sentence_detail.recalled?).to be true
+    end
+
+    it 'is false for non-recall ORA sentence codes when the recall flag is absent' do
+      sentence_detail = build(:sentence_detail, recall: false, imprisonmentStatus: 'ADIMP_ORA')
+
+      expect(sentence_detail.recalled?).to be false
+    end
+  end
 end

--- a/spec/models/sentence_type_spec.rb
+++ b/spec/models/sentence_type_spec.rb
@@ -15,8 +15,27 @@ RSpec.describe SentenceType, type: :model do
     expect(sentence_type.code).to eq('UNK_SENT')
   end
 
-  it 'knows what a civil sentence is' do
-    expect(described_class.new('CIVIL').civil_sentence?).to be true
+  it 'recognises the configured civil sentence types' do
+    expect(described_class::CIVIL_SENTENCE_TYPES).to all(satisfy { |code| described_class.new(code).civil_sentence? })
+  end
+
+  it 'treats upstream fine-code variants as civil sentences' do
+    expect(described_class.new('A/FINE').civil_sentence?).to be true
+    expect(described_class.new('A_FINE').civil_sentence?).to be true
+  end
+
+  it 'does not treat criminal sentence types as civil' do
     expect(described_class.new('IPP').civil_sentence?).to be false
+  end
+
+  describe '#recall?' do
+    it 'recognises the current upstream Prison API recall sentence codes' do
+      expect(described_class::RECALL_SENTENCE_TYPES).to all(satisfy { |code| described_class.new(code).recall? })
+    end
+
+    it 'does not treat non-recall sentence codes as recall' do
+      expect(described_class.new('ADIMP_ORA').recall?).to be false
+      expect(described_class.new('EDS21').recall?).to be false
+    end
   end
 end

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -13,15 +13,20 @@ describe HmppsApi::PrisonApi::OffenderApi do
 
   # These offenders should be filtered out because of their legal status or imprisonment code
   let(:rejected_offenders) do
-    [
+    base_rejected = [
       build(:nomis_offender, legalStatus: 'CIVIL_PRISONER'),
       build(:nomis_offender, legalStatus: 'CONVICTED_UNSENTENCED'),
       build(:nomis_offender, legalStatus: 'DEAD'),
       build(:nomis_offender, legalStatus: 'OTHER'),
       build(:nomis_offender, legalStatus: 'REMAND'),
       build(:nomis_offender, legalStatus: 'UNKNOWN'),
-      build(:nomis_offender, legalStatus: 'SENTENCED', sentence: { imprisonmentStatus: 'A_FINE' })
     ]
+
+    civil_status_rejected = SentenceType::CIVIL_SENTENCE_TYPES.map do |status|
+      build(:nomis_offender, legalStatus: 'SENTENCED', sentence: { imprisonmentStatus: status })
+    end
+
+    base_rejected + civil_status_rejected
   end
 
   describe 'List of offenders' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1965

Some recall sentences were not being recognised upstream due to new codes being added recently but the `recall` flag still coming as false for these.

In the interim we are going to do the check on our side, but soonish this will be reverted back to using trusting upstream `recall` flag.

As part of this, other lists of codes have been hardened/aligned that could produce wrong handover calculations as well as improving the sentenced civil cases check.