### PR TITLE
Improve calculated handover history in debugging

### DIFF
--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -34,7 +34,13 @@ module OffenderHelper
 
   def last_event(allocation)
     event = event_type(allocation.event)
-    "#{event} - #{allocation.created_at.strftime('%d/%m/%Y')}"
+    timestamp = if allocation.respond_to?(:updated_at) && allocation.updated_at.present?
+                  allocation.updated_at
+                else
+                  allocation.created_at
+                end
+
+    "#{event} - #{timestamp.strftime('%d/%m/%Y')}"
   end
 
   def event_type(event)

--- a/app/presenters/debugging/handover_attribute_comparison.rb
+++ b/app/presenters/debugging/handover_attribute_comparison.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Debugging
+  class HandoverAttributeComparison
+    def initialize(item, previous_item)
+      @item = item
+      @previous_item = previous_item
+    end
+
+    def rows
+      (current_attributes.keys | previous_attributes.keys).sort.map do |key|
+        current_state = attribute_state(current_attributes, key)
+        previous_state = attribute_state(previous_attributes, key)
+
+        {
+          label: key.humanize,
+          before: @previous_item.nil? ? 'No earlier value' : previous_attribute_value(previous_attributes, key),
+          after: current_attribute_value(current_attributes, previous_attributes, key),
+          changed: attribute_changed?(previous_state, current_state, previous_attributes[key], current_attributes[key])
+        }
+      end
+    end
+
+  private
+
+    def current_attributes
+      @item.offender_attributes
+    end
+
+    def previous_attributes
+      @previous_item&.offender_attributes || {}
+    end
+
+    def attribute_state(attributes, key)
+      return :missing unless attributes.key?(key)
+
+      attributes[key].nil? ? :unset : :value
+    end
+
+    def previous_attribute_value(attributes, key)
+      case attribute_state(attributes, key)
+      when :missing then 'Not recorded'
+      when :unset then '—'
+      else attributes[key]
+      end
+    end
+
+    def current_attribute_value(current_attributes, previous_attributes, key)
+      current_state = attribute_state(current_attributes, key)
+      previous_state = attribute_state(previous_attributes, key)
+
+      case current_state
+      when :missing
+        'Not recorded'
+      when :unset
+        previous_state == :value ? '(unset)' : '—'
+      else
+        current_attributes[key]
+      end
+    end
+
+    def attribute_changed?(previous_state, current_state, previous_value, current_value)
+      if previous_state == :value && current_state == :value
+        previous_value != current_value
+      elsif previous_state == :value || current_state == :value
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/views/debugging/_offender_details.html.erb
+++ b/app/views/debugging/_offender_details.html.erb
@@ -58,6 +58,10 @@
         <dd class="govuk-summary-list__value"><%= probation_field(@offender, :tier) || 'Not provided' %></dd>
       </div>
       <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">ROSH level</dt>
+        <dd class="govuk-summary-list__value"><%= probation_field(@offender, :rosh_level) || 'Not provided' %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">MAPPA level</dt>
         <dd class="govuk-summary-list__value"><%= probation_field(@offender, :mappa_level) || 'Not provided' %></dd>
       </div>

--- a/app/views/debugging/_responsibility_history.html.erb
+++ b/app/views/debugging/_responsibility_history.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="govuk-summary-card__content">
     <% if history&.any? %>
+      <% history_items = history.to_a %>
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -18,7 +19,9 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% history.each do |item| %>
+          <% history_items.each.with_index(1) do |item, index| %>
+            <% previous_item = history_items[index] %>
+            <% comparison = Debugging::HandoverAttributeComparison.new(item, previous_item) %>
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header"><%= item.updated_at.strftime('%d/%m/%Y %H:%M:%S') %></th>
               <td class="govuk-table__cell"><%= item.responsibility %></td>
@@ -38,14 +41,30 @@
                     </span>
                   </summary>
                   <div class="govuk-details__text">
-                    <dl class="govuk-summary-list">
-                      <% item.offender_attributes.sort.each do |key, value| %>
-                        <div class="govuk-summary-list__row">
-                          <dt class="govuk-summary-list__key"><%= key.humanize %></dt>
-                          <dd class="govuk-summary-list__value"><%= value %></dd>
-                        </div>
-                      <% end %>
-                    </dl>
+                    <table class="govuk-table govuk-!-margin-bottom-0">
+                      <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                          <th scope="col" class="govuk-table__header"></th>
+                          <th scope="col" class="govuk-table__header">Before</th>
+                          <th scope="col" class="govuk-table__header">After</th>
+                        </tr>
+                      </thead>
+                      <tbody class="govuk-table__body">
+                        <% comparison.rows.each do |row| %>
+                          <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header"><%= row[:label] %></th>
+                            <td class="govuk-table__cell"><%= row[:before] %></td>
+                            <td class="govuk-table__cell">
+                              <% if row[:changed] %>
+                                <strong><%= row[:after] %></strong>
+                              <% else %>
+                                <%= row[:after] %>
+                              <% end %>
+                            </td>
+                          </tr>
+                        <% end %>
+                      </tbody>
+                    </table>
                   </div>
                 </details>
               </td>

--- a/spec/controllers/allocations_controller_spec.rb
+++ b/spec/controllers/allocations_controller_spec.rb
@@ -148,6 +148,32 @@ RSpec.describe AllocationsController, type: :controller do
           expect(page.css('#oasys-date')).to have_text('No OASys information')
         end
       end
+
+      context 'when rendering the allocation summary' do
+        let(:active_pom) { poms.last }
+        let(:allocation_event_date) { Time.zone.local(2026, 3, 4, 12, 0, 0) }
+
+        render_views
+
+        before do
+          allow(HmppsApi::AssessRisksAndNeedsApi).to receive(:get_latest_oasys_date).with(offender_no).and_return(nil)
+          create(:allocation_history,
+                 prison: prison_code,
+                 nomis_offender_id: offender_no,
+                 primary_pom_nomis_id: active_pom.staffId,
+                 event: AllocationHistory::ALLOCATE_PRIMARY_POM,
+                 created_at: allocation_event_date,
+                 updated_at: allocation_event_date)
+        end
+
+        it 'renders the last allocation event for the CaseHistory presenter' do
+          get :show, params: { prison_id: prison_code, prisoner_id: offender_no }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('Allocation history')
+          expect(response.body).to include("POM allocated - #{allocation_event_date.strftime('%d/%m/%Y')}")
+        end
+      end
     end
 
     describe '#history' do

--- a/spec/controllers/debugging_controller_spec.rb
+++ b/spec/controllers/debugging_controller_spec.rb
@@ -47,6 +47,56 @@ RSpec.describe DebuggingController, type: :controller do
       expect(movements.from_agency).to eq "LEI"
       expect(movements.to_agency).to eq prison_id
     end
+
+    context 'when rendering handover history comparisons' do
+      render_views
+
+      it 'renders the handover history comparison block' do
+        stub_offender(build(:nomis_offender, prisonId: prison.code, sentence: attributes_for(:sentence_detail, :indeterminate), prisonerNumber: offender_no))
+
+        stub_movements_for offender_no, [attributes_for(:movement, offenderNo: offender_no,
+                                                                   fromAgency: 'LEI',
+                                                                   toAgency: prison_id,
+                                                                   movementType: 'TRN',
+                                                                   directionCode: 'IN')], movement_types: %w[ADM TRN REL]
+
+        offender = create(:offender, nomis_offender_id: offender_no)
+        create(:case_information, offender:)
+        create(:allocation_history, prison: prison.code, nomis_offender_id: offender_no, primary_pom_nomis_id: pom_staff_id, primary_pom_name: primary_pom_name)
+
+        calculated_handover = build(:calculated_handover_date,
+                                    offender:,
+                                    nomis_offender_id: offender_no,
+                                    responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+                                    reason: :recall_case)
+        calculated_handover.offender_attributes_to_archive = {
+          'mappa_level' => 1,
+          'recalled?' => false,
+          'test_same_value' => 'same',
+          'ldu_email_address' => 'pom@example.com',
+          'team_name' => nil
+        }
+        calculated_handover.save!
+
+        calculated_handover.offender_attributes_to_archive = {
+          'mappa_level' => 2,
+          'recalled?' => true,
+          'test_same_value' => 'same',
+          'ldu_email_address' => nil,
+          'team_name' => nil
+        }
+        calculated_handover.update!(reason: :determinate_short)
+
+        get :debugging, params: { prison_id: prison_id, offender_no: offender_no }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Offender details recorded at this point')
+        expect(response.body).to include('Before')
+        expect(response.body).to include('After')
+        expect(response.body).to include('Ldu email address')
+        expect(response.body).to include('(unset)')
+      end
+    end
   end
 
   describe 'debugging the timeline of events' do

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe OffenderHelper do
     end
   end
 
-  describe '#event_type' do
+  describe '#last_event' do
     let(:nomis_staff_id) { 456_789 }
     let(:nomis_offender_id) { 123_456 }
+    let(:first_allocation_date) { Time.zone.local(2026, 1, 10, 9, 0, 0) }
+    let(:last_allocation_event_date) { Time.zone.local(2026, 2, 20, 14, 30, 0) }
 
     let!(:allocation) do
       create(
@@ -22,12 +24,30 @@ RSpec.describe OffenderHelper do
         prison: prison.code,
         nomis_offender_id: nomis_offender_id,
         primary_pom_nomis_id: nomis_staff_id,
-        event: 'allocate_primary_pom'
+        event: 'allocate_primary_pom',
+        created_at: first_allocation_date,
+        updated_at: last_allocation_event_date
       )
     end
 
+    it 'returns the event in a more readable format using the latest event date' do
+      expect(helper.last_event(allocation)).to eq("POM allocated - #{last_allocation_event_date.strftime('%d/%m/%Y')}")
+    end
+
+    it 'falls back to created_at for CaseHistory-style objects without updated_at' do
+      allocation_history = instance_double(
+        CaseHistory,
+        event: 'allocate_primary_pom',
+        created_at: last_allocation_event_date
+      )
+
+      expect(helper.last_event(allocation_history)).to eq("POM allocated - #{last_allocation_event_date.strftime('%d/%m/%Y')}")
+    end
+  end
+
+  describe '#event_type' do
     it 'returns the event in a more readable format' do
-      expect(helper.last_event(allocation)).to eq("POM allocated - #{allocation.updated_at.strftime('%d/%m/%Y')}")
+      expect(helper.event_type('allocate_primary_pom')).to eq('POM allocated')
     end
   end
 

--- a/spec/presenters/debugging/handover_attribute_comparison_spec.rb
+++ b/spec/presenters/debugging/handover_attribute_comparison_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+module Debugging
+  describe HandoverAttributeComparison do
+    let(:current_item) do
+      instance_double(
+        CalculatedHandoverDate::History::Item,
+        offender_attributes: {
+          'mappa_level' => 2,
+          'recalled?' => true,
+          'earliest_release_for_handover' => { 'name' => 'TED', 'date' => '2026-06-01' },
+          'test_same_value' => 'same',
+          'ldu_email_address' => nil,
+          'team_name' => nil
+        }
+      )
+    end
+
+    let(:previous_item) do
+      instance_double(
+        CalculatedHandoverDate::History::Item,
+        offender_attributes: {
+          'mappa_level' => 1,
+          'recalled?' => false,
+          'earliest_release_for_handover' => { 'name' => 'TED', 'date' => '2026-05-01' },
+          'test_same_value' => 'same',
+          'ldu_email_address' => 'pom@example.com',
+          'team_name' => nil
+        }
+      )
+    end
+
+    describe '#rows' do
+      it 'builds comparable before and after rows for each archived field' do
+        rows = described_class.new(current_item, previous_item).rows
+
+        expect(rows).to include(
+          {
+            label: 'Mappa level',
+            before: 1,
+            after: 2,
+            changed: true
+          },
+          {
+            label: 'Recalled?',
+            before: false,
+            after: true,
+            changed: true
+          },
+          {
+            label: 'Earliest release for handover',
+            before: { 'name' => 'TED', 'date' => '2026-05-01' },
+            after: { 'name' => 'TED', 'date' => '2026-06-01' },
+            changed: true
+          },
+          {
+            label: 'Test same value',
+            before: 'same',
+            after: 'same',
+            changed: false
+          },
+          {
+            label: 'Ldu email address',
+            before: 'pom@example.com',
+            after: '(unset)',
+            changed: true
+          },
+          {
+            label: 'Team name',
+            before: '—',
+            after: '—',
+            changed: false
+          }
+        )
+      end
+
+      it 'shows that the oldest snapshot has no earlier value' do
+        rows = described_class.new(current_item, nil).rows
+
+        expect(rows).to include(
+          {
+            label: 'Mappa level',
+            before: 'No earlier value',
+            after: 2,
+            changed: true
+          },
+          {
+            label: 'Ldu email address',
+            before: 'No earlier value',
+            after: '—',
+            changed: false
+          },
+          {
+            label: 'Team name',
+            before: 'No earlier value',
+            after: '—',
+            changed: false
+          }
+        )
+      end
+
+      it 'shows not recorded only when a key was absent from the earlier snapshot' do
+        rows = described_class.new(
+          instance_double(CalculatedHandoverDate::History::Item, offender_attributes: { 'target_hearing_date' => Date.new(2026, 6, 1) }),
+          instance_double(CalculatedHandoverDate::History::Item, offender_attributes: {})
+        ).rows
+
+        expect(rows).to include(
+          {
+            label: 'Target hearing date',
+            before: 'Not recorded',
+            after: Date.new(2026, 6, 1),
+            changed: true
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Better calculated responsibility & handover history in the debugging page, showing the before and after values and more clearly indicating which ones changed or were unset.

Also fixed a bug with the date of the last_event in the debugging page. Adding rosh level too.