### PR TITLE
Tag word wrapping and styling fixes

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -77,7 +77,14 @@
   align-items: flex-start;
 
   span.govuk-tag {
-    max-width: 162px;
+    white-space: nowrap;
+    width: fit-content;
+    max-width: fit-content;
+  }
+
+  span.app-tag--stacked .app-tag__line {
+    display: block;
+    white-space: nowrap;
   }
 }
 

--- a/app/views/shared/_badges.html.erb
+++ b/app/views/shared/_badges.html.erb
@@ -6,7 +6,10 @@
   <% end %>
 
   <% if offender.responsibility_override? %>
-    <span id="responsibility-override-badge" class="govuk-tag govuk-tag--yellow">Overridden</span>
+    <span id="responsibility-override-badge" class="govuk-tag govuk-tag--yellow app-tag--stacked">
+      <span class="app-tag__line">Responsibility</span>
+      <span class="app-tag__line">overridden</span>
+    </span>
   <% end %>
 
   <% if offender.active_vlo? || offender.victim_liaison_officers.any? %>
@@ -23,8 +26,9 @@
 
   <% status = offender.early_allocation_state %>
   <% if EarlyAllocationHelper::EARLY_ALLOCATION_STATUSES.key?(status) %>
-    <span id="early-allocation-badge" class="govuk-tag govuk-tag--blue">
-      Early allocation <%= EarlyAllocationHelper::EARLY_ALLOCATION_STATUSES.fetch(status) %>
+    <span id="early-allocation-badge" class="govuk-tag govuk-tag--blue app-tag--stacked">
+      <span class="app-tag__line">Early allocation</span>
+      <span class="app-tag__line"><%= EarlyAllocationHelper::EARLY_ALLOCATION_STATUSES.fetch(status) %></span>
     </span>
   <% end %>
 

--- a/spec/features/responsibility/homd_overrides_responsibilities_spec.rb
+++ b/spec/features/responsibility/homd_overrides_responsibilities_spec.rb
@@ -25,7 +25,7 @@ describe 'HOMD overrides responsibilities' do
 
     visit allocated_prison_prisoners_path(prison)
     click_on 'Offender, Overridden'
-    expect(page).to have_css('#responsibility-override-badge', text: 'Overridden')
+    expect(page).to have_css('#responsibility-override-badge', text: 'Responsibility overridden')
     within('tr', text: 'Current responsibility Community') { click_on 'Change' }
     fill_in 'Why are you changing responsibility for this case?', with: 'Reasons are thus'
     click_on 'Confirm'
@@ -58,6 +58,6 @@ describe 'HOMD overrides responsibilities' do
     visit allocated_prison_prisoners_path(prison)
     click_on 'Offender, Calculated'
     expect(page).to have_content('Current responsibility Community')
-    expect(page).to have_css('#responsibility-override-badge', text: 'Overridden')
+    expect(page).to have_css('#responsibility-override-badge', text: 'Responsibility overridden')
   end
 end

--- a/spec/views/shared/badges.html.erb_spec.rb
+++ b/spec/views/shared/badges.html.erb_spec.rb
@@ -66,13 +66,13 @@ RSpec.describe "shared/badges", type: :view do
 
     it 'displays a responsibility override badge' do
       expect(responsibility_override_badge.first.attributes['class'].value).to include 'govuk-tag--yellow'
-      expect(responsibility_override_badge.text).to include 'Overridden'
+      expect(responsibility_override_badge.text.squish).to eq 'Responsibility overridden'
     end
 
     it 'places the responsibility override badge immediately after the case type badge' do
       badge_text = page.css('.govuk-tag').map { |tag| tag.text.squish }
 
-      expect(badge_text.last(3)).to eq(['Determinate', 'Overridden', 'VLO contact'])
+      expect(badge_text.last(3)).to eq(['Determinate', 'Responsibility overridden', 'VLO contact'])
     end
   end
 

--- a/spec/views/shared/early_allocation_badge.html.erb_spec.rb
+++ b/spec/views/shared/early_allocation_badge.html.erb_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "prisoners/show", type: :view do
         it 'displays corresponding badge' do
           expect(badge_count).to eq(1)
           expect(early_allocation_badge.attributes['class'].value).to include 'govuk-tag--blue'
-          expect(early_allocation_badge.text.strip).to eq 'Early allocation assessment saved'
+          expect(early_allocation_badge.text.squish).to eq 'Early allocation assessment saved'
         end
       end
 
@@ -42,7 +42,7 @@ RSpec.describe "prisoners/show", type: :view do
           it 'displays corresponding badge' do
             expect(badge_count).to eq(1)
             expect(early_allocation_badge.attributes['class'].value).to include 'govuk-tag--blue'
-            expect(early_allocation_badge.text.strip).to eq 'Early allocation assessment saved'
+            expect(early_allocation_badge.text.squish).to eq 'Early allocation assessment saved'
           end
         end
 
@@ -52,7 +52,7 @@ RSpec.describe "prisoners/show", type: :view do
           it 'displays corresponding badge' do
             expect(badge_count).to eq(1)
             expect(early_allocation_badge.attributes['class'].value).to include 'govuk-tag--blue'
-            expect(early_allocation_badge.text.strip).to eq 'Early allocation decision pending'
+            expect(early_allocation_badge.text.squish).to eq 'Early allocation decision pending'
           end
         end
 
@@ -62,7 +62,7 @@ RSpec.describe "prisoners/show", type: :view do
           it 'displays corresponding badge' do
             expect(badge_count).to eq(1)
             expect(early_allocation_badge.attributes['class'].value).to include 'govuk-tag--blue'
-            expect(early_allocation_badge.text.strip).to eq 'Early allocation eligible'
+            expect(early_allocation_badge.text.squish).to eq 'Early allocation eligible'
           end
         end
 
@@ -71,7 +71,7 @@ RSpec.describe "prisoners/show", type: :view do
 
           it 'displays corresponding badge' do
             expect(early_allocation_badge.attributes['class'].value).to include 'govuk-tag--blue'
-            expect(early_allocation_badge.text.strip).to eq 'Early allocation eligible'
+            expect(early_allocation_badge.text.squish).to eq 'Early allocation eligible'
           end
         end
       end


### PR DESCRIPTION
Some minor fixes for tags to avoid unnecessary word wrapping unless explicitly done (which we need to do for 2 tags that are otherwise too lengthy).