### PR TITLE
Cleanup no longer needed recall check

### DIFF
--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -13,10 +13,33 @@ module HmppsApi
                 :tariff_date,
                 :legal_status
 
-    delegate :criminal_sentence?, :immigration_case?, :civil_sentence?, :recall?, to: :@sentence_type
+    delegate :criminal_sentence?, :immigration_case?, :civil_sentence?, to: :@sentence_type
 
     # Note - this is hiding a defect - we never get sentence_expiry_date from NOMIS (but maybe we should?)
     attr_accessor :sentence_expiry_date
+
+    def initialize(payload)
+      @actual_parole_date = payload['actualParoleDate']&.to_date
+      @automatic_release_date = payload['automaticReleaseDate']&.to_date
+      @automatic_release_override_date = payload['automaticReleaseOverrideDate']&.to_date
+      @conditional_release_date = payload['conditionalReleaseDate']&.to_date
+      @conditional_release_override_date = payload['conditionalReleaseOverrideDate']&.to_date
+      @home_detention_curfew_actual_date = payload['homeDetentionCurfewActualDate']&.to_date
+      @home_detention_curfew_eligibility_date = payload['homeDetentionCurfewEligibilityDate']&.to_date
+      @licence_expiry_date = payload['licenceExpiryDate']&.to_date
+      @nomis_post_recall_release_date = payload['postRecallReleaseDate']&.to_date
+      @nomis_post_recall_release_override_date = payload['postRecallReleaseOverrideDate']&.to_date
+      @parole_eligibility_date = payload['paroleEligibilityDate']&.to_date
+      @release_date = payload['releaseDate']&.to_date
+      @sentence_start_date = payload['sentenceStartDate']&.to_date
+      @tariff_date = payload['tariffDate']&.to_date
+
+      @sentence_type = SentenceType.new payload.fetch('imprisonmentStatus', 'UNK_SENT')
+      @recall = payload.fetch('recall', false)
+      @indeterminate_sentence = payload['indeterminateSentence']
+      @description = payload.fetch('imprisonmentStatusDescription', 'Unknown Sentenced')
+      @legal_status = payload['legalStatus']
+    end
 
     def automatic_release_date
       @automatic_release_override_date.presence || @automatic_release_date
@@ -77,30 +100,7 @@ module HmppsApi
     end
 
     def recalled?
-      @recall || recall?
-    end
-
-    def initialize(payload)
-      @actual_parole_date = payload['actualParoleDate']&.to_date
-      @automatic_release_date = payload['automaticReleaseDate']&.to_date
-      @automatic_release_override_date = payload['automaticReleaseOverrideDate']&.to_date
-      @conditional_release_date = payload['conditionalReleaseDate']&.to_date
-      @conditional_release_override_date = payload['conditionalReleaseOverrideDate']&.to_date
-      @home_detention_curfew_actual_date = payload['homeDetentionCurfewActualDate']&.to_date
-      @home_detention_curfew_eligibility_date = payload['homeDetentionCurfewEligibilityDate']&.to_date
-      @licence_expiry_date = payload['licenceExpiryDate']&.to_date
-      @nomis_post_recall_release_date = payload['postRecallReleaseDate']&.to_date
-      @nomis_post_recall_release_override_date = payload['postRecallReleaseOverrideDate']&.to_date
-      @parole_eligibility_date = payload['paroleEligibilityDate']&.to_date
-      @release_date = payload['releaseDate']&.to_date
-      @sentence_start_date = payload['sentenceStartDate']&.to_date
-      @tariff_date = payload['tariffDate']&.to_date
-
-      @sentence_type = SentenceType.new payload.fetch('imprisonmentStatus', 'UNK_SENT')
-      @recall = payload.fetch('recall', false)
-      @indeterminate_sentence = payload['indeterminateSentence']
-      @description = payload.fetch('imprisonmentStatusDescription', 'Unknown Sentenced')
-      @legal_status = payload['legalStatus']
+      @recall
     end
 
     def indeterminate_sentence?

--- a/app/models/sentence_type.rb
+++ b/app/models/sentence_type.rb
@@ -1,51 +1,6 @@
 # frozen_string_literal: true
 
 class SentenceType
-  # Source of truth for recall sentence types:
-  # https://github.com/ministryofjustice/prison-api/blob/main/src/main/java/uk/gov/justice/hmpps/prison/api/model/SentenceTypeRecallType.kt
-  # Keep this list aligned exactly with the upstream enum until we can rely on upstream `recall` attribute again.
-  RECALL_SENTENCE_TYPES = %w[
-    14FTR_ORA
-    CUR
-    CUR_ORA
-    FTR
-    FTRSCH15_ORA
-    FTRSCH18
-    FTRSCH18_ORA
-    FTR_14_HDC_ORA
-    FTR_56ORA
-    FTR_HDC
-    FTR_HDC_ORA
-    FTR_ORA
-    FTR_SCH15
-    HDR
-    HDR_ORA
-    LR
-    LRSEC250_ORA
-    LR_ALP
-    LR_ALP_CDE18
-    LR_ALP_CDE21
-    LR_ALP_LASPO
-    LR_DLP
-    LR_DPP
-    LR_EDS18
-    LR_EDS21
-    LR_EDSU18
-    LR_EPP
-    LR_ES
-    LR_IPP
-    LR_LASPO_AR
-    LR_LASPO_DR
-    LR_LIFE
-    LR_MLP
-    LR_ORA
-    LR_SEC236A
-    LR_SEC91_ORA
-    LR_SOPC18
-    LR_SOPC21
-    LR_YOI_ORA
-  ].freeze
-
   CIVIL_SENTENCE_TYPES = %w[
     A/FINE
     A_FINE
@@ -71,10 +26,6 @@ class SentenceType
 
   def criminal_sentence?
     !civil_sentence?
-  end
-
-  def recall?
-    RECALL_SENTENCE_TYPES.include?(@code)
   end
 
   def civil_sentence?

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -257,15 +257,15 @@ describe HmppsApi::Offender do
       end
     end
 
-    context 'when recall flag is false but imprisonment status is an upstream recall code' do
+    context 'when recall flag unset' do
       let(:sentence) { attributes_for(:sentence_detail, recall: false, imprisonmentStatus: 'FTR_56ORA') }
 
-      it 'is true' do
-        expect(subject.recalled?).to eq(true)
+      it 'is false' do
+        expect(subject.recalled?).to eq(false)
       end
     end
 
-    context 'when recall flag unset' do
+    context 'when recall flag is false' do
       let(:sentence) { attributes_for(:sentence_detail, recall: false) }
 
       it 'is false' do

--- a/spec/models/hmpps_api/sentence_detail_spec.rb
+++ b/spec/models/hmpps_api/sentence_detail_spec.rb
@@ -135,14 +135,8 @@ describe HmppsApi::SentenceDetail, model: true do
       expect(build(:sentence_detail, recall: true).recalled?).to be true
     end
 
-    it 'is true for upstream fixed-term recall sentence codes even without the recall flag' do
+    it 'is false when the recall flag is absent' do
       sentence_detail = build(:sentence_detail, recall: false, imprisonmentStatus: 'FTR_56ORA')
-
-      expect(sentence_detail.recalled?).to be true
-    end
-
-    it 'is false for non-recall ORA sentence codes when the recall flag is absent' do
-      sentence_detail = build(:sentence_detail, recall: false, imprisonmentStatus: 'ADIMP_ORA')
 
       expect(sentence_detail.recalled?).to be false
     end

--- a/spec/models/sentence_type_spec.rb
+++ b/spec/models/sentence_type_spec.rb
@@ -27,15 +27,4 @@ RSpec.describe SentenceType, type: :model do
   it 'does not treat criminal sentence types as civil' do
     expect(described_class.new('IPP').civil_sentence?).to be false
   end
-
-  describe '#recall?' do
-    it 'recognises the current upstream Prison API recall sentence codes' do
-      expect(described_class::RECALL_SENTENCE_TYPES).to all(satisfy { |code| described_class.new(code).recall? })
-    end
-
-    it 'does not treat non-recall sentence codes as recall' do
-      expect(described_class.new('ADIMP_ORA').recall?).to be false
-      expect(described_class.new('EDS21').recall?).to be false
-    end
-  end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1967

In PR #2822, we introduced an interim solution to make sure new recall sentence types were being correctly detected as recalls in our service, because the upstream flag from prisoner-search was still using old codes.

Now this has been fixed upstream and we can rely again on the flag from the API response, instead of having to maintain the codes ourselves.