### PR TITLE
Use sentenceExpiryDate value from the API

### DIFF
--- a/app/models/hmpps_api/offender.rb
+++ b/app/models/hmpps_api/offender.rb
@@ -7,6 +7,7 @@ module HmppsApi
     delegate :home_detention_curfew_eligibility_date,
              :home_detention_curfew_actual_date,
              :conditional_release_date, :release_date,
+             :sentence_expiry_date, :actual_parole_date,
              :parole_eligibility_date, :tariff_date,
              :automatic_release_date, :licence_expiry_date,
              :post_recall_release_date, :earliest_release_date, :earliest_release,

--- a/app/models/hmpps_api/sentence_detail.rb
+++ b/app/models/hmpps_api/sentence_detail.rb
@@ -10,13 +10,11 @@ module HmppsApi
                 :recall,
                 :release_date,
                 :sentence_start_date,
+                :sentence_expiry_date,
                 :tariff_date,
                 :legal_status
 
     delegate :criminal_sentence?, :immigration_case?, :civil_sentence?, to: :@sentence_type
-
-    # Note - this is hiding a defect - we never get sentence_expiry_date from NOMIS (but maybe we should?)
-    attr_accessor :sentence_expiry_date
 
     def initialize(payload)
       @actual_parole_date = payload['actualParoleDate']&.to_date
@@ -32,6 +30,7 @@ module HmppsApi
       @parole_eligibility_date = payload['paroleEligibilityDate']&.to_date
       @release_date = payload['releaseDate']&.to_date
       @sentence_start_date = payload['sentenceStartDate']&.to_date
+      @sentence_expiry_date = payload['sentenceExpiryDate']&.to_date
       @tariff_date = payload['tariffDate']&.to_date
 
       @sentence_type = SentenceType.new payload.fetch('imprisonmentStatus', 'UNK_SENT')

--- a/app/models/mpc_offender.rb
+++ b/app/models/mpc_offender.rb
@@ -272,6 +272,8 @@ class MpcOffender
   # Sentencing / Movements
   #
 
+  delegate :sentenced_to_additional_future_isp?, to: :sentences
+
   def sentences = @sentences ||= Offenders::Sentences.new(booking_id:)
 
   def prison_timeline
@@ -358,6 +360,8 @@ class MpcOffender
            :sentence_start_date,
            :conditional_release_date,
            :automatic_release_date,
+           :sentence_expiry_date,
+           :actual_parole_date,
            :parole_eligibility_date,
            :tariff_date,
            :post_recall_release_date,
@@ -412,6 +416,8 @@ class MpcOffender
       sentence_start_date
       conditional_release_date
       automatic_release_date
+      sentence_expiry_date
+      actual_parole_date
       parole_eligibility_date
       tariff_date
       post_recall_release_date
@@ -419,7 +425,6 @@ class MpcOffender
       home_detention_curfew_actual_date
       home_detention_curfew_eligibility_date
       prison_arrival_date
-      earliest_release_date
       earliest_release
       earliest_release_for_handover
       latest_temp_movement_date
@@ -448,6 +453,9 @@ class MpcOffender
       allocated_com_name
       allocated_com_email
       target_hearing_date
+      parole_outcome_not_release?
+      sentenced_to_additional_future_isp?
+      early_allocation?
       early_allocation_state
     ]
 

--- a/spec/factories/sentence_details.rb
+++ b/spec/factories/sentence_details.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
 
     # 1 day after policy start in Wales
     sentenceStartDate { '2019-02-05' }
+    sentenceExpiryDate { nil }
     releaseDate { Time.zone.today + 2.years }
     conditionalReleaseDate { Time.zone.today + 1.year }
 
@@ -115,9 +116,9 @@ FactoryBot.define do
 
     trait :criminal_sentence do
     end
-    
+
     trait :civil_sentence do
-      imprisonmentStatus {'CIVIL'}
+      imprisonmentStatus { 'CIVIL' }
     end
 
     trait :less_than_10_months_to_serve do

--- a/spec/models/hmpps_api/offender_spec.rb
+++ b/spec/models/hmpps_api/offender_spec.rb
@@ -94,12 +94,7 @@ describe HmppsApi::Offender do
       let(:today_plus1) { Time.zone.today + 1.day }
 
       context 'with just the sentence expiry date' do
-        let(:sentence) { attributes_for(:sentence_detail, :blank) }
-
-        before do
-          # Set the sentence expiry date – this one is a bit odd because we don't actually populate it from the API
-          subject.sentence.sentence_expiry_date = today_plus1
-        end
+        let(:sentence) { attributes_for(:sentence_detail, :blank, sentenceExpiryDate: today_plus1) }
 
         it 'uses the SED' do
           expect(subject.earliest_release_date).to eq(today_plus1)
@@ -109,13 +104,10 @@ describe HmppsApi::Offender do
       context 'with many dates' do
         let(:sentence) do
           attributes_for(:sentence_detail, :blank,
+                         sentenceExpiryDate: sentence_expiry_date,
                          licenceExpiryDate: licence_expiry_date,
                          postRecallReleaseDate: post_recall_release_date,
                          actualParoleDate: actual_parole_date)
-        end
-
-        before do
-          subject.sentence.sentence_expiry_date = sentence_expiry_date
         end
 
         context 'with future dates' do

--- a/spec/models/hmpps_api/sentence_detail_spec.rb
+++ b/spec/models/hmpps_api/sentence_detail_spec.rb
@@ -78,6 +78,12 @@ describe HmppsApi::SentenceDetail, model: true do
     end
   end
 
+  describe '#sentence_expiry_date' do
+    it 'populates the sentence expiry date from the payload' do
+      expect(build(:sentence_detail, sentenceExpiryDate: date.to_s).sentence_expiry_date).to eq(date)
+    end
+  end
+
   describe "#post_recall_release_date" do
     subject do
       build :sentence_detail, automaticReleaseDate: date,

--- a/spec/models/mpc_offender_spec.rb
+++ b/spec/models/mpc_offender_spec.rb
@@ -251,6 +251,8 @@ RSpec.describe MpcOffender, type: :model do
         sentence_start_date
         conditional_release_date
         automatic_release_date
+        sentence_expiry_date
+        actual_parole_date
         parole_eligibility_date
         tariff_date
         post_recall_release_date
@@ -258,7 +260,6 @@ RSpec.describe MpcOffender, type: :model do
         home_detention_curfew_actual_date
         home_detention_curfew_eligibility_date
         prison_arrival_date
-        earliest_release_date
         earliest_release
         earliest_release_for_handover
         latest_temp_movement_date
@@ -287,6 +288,9 @@ RSpec.describe MpcOffender, type: :model do
         allocated_com_name
         allocated_com_email
         target_hearing_date
+        parole_outcome_not_release?
+        sentenced_to_additional_future_isp?
+        early_allocation?
         early_allocation_state
       ]
 


### PR DESCRIPTION
This might have been true in the past but I've checked and we now receive the `sentenceExpiryDate` attribute from the upstream API payload, so we can use it.

Also added a few more attributes to the archive (showing up in the debugging page).