### PR TITLE
MO-1969 Migrate SAR template

### DIFF
--- a/app/controllers/api/sar_controller.rb
+++ b/app/controllers/api/sar_controller.rb
@@ -1,7 +1,10 @@
 module Api
   class SarController < Api::ApiController
     SAR_ROLE = 'ROLE_SAR_DATA_ACCESS'.freeze
-    MPC_ADMIN_ROLE = 'ROLE_MPC_ADMIN'.freeze
+
+    def template
+      render plain: SubjectAccessRequestTemplateService.content, content_type: 'text/plain'
+    end
 
     def show
       return render_error('PRN and CRN parameters passed', 2, 400) if parameter_conflict?
@@ -22,14 +25,15 @@ module Api
         return render_error('Valid authorisation token required', 1, 401)
       end
 
-      unless token.valid_token_with_scope?('read', role: SAR_ROLE) ||
-             token.valid_token_with_scope?('read', role: MPC_ADMIN_ROLE)
+      unless token.valid_token_with_scope?('read', role: SAR_ROLE)
         render_error('Invalid token role', 5, 403)
       end
     end
 
     # Overrides parent due to endpoint-specific error schema
     def render_error(msg, error_code, status)
+      Rails.logger.warn("event=subject_access_request_error|status=#{status}|error_code=#{error_code}|message=#{msg}")
+
       render json: {
         developerMessage: msg,
         errorCode: error_code,
@@ -62,8 +66,8 @@ module Api
         @from_date = nil
         @to_date = nil
       else
-        @from_date = Date.parse(params[:fromDate])
-        @to_date = Date.parse(params[:toDate])
+        @from_date = Date.parse(params[:fromDate].to_s)
+        @to_date = Date.parse(params[:toDate].to_s)
       end
 
       true

--- a/app/presenters/sar/case_information.rb
+++ b/app/presenters/sar/case_information.rb
@@ -4,7 +4,7 @@ module Sar
   class CaseInformation < BaseSarPresenter
     class << self
       def omitted_attributes
-        [:ldu_code, :local_delivery_unit_id, :com_name, :com_email]
+        [:ldu_code, :local_delivery_unit_id, :com_name, :com_email, :rosh_start_date]
       end
 
       def additional_methods

--- a/app/services/subject_access_request_template_service.rb
+++ b/app/services/subject_access_request_template_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SubjectAccessRequestTemplateService
+  TEMPLATE_PATH = Rails.root.join('config/templates/sar_template.mustache').freeze
+
+  class ConfigurationError < StandardError; end
+
+  class << self
+    def template_path
+      TEMPLATE_PATH
+    end
+
+    def content
+      File.read(template_path, encoding: 'UTF-8')
+    end
+
+    def validate_configuration!
+      return if template_path.file?
+
+      raise ConfigurationError, "Invalid subject access request configuration. File '#{template_path}' not found"
+    end
+  end
+end

--- a/config/initializers/sar_template.rb
+++ b/config/initializers/sar_template.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  SubjectAccessRequestTemplateService.validate_configuration!
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,7 +200,9 @@ Rails.application.routes.draw do
 
   get '/api/allocation/:offender_no/primary_pom', to: 'api/allocation_api#primary_pom'
   get '/api/allocation/:offender_no', to: 'api/allocation_api#show'
+
   get '/subject-access-request', to: 'api/sar#show'
+  get '/subject-access-request/template', to: 'api/sar#template'
 
   # '/admin' was taken by ActiveAdmin in the past
   namespace :manage do

--- a/config/templates/sar_template.mustache
+++ b/config/templates/sar_template.mustache
@@ -1,0 +1,386 @@
+<h1 class="title">Manage Prison Offender Manager Cases</h1>
+<br>
+{{#.}}
+    <h3>Allocation history</h3>
+    <br>
+    {{#allocationHistory}}
+        <h4>Allocation</h4>
+        <br>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Prison name</td>
+                <td class="data-column-30">Allocated at tier</td>
+                <td class="data-column-35">Allocated at Risk of Serious Harm overall level</td>
+            </tr>
+            <tr>
+                <td>{{ getPrisonName prison }}</td>
+                <td>{{ optionalValue allocatedAtTier }}</td>
+                <td>{{ optionalValue allocatedAtRosh }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Event</td>
+                <td class="data-column-30">Event trigger</td>
+                <td class="data-column-35">Primary prison or probation offender manager allocated at</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue event }}</td>
+                <td>{{ optionalValue eventTrigger }}</td>
+                <td>{{ optionalValue (formatDate primaryPomAllocatedAt) }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Recommended prison or probation offender manager type</td>
+                <td class="data-column-30">Created at</td>
+                <td class="data-column-35">Updated at</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue recommendedPomType }}</td>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue (formatDate updatedAt) }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Override reasons</td>
+                <td class="data-column-30">Created by last name</td>
+                <td class="data-column-35"></td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue overrideReasons }}</td>
+                <td>{{ optionalValue createdByLastname }}</td>
+                <td></td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-100">Override detail</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue overrideDetail }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-100">Message</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue message }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-100">Suitability detail</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue suitabilityDetail }}</td>
+            </tr>
+        </table>
+    {{/allocationHistory}}
+    {{^allocationHistory}}
+        <p>No Data Held</p>
+    {{/allocationHistory}}
+
+    <br>
+    <h3>Calculated early allocation status</h3>
+    <br>
+    {{#calculatedEarlyAllocationStatus}}
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Eligible</td>
+                <td class="data-column-30">Created at</td>
+                <td class="data-column-35">Updated at</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean eligible }}</td>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue (formatDate updatedAt) }}</td>
+            </tr>
+        </table>
+    {{/calculatedEarlyAllocationStatus}}
+    {{^calculatedEarlyAllocationStatus}}
+        <p>No Data Held</p>
+    {{/calculatedEarlyAllocationStatus}}
+
+    <br>
+    <h3>Calculated handover date</h3>
+    <br>
+    {{#calculatedHandoverDate}}
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Start date</td>
+                <td class="data-column-30">Handover date</td>
+                <td class="data-column-35">Responsibility</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue (formatDate startDate) }}</td>
+                <td>{{ optionalValue (formatDate handoverDate) }}</td>
+                <td>{{ optionalValue responsibility }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Created at</td>
+                <td class="data-column-30">Updated at</td>
+                <td class="data-column-35">Last calculated at</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue (formatDate updatedAt) }}</td>
+                <td>{{ optionalValue (formatDate lastCalculatedAt) }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-100">Reason</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue reason }}</td>
+            </tr>
+        </table>
+    {{/calculatedHandoverDate}}
+    {{^calculatedHandoverDate}}
+        <p>No Data Held</p>
+    {{/calculatedHandoverDate}}
+
+    <br>
+    <h3>Case information</h3>
+    <br>
+    {{#caseInformation}}
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Tier</td>
+                <td class="data-column-30">Risk of Serious Harm overall level</td>
+                <td class="data-column-35">Is manual entry</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue tier }}</td>
+                <td>{{ optionalValue roshLevel }}</td>
+                <td>{{ convertBoolean manualEntry }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Multi Agency Public Protection Arrangements level</td>
+                <td class="data-column-30">Enhanced resourcing</td>
+                <td class="data-column-35">Probation service</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue mappaLevel }}</td>
+                <td>{{ convertBoolean enhancedResourcing }}</td>
+                <td>{{ optionalValue probationService }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Created at</td>
+                <td class="data-column-30">Updated at</td>
+                <td class="data-column-35">Active Victims Liaison Officer</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue (formatDate updatedAt) }}</td>
+                <td>{{ convertBoolean activeVlo }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+          <tr>
+            <td class="data-column-100">Team name</td>
+          </tr>
+          <tr>
+            <td>{{ optionalValue teamName }}</td>
+          </tr>
+        </table>
+        <table class="data-table">
+          <tr>
+            <td class="data-column-100">Local delivery unit</td>
+          </tr>
+          <tr>
+            <td>{{ optionalValue localDeliveryUnit }}</td>
+          </tr>
+        </table>
+    {{/caseInformation}}
+    {{^caseInformation}}
+        <p>No Data Held</p>
+    {{/caseInformation}}
+
+    <br>
+    <h3>Early allocations</h3>
+    <br>
+    {{#earlyAllocations}}
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Offender Assessment System risk assessment date</td>
+                <td class="data-column-30">High profile</td>
+                <td class="data-column-35">Convicted under terrorism act 2000</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue (formatDate oasysRiskAssessmentDate) }}</td>
+                <td>{{ convertBoolean highProfile }}</td>
+                <td>{{ convertBoolean convictedUnderTerrorisomAct2000 }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Serious crime prevention order</td>
+                <td class="data-column-30">Multi Agency Public Protection Arrangements level 3</td>
+                <td class="data-column-35">CPPC case</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean seriousCrimePreventionOrder }}</td>
+                <td>{{ convertBoolean mappaLevel3 }}</td>
+                <td>{{ convertBoolean cppcCase }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">High risk of serious harm</td>
+                <td class="data-column-30">Multi Agency Public Protection Arrangements level 2</td>
+                <td class="data-column-35">Pathfinder process</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean highRiskOfSeriousHarm }}</td>
+                <td>{{ convertBoolean mappaLevel2 }}</td>
+                <td>{{ convertBoolean pathfinderProcess }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Other reason</td>
+                <td class="data-column-30">Extremism separation</td>
+                <td class="data-column-35">Due for release in less than 24 months</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean otherReason }}</td>
+                <td>{{ convertBoolean extremismSeparation }}</td>
+                <td>{{ convertBoolean dueForReleaseInLessThan24months }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Community decision</td>
+                <td class="data-column-30">Prison</td>
+                <td class="data-column-35">Outcome</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean communityDecision }}</td>
+                <td>{{ getPrisonName prison }}</td>
+                <td>{{ optionalValue outcome }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Approved</td>
+                <td class="data-column-30">Created within referral window</td>
+                <td class="data-column-35">Reason</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean approved }}</td>
+                <td>{{ convertBoolean createdWithinReferralWindow }}</td>
+                <td>{{ optionalValue reason }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Created at</td>
+                <td class="data-column-30">Created by last name</td>
+                <td class="data-column-35"></td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue createdByLastname }}</td>
+                <td></td>
+            </tr>
+        </table>
+        <table class="data-table">
+          <tr>
+            <td class="data-column-35">Updated at</td>
+            <td class="data-column-30">Updated by last name</td>
+            <td class="data-column-35"></td>
+          </tr>
+          <tr>
+            <td>{{ optionalValue (formatDate updatedAt) }}</td>
+            <td>{{ optionalValue updatedByLastname }}</td>
+            <td></td>
+          </tr>
+        </table>
+    {{/earlyAllocations}}
+    {{^earlyAllocations}}
+        <p>No Data Held</p>
+    {{/earlyAllocations}}
+
+    <br>
+    <h3>Handover progress checklist</h3>
+    <br>
+    {{#handoverProgressChecklist}}
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Reviewed Offender Assessment System</td>
+                <td class="data-column-30">Contacted Community Offender Managers</td>
+                <td class="data-column-35">Attended handover meeting</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean reviewedOasys }}</td>
+                <td>{{ convertBoolean contactedCom }}</td>
+                <td>{{ convertBoolean attendedHandoverMeeting }}</td>
+            </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Sent handover report</td>
+                <td class="data-column-30">Created at</td>
+                <td class="data-column-35">Updated at</td>
+            </tr>
+            <tr>
+                <td>{{ convertBoolean sentHandoverReport }}</td>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue (formatDate updatedAt) }}</td>
+            </tr>
+        </table>
+    {{/handoverProgressChecklist}}
+    {{^handoverProgressChecklist}}
+        <p>No Data Held</p>
+    {{/handoverProgressChecklist}}
+
+    <br>
+    <h3>Responsibility</h3>
+    <br>
+    {{#responsibility}}
+        <table class="data-table">
+          <tr>
+            <td class="data-column-100">Reason</td>
+          </tr>
+          <tr>
+            <td>{{ optionalValue reason }}</td>
+          </tr>
+        </table>
+        <table class="data-table">
+          <tr>
+            <td class="data-column-100">Reason text</td>
+          </tr>
+          <tr>
+            <td>{{ optionalValue reasonText }}</td>
+          </tr>
+        </table>
+        <table class="data-table">
+            <tr>
+                <td class="data-column-35">Value</td>
+                <td class="data-column-30">Created at</td>
+                <td class="data-column-35">Updated at</td>
+            </tr>
+            <tr>
+                <td>{{ optionalValue value }}</td>
+                <td>{{ optionalValue (formatDate createdAt) }}</td>
+                <td>{{ optionalValue (formatDate updatedAt) }}</td>
+            </tr>
+        </table>
+    {{/responsibility}}
+    {{^responsibility}}
+        <p>No Data Held</p>
+    {{/responsibility}}
+{{/.}}
+{{^.}}
+    <p>No Data Held</p>
+{{/.}}

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -165,7 +165,6 @@ components:
       - activeVlo
       - enhancedResourcing
       - roshLevel
-      - roshStartDate
       - createdAt
       - updatedAt
       properties:
@@ -193,10 +192,6 @@ components:
           nullable: true
         roshLevel:
           type: string
-          nullable: true
-        roshStartDate:
-          type: string
-          format: date
           nullable: true
         createdAt:
           type: string
@@ -653,3 +648,32 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SarOffenderData"
+  "/subject-access-request/template":
+    get:
+      summary: Retrieves the SAR Mustache template for this service
+      tags:
+      - Subject Access Request
+      description: |-
+        * The role ROLE_SAR_DATA_ACCESS is required
+        * Returns the plain-text Mustache template configured for the service
+      security:
+      - Bearer: []
+      responses:
+        '401':
+          description: Request is not authorised
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SarError"
+        '403':
+          description: Invalid token role
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SarError"
+        '200':
+          description: Template returned for SAR users
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/spec/api/sar_api_spec.rb
+++ b/spec/api/sar_api_spec.rb
@@ -49,18 +49,8 @@ describe 'SAR API' do
       end
 
       describe 'when forbidden due to role' do
-        let(:payload) do
-          {
-            'internal_user' => false,
-            'scope' => %w[read],
-            'exp' => 1.hour.from_now.to_i,
-            'client_id' => 'offender-management-allocation-manager',
-            'authorities' => %w[ROLE_FOOBAR]
-          }
-        end
-
         before do
-          allow(JwksDecoder).to receive(:decode_token).and_return([payload])
+          stub_decoded_token(authorities: %w[ROLE_FOOBAR])
         end
 
         response '403', 'Invalid token role' do

--- a/spec/api/sar_template_api_spec.rb
+++ b/spec/api/sar_template_api_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'SAR template API' do
+  let(:Authorization) { 'Bearer TEST_TOKEN' }
+  let(:template_path) { SubjectAccessRequestTemplateService.template_path }
+
+  path '/subject-access-request/template' do
+    get 'Retrieves the SAR Mustache template for this service' do
+      tags 'Subject Access Request'
+      description "* The role ROLE_SAR_DATA_ACCESS is required
+* Returns the plain-text Mustache template configured for the service"
+
+      response '401', 'Request is not authorised' do
+        security [{ Bearer: [] }]
+        metadata[:response][:schema] = { '$ref' => '#/components/schemas/SarError' }
+        metadata[:response][:content] = {
+          'application/json' => {
+            schema: { '$ref' => '#/components/schemas/SarError' }
+          }
+        }
+
+        let(:Authorization) { nil }
+
+        run_test!
+      end
+
+      response '403', 'Invalid token role' do
+        security [{ Bearer: [] }]
+        metadata[:response][:schema] = { '$ref' => '#/components/schemas/SarError' }
+        metadata[:response][:content] = {
+          'application/json' => {
+            schema: { '$ref' => '#/components/schemas/SarError' }
+          }
+        }
+
+        before do
+          stub_decoded_token(authorities: %w[ROLE_FOOBAR])
+        end
+
+        run_test!
+      end
+
+      response '200', 'Template returned for SAR users' do
+        security [{ Bearer: [] }]
+        metadata[:response][:schema] = { type: :string }
+        metadata[:response][:content] = {
+          'text/plain' => {
+            schema: { type: :string }
+          }
+        }
+
+        before do
+          stub_decoded_token(authorities: %w[ROLE_SAR_DATA_ACCESS])
+        end
+
+        run_test! do |response|
+          expect(response.media_type).to eq('text/plain')
+          expect(response.body).to eq(File.read(template_path, encoding: 'UTF-8'))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -92,14 +92,7 @@ RSpec.describe Api::ApiController, type: :controller do
   end
 
   def request_header(payload = {})
-    allow(JwksDecoder).to receive(:decode_token).and_return(
-      [
-        {
-          scope: %w[read write],
-          exp: 4.hours.from_now.to_i,
-        }.merge(payload)
-      ]
-    )
+    stub_decoded_token(payload)
     request.headers['AUTHORIZATION'] = "Bearer xxxxxxx"
   end
 end

--- a/spec/requests/subject_access_request_template_spec.rb
+++ b/spec/requests/subject_access_request_template_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Subject access request template' do
+  let(:endpoint) { '/subject-access-request/template' }
+  let(:token) { 'Bearer TEST_TOKEN' }
+  let(:headers) { { 'AUTHORIZATION' => token } }
+  let(:template_path) { SubjectAccessRequestTemplateService.template_path }
+
+  describe 'GET /subject-access-request/template' do
+    context 'when the client has the ROLE_SAR_DATA_ACCESS role' do
+      before do
+        stub_decoded_token(authorities: %w[ROLE_SAR_DATA_ACCESS])
+        get endpoint, headers: headers
+      end
+
+      it 'returns status OK' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the template body as plain text' do
+        expect(response.media_type).to eq('text/plain')
+        expect(response.body).to eq(File.read(template_path, encoding: 'UTF-8'))
+      end
+    end
+
+    context 'when the client lacks an allowed role' do
+      before do
+        stub_decoded_token(authorities: %w[ROLE_WHATEVER])
+        get endpoint, headers: headers
+      end
+
+      it 'returns a SAR forbidden response' do
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)).to eq(
+          'developerMessage' => 'Invalid token role',
+          'errorCode' => 5,
+          'status' => 403,
+          'userMessage' => 'Invalid token role'
+        )
+      end
+    end
+
+    context 'when the client is unauthenticated' do
+      before do
+        get endpoint
+      end
+
+      it 'returns a SAR unauthorized response' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq(
+          'developerMessage' => 'Valid authorisation token required',
+          'errorCode' => 1,
+          'status' => 401,
+          'userMessage' => 'Valid authorisation token required'
+        )
+      end
+    end
+  end
+end

--- a/spec/services/hmpps_api/oauth/token_spec.rb
+++ b/spec/services/hmpps_api/oauth/token_spec.rb
@@ -2,13 +2,7 @@ require 'rails_helper'
 
 describe HmppsApi::Oauth::Token do
   def mock_jwt_token(options = {})
-    payload = {
-      'internal_user' => false,
-      'scope' => %w[read write],
-      'exp' => 4.hours.from_now.to_i,
-      'client_id' => 'offender-management-allocation-manager',
-    }.merge(options)
-    allow(JwksDecoder).to receive(:decode_token).and_return([payload])
+    stub_decoded_token(options)
   end
 
   it 'can confirm if it is not expired' do

--- a/spec/services/sar_offender_data_service_spec.rb
+++ b/spec/services/sar_offender_data_service_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe SarOffenderDataService do
             expect(case_information.keys).not_to include('crn')
             expect(case_information.keys).not_to include('localDeliveryUnitId')
             expect(case_information.keys).not_to include('lduCode')
+            expect(case_information.keys).not_to include('roshStartDate')
           end
 
           it 'returns booleans' do

--- a/spec/services/subject_access_request_template_service_spec.rb
+++ b/spec/services/subject_access_request_template_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubjectAccessRequestTemplateService do
+  let(:template_path) { described_class.template_path }
+
+  describe 'DB schema change guard' do
+    # Keep this updated once any potential SAR drifting is asserted
+    let(:reviewed_version) { '20260409_113634' }
+
+    let(:current_version) { ActiveRecord::Base.connection_pool.migration_context.current_version }
+    let(:message) do
+      <<~MESSAGE
+        A new migration has been added.
+
+        Please review whether the SAR payload or template should change before updating this guard version.
+        Check:
+        - app/services/sar_offender_data_service.rb
+        - config/templates/sar_template.mustache
+        - spec/api/sar_api_spec.rb
+        - spec/api/sar_template_api_spec.rb
+      MESSAGE
+    end
+
+    it 'requires a SAR template and payload review when the DB schema changes' do
+      expect(current_version).to eq(reviewed_version.to_i), message
+    end
+  end
+
+  describe '.validate_configuration!' do
+    subject(:validate_configuration!) { described_class.validate_configuration! }
+
+    it 'does not raise when the template exists' do
+      expect { validate_configuration! }.not_to raise_error
+    end
+
+    context 'when the template path does not exist' do
+      before do
+        allow(described_class).to receive(:template_path).and_return(Pathname.new('/tmp/missing-sar.mustache'))
+      end
+
+      it 'raises a configuration error' do
+        expect { validate_configuration! }
+          .to raise_error(described_class::ConfigurationError, /missing-sar.mustache/)
+      end
+    end
+  end
+
+  describe '.content' do
+    subject(:content) { described_class.content }
+
+    let(:expected_content) { File.read(template_path, encoding: 'UTF-8') }
+
+    it 'returns the template body' do
+      expect(content).to eq(expected_content)
+    end
+  end
+end

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -29,6 +29,21 @@ module AuthHelper
       }.to_json)
   end
 
+  def stub_decoded_token(payload_overrides = nil, access_token: 'TEST_TOKEN', **keyword_overrides)
+    payload_overrides = (payload_overrides || {}).merge(keyword_overrides)
+
+    payload = {
+      'internal_user' => false,
+      'scope' => %w[read write],
+      'exp' => 4.hours.from_now.to_i,
+      'client_id' => 'offender-management-allocation-manager'
+    }.merge(payload_overrides.deep_stringify_keys)
+
+    allow(JwksDecoder).to receive(:decode_token).and_return([payload])
+
+    access_token
+  end
+
   def stub_sso_data(prison, username: 'user', staff_id: 754_732, first_name: 'MOIC', last_name: 'POM',
                     roles: [SsoIdentity::SPO_ROLE], email: '754732@example.com',
                     active_caseload: prison, caseloads: [prison], token: USER_ACCESS_TOKEN)

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -144,7 +144,6 @@ RSpec.configure do |config|
               activeVlo
               enhancedResourcing
               roshLevel
-              roshStartDate
               createdAt
               updatedAt
             ],
@@ -158,7 +157,6 @@ RSpec.configure do |config|
               activeVlo: { type: :boolean },
               enhancedResourcing: { type: :boolean, nullable: true },
               roshLevel: { type: :string, nullable: true },
-              roshStartDate: { type: :string, format: :date, nullable: true },
               createdAt: { type: :string },
               updatedAt: { type: :string },
             }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1969
Parent: https://dsdmoj.atlassian.net/browse/MO-1960

Move existing SAR template from the `hmpps-subject-access-request-html-renderer` repo to be served by our own service.

Minor template defects fixed: using convertBoolean helper in 3 boolean attributes (was using optionalValue before) and fixing responsibility reason/reasonText column width.

Removed `ROLE_MPC_ADMIN` role from being able to access SAR endpoints.

Removed `roshStartDate` from the JSON payload as it is not used in the template.