### PR TITLE
MO-1973 Revamp swagger documentation

### DIFF
--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -1,20 +1,38 @@
 ---
 openapi: 3.0.3
 info:
-  title: MPC/MOIC API
+  title: Manage POM Cases API
   version: v2
+  description: |-
+    API endpoints for Manage POM Cases, covering offender allocations, handovers, early allocation status, and subject access request (SAR) data.
+
+    ### Authentication
+
+    This API is secured by OAuth 2 with Bearer tokens supplied by HMPPS Auth.
+
+    Most read endpoints require the role `ROLE_VIEW_POM_ALLOCATIONS`.
+
+    SAR endpoints require the role `ROLE_SAR_DATA_ACCESS`.
+
+    ---
+
+    Owned by the **Manage POM Cases** team
+
+    - Slack: [#manage-pom-cases](https://mojdt.slack.com/channels/manage-pom-cases)
+    - GitHub: [ministryofjustice/offender-management-allocation-manager](https://github.com/ministryofjustice/offender-management-allocation-manager)
 servers:
-- url: "{protocol}://{defaultHost}"
-  variables:
-    protocol:
-      default: https
-    defaultHost:
-      default: dev.moic.service.justice.gov.uk
+- url: https://dev.moic.service.justice.gov.uk
+  description: Staging/dev environment
+- url: https://preprod.moic.service.justice.gov.uk
+  description: Pre-production environment
+- url: https://moic.service.justice.gov.uk
+  description: Production environment
 components:
   securitySchemes:
     Bearer:
       type: apiKey
-      description: A bearer token obtained from HMPPS SSO
+      description: A Bearer token obtained from HMPPS Auth and supplied in the Authorization
+        header
       name: Authorization
       in: header
   schemas:
@@ -365,20 +383,38 @@ components:
               "$ref": "#/components/schemas/SarHandoverProgressChecklist"
             responsibility:
               "$ref": "#/components/schemas/SarResponsibility"
+tags:
+- name: Allocations
+  description: Retrieve current prison offender manager allocation details for a prisoner
+- name: Handovers
+  description: Retrieve handover dates and current responsibility between prison and
+    probation
+- name: Offenders
+  description: Retrieve prisoner-level data exposed by Manage POM Cases APIs
+- name: Subject Access Request
+  description: SAR endpoints for retrieving service data and the Mustache template
+    used by the SAR HTML renderer
 paths:
   "/api/allocation/{nomsNumber}":
     get:
       summary: Retrieves the current allocation for an offender
+      security:
+      - Bearer: []
       tags:
       - Allocations
+      description: |-
+        Returns the current primary and secondary prison offender manager allocation for the supplied prisoner.
+
+        Authentication requirements:
+        * A valid Bearer token must be supplied in the Authorization header.
+        * The role ROLE_VIEW_POM_ALLOCATIONS is required.
       parameters:
       - name: nomsNumber
         in: path
         schema:
           "$ref": "#/components/schemas/NomsNumber"
+        description: NOMIS Prison Number for the prisoner
         required: true
-      security:
-      - Bearer: []
       responses:
         '401':
           description: Request is not authorised
@@ -419,16 +455,23 @@ paths:
   "/api/allocation/{nomsNumber}/primary_pom":
     get:
       summary: Retrieves the primary POM for an offender
+      security:
+      - Bearer: []
       tags:
       - Allocations
+      description: |-
+        Returns the currently allocated primary prison offender manager for the supplied prisoner, including live manager details and prison code.
+
+        Authentication requirements:
+        * A valid Bearer token must be supplied in the Authorization header.
+        * The role ROLE_VIEW_POM_ALLOCATIONS is required.
       parameters:
       - name: nomsNumber
         in: path
         schema:
           "$ref": "#/components/schemas/NomsNumber"
+        description: NOMIS Prison Number for the prisoner
         required: true
-      security:
-      - Bearer: []
       responses:
         '401':
           description: Request is not authorised
@@ -469,16 +512,23 @@ paths:
   "/api/handovers/{nomsNumber}":
     get:
       summary: Retrieves the handover information for an offender
+      security:
+      - Bearer: []
       tags:
       - Handovers
+      description: |-
+        Returns handover dates and the current responsibility split between prison and probation for the supplied prisoner.
+
+        Authentication requirements:
+        * A valid Bearer token must be supplied in the Authorization header.
+        * The role ROLE_VIEW_POM_ALLOCATIONS is required.
       parameters:
       - name: nomsNumber
         in: path
         schema:
           "$ref": "#/components/schemas/NomsNumber"
+        description: NOMIS Prison Number for the prisoner
         required: true
-      security:
-      - Bearer: []
       responses:
         '401':
           description: Request is not authorised
@@ -530,16 +580,23 @@ paths:
   "/api/offenders/{nomsNumber}":
     get:
       summary: Retrieves information for a prisoner including early allocation status
+      security:
+      - Bearer: []
       tags:
       - Offenders
+      description: |-
+        Returns prisoner information exposed by Manage POM Cases for the supplied prisoner number, including whether the prisoner currently has early allocation eligibility.
+
+        Authentication requirements:
+        * A valid Bearer token must be supplied in the Authorization header.
+        * The role ROLE_VIEW_POM_ALLOCATIONS is required.
       parameters:
       - name: nomsNumber
         in: path
         schema:
           "$ref": "#/components/schemas/NomsNumber"
+        description: NOMIS Prison Number for the prisoner
         required: true
-      security:
-      - Bearer: []
       responses:
         '401':
           description: Request is not authorised
@@ -575,9 +632,12 @@ paths:
   "/subject-access-request":
     get:
       summary: Retrieves all held info for offender
+      security:
+      - Bearer: []
       tags:
       - Subject Access Request
       description: |-
+        * A valid Bearer token must be supplied in the Authorization header.
         * NOMIS Prison Number (PRN) must be provided as part of the request.
         * The role ROLE_SAR_DATA_ACCESS is required
         * If the product uses the identifier type transmitted in the request, it can respond with its data and HTTP code 200
@@ -607,37 +667,70 @@ paths:
           which should be returned in the response (if used, both dates must be provided)
         schema:
           type: string
-      security:
-      - Bearer: []
       responses:
         '401':
           description: Request is not authorised
           content:
             application/json:
+              examples:
+                error_example:
+                  value:
+                    developerMessage: Valid authorisation token required
+                    errorCode: 1
+                    status: 401
+                    userMessage: Valid authorisation token required
               schema:
                 "$ref": "#/components/schemas/SarError"
         '403':
           description: Invalid token role
           content:
             application/json:
+              examples:
+                error_example:
+                  value:
+                    developerMessage: Invalid token role
+                    errorCode: 5
+                    status: 403
+                    userMessage: Invalid token role
               schema:
                 "$ref": "#/components/schemas/SarError"
         '400':
-          description: Both PRN and CRN parameter passed
+          description: PRN and CRN parameters passed
           content:
             application/json:
+              examples:
+                error_example:
+                  value:
+                    developerMessage: PRN and CRN parameters passed
+                    errorCode: 2
+                    status: 400
+                    userMessage: PRN and CRN parameters passed
               schema:
                 "$ref": "#/components/schemas/SarError"
         '209':
-          description: Just CRN parameter passed
+          description: CRN parameter not allowed
           content:
             application/json:
+              examples:
+                error_example:
+                  value:
+                    developerMessage: CRN parameter not allowed
+                    errorCode: 3
+                    status: 209
+                    userMessage: CRN parameter not allowed
               schema:
                 "$ref": "#/components/schemas/SarError"
         '210':
           description: Invalid date format
           content:
             application/json:
+              examples:
+                error_example:
+                  value:
+                    developerMessage: Invalid date format
+                    errorCode: 4
+                    status: 210
+                    userMessage: Invalid date format
               schema:
                 "$ref": "#/components/schemas/SarError"
         '204':
@@ -651,13 +744,14 @@ paths:
   "/subject-access-request/template":
     get:
       summary: Retrieves the SAR Mustache template for this service
+      security:
+      - Bearer: []
       tags:
       - Subject Access Request
       description: |-
+        * A valid Bearer token must be supplied in the Authorization header.
         * The role ROLE_SAR_DATA_ACCESS is required
         * Returns the plain-text Mustache template configured for the service
-      security:
-      - Bearer: []
       responses:
         '401':
           description: Request is not authorised
@@ -665,14 +759,28 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SarError"
+              examples:
+                error_example:
+                  value:
+                    developerMessage: Valid authorisation token required
+                    errorCode: 1
+                    status: 401
+                    userMessage: Valid authorisation token required
         '403':
           description: Invalid token role
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SarError"
+              examples:
+                error_example:
+                  value:
+                    developerMessage: Invalid token role
+                    errorCode: 5
+                    status: 403
+                    userMessage: Invalid token role
         '200':
-          description: Template returned for SAR users
+          description: Template returned
           content:
             text/plain:
               schema:

--- a/spec/api/allocation_api_spec.rb
+++ b/spec/api/allocation_api_spec.rb
@@ -8,13 +8,27 @@ describe 'Allocation API' do
 
   path '/api/allocation/{nomsNumber}' do
     get 'Retrieves the current allocation for an offender' do
+      security [{ Bearer: [] }]
+
       tags 'Allocations'
+      description(
+        [
+          'Returns the current primary and secondary prison offender manager allocation for the supplied prisoner.',
+          '',
+          'Authentication requirements:',
+          '* A valid Bearer token must be supplied in the Authorization header.',
+          '* The role ROLE_VIEW_POM_ALLOCATIONS is required.'
+        ].join("\n")
+      )
+
       produces 'application/json'
-      parameter name: :nomsNumber, in: :path, schema: { '$ref' => '#/components/schemas/NomsNumber' }
+      parameter name: :nomsNumber,
+                in: :path,
+                schema: { '$ref' => '#/components/schemas/NomsNumber' },
+                description: 'NOMIS Prison Number for the prisoner'
 
       describe 'when not authorised' do
         response '401', 'Request is not authorised' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }
@@ -28,7 +42,6 @@ describe 'Allocation API' do
         end
 
         response '200', 'Offender is allocated' do
-          security [{ Bearer: [] }]
           schema required: %w[primary_pom secondary_pom],
                  type: :object,
                  properties: {
@@ -65,7 +78,6 @@ describe 'Allocation API' do
         end
 
         response '404', 'Allocation for offender not found' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }
@@ -77,13 +89,27 @@ describe 'Allocation API' do
 
   path '/api/allocation/{nomsNumber}/primary_pom' do
     get 'Retrieves the primary POM for an offender' do
+      security [{ Bearer: [] }]
+
       tags 'Allocations'
+      description(
+        [
+          'Returns the currently allocated primary prison offender manager for the supplied prisoner, including live manager details and prison code.',
+          '',
+          'Authentication requirements:',
+          '* A valid Bearer token must be supplied in the Authorization header.',
+          '* The role ROLE_VIEW_POM_ALLOCATIONS is required.'
+        ].join("\n")
+      )
+
       produces 'application/json'
-      parameter name: :nomsNumber, in: :path, schema: { '$ref' => '#/components/schemas/NomsNumber' }
+      parameter name: :nomsNumber,
+                in: :path,
+                schema: { '$ref' => '#/components/schemas/NomsNumber' },
+                description: 'NOMIS Prison Number for the prisoner'
 
       describe 'when not authorised' do
         response '401', 'Request is not authorised' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }
@@ -101,7 +127,6 @@ describe 'Allocation API' do
         end
 
         response '200', 'Offender is allocated' do
-          security [{ Bearer: [] }]
           schema required: %w[manager prison],
                  type: :object,
                  properties: {
@@ -141,7 +166,6 @@ describe 'Allocation API' do
         end
 
         response '404', 'Allocation for offender not found' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }

--- a/spec/api/handover_api_spec.rb
+++ b/spec/api/handover_api_spec.rb
@@ -7,13 +7,27 @@ describe 'Handover API' do
 
   path '/api/handovers/{nomsNumber}' do
     get 'Retrieves the handover information for an offender' do
+      security [{ Bearer: [] }]
+
       tags 'Handovers'
+      description(
+        [
+          'Returns handover dates and the current responsibility split between prison and probation for the supplied prisoner.',
+          '',
+          'Authentication requirements:',
+          '* A valid Bearer token must be supplied in the Authorization header.',
+          '* The role ROLE_VIEW_POM_ALLOCATIONS is required.'
+        ].join("\n")
+      )
+
       produces 'application/json'
-      parameter name: :nomsNumber, in: :path, schema: { '$ref' => '#/components/schemas/NomsNumber' }
+      parameter name: :nomsNumber,
+                in: :path,
+                schema: { '$ref' => '#/components/schemas/NomsNumber' },
+                description: 'NOMIS Prison Number for the prisoner'
 
       describe 'when not authorised' do
         response '401', 'Request is not authorised' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }
@@ -39,7 +53,6 @@ describe 'Handover API' do
           end
 
           response '200', 'Handover information successfully found' do
-            security [{ Bearer: [] }]
             schema required: %w[nomsNumber handoverDate responsibility responsibleComName responsibleComEmail responsiblePomName responsiblePomNomisId],
                    type: :object,
                    properties: {
@@ -73,7 +86,6 @@ describe 'Handover API' do
         end
 
         response '404', 'Handover information for offender not found' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }

--- a/spec/api/offender_api_spec.rb
+++ b/spec/api/offender_api_spec.rb
@@ -13,13 +13,27 @@ describe 'Offender Early Allocation API' do
 
   path '/api/offenders/{nomsNumber}' do
     get 'Retrieves information for a prisoner including early allocation status' do
+      security [{ Bearer: [] }]
+
       tags 'Offenders'
+      description(
+        [
+          'Returns prisoner information exposed by Manage POM Cases for the supplied prisoner number, including whether the prisoner currently has early allocation eligibility.',
+          '',
+          'Authentication requirements:',
+          '* A valid Bearer token must be supplied in the Authorization header.',
+          '* The role ROLE_VIEW_POM_ALLOCATIONS is required.'
+        ].join("\n")
+      )
+
       produces 'application/json'
-      parameter name: :nomsNumber, in: :path, schema: { '$ref' => '#/components/schemas/NomsNumber' }
+      parameter name: :nomsNumber,
+                in: :path,
+                schema: { '$ref' => '#/components/schemas/NomsNumber' },
+                description: 'NOMIS Prison Number for the prisoner'
 
       describe 'when not authorised' do
         response '401', 'Request is not authorised' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }
@@ -33,7 +47,6 @@ describe 'Offender Early Allocation API' do
         end
 
         response '200', 'Offender has an early allocation' do
-          security [{ Bearer: [] }]
           schema type: :object,
                  properties: {
                    offender_no: { '$ref' => '#/components/schemas/NomsNumber' },
@@ -57,7 +70,6 @@ describe 'Offender Early Allocation API' do
         end
 
         response '404', 'Offender not found' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/Status'
 
           let(:nomsNumber) { 'A1111AA' }

--- a/spec/api/sar_api_spec.rb
+++ b/spec/api/sar_api_spec.rb
@@ -5,12 +5,19 @@ describe 'SAR API' do
 
   path '/subject-access-request' do
     get 'Retrieves all held info for offender' do
+      security [{ Bearer: [] }]
+
       tags 'Subject Access Request'
-      description "* NOMIS Prison Number (PRN) must be provided as part of the request.
-* The role ROLE_SAR_DATA_ACCESS is required
-* If the product uses the identifier type transmitted in the request, it can respond with its data and HTTP code 200
-* If the product uses the identifier type transmitted in the request but has no data to respond with, it should respond with HTTP code 204
-* If the product does not use the identifier type transmitted in the request, it should respond with HTTP code 209"
+      description(
+        [
+          '* A valid Bearer token must be supplied in the Authorization header.',
+          '* NOMIS Prison Number (PRN) must be provided as part of the request.',
+          '* The role ROLE_SAR_DATA_ACCESS is required',
+          '* If the product uses the identifier type transmitted in the request, it can respond with its data and HTTP code 200',
+          '* If the product uses the identifier type transmitted in the request but has no data to respond with, it should respond with HTTP code 204',
+          '* If the product does not use the identifier type transmitted in the request, it should respond with HTTP code 209'
+        ].join("\n")
+      )
 
       produces 'application/json'
       consumes 'application/json'
@@ -36,8 +43,14 @@ describe 'SAR API' do
         let(:Authorization) { nil }
 
         response '401', 'Request is not authorised' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/SarError'
+
+          example 'application/json', :error_example, {
+            developerMessage: 'Valid authorisation token required',
+            errorCode: 1,
+            status: 401,
+            userMessage: 'Valid authorisation token required',
+          }
 
           let(:crn) { nil }
           let(:prn) { 'A1111AA' }
@@ -54,8 +67,14 @@ describe 'SAR API' do
         end
 
         response '403', 'Invalid token role' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/SarError'
+
+          example 'application/json', :error_example, {
+            developerMessage: 'Invalid token role',
+            errorCode: 5,
+            status: 403,
+            userMessage: 'Invalid token role',
+          }
 
           let(:crn) { nil }
           let(:prn) { 'A1111AA' }
@@ -71,9 +90,15 @@ describe 'SAR API' do
           allow_any_instance_of(Api::SarController).to receive(:verify_token)
         end
 
-        response '400', 'Both PRN and CRN parameter passed' do
-          security [{ Bearer: [] }]
+        response '400', 'PRN and CRN parameters passed' do
           schema '$ref' => '#/components/schemas/SarError'
+
+          example 'application/json', :error_example, {
+            developerMessage: 'PRN and CRN parameters passed',
+            errorCode: 2,
+            status: 400,
+            userMessage: 'PRN and CRN parameters passed',
+          }
 
           let(:crn) { '123456' }
           let(:prn) { 'A1111AA' }
@@ -83,9 +108,15 @@ describe 'SAR API' do
           run_test!
         end
 
-        response '209', 'Just CRN parameter passed' do
-          security [{ Bearer: [] }]
+        response '209', 'CRN parameter not allowed' do
           schema '$ref' => '#/components/schemas/SarError'
+
+          example 'application/json', :error_example, {
+            developerMessage: 'CRN parameter not allowed',
+            errorCode: 3,
+            status: 209,
+            userMessage: 'CRN parameter not allowed',
+          }
 
           let(:crn) { '123456' }
           let(:prn) { nil }
@@ -96,8 +127,14 @@ describe 'SAR API' do
         end
 
         response '210', 'Invalid date format' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/SarError'
+
+          example 'application/json', :error_example, {
+            developerMessage: 'Invalid date format',
+            errorCode: 4,
+            status: 210,
+            userMessage: 'Invalid date format',
+          }
 
           let(:crn) { nil }
           let(:prn) { 'A1111AA' }
@@ -108,8 +145,6 @@ describe 'SAR API' do
         end
 
         response '204', 'Offender not found' do
-          security [{ Bearer: [] }]
-
           let(:crn) { nil }
           let(:prn) { 'A1111AA' }
           let(:fromDate) { nil }
@@ -119,7 +154,6 @@ describe 'SAR API' do
         end
 
         response '200', 'Offender found' do
-          security [{ Bearer: [] }]
           schema '$ref' => '#/components/schemas/SarOffenderData'
 
           before do

--- a/spec/api/sar_template_api_spec.rb
+++ b/spec/api/sar_template_api_spec.rb
@@ -8,16 +8,32 @@ describe 'SAR template API' do
 
   path '/subject-access-request/template' do
     get 'Retrieves the SAR Mustache template for this service' do
+      security [{ Bearer: [] }]
+
       tags 'Subject Access Request'
-      description "* The role ROLE_SAR_DATA_ACCESS is required
-* Returns the plain-text Mustache template configured for the service"
+      description(
+        [
+          '* A valid Bearer token must be supplied in the Authorization header.',
+          '* The role ROLE_SAR_DATA_ACCESS is required',
+          '* Returns the plain-text Mustache template configured for the service'
+        ].join("\n")
+      )
 
       response '401', 'Request is not authorised' do
-        security [{ Bearer: [] }]
         metadata[:response][:schema] = { '$ref' => '#/components/schemas/SarError' }
         metadata[:response][:content] = {
           'application/json' => {
-            schema: { '$ref' => '#/components/schemas/SarError' }
+            schema: { '$ref' => '#/components/schemas/SarError' },
+            examples: {
+              error_example: {
+                value: {
+                  developerMessage: 'Valid authorisation token required',
+                  errorCode: 1,
+                  status: 401,
+                  userMessage: 'Valid authorisation token required'
+                }
+              }
+            }
           }
         }
 
@@ -27,11 +43,20 @@ describe 'SAR template API' do
       end
 
       response '403', 'Invalid token role' do
-        security [{ Bearer: [] }]
         metadata[:response][:schema] = { '$ref' => '#/components/schemas/SarError' }
         metadata[:response][:content] = {
           'application/json' => {
-            schema: { '$ref' => '#/components/schemas/SarError' }
+            schema: { '$ref' => '#/components/schemas/SarError' },
+            examples: {
+              error_example: {
+                value: {
+                  developerMessage: 'Invalid token role',
+                  errorCode: 5,
+                  status: 403,
+                  userMessage: 'Invalid token role'
+                }
+              }
+            }
           }
         }
 
@@ -42,8 +67,7 @@ describe 'SAR template API' do
         run_test!
       end
 
-      response '200', 'Template returned for SAR users' do
-        security [{ Bearer: [] }]
+      response '200', 'Template returned' do
         metadata[:response][:schema] = { type: :string }
         metadata[:response][:content] = {
           'text/plain' => {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,27 +6,46 @@ RSpec.configure do |config|
     'public/openapi.yml' => {
       openapi: '3.0.3',
       info: {
-        title: 'MPC/MOIC API',
+        title: 'Manage POM Cases API',
         version: 'v2',
+        description: [
+          'API endpoints for Manage POM Cases, covering offender allocations, handovers, early allocation status, and subject access request (SAR) data.',
+          '',
+          '### Authentication',
+          '',
+          'This API is secured by OAuth 2 with Bearer tokens supplied by HMPPS Auth.',
+          '',
+          'Most read endpoints require the role `ROLE_VIEW_POM_ALLOCATIONS`.',
+          '',
+          'SAR endpoints require the role `ROLE_SAR_DATA_ACCESS`.',
+          '',
+          '---',
+          '',
+          'Owned by the **Manage POM Cases** team',
+          '',
+          '- Slack: [#manage-pom-cases](https://mojdt.slack.com/channels/manage-pom-cases)',
+          '- GitHub: [ministryofjustice/offender-management-allocation-manager](https://github.com/ministryofjustice/offender-management-allocation-manager)'
+        ].join("\n")
       },
       servers: [
         {
-          url: '{protocol}://{defaultHost}',
-          variables: {
-            protocol: {
-              default: :https
-            },
-            defaultHost: {
-              default: 'dev.moic.service.justice.gov.uk'
-            }
-          }
+          url: 'https://dev.moic.service.justice.gov.uk',
+          description: 'Staging/dev environment',
+        },
+        {
+          url: 'https://preprod.moic.service.justice.gov.uk',
+          description: 'Pre-production environment',
+        },
+        {
+          url: 'https://moic.service.justice.gov.uk',
+          description: 'Production environment',
         },
       ],
       components: {
         securitySchemes: {
           Bearer: {
             type: "apiKey",
-            description: "A bearer token obtained from HMPPS SSO",
+            description: "A Bearer token obtained from HMPPS Auth and supplied in the Authorization header",
             name: "Authorization",
             in: "header",
           }
@@ -292,6 +311,24 @@ RSpec.configure do |config|
           },
         },
       },
+      tags: [
+        {
+          name: 'Allocations',
+          description: 'Retrieve current prison offender manager allocation details for a prisoner',
+        },
+        {
+          name: 'Handovers',
+          description: 'Retrieve handover dates and current responsibility between prison and probation',
+        },
+        {
+          name: 'Offenders',
+          description: 'Retrieve prisoner-level data exposed by Manage POM Cases APIs',
+        },
+        {
+          name: 'Subject Access Request',
+          description: 'SAR endpoints for retrieving service data and the Mustache template used by the SAR HTML renderer',
+        },
+      ],
       paths: {}
     }
   }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1973

We had quite a minimal swagger documentation. Improved/expanded a bit, to add information on the roles needed, what each endpoint is used for, etc. and some general formatting and layout fixes.

No functional changes, just `openapi.yml` output (through the specs).