### PR TITLE
Retry sporadic 401 API requests refreshing token

### DIFF
--- a/app/lib/domain_events/handlers/tier_change_handler.rb
+++ b/app/lib/domain_events/handlers/tier_change_handler.rb
@@ -15,12 +15,7 @@ module DomainEvents
         new_tier = api_tier_info[:tier][0]
         old_tier = case_info.tier
 
-        if new_tier == old_tier
-          logger.info "event=domain_event_handle_noop,domain_event_type=#{event.event_type},crn=#{event.crn_number}" \
-                      '|Tier value has not changed'
-
-          return
-        end
+        return if new_tier == old_tier
 
         case_info.tier = new_tier
 

--- a/app/services/hmpps_api/client.rb
+++ b/app/services/hmpps_api/client.rb
@@ -5,17 +5,22 @@ require 'typhoeus/adapters/faraday'
 
 module HmppsApi
   class Client
-    def initialize(root, extra_retry_methods: [], user_token: nil)
+    def initialize(root, extra_retry_methods: [])
       @root = root
-      @user_token = user_token
       @connection = Faraday.new do |faraday|
-        faraday.request :retry, max: 3, interval: 0.05,
-                                interval_randomness: 0.5, backoff_factor: 2,
-                                # We appear to get occasional transient 5xx errors, so retry them
-                                retry_statuses: [500, 502],
-                                methods: Faraday::Request::Retry::IDEMPOTENT_METHODS + extra_retry_methods,
-                                # we get Faraday::ConnectionFailed (error in HTTP2 Framing Layer) sometimes
-                                exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed]
+        faraday.request(
+          :retry,
+          max: 3, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2,
+          # We appear to get occasional transient 5xx errors
+          retry_statuses: [500, 502],
+          methods: Faraday::Request::Retry::IDEMPOTENT_METHODS + extra_retry_methods,
+          # For 401s we refresh the app token in the retry callback and
+          # update the retried request's Authorization header there
+          exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed, Faraday::UnauthorizedError],
+          retry_block: lambda { |env, _options, retries_remaining, exception|
+            refresh_token_on_retry(env, retries_remaining, exception)
+          },
+        )
 
         faraday.options.params_encoder = Faraday::FlatParamsEncoder
         faraday.request :instrumentation
@@ -112,11 +117,10 @@ module HmppsApi
 
     def send_request(method, route, queryparams:, extra_headers:, body:)
       url = @root + route
-      bearer = @user_token || token.access_token
 
       @connection.send(method) do |req|
         req.url(url)
-        req.headers['Authorization'] = "Bearer #{bearer}"
+        req.headers['Authorization'] = "Bearer #{token.access_token}"
         req.headers['Content-Type'] = 'application/json' unless body.nil?
         req.headers.merge!(extra_headers)
         req.params.update(queryparams)
@@ -148,6 +152,18 @@ module HmppsApi
 
     def token
       HmppsApi::Oauth::TokenService.valid_token
+    end
+
+    def refresh_token_on_retry(env, retries_remaining, exception)
+      return unless exception.is_a?(Faraday::UnauthorizedError)
+
+      Rails.logger.warn(
+        "event=hmpps_api_retry_refresh_token,method=#{env.method.to_s.upcase},route=#{env.url.path}," \
+        "retries_remaining=#{retries_remaining}"
+      )
+
+      refreshed_token = HmppsApi::Oauth::TokenService.refresh_token!
+      env.request_headers['Authorization'] = "Bearer #{refreshed_token.access_token}"
     end
 
     def response_cache

--- a/app/services/hmpps_api/oauth/token_service.rb
+++ b/app/services/hmpps_api/oauth/token_service.rb
@@ -6,12 +6,16 @@ module HmppsApi
       include Singleton
 
       class << self
-        delegate :valid_token, to: :instance
+        delegate :valid_token, :refresh_token!, to: :instance
       end
 
       def valid_token
         set_new_token if token.needs_refresh?
         token
+      end
+
+      def refresh_token!
+        set_new_token
       end
 
     private

--- a/config/initializers/health.rb
+++ b/config/initializers/health.rb
@@ -33,10 +33,8 @@ config.health_checks = Health.new(timeout_in_seconds_per_check: 2, num_retries_p
     name: 'tieringApi',
     get_response: -> { HmppsApi::Client.new(config.tiering_api_host).get('/health/ping', cache: false) })
   .add_check(
-    # TODO: we nil the `Authorization` header because of a bug with this service, returning a different
-    # response body when passing the Bearer token. A nil authorization will make it behave like the other services.
     name: 'assessRisksAndNeedsApi',
-    get_response: -> { HmppsApi::Client.new(config.assess_risks_and_needs_api_host).get('/health/ping', extra_headers: { 'Authorization' => nil }, cache: false) })
+    get_response: -> { HmppsApi::Client.new(config.assess_risks_and_needs_api_host).get('/health/ping', cache: false) })
   .add_check(
     name: 'prisonAlertsApi',
     get_response: -> { HmppsApi::Client.new(config.prison_alerts_api_host).get('/health/ping', cache: false) })

--- a/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
     context 'when tier has not changed' do
       let(:tier) { 'D' }
 
-      it 'emits a log noop message' do
-        expect(Shoryuken::Logging.logger).to have_received(:info).with(/domain_event_handle_noop/)
-      end
-
       it 'emits no audit event' do
         expect(AuditEvent).not_to have_received(:publish)
       end

--- a/spec/services/hmpps_api/client_spec.rb
+++ b/spec/services/hmpps_api/client_spec.rb
@@ -17,6 +17,8 @@ describe HmppsApi::Client do
 
   before do
     allow(token_service).to receive(:valid_token).and_return(valid_token)
+    allow(token_service).to receive(:refresh_token!).and_return(valid_token)
+    allow(Rails.logger).to receive(:warn)
   end
 
   describe 'with a valid request' do
@@ -47,6 +49,30 @@ describe HmppsApi::Client do
       it 'raises a HmppsApi::Error::Unauthorized error' do
         expect { client.get(route) }
           .to raise_error(HmppsApi::Error::Unauthorized, "the server responded with status #{status}")
+      end
+
+      context 'when a refreshed token resolves the request' do
+        let(:refreshed_access_token) { 'refreshed_access_token' }
+        let(:refreshed_token) { HmppsApi::Oauth::Token.new(access_token: refreshed_access_token) }
+
+        before do
+          allow(token_service).to receive(:valid_token).and_return(valid_token, refreshed_token)
+          allow(token_service).to receive(:refresh_token!).and_return(refreshed_token)
+          WebMock.stub_request(:get, api_host + route)
+            .to_return({ status: 401 }, { status: 200, body: '{}' })
+        end
+
+        it 'retries with a refreshed token' do
+          expect(client.get(route)).to eq({})
+          expect(token_service).to have_received(:refresh_token!).once
+          expect(Rails.logger).to have_received(:warn).with(
+            'event=hmpps_api_retry_refresh_token,method=GET,route=/api/endpoint,retries_remaining=2'
+          ).once
+          expect(WebMock).to have_requested(:get, api_host + route)
+            .with(headers: { 'Authorization' => "Bearer #{access_token}" }).once
+          expect(WebMock).to have_requested(:get, api_host + route)
+            .with(headers: { 'Authorization' => "Bearer #{refreshed_access_token}" }).once
+        end
       end
     end
 

--- a/spec/services/hmpps_api/oauth/token_service_spec.rb
+++ b/spec/services/hmpps_api/oauth/token_service_spec.rb
@@ -32,4 +32,19 @@ describe HmppsApi::Oauth::TokenService do
 
     expect(token_service.valid_token).to eq(unexpired_token)
   end
+
+  it 'can refresh the token explicitly' do
+    current_token = HmppsApi::Oauth::Token.new(access_token: 'xxxxxxxxxxxxxxxxxxxxxxxx', expires_in: 3600)
+    refreshed_token = HmppsApi::Oauth::Token.new(access_token: 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy', expires_in: 3600)
+
+    allow(HmppsApi::Oauth::Api)
+      .to receive(:fetch_new_auth_token)
+      .and_return(current_token, refreshed_token)
+
+    token_service = described_class.instance
+
+    expect(token_service.valid_token).to eq(current_token)
+    expect(token_service.refresh_token!).to eq(refreshed_token)
+    expect(token_service.valid_token).to eq(refreshed_token)
+  end
 end


### PR DESCRIPTION
Although we usually have code to cope with these (mostly on queued jobs) we can retry sporadic 401 at the http client level which should be more optimal.

It also makes the tiering handler which is synchronous more resilient (I've seen a handful 401 in the logs over the past month, which is the main reason for this PR).