### PR TITLE
MO-1975 Add bulk reallocation emails

### DIFF
--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -83,6 +83,20 @@ class PomMailer < ApplicationMailer
     mail(to: params[:previous_pom_email])
   end
 
+  def bulk_allocations_created
+    set_template('5516c944-2e2c-4227-b08f-2084b799d12a')
+    set_personalisation(**params.slice(:pom_name, :old_pom_name, :message, :allocations, :url))
+
+    mail(to: params[:pom_email])
+  end
+
+  def bulk_allocations_removed
+    set_template('2c5b87eb-9e1e-4ca6-a011-3b9b01532a2f')
+    set_personalisation(**params.slice(:pom_name, :new_pom_name, :message, :allocations, :url))
+
+    mail(to: params[:pom_email])
+  end
+
   def offender_deallocated
     set_template('1df51f52-512d-434b-9088-50eacaa47c59')
     set_personalisation(**params.slice(:pom_name, :offender_name, :nomis_offender_id, :prison_name, :url))

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -2,12 +2,12 @@
 
 class EmailService
   class << self
-    def send_email(message:, allocation:, pom_nomis_id:, further_info: {})
+    def send_email(message:, allocation:, pom_nomis_id:, further_info: {}, notify_previous_pom: true)
       pom = pom_for(allocation, pom_nomis_id)
       return if pom.email_address.blank?
 
-      send_deallocation_email pom: pom, allocation: allocation, further_info: further_info
-      deliver_new_allocation_email pom: pom, message: message, allocation: allocation, further_info: further_info
+      send_deallocation_email(pom:, allocation:, further_info:) if notify_previous_pom
+      deliver_new_allocation_email(pom:, message:, allocation:, further_info:)
     end
 
     def send_coworking_primary_email(message:, allocation:)

--- a/app/services/reallocation/bulk_reallocation_notifier.rb
+++ b/app/services/reallocation/bulk_reallocation_notifier.rb
@@ -1,18 +1,67 @@
 # frozen_string_literal: true
 
-# TODO: this is a bit finger in the air as the handling of the new emails
-# is still not ready or even started
 module Reallocation
   class BulkReallocationNotifier
+    attr_reader :prison, :source_pom, :target_pom, :email_service, :mailer
+
+    def initialize(prison:, source_pom:, target_pom:, email_service: EmailService, mailer: PomMailer)
+      @prison = prison
+      @source_pom = source_pom
+      @target_pom = target_pom
+      @email_service = email_service
+      @mailer = mailer
+    end
+
     def call(result)
+      return if result.reallocated_cases.empty?
+
+      deliver_individual_emails(result)
+      deliver_allocations_created_email(result)
+      deliver_allocations_removed_email(result)
+    end
+
+  private
+
+    def deliver_individual_emails(result)
       result.reallocated_cases.each do |reallocated_case|
-        EmailService.send_email(
+        email_service.send_email(
           allocation: reallocated_case.allocation,
           message: result.message,
           pom_nomis_id: reallocated_case.allocation.primary_pom_nomis_id,
           further_info: reallocated_case.further_info,
+          notify_previous_pom: false,
         )
       end
+    end
+
+    def deliver_allocations_created_email(result)
+      return if target_pom.email_address.blank?
+
+      mailer.with(
+        pom_name: target_pom.full_name_ordered,
+        pom_email: target_pom.email_address,
+        old_pom_name: source_pom.full_name_ordered,
+        message: result.message,
+        allocations: result.allocations_for_email,
+        url: caseload_url_for(target_pom),
+      ).bulk_allocations_created.deliver_later
+    end
+
+    def deliver_allocations_removed_email(result)
+      return if source_pom.email_address.blank?
+
+      mailer.with(
+        pom_name: source_pom.full_name_ordered,
+        pom_email: source_pom.email_address,
+        new_pom_name: target_pom.full_name_ordered,
+        message: result.message,
+        allocations: result.allocations_for_email,
+        url: caseload_url_for(source_pom),
+      ).bulk_allocations_removed.deliver_later
+    end
+
+    def caseload_url_for(pom)
+      Rails.application.routes.url_helpers.prison_staff_caseload_url(prison.code, pom.staff_id)
     end
   end
 end

--- a/app/services/reallocation/bulk_reallocation_result.rb
+++ b/app/services/reallocation/bulk_reallocation_result.rb
@@ -2,12 +2,20 @@
 
 module Reallocation
   class BulkReallocationResult
-    ReallocatedCase = Struct.new(:allocation, :selected_case, :further_info, keyword_init: true) do
+    ReallocatedCase = Struct.new(:allocation, :selected_case, :further_info, :email_context, keyword_init: true) do
       def confirmation_attributes
         {
           full_name: selected_case.full_name,
           nomis_offender_id: selected_case.nomis_offender_id,
         }
+      end
+
+      def email_attributes
+        offender_name = email_context.fetch(:offender_name)
+        nomis_offender_id = email_context.fetch(:prisoner_number)
+        pom_responsibility = email_context.fetch(:pom_role).to_s.downcase
+
+        "#{offender_name} (#{nomis_offender_id}) – #{pom_responsibility}"
       end
     end
 
@@ -23,6 +31,10 @@ module Reallocation
 
     def selected_cases
       reallocated_cases.map(&:confirmation_attributes)
+    end
+
+    def allocations_for_email
+      reallocated_cases.map(&:email_attributes)
     end
 
     def to_confirmation

--- a/app/services/reallocation/bulk_reallocation_service.rb
+++ b/app/services/reallocation/bulk_reallocation_service.rb
@@ -2,17 +2,16 @@
 
 module Reallocation
   class BulkReallocationService
+    attr_reader :prison, :source_pom, :target_pom, :journey, :current_user, :email_context_builder
+
     def initialize(prison:, source_pom:, target_pom:, journey:, current_user:,
-                   email_context_builder: EmailContextBuilder.new, notifier: BulkReallocationNotifier.new,
-                   notify_individually: true)
+                   email_context_builder: EmailContextBuilder.new)
       @prison = prison
       @source_pom = source_pom
       @target_pom = target_pom
       @journey = journey
       @current_user = current_user
       @email_context_builder = email_context_builder
-      @notifier = notifier
-      @notify_individually = notify_individually
     end
 
     # Reallocates every selected (non-excluded) case, then applies the current
@@ -27,15 +26,12 @@ module Reallocation
         remaining_cases_count:,
       )
 
-      notifier.call(result) if notify_individually
+      BulkReallocationNotifier.new(prison:, source_pom:, target_pom:).call(result)
 
       result
     end
 
   private
-
-    attr_reader :prison, :source_pom, :target_pom, :journey, :current_user,
-                :email_context_builder, :notifier, :notify_individually
 
     def build_reallocation_result_for(selected_case, message)
       offender = offender_for(selected_case.nomis_offender_id)
@@ -58,11 +54,15 @@ module Reallocation
         override_detail: override[:more_detail],
       }
 
-      notification_context = email_context_builder.build(
+      email_context = email_context_builder.build(
         offender: offender,
         pom: target_pom,
         prev_pom_name: source_pom.full_name_ordered,
-      ).slice(:last_oasys_completed, :handover_start_date, :handover_completion_date, :com_name, :com_email)
+      )
+
+      notification_context = email_context.slice(
+        :last_oasys_completed, :handover_start_date, :handover_completion_date, :com_name, :com_email
+      )
 
       persisted_allocation = AllocationService.create_or_update(allocation_attributes, notification_context, notify: false)
 
@@ -70,6 +70,7 @@ module Reallocation
         allocation: persisted_allocation,
         selected_case: selected_case,
         further_info: notification_context,
+        email_context: email_context,
       )
     end
 

--- a/spec/mailers/pom_mailer_spec.rb
+++ b/spec/mailers/pom_mailer_spec.rb
@@ -140,4 +140,110 @@ RSpec.describe PomMailer, type: :mailer do
           )
     end
   end
+
+  describe 'bulk_allocations_created' do
+    let(:params) do
+      {
+        pom_name: 'New Pom',
+        pom_email: 'new.pom@example.com',
+        old_pom_name: 'Old Pom',
+        message: 'Bulk move',
+        allocations: [
+          'Alice Zephyr (G1234AA) – responsible',
+          'Bob Amber (G5678BB) – supporting'
+        ],
+        url: 'http://example.com/prisons/LEI/staff/10002/caseload'
+      }
+    end
+
+    let(:mail) { described_class.with(**params).bulk_allocations_created }
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template)
+        .to eq '5516c944-2e2c-4227-b08f-2084b799d12a'
+    end
+
+    it 'sets the To address of the email using the provided user' do
+      expect(mail.to).to eq(['new.pom@example.com'])
+    end
+
+    it 'personalises the email' do
+      expect(mail.govuk_notify_personalisation)
+        .to eq(
+          pom_name: params[:pom_name],
+          old_pom_name: params[:old_pom_name],
+          message: 'Bulk move',
+          allocations: params[:allocations],
+          url: params[:url]
+        )
+    end
+
+    context 'when no optional message has been added to the email' do
+      it 'personalises the email with an empty message' do
+        params[:message] = ''
+
+        expect(mail.govuk_notify_personalisation)
+          .to eq(
+            pom_name: params[:pom_name],
+            old_pom_name: params[:old_pom_name],
+            message: '',
+            allocations: params[:allocations],
+            url: params[:url]
+          )
+      end
+    end
+  end
+
+  describe 'bulk_allocations_removed' do
+    let(:params) do
+      {
+        pom_name: 'Old Pom',
+        pom_email: 'old.pom@example.com',
+        new_pom_name: 'New Pom',
+        message: 'Bulk move',
+        allocations: [
+          'Alice Zephyr (G1234AA) – responsible',
+          'Bob Amber (G5678BB) – supporting'
+        ],
+        url: 'http://example.com/prisons/LEI/staff/10001/caseload'
+      }
+    end
+
+    let(:mail) { described_class.with(**params).bulk_allocations_removed }
+
+    it 'sets the template' do
+      expect(mail.govuk_notify_template)
+        .to eq '2c5b87eb-9e1e-4ca6-a011-3b9b01532a2f'
+    end
+
+    it 'sets the To address of the email using the provided user' do
+      expect(mail.to).to eq(['old.pom@example.com'])
+    end
+
+    it 'personalises the email' do
+      expect(mail.govuk_notify_personalisation)
+        .to eq(
+          pom_name: params[:pom_name],
+          new_pom_name: params[:new_pom_name],
+          message: 'Bulk move',
+          allocations: params[:allocations],
+          url: params[:url]
+        )
+    end
+
+    context 'when no optional message has been added to the email' do
+      it 'personalises the email with an empty message' do
+        params[:message] = ''
+
+        expect(mail.govuk_notify_personalisation)
+          .to eq(
+            pom_name: params[:pom_name],
+            new_pom_name: params[:new_pom_name],
+            message: '',
+            allocations: params[:allocations],
+            url: params[:url]
+          )
+      end
+    end
+  end
 end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -79,9 +79,16 @@ RSpec.describe EmailService do
   end
 
   context 'when queueing', :queueing do
-    it "Can send an allocation email"  do
+    it 'skips the deallocation email for bulk reallocations' do
+      allow(reallocation).to receive(:get_old_versions).and_return([original_allocation])
+
       expect {
-        described_class.send_email(allocation: allocation, message: "", pom_nomis_id: allocation.primary_pom_nomis_id)
+        described_class.send_email(
+          allocation: reallocation,
+          message: '',
+          pom_nomis_id: reallocation.primary_pom_nomis_id,
+          notify_previous_pom: false,
+        )
       }.to change(enqueued_jobs, :size).by(1)
     end
 

--- a/spec/services/reallocation/bulk_reallocation_notifier_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_notifier_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reallocation::BulkReallocationNotifier do
+  subject(:notifier) do
+    described_class.new(
+      prison: prison,
+      source_pom: source_pom,
+      target_pom: target_pom,
+      email_service: email_service,
+      mailer: mailer,
+    )
+  end
+
+  let(:prison) { create(:prison, code: 'LEI') }
+  let(:source_pom) do
+    instance_double(StaffMember, staff_id: 10_001, full_name_ordered: 'Old Pom', email_address: 'old.pom@example.com')
+  end
+  let(:target_pom) do
+    instance_double(StaffMember, staff_id: 10_002, full_name_ordered: 'New Pom', email_address: 'new.pom@example.com')
+  end
+  let(:email_service) { class_double(EmailService, send_email: nil) }
+  let(:mailer) { class_double(PomMailer) }
+  let(:created_email) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+  let(:removed_email) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+  let(:allocation) { instance_double(AllocationHistory, primary_pom_nomis_id: target_pom.staff_id) }
+
+  let(:reallocated_case) do
+    Reallocation::BulkReallocationResult::ReallocatedCase.new(
+      allocation: allocation,
+      selected_case: instance_double(AllocatedOffender, full_name: 'Zephyr, Alice', nomis_offender_id: 'G1234AA'),
+      further_info: { com_name: 'John Smith' },
+      email_context: {
+        offender_name: 'Alice Zephyr',
+        prisoner_number: 'G1234AA',
+        pom_role: 'Responsible'
+      }
+    )
+  end
+
+  let(:result) do
+    Reallocation::BulkReallocationResult.new(
+      source_pom_id: source_pom.staff_id,
+      target_pom_id: target_pom.staff_id,
+      message: 'Bulk move',
+      reallocated_cases: [reallocated_case],
+      remaining_cases_count: 3,
+    )
+  end
+
+  it 'sends one aggregated email to the new POM and one to the old POM' do
+    allow(mailer).to receive(:with).and_raise('Unexpected arguments')
+    allow(mailer).to receive(:with).with(
+      pom_name: 'New Pom',
+      pom_email: 'new.pom@example.com',
+      old_pom_name: 'Old Pom',
+      message: 'Bulk move',
+      allocations: ['Alice Zephyr (G1234AA) – responsible'],
+      url: 'http://localhost:3000/prisons/LEI/staff/10002/caseload'
+    ).and_return(instance_double(PomMailer, bulk_allocations_created: created_email))
+    allow(mailer).to receive(:with).with(
+      pom_name: 'Old Pom',
+      pom_email: 'old.pom@example.com',
+      new_pom_name: 'New Pom',
+      message: 'Bulk move',
+      allocations: ['Alice Zephyr (G1234AA) – responsible'],
+      url: 'http://localhost:3000/prisons/LEI/staff/10001/caseload'
+    ).and_return(instance_double(PomMailer, bulk_allocations_removed: removed_email))
+
+    notifier.call(result)
+
+    expect(email_service).to have_received(:send_email).with(
+      allocation: allocation,
+      message: 'Bulk move',
+      pom_nomis_id: target_pom.staff_id,
+      further_info: { com_name: 'John Smith' },
+      notify_previous_pom: false,
+    )
+    expect(created_email).to have_received(:deliver_later).with(no_args)
+    expect(removed_email).to have_received(:deliver_later).with(no_args)
+  end
+
+  it 'skips the new POM email when the target POM has no email address' do
+    allow(target_pom).to receive(:email_address).and_return(nil)
+    allow(mailer).to receive(:with).with(
+      pom_name: 'Old Pom',
+      pom_email: 'old.pom@example.com',
+      new_pom_name: 'New Pom',
+      message: 'Bulk move',
+      allocations: ['Alice Zephyr (G1234AA) – responsible'],
+      url: 'http://localhost:3000/prisons/LEI/staff/10001/caseload'
+    ).and_return(instance_double(PomMailer, bulk_allocations_removed: removed_email))
+
+    notifier.call(result)
+
+    expect(mailer).not_to have_received(:with).with(hash_including(pom_email: nil))
+    expect(removed_email).to have_received(:deliver_later).with(no_args)
+  end
+
+  it 'skips the old POM email when the source POM has no email address' do
+    allow(source_pom).to receive(:email_address).and_return(nil)
+    allow(mailer).to receive(:with).with(
+      pom_name: 'New Pom',
+      pom_email: 'new.pom@example.com',
+      old_pom_name: 'Old Pom',
+      message: 'Bulk move',
+      allocations: ['Alice Zephyr (G1234AA) – responsible'],
+      url: 'http://localhost:3000/prisons/LEI/staff/10002/caseload'
+    ).and_return(instance_double(PomMailer, bulk_allocations_created: created_email))
+
+    notifier.call(result)
+
+    expect(created_email).to have_received(:deliver_later).with(no_args)
+    expect(mailer).not_to have_received(:with).with(hash_including(pom_email: nil))
+  end
+end

--- a/spec/services/reallocation/bulk_reallocation_service_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_service_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Reallocation::BulkReallocationService do
       journey: journey,
       current_user: 'spo-user',
       email_context_builder: email_context_builder,
-      notifier: notifier,
-      notify_individually: notify_individually,
     )
   end
 
@@ -74,12 +72,14 @@ RSpec.describe Reallocation::BulkReallocationService do
   end
   let(:persisted_allocation) { instance_double(AllocationHistory, primary_pom_nomis_id: target_pom.staff_id) }
   let(:notifier) { instance_double(Reallocation::BulkReallocationNotifier, call: nil) }
-  let(:notify_individually) { true }
 
   let(:email_context_builder) do
     instance_double(
       Reallocation::EmailContextBuilder,
       build: {
+        offender_name: 'Zephyr, Alice',
+        prisoner_number: offender_no,
+        pom_role: 'Responsible',
         last_oasys_completed: 'No OASys information',
         handover_start_date: '01 Jan 2027',
         handover_completion_date: '01 Jan 2028',
@@ -100,6 +100,7 @@ RSpec.describe Reallocation::BulkReallocationService do
     allow(OffenderService).to receive(:get_offender).with(offender_no).and_return(offender)
     allow(AllocationService).to receive(:create_or_update).and_return(persisted_allocation)
     allow(StaffMember).to receive(:new).with(prison, source_pom.staff_id, nil).and_return(refreshed_source_pom)
+    allow(Reallocation::BulkReallocationNotifier).to receive(:new).with(prison:, source_pom:, target_pom:).and_return(notifier)
   end
 
   describe '#call' do
@@ -158,6 +159,14 @@ RSpec.describe Reallocation::BulkReallocationService do
       expect(result.to_confirmation[:selected_cases]).to eq([{ full_name: 'Zephyr, Alice', nomis_offender_id: offender_no }])
     end
 
+    it 'returns the allocations summary needed for the bulk email templates' do
+      result = service.call([selected_case], message: 'Moving cases')
+
+      expect(result.allocations_for_email).to eq([
+        'Zephyr, Alice (A1111AA) – responsible'
+      ])
+    end
+
     context 'when the allocation history does not exist (new allocation)' do
       before do
         AllocationHistory.where(nomis_offender_id: offender_no).delete_all
@@ -170,16 +179,6 @@ RSpec.describe Reallocation::BulkReallocationService do
           expect(attributes).to include(event: :allocate_primary_pom)
           expect(options).to include(notify: false)
         end
-      end
-    end
-
-    context 'when individual notifications are disabled' do
-      let(:notify_individually) { false }
-
-      it 'does not notify after persisting the batch' do
-        service.call([selected_case], message: 'Moving cases')
-
-        expect(notifier).not_to have_received(:call)
       end
     end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1975

First pass to the new emails sent in the bulk reallocation journey and, as agreed with content designer, skipping individual deallocation emails (we leave the allocation ones as these contain useful details per-offender).