### PR TITLE
MO-1978 Handle tier v3 events/endpoints

### DIFF
--- a/app/lib/domain_events/event.rb
+++ b/app/lib/domain_events/event.rb
@@ -50,6 +50,10 @@ class DomainEvents::Event
     @message['detailUrl']
   end
 
+  def version
+    @message['version']
+  end
+
   def publish(now: Time.zone.now.utc, job: nil)
     full_message = @message.merge('occurredAt' => now.iso8601)
     self.class.json_validate!(full_message)

--- a/app/lib/domain_events/handlers/tier_change_handler.rb
+++ b/app/lib/domain_events/handlers/tier_change_handler.rb
@@ -2,13 +2,14 @@ module DomainEvents
   module Handlers
     class TierChangeHandler
       def handle(event, logger: Shoryuken::Logging.logger)
-        logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},crn=#{event.crn_number}"
+        logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type}," \
+                      "version=#{event.version},crn=#{event.crn_number}"
 
         case_info = CaseInformation.find_by(crn: event.crn_number)
         return if case_info.nil?
 
         api_tier_info = HmppsApi::TieringApi.get_calculation(
-          event.crn_number, event.additional_information['calculationId']
+          event.crn_number, event.additional_information['calculationId'], version: event.version
         )
         return if api_tier_info.try(:[], :tier).nil?
 
@@ -31,10 +32,10 @@ module DomainEvents
           )
 
           logger.info "event=domain_event_handle_success,domain_event_type=#{event.event_type}," \
-                        "crn=#{event.crn_number},old_tier=#{old_tier},new_tier=#{new_tier}"
+                        "version=#{event.version},crn=#{event.crn_number},old_tier=#{old_tier},new_tier=#{new_tier}"
         else
           logger.error "event=domain_event_handle_failure,domain_event_type=#{event.event_type}," \
-            "crn=#{event.crn_number}|Error saving case information"
+            "version=#{event.version},crn=#{event.crn_number}|#{case_info.errors.full_messages.join(',')}"
         end
       end
     end

--- a/app/services/hmpps_api/tiering_api.rb
+++ b/app/services/hmpps_api/tiering_api.rb
@@ -5,10 +5,8 @@ module HmppsApi
       HmppsApi::Client.new(host)
     end
 
-    def self.get_calculation(crn, calculation_id)
-      safe_crn = URI.encode_www_form_component(crn)
-      safe_calculation_id = URI.encode_www_form_component(calculation_id)
-      route = "/crn/#{safe_crn}/tier/#{safe_calculation_id}"
+    def self.get_calculation(crn, calculation_id, version:)
+      route = "/v#{version}/crn/#{crn}/tier/#{calculation_id}"
       response = client.get(route)
 
       {

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -10,5 +10,6 @@ feature_flags:
     staging: true
   new_tiers:
     staging: true
+    preprod: true
   rosh_recommendations:
     staging: true

--- a/spec/lib/domain_events/event_spec.rb
+++ b/spec/lib/domain_events/event_spec.rb
@@ -187,5 +187,10 @@ RSpec.describe DomainEvents::Event, :enable_domain_event_publish do
       expect(basic_event.detail_url).to eq nil
       expect(full_event.detail_url).to eq('https://example.com/event_detail_url')
     end
+
+    it 'has #version', :aggregate_failures do
+      expect(basic_event.version).to eq 77
+      expect(full_event.version).to eq 8
+    end
   end
 end

--- a/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
@@ -1,33 +1,41 @@
 RSpec.describe DomainEvents::Handlers::TierChangeHandler do
   subject!(:handler) { described_class.new }
 
-  before do
-    allow(Shoryuken::Logging.logger).to receive(:info).and_return(nil)
-    allow(Shoryuken::Logging.logger).to receive(:error).and_return(nil)
-    allow(AuditEvent).to receive(:publish).and_return(nil)
-    allow(HmppsApi::TieringApi).to receive(:get_calculation).and_return({ tier: tier_from_api })
-  end
-
+  let(:crn) { 'X408769' }
   let(:event) do
     DomainEvents::Event.new(
       event_type: 'tier.calculation.complete',
-      version: 1,
-      description: 'A fabulous description',
-      detail_url: 'https://example.org/irrelevant',
-      additional_information: { 'calculationId' => 'bishboshbash' },
+      version: event_version,
+      description: 'Tier calculation complete',
+      detail_url: "https://hmpps-tier.example.org/crn/#{crn}/tier/#{calculation_id}",
+      additional_information: { 'calculationId' => calculation_id },
       crn_number: crn,
       external_event: true
     )
   end
-
-  let(:crn) { 'X08769' }
   let(:tier_from_api) { 'D1' }
+  let(:calculation_id) { 'a5e7d3c1-9b4f-4e2a-8c6d-1f3b5a7e9d02' }
+  let(:event_version) { 3 }
+
+  before do
+    allow(Shoryuken::Logging.logger).to receive(:info).and_return(nil)
+    allow(Shoryuken::Logging.logger).to receive(:error).and_return(nil)
+    allow(AuditEvent).to receive(:publish).and_return(nil)
+    allow(HmppsApi::TieringApi).to receive(:get_calculation)
+      .with(crn, calculation_id, version: event_version)
+      .and_return({ tier: tier_from_api })
+  end
 
   context 'when local case information found' do
     let!(:case_information) { create(:case_information, crn: crn, tier: tier) }
     let(:tier) { 'A' }
 
     before { handler.handle(event) }
+
+    it 'passes crn, calculationId, and version to TieringApi' do
+      expect(HmppsApi::TieringApi).to have_received(:get_calculation)
+        .with(crn, calculation_id, version: event_version)
+    end
 
     context 'when tier has not changed' do
       let(:tier) { 'D' }
@@ -40,14 +48,6 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
     context 'when case information update successful' do
       it 'updates tier with first char of new value' do
         expect(case_information.reload.tier).to eq('D')
-      end
-
-      context 'when supervision has been suspended' do
-        let(:tier_from_api) { 'D3S' }
-
-        it 'updates tier with first char of new value' do
-          expect(case_information.reload.tier).to eq('D')
-        end
       end
 
       it 'emits a log info message' do

--- a/spec/services/hmpps_api/tiering_api_spec.rb
+++ b/spec/services/hmpps_api/tiering_api_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HmppsApi::TieringApi do
+  describe '.get_calculation' do
+    let(:api_host) { Rails.configuration.tiering_api_host }
+    let(:crn) { 'X408769' }
+    let(:calculation_id) { 'a5e7d3c1-9b4f-4e2a-8c6d-1f3b5a7e9d02' }
+    let(:response_body) do
+      { 'tierScore' => 'E', 'calculationDate' => '2024-03-15' }.to_json
+    end
+
+    context 'with version 3' do
+      let(:endpoint) { "#{api_host}/v3/crn/#{crn}/tier/#{calculation_id}" }
+
+      before do
+        stub_request(:get, endpoint).to_return(status: 200, body: response_body)
+      end
+
+      it 'calls the v3 endpoint' do
+        result = described_class.get_calculation(crn, calculation_id, version: 3)
+        expect(result).to eq(tier: 'E', calculation_date: Date.parse('2024-03-15'))
+        expect(WebMock).to have_requested(:get, endpoint)
+      end
+    end
+
+    context 'with version 2' do
+      let(:endpoint) { "#{api_host}/v2/crn/#{crn}/tier/#{calculation_id}" }
+      let(:response_body) do
+        { 'tierScore' => 'D1', 'calculationDate' => '2024-03-15' }.to_json
+      end
+
+      before do
+        stub_request(:get, endpoint).to_return(status: 200, body: response_body)
+      end
+
+      it 'calls the v2 endpoint' do
+        result = described_class.get_calculation(crn, calculation_id, version: 2)
+        expect(result).to eq(tier: 'D1', calculation_date: Date.parse('2024-03-15'))
+        expect(WebMock).to have_requested(:get, endpoint)
+      end
+    end
+
+    context 'when the endpoint returns 404' do
+      let(:endpoint) { "#{api_host}/v3/crn/#{crn}/tier/#{calculation_id}" }
+
+      before do
+        stub_request(:get, endpoint).to_return(status: 404, body: '')
+      end
+
+      it 'returns nil' do
+        result = described_class.get_calculation(crn, calculation_id, version: 3)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the endpoint returns a server error' do
+      let(:endpoint) { "#{api_host}/v3/crn/#{crn}/tier/#{calculation_id}" }
+
+      before do
+        stub_request(:get, endpoint).to_return(status: 500, body: 'Internal Server Error')
+      end
+
+      it 'returns an error hash' do
+        result = described_class.get_calculation(crn, calculation_id, version: 3)
+        expect(result).to eq(tier: nil, calculation_date: nil, error: Faraday::ServerError)
+      end
+
+      it 'logs the error' do
+        allow(Rails.logger).to receive(:error)
+        described_class.get_calculation(crn, calculation_id, version: 3)
+        expect(Rails.logger).to have_received(:error).with(%r{event=tiering_get_calculation,route=/v3/crn/#{crn}/tier/#{calculation_id}})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1978

In preparation for the new tier calculations and v3 events that we will start receiving soon.

Enabling our feat-flag (in `preprod`) allows these new tier levels to pass our validations and also to show up in the UI and be added in the missing info page.