### PR TITLE
MO-1855 Guard against stale POM notifications

### DIFF
--- a/app/jobs/auto_early_allocation_email_job.rb
+++ b/app/jobs/auto_early_allocation_email_job.rb
@@ -15,6 +15,13 @@ class AutoEarlyAllocationEmailJob < ApplicationJob
     allocation = AllocationHistory.find_by(nomis_offender_id: offender_no)
     return if offender.nil? || allocation.nil?
 
+    # Skip if the offender has transferred but the allocation hasn't been updated yet
+    if allocation.prison != offender.prison_id
+      logger.info("job=auto_early_allocation_email_job,nomis_offender_id=#{offender_no}," \
+                  "event=skipped_transfer|Offender prison (#{offender.prison_id}) does not match allocation prison (#{allocation.prison})")
+      return
+    end
+
     pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.with(email: offender.ldu_email_address,

--- a/app/jobs/community_early_allocation_email_job.rb
+++ b/app/jobs/community_early_allocation_email_job.rb
@@ -13,6 +13,13 @@ class CommunityEarlyAllocationEmailJob < ApplicationJob
     allocation = AllocationHistory.find_by(nomis_offender_id: offender_no)
     return if offender.nil? || allocation.nil?
 
+    # Skip if the offender has transferred but the allocation hasn't been updated yet
+    if allocation.prison != offender.prison_id
+      logger.info("job=community_early_allocation_email_job,nomis_offender_id=#{offender_no}," \
+                  "event=skipped_transfer|Offender prison (#{offender.prison_id}) does not match allocation prison (#{allocation.prison})")
+      return
+    end
+
     pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
     pdf = Base64.decode64 encoded_pdf
     EarlyAllocationMailer.with(email: offender.ldu_email_address,

--- a/app/jobs/handover_follow_up_job/follow_up_email_details.rb
+++ b/app/jobs/handover_follow_up_job/follow_up_email_details.rb
@@ -21,10 +21,20 @@ class HandoverFollowUpJob::FollowUpEmailDetails
       prison: prison.name,
       start_date: offender.handover_start_date,
       responsibility_handover_date: offender.handover_date,
-    }.merge(allocation.try(:active?) ? active_pom_details : no_active_pom_details)
+    }.merge(pom_details)
   end
 
 private
+
+  def pom_details
+    # If the offender has transferred but the allocation still references the old prison,
+    # treat as if there's no active POM to avoid sending stale contact info.
+    if allocation.try(:active?) && allocation.prison == prison.code
+      active_pom_details
+    else
+      no_active_pom_details
+    end
+  end
 
   def active_pom_details
     pom = prison.get_single_pom(allocation.primary_pom_nomis_id)

--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -13,9 +13,16 @@ class SuitableForEarlyAllocationEmailJob < ApplicationJob
     return if allocation.nil?
 
     prisoner = OffenderService.get_offender(offender_no)
+    return if prisoner.nil?
 
-    if !prisoner.nil? && prisoner.within_early_allocation_window?
+    # Skip if the offender has transferred but the allocation hasn't been updated yet
+    if allocation.prison != prisoner.prison_id
+      logger.info("job=suitable_for_early_allocation_email_job,nomis_offender_id=#{offender_no}," \
+                  "event=skipped_transfer|Offender prison (#{prisoner.prison_id}) does not match allocation prison (#{allocation.prison})")
+      return
+    end
 
+    if prisoner.within_early_allocation_window?
       already_emailed = EmailHistory.sent_within_current_sentence(prisoner, EmailHistory::SUITABLE_FOR_EARLY_ALLOCATION)
 
       if already_emailed.empty?

--- a/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
+++ b/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
@@ -55,6 +55,23 @@ describe HandoverFollowUpJob::FollowUpEmailDetails do
       end
     end
 
+    context "when the offender has a POM allocated but has transferred to a different prison" do
+      let(:other_prison) { Prison.find_by(code: "MDI") || create(:prison, code: "MDI") }
+
+      before do
+        FactoryBot.create(:allocation_history, nomis_offender_id: offender.offender_no, prison: other_prison.code, primary_pom_nomis_id: "486154")
+      end
+
+      it "does not include active POM details to avoid sending stale info" do
+        details = described_class.for(offender:)
+
+        expect(details).to include(
+          pom_email: "n/a",
+          pom_name: "This offender does not have an allocated POM",
+        )
+      end
+    end
+
     context "when the offender has a POM allocated but is not included in the list of POMs for that prison" do
       before do
         FactoryBot.create(:allocation_history, nomis_offender_id: offender.offender_no, prison: prison.code, primary_pom_nomis_id: "9999")

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -38,6 +38,34 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
       create(:allocation_history, prison: prison.code, nomis_offender_id: api_offender.offender_no, primary_pom_nomis_id: pom.staff_id, primary_pom_name: pom.full_name)
     end
 
+    context 'when offender has transferred but allocation has not been updated' do
+      let(:release_date) { Time.zone.today + 17.months }
+      let(:other_prison) { create(:prison) }
+
+      before do
+        # Simulate transfer: offender is now at a different prison than the allocation
+        transferred_api_offender = build(:hmpps_api_offender, prisonId: other_prison.code,
+                                                              sentence: attributes_for(:sentence_detail,
+                                                                                       :determinate,
+                                                                                       sentenceStartDate: Time.zone.today - 10.months,
+                                                                                       conditionalReleaseDate: release_date,
+                                                                                       automaticReleaseDate: release_date,
+                                                                                       releaseDate: release_date,
+                                                                                       tariffDate: nil))
+        case_info = CaseInformation.find_by(nomis_offender_id: api_offender.offender_no)
+        transferred_offender = build(:mpc_offender, prison: other_prison, offender: case_info.offender, prison_record: transferred_api_offender)
+        allow(OffenderService).to receive(:get_offender).and_return(transferred_offender)
+      end
+
+      it 'does not send email' do
+        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
+                                  created_within_referral_window: false, nomis_offender_id: api_offender.offender_no)
+
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now(api_offender.offender_no)
+      end
+    end
+
     context 'when form created outside of the referral window (more than 18 months to release)' do
       context 'when form outcome is ineligible' do
         let(:release_date) { Time.zone.today + 28.months }


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1855

Under certain circumstances (transfers) there might be a race condition between events/jobs.

In the transfer window, we don't know who the correct POM is, as the old POM no longer manages this prisoner and there is no new POM yet as the prisoner hasn't been re-allocated at the new prison.

This should be a very rare situation and not happening frequently but logging has been added to better understand the impact.