### PR TITLE
Fix error in import_with_catchup for blank history

### DIFF
--- a/app/services/parole_data_import_service.rb
+++ b/app/services/parole_data_import_service.rb
@@ -34,20 +34,34 @@ class ParoleDataImportService
     latest_imported_date = ParoleReviewImport.maximum(:snapshot_date)
 
     dates_to_import = if latest_imported_date.nil?
-                        date
+                        [date]
                       elsif latest_imported_date < date
                         (latest_imported_date + 1..date)
+                      else
+                        []
                       end
 
-    dates_to_import.to_a.each do |dt|
+    total_import_count = 0
+    total_row_count = 0
+
+    dates_to_import.each do |dt|
       Rails.logger.info(format_log("Importing date #{dt}.", dt))
       import_from_s3_bucket(dt)
+      total_import_count += @csv_row_import_count
+      total_row_count += @csv_row_count
     end
 
-    [@csv_row_import_count, @csv_row_count]
+    if dates_to_import.any? && total_row_count.zero?
+      Rails.logger.error(format_log('No CSV files found for any of the dates attempted.', date))
+    end
+
+    [total_import_count, total_row_count]
   end
 
   def import_from_s3_bucket(date)
+    @csv_row_count = 0
+    @csv_row_import_count = 0
+
     prefix = [S3_OBJECT_PREFIX, date.strftime('%Y%m%d')].join('_')
     csv_files = S3::List.new(prefix:).call
 
@@ -74,9 +88,6 @@ class ParoleDataImportService
 private
 
   def import_from_rows(csv_rows, date)
-    @csv_row_count = 0
-    @csv_row_import_count = 0
-
     ApplicationRecord.transaction do # To improve performance. The index can cause drag
       csv_rows.each do |csv_row|
         @csv_row_count += 1

--- a/app/services/parole_data_import_service.rb
+++ b/app/services/parole_data_import_service.rb
@@ -52,7 +52,10 @@ class ParoleDataImportService
     end
 
     if dates_to_import.any? && total_row_count.zero?
-      Rails.logger.error(format_log('No CSV files found for any of the dates attempted.', date))
+      Sentry.capture_message(
+        'No PPUD CSV files found in S3 for any of the dates attempted',
+        extra: { import_id: @import_id, latest_imported_date:, dates_attempted: dates_to_import.to_a }
+      )
     end
 
     [total_import_count, total_row_count]


### PR DESCRIPTION
There was a bug in the parole import, when we didn't have any previous history records (as these are purged based on date every time we run the import job), trying to convert a date to an array (date.to_a)

Fixed the logic and also improved the accumulation counters when multiple days are imported at once. Counters are now properly reset per-date and accumulated for the full range.