### PR TITLE
MO-1976 Bulk reallocation info banner/copy tweaks

### DIFF
--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -4,6 +4,7 @@ class PrisonersController < PrisonsApplicationController
   before_action :ensure_spo_user, except: [:show, :image, :search]
 
   before_action :load_all_offenders, only: [:allocated, :missing_information, :unallocated, :search]
+  before_action :load_reallocation_alert, only: [:unallocated]
 
   def allocated
     retrieve_latest_allocation_details
@@ -130,5 +131,15 @@ private
   def search_term
     # defaults to an empty string if the key 'q' can't be found
     params.fetch('q', '').strip
+  end
+
+  def load_reallocation_alert
+    return unless FeatureFlags.limbo_bulk_reallocation.enabled?
+
+    poms = @prison.get_list_of_poms
+    @removed_poms = @prison.get_removed_poms(existing_poms: poms)
+  rescue StandardError => e
+    Rails.logger.error("event=load_reallocation_alert_failed|#{e.message}")
+    @removed_poms = []
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,8 +29,8 @@ module ApplicationHelper
 
   def pom_level_long(level, fallback: 'N/A')
     {
-      'PO' => 'Probation Officer POM',
-      'PRO' => 'Prison Officer POM',
+      'PO' => 'Probation POM',
+      'PRO' => 'Prison POM',
       'STAFF' => fallback
     }[level]
   end

--- a/app/services/reallocation/bulk_reallocation_service.rb
+++ b/app/services/reallocation/bulk_reallocation_service.rb
@@ -20,6 +20,13 @@ module Reallocation
     def call(selected_cases, message:)
       reallocated_cases, failed_cases = reallocate_each(selected_cases, message)
 
+      # Deallocate any co-worker leftover cases
+      if remaining_cases_count.zero?
+        AllocationHistory.deallocate_secondary_pom(
+          source_pom.staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
+        )
+      end
+
       build_result(message, reallocated_cases, failed_cases).tap do |result|
         BulkReallocationNotifier.new(prison:, source_pom:, target_pom:).call(result)
       end

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -10,7 +10,7 @@
     <div class='govuk-!-margin-top-6'>
       <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          <h1 class="govuk-fieldset__heading">Working pattern</h1>
+          <h1 class="govuk-fieldset__heading">Select working pattern</h1>
         </legend>
         <div class="govuk-form-group <% if @errors[:working_pattern].present? %>govuk-form-group--error<% end %>">
         <% if @errors[:working_pattern].present? %>
@@ -54,7 +54,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h3 class="govuk-fieldset__heading">Status</h3>
+            <h3 class="govuk-fieldset__heading">Select status</h3>
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -18,12 +18,12 @@
   <ul class="govuk-tabs__list govuk-!-margin-top-9" role='tablist'>
     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
       <a class="govuk-tabs__tab" href="#active_probation_poms">
-        Active probation officer POMs (<%= active_probation_poms(@poms).count %>)
+        Available probation POMs (<%= active_probation_poms(@poms).count %>)
       </a>
     </li>
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#active_prison_poms">
-        Active prison officer POMs (<%= active_prison_poms(@poms).count %>)
+        Available prison POMs (<%= active_prison_poms(@poms).count %>)
       </a>
     </li>
     <li class="govuk-tabs__list-item">
@@ -46,7 +46,7 @@
   <section class="govuk-tabs__panel" id="active_probation_poms">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-l">Active probation officer POMs</h2>
+        <h2 class="govuk-heading-l">Available probation POMs</h2>
         <p class="govuk-body govuk-!-margin-bottom-8">
           If someone has left or will be absent for a while, make sure their status is set to inactive by selecting
           their name below. You will then need to reallocate any cases they have.
@@ -59,7 +59,7 @@
   <section class="govuk-tabs__panel" id="active_prison_poms">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-l">Active prison officer POMs</h2>
+        <h2 class="govuk-heading-l">Available prison POMs</h2>
         <p class="govuk-body govuk-!-margin-bottom-8">
           If someone has left or will be absent for a while, make sure their status is set to inactive by selecting
           their name below. You will then need to reallocate any cases they have.

--- a/app/views/poms/reallocate.html.erb
+++ b/app/views/poms/reallocate.html.erb
@@ -64,6 +64,14 @@
           <%= @pom.allocations.count(&:pom_supporting?) %>
         </dd>
       </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Coworker cases
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @pom.coworking_allocations_count %>
+        </dd>
+      </div>
     </dl>
 
     <div class="govuk-button-group">

--- a/app/views/prisoners/_reallocation_alert.html.erb
+++ b/app/views/prisoners/_reallocation_alert.html.erb
@@ -1,0 +1,16 @@
+<% if @removed_poms.present? && @removed_poms.any? %>
+  <div role="region" class="moj-alert moj-alert--information moj-alert--with-heading govuk-!-margin-bottom-7"
+       aria-label="information: The finance section has moved" data-module="moj-alert">
+    <div>
+      <svg class="moj-alert__icon" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" height="30" width="30">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M10.2165 3.45151C11.733 2.82332 13.3585 2.5 15 2.5C16.6415 2.5 18.267 2.82332 19.7835 3.45151C21.3001 4.07969 22.6781 5.00043 23.8388 6.16117C24.9996 7.3219 25.9203 8.69989 26.5485 10.2165C27.1767 11.733 27.5 13.3585 27.5 15C27.5 18.3152 26.183 21.4946 23.8388 23.8388C21.4946 26.183 18.3152 27.5 15 27.5C13.3585 27.5 11.733 27.1767 10.2165 26.5485C8.69989 25.9203 7.3219 24.9996 6.16117 23.8388C3.81696 21.4946 2.5 18.3152 2.5 15C2.5 11.6848 3.81696 8.50537 6.16117 6.16117C7.3219 5.00043 8.69989 4.07969 10.2165 3.45151ZM16.3574 22.4121H13.6621V12.95H16.3574V22.4121ZM13.3789 9.20898C13.3789 8.98763 13.4212 8.7793 13.5059 8.58398C13.5905 8.38216 13.7044 8.20964 13.8477 8.06641C13.9974 7.91667 14.1699 7.79948 14.3652 7.71484C14.5605 7.63021 14.7721 7.58789 15 7.58789C15.2214 7.58789 15.4297 7.63021 15.625 7.71484C15.8268 7.79948 15.9993 7.91667 16.1426 8.06641C16.2923 8.20964 16.4095 8.38216 16.4941 8.58398C16.5788 8.7793 16.6211 8.98763 16.6211 9.20898C16.6211 9.43685 16.5788 9.64844 16.4941 9.84375C16.4095 10.0391 16.2923 10.2116 16.1426 10.3613C15.9993 10.5046 15.8268 10.6185 15.625 10.7031C15.4297 10.7878 15.2214 10.8301 15 10.8301C14.7721 10.8301 14.5605 10.7878 14.3652 10.7031C14.1699 10.6185 13.9974 10.5046 13.8477 10.3613C13.7044 10.2116 13.5905 10.0391 13.5059 9.84375C13.4212 9.64844 13.3789 9.43685 13.3789 9.20898Z" fill="currentColor"/>
+      </svg>
+    </div>
+    <div class="moj-alert__content">
+      <h2 class="moj-alert__heading">Cases to reallocate</h2>
+      You need to reallocate cases of people who no longer work at this prison.<br/>
+      <%= link_to 'Go to the attention needed part of the staff section', prison_poms_path(@prison.code, anchor: 'attention_needed!top'), class: 'govuk-link' %>
+      to do this.
+    </div>
+  </div>
+<% end %>

--- a/app/views/prisoners/unallocated.html.erb
+++ b/app/views/prisoners/unallocated.html.erb
@@ -19,6 +19,8 @@
   </p>
 <% end %>
 
+<%= render 'reallocation_alert' %>
+
 <div class="govuk-!-margin-bottom-4">
   <%= render "search/search_box" %>
 </div>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -5,7 +5,7 @@ feature_flags:
   example_feature:
     staging: true
   limbo_bulk_reallocation:
-    staging: false
+    staging: true
   rosh_level:
     staging: true
   new_tiers:

--- a/spec/controllers/prisoners_controller_spec.rb
+++ b/spec/controllers/prisoners_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PrisonersController, type: :controller do
 
     before do
       stub_offenders_for_prison(prison.code, offenders)
+      stub_poms(prison.code, [])
       stub_sso_data(prison.code)
     end
 
@@ -253,7 +254,10 @@ RSpec.describe PrisonersController, type: :controller do
   context 'with a mens prison' do
     let(:prison) { create(:prison).code }
 
-    before { stub_sso_data(prison) }
+    before do
+      stub_sso_data(prison)
+      stub_poms(prison, [])
+    end
 
     context 'with 4 offenders' do
       let(:today_plus_10_days) { (Time.zone.today + 10.days).to_s }
@@ -628,6 +632,69 @@ RSpec.describe PrisonersController, type: :controller do
       expect(response.status).to be(200)
       expect(assigns(:primary_pom_name)).to be_nil
       expect(assigns(:secondary_pom_name)).to eq('Secondary Pom')
+    end
+  end
+
+  describe 'reallocation alert banner' do
+    let(:prison) { create(:prison) }
+    let(:offender) { build(:nomis_offender) }
+    let(:pom_record) { build(:pom, staffId: 10_001) }
+    let(:removed_staff_id) { 99_999 }
+
+    before do
+      stub_sso_data(prison.code)
+      stub_offenders_for_prison(prison.code, [offender])
+      stub_poms(prison.code, [pom_record])
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)))
+      create(:allocation_history, nomis_offender_id: offender.fetch(:prisonerNumber), prison: prison.code, primary_pom_nomis_id: pom_record.staff_id)
+    end
+
+    render_views
+
+    context 'when limbo_bulk_reallocation is enabled and there are removed POMs with cases' do
+      let(:removed_offender) { build(:nomis_offender) }
+
+      before do
+        stub_feature_flag(:limbo_bulk_reallocation, enabled: true)
+        stub_offenders_for_prison(prison.code, [offender, removed_offender])
+        create(:pom_detail, prison_code: prison.code, nomis_staff_id: removed_staff_id)
+        create(:case_information, offender: build(:offender, nomis_offender_id: removed_offender.fetch(:prisonerNumber)))
+        create(:allocation_history, nomis_offender_id: removed_offender.fetch(:prisonerNumber), prison: prison.code, primary_pom_nomis_id: removed_staff_id)
+
+        stub_request(:get, "#{ApiHelper::NOMIS_USER_ROLES_API_HOST}/users/staff/#{removed_staff_id}")
+          .to_return(body: { staffId: removed_staff_id, lastName: 'Gone', firstName: 'Person' }.to_json)
+      end
+
+      it 'shows the reallocation alert on the unallocated page' do
+        get :unallocated, params: { prison_id: prison.code }
+
+        expect(response.body).to include('Cases to reallocate')
+        expect(response.body).to include('Go to the attention needed part of the staff section')
+      end
+    end
+
+    context 'when limbo_bulk_reallocation is disabled' do
+      before do
+        stub_feature_flag(:limbo_bulk_reallocation, enabled: false)
+      end
+
+      it 'does not show the reallocation alert' do
+        get :unallocated, params: { prison_id: prison.code }
+
+        expect(response.body).not_to include('Cases to reallocate')
+      end
+    end
+
+    context 'when there are no removed POMs with cases' do
+      before do
+        stub_feature_flag(:limbo_bulk_reallocation, enabled: true)
+      end
+
+      it 'does not show the reallocation alert' do
+        get :unallocated, params: { prison_id: prison.code }
+
+        expect(response.body).not_to include('Cases to reallocate')
+      end
     end
   end
 end

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -77,12 +77,12 @@ FactoryBot.define do
 
     trait :probation_officer do
       position { 'PO' }
-      positionDescription { 'Probation Officer POM' }
+      positionDescription { 'Probation POM' }
     end
 
     trait :prison_officer do
       position { 'PRO' }
-      positionDescription { 'Prison Officer POM' }
+      positionDescription { 'Prison POM' }
     end
   end
   

--- a/spec/features/allocations_summary_feature_spec.rb
+++ b/spec/features/allocations_summary_feature_spec.rb
@@ -14,6 +14,7 @@ feature 'summary summary feature' do
     stub_bank_holidays
     stub_signin_spo(build(:pom), prison.code)
     stub_offenders_for_prison(prison.code, offenders)
+    stub_poms(prison.code, [])
   end
 
   describe 'awaiting summary table' do

--- a/spec/features/female_prison_index_page_feature_spec.rb
+++ b/spec/features/female_prison_index_page_feature_spec.rb
@@ -6,6 +6,7 @@ feature "female prison index page" do
   before do
     stub_signin_spo(pom, [prison.code])
     stub_offenders_for_prison(prison.code, offenders)
+    stub_poms(prison.code, [])
     stub_bank_holidays
 
     create(:case_information, offender: build(:offender, nomis_offender_id: allocated_offender_one.fetch(:prisonerNumber)))

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -20,8 +20,8 @@ feature "get poms list", flaky: true do
 
     # shows 3 tabs - probation, prison and inactive
     expect(page).to have_css(".govuk-tabs__list-item", count: 3)
-    expect(page).to have_content("Active probation officer POMs")
-    expect(page).to have_content("Active prison officer POMs")
+    expect(page).to have_content("Available probation POMs")
+    expect(page).to have_content("Available prison POMs")
     expect(page).to have_content("Inactive staff")
   end
 

--- a/spec/features/staff/homd_manages_poms_statuses_spec.rb
+++ b/spec/features/staff/homd_manages_poms_statuses_spec.rb
@@ -20,13 +20,13 @@ describe 'HOMD manages POMS statuses' do
     visit prison_poms_path(prison)
     within('section', text: 'Inactive staff') { click_on 'Anette Pomme' }
     within('.govuk-summary-list__row', text: 'Status Inactive') { click_on 'Change' }
-    within('fieldset', text: 'Status') { choose 'Active' }
+    within('fieldset', text: 'Select status') { choose 'Active' }
     click_on 'Save'
 
     # Then I see the POM in the active staff section
     visit prison_poms_path(prison)
     within('section', text: 'Inactive staff') { expect(page).not_to have_content('Anette Pomme') }
-    within('section', text: 'Active prison officer POMs') { expect(page).to have_content('Anette Pomme') }
+    within('section', text: 'Available prison POMs') { expect(page).to have_content('Anette Pomme') }
   end
 
   specify 'HOMD making POM inactive de-allocates any allocated cases' do
@@ -42,15 +42,15 @@ describe 'HOMD manages POMS statuses' do
 
     # When I make the POM inactive
     visit prison_poms_path(prison)
-    within('section', text: 'Active prison officer POMs') { click_on 'Anette Pomme' }
+    within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
     within('.govuk-summary-list__row', text: 'Status Active') { click_on 'Change' }
-    within('fieldset', text: 'Status') { choose 'Inactive' }
+    within('fieldset', text: 'Select status') { choose 'Inactive' }
     click_on 'Save'
 
     # Then they appear in the inactive staff section
     visit prison_poms_path(prison)
     within('section', text: 'Inactive staff') { expect(page).to have_content('Anette Pomme') }
-    within('section', text: 'Active prison officer POMs') { expect(page).not_to have_content('Anette Pomme') }
+    within('section', text: 'Available prison POMs') { expect(page).not_to have_content('Anette Pomme') }
 
     # And the previosly allocated cases are now on the unallocated cases screen
     visit unallocated_prison_prisoners_path(prison)

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -250,8 +250,8 @@ feature "staff pages" do
 
     it 'shows the POM staff page' do
       expect(page).to have_content("Manage your staff")
-      expect(page).to have_content("Active probation officer POMs")
-      expect(page).to have_content("Active prison officer POMs")
+      expect(page).to have_content("Available probation POMs")
+      expect(page).to have_content("Available prison POMs")
       expect(page).to have_content("Inactive staff")
     end
 
@@ -270,7 +270,7 @@ feature "staff pages" do
     end
 
     it 'can display active prison POMs case mix' do
-      click_on('Active prison officer POMs')
+      click_on('Available prison POMs')
 
       pom_row = find('td', text: poms.last.full_name_ordered).ancestor('tr')
 

--- a/spec/features/summary_feature_spec.rb
+++ b/spec/features/summary_feature_spec.rb
@@ -5,6 +5,7 @@ feature 'male prisoners summary navigation tabs' do
     signin_spo_user([prison.code, 'AGI'])
     stub_signin_spo(pom, [prison.code, 'AGI'])
     stub_offenders_for_prison(prison.code, offenders)
+    stub_poms(prison.code, [pom])
     stub_bank_holidays
 
     create(:case_information, offender: build(:offender, nomis_offender_id: offender_ready_to_allocate.fetch(:prisonerNumber)))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe ApplicationHelper do
     let(:fallback) { 'Support staff' }
 
     it 'returns long Probation Officer' do
-      expect(pom_level_long(po)).to eq('Probation Officer POM')
+      expect(pom_level_long(po)).to eq('Probation POM')
     end
 
     it 'returns long Prison Officer' do
-      expect(pom_level_long(pom)).to eq('Prison Officer POM')
+      expect(pom_level_long(pom)).to eq('Prison POM')
     end
 
     it 'returns the supplied fallback for staff members' do

--- a/spec/services/reallocation/bulk_reallocation_service_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_service_spec.rb
@@ -278,5 +278,56 @@ RSpec.describe Reallocation::BulkReallocationService do
         expect(notifier).to have_received(:call)
       end
     end
+
+    context 'when no primary allocations remain after reallocation' do
+      before do
+        # Remove the primary allocation so remaining_cases_count is 0
+        allocation.update!(primary_pom_nomis_id: target_pom.staff_id)
+      end
+
+      let!(:coworking_allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               nomis_offender_id: 'D4444DD',
+               primary_pom_nomis_id: 99_999,
+               secondary_pom_nomis_id: source_pom.staff_id,
+               secondary_pom_name: 'Old, Pom')
+      end
+
+      it 'deallocates the source POM from all coworking allocations at that prison' do
+        service.call([selected_case], message: 'Moving cases')
+
+        coworking_allocation.reload
+        expect(coworking_allocation.secondary_pom_nomis_id).to be_nil
+        expect(coworking_allocation.secondary_pom_name).to be_nil
+        expect(coworking_allocation.event).to eq('deallocate_secondary_pom')
+        expect(coworking_allocation.event_trigger).to eq('inactive_pom')
+      end
+    end
+
+    context 'when primary allocations still remain after reallocation' do
+      let!(:another_primary_allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               nomis_offender_id: 'F6666FF',
+               primary_pom_nomis_id: source_pom.staff_id)
+      end
+
+      let!(:coworking_allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               nomis_offender_id: 'G7777GG',
+               primary_pom_nomis_id: 99_999,
+               secondary_pom_nomis_id: source_pom.staff_id,
+               secondary_pom_name: 'Old, Pom')
+      end
+
+      it 'does not deallocate coworking allocations' do
+        service.call([selected_case], message: 'Moving cases')
+
+        coworking_allocation.reload
+        expect(coworking_allocation.secondary_pom_nomis_id).to eq(source_pom.staff_id)
+      end
+    end
   end
 end

--- a/spec/views/poms/reallocate.html.erb_spec.rb
+++ b/spec/views/poms/reallocate.html.erb_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'poms/reallocate', type: :view do
+  let(:prison) { create(:prison) }
+  let(:pom_record) { build(:pom, :prison_officer, staffId: 10_001, firstName: 'John', lastName: 'Doe') }
+  let(:pom) { StaffMember.new(prison, pom_record.staff_id) }
+
+  before do
+    stub_poms(prison.code, [pom_record])
+    stub_offenders_for_prison(prison.code, offenders)
+
+    view.request.path_parameters[:prison_id] = prison.code
+    view.request.path_parameters[:nomis_staff_id] = pom_record.staff_id
+
+    assign(:prison, prison)
+    assign(:pom, pom)
+    assign(:summary, {
+      last_allocated_date: 1.day.ago.to_date,
+      last_seven_days: 1,
+      release_next_four_weeks: 0,
+    })
+  end
+
+  context 'when the POM has coworking allocations' do
+    let(:offenders) { build_list(:nomis_offender, 3) }
+
+    before do
+      offenders.each do |offender|
+        offender_no = offender.fetch(:prisonerNumber)
+        create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+      end
+
+      # 2 primary allocations
+      create(:allocation_history, prison: prison.code,
+                                  nomis_offender_id: offenders[0].fetch(:prisonerNumber),
+                                  primary_pom_nomis_id: pom_record.staff_id)
+      create(:allocation_history, prison: prison.code,
+                                  nomis_offender_id: offenders[1].fetch(:prisonerNumber),
+                                  primary_pom_nomis_id: pom_record.staff_id)
+
+      # 1 coworking allocation
+      create(:allocation_history, prison: prison.code,
+                                  nomis_offender_id: offenders[2].fetch(:prisonerNumber),
+                                  primary_pom_nomis_id: 99_999,
+                                  secondary_pom_nomis_id: pom_record.staff_id,
+                                  secondary_pom_name: 'Doe, John')
+
+      render
+    end
+
+    it 'shows the coworker cases count' do
+      expect(rendered).to include('Coworker cases')
+      expect(rendered).to include('1')
+    end
+  end
+
+  context 'when the POM has no coworking allocations' do
+    let(:offenders) { build_list(:nomis_offender, 1) }
+
+    before do
+      offender_no = offenders[0].fetch(:prisonerNumber)
+      create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))
+      create(:allocation_history, prison: prison.code,
+                                  nomis_offender_id: offender_no,
+                                  primary_pom_nomis_id: pom_record.staff_id)
+
+      render
+    end
+
+    it 'shows the coworker cases row with zero' do
+      expect(rendered).to include('Coworker cases')
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1976

Continuation to previous work. Adding info banner when there are cases in limbo, some copy changes to align with the designs, and enabling the feature on staging to facilitate some initial testing.