### PR TITLE
MO-1987 Removal/cleanup of POM upon bulk realloc

### DIFF
--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -62,6 +62,6 @@ module PomHelper
   end
 
   def inactive_poms(poms)
-    poms.reject { |pom| %w[active unavailable].include? pom.status }
+    poms.select(&:inactive?)
   end
 end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -9,7 +9,7 @@ class Prison < ApplicationRecord
 
   scope :active, -> { where(code: AllocationHistory.distinct.pluck(:prison)) }
 
-  def get_list_of_poms(staff_id: nil)
+  def get_list_of_poms(staff_id: nil, include_deleted: false)
     # This API call doesn't do what it says on the tin. It can return duplicate
     # staff_ids in the situation where someone has more than one role.
     poms = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(code, staff_id:)
@@ -17,13 +17,14 @@ class Prison < ApplicationRecord
 
     details = pom_details.where(nomis_staff_id: poms.map(&:staff_id))
 
-    poms.map { |pom| PomWrapper.new(pom, get_pom_detail(details,  pom)) }
+    result = poms.map { |pom| PomWrapper.new(pom, get_pom_detail(details, pom)) }
+    include_deleted ? result : result.reject(&:deleted?)
   end
 
   def get_single_pom(nomis_staff_id)
     raise ArgumentError, 'Prison#get_single_pom(nil)' if nomis_staff_id.nil?
 
-    pom = get_list_of_poms(staff_id: nomis_staff_id).first
+    pom = get_list_of_poms(staff_id: nomis_staff_id, include_deleted: true).first
     if pom.nil?
       raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{code}"
     end

--- a/app/services/nomis_user_roles_service.rb
+++ b/app/services/nomis_user_roles_service.rb
@@ -51,7 +51,7 @@ class NomisUserRolesService
       nomis_staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
     )
 
-    prison.pom_details.destroy_by(nomis_staff_id:)
+    prison.pom_details.find_by(nomis_staff_id:)&.deleted!
 
     pom = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(
       prison.code, staff_id: nomis_staff_id

--- a/app/services/reallocation/bulk_reallocation_service.rb
+++ b/app/services/reallocation/bulk_reallocation_service.rb
@@ -20,12 +20,10 @@ module Reallocation
     def call(selected_cases, message:)
       reallocated_cases, failed_cases = reallocate_each(selected_cases, message)
 
-      # Deallocate any co-worker leftover cases
-      if remaining_cases_count.zero?
-        AllocationHistory.deallocate_secondary_pom(
-          source_pom.staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
-        )
-      end
+      # When no OMIC-eligible primary cases remain, fully remove the POM:
+      # deallocates all leftover allocations, soft-deletes the PomDetail,
+      # and removes their NOMIS role.
+      NomisUserRolesService.remove_pom(prison, source_pom.staff_id) if remaining_cases_count.zero?
 
       build_result(message, reallocated_cases, failed_cases).tap do |result|
         BulkReallocationNotifier.new(prison:, source_pom:, target_pom:).call(result)
@@ -118,7 +116,8 @@ module Reallocation
     end
 
     def remaining_cases_count
-      AllocationHistory.active.for_primary_pom(source_pom.staff_id).at_prison(prison).count
+      AllocationHistory.active.for_primary_pom(source_pom.staff_id).at_prison(prison)
+        .where(nomis_offender_id: prison.all_policy_offenders.map(&:offender_no)).count
     end
   end
 end

--- a/app/views/poms/reallocate.html.erb
+++ b/app/views/poms/reallocate.html.erb
@@ -13,8 +13,8 @@
         <br/>
         You can do this now or later.
       <% else %>
-        As <%= full_name_ordered(@pom) %> will be away from work, you can reallocate their cases or skip if their cases
-        do not need to be reallocated.
+        As <%= full_name_ordered(@pom) %> will be away from work, you can reallocate their cases or skip this if their
+        cases do not need to be reallocated.
         <br/>
         You can also reallocate their cases later.
       <% end %>
@@ -76,8 +76,14 @@
 
     <div class="govuk-button-group">
       <%= link_to 'Continue', prison_reallocation_path, role: 'button', class: 'govuk-button' %>
-      <%= link_to @pom.in_limbo? ? 'Reallocate cases later' : 'Skip this', prison_poms_path(anchor: 'attention_needed!top'),
-                  role: 'button', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button--secondary' } %>
+
+      <% if @pom.in_limbo? %>
+        <%= link_to 'Reallocate cases later', prison_poms_path(anchor: 'attention_needed!top'),
+                    role: 'button', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button--secondary' } %>
+      <% else %>
+        <%= link_to 'Skip this', prison_poms_path(anchor: 'inactive_poms!top'),
+                    role: 'button', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button--secondary' } %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/reallocations/confirmation.html.erb
+++ b/app/views/reallocations/confirmation.html.erb
@@ -18,7 +18,7 @@
 
     <p class="govuk-body">
       You have reallocated <%= pluralize(@selected_cases.size, 'case') %> from
-      <%= pom_level(@pom.position, titleize: false) %> <%= @pom.full_name_ordered %> to
+      <%= pom_level(@pom.position, titleize: false, fallback: '') %> <%= @pom.full_name_ordered %> to
       <%= pom_level(@new_pom.position, titleize: false) %> <%= @new_pom.full_name_ordered %>.
     </p>
 

--- a/spec/controllers/poms_controller_spec.rb
+++ b/spec/controllers/poms_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe PomsController, type: :controller do
 
     let(:active_staff_id) { PomDetail.where(status: 'active').first!.nomis_staff_id }
     let(:unavailable_staff_id) { PomDetail.where(status: 'unavailable').first!.nomis_staff_id }
-    let(:inactive_poms) { assigns(:poms).reject { |pom| %w[active unavailable].include? pom.status } }
+    let(:inactive_poms) { assigns(:poms).select(&:inactive?) }
     let(:active_poms) { assigns(:poms).select { |pom| %w[active unavailable].include? pom.status } }
 
     it 'does omit the allocation which does not show up in Prison#offenders' do

--- a/spec/factories/pom_details.rb
+++ b/spec/factories/pom_details.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
       status { 'unavailable' }
     end
 
+    trait :deleted do
+      status { 'deleted' }
+    end
+
     trait :part_time do
       working_pattern { 0.5 }
     end

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -137,7 +137,7 @@ feature "remove a POM no longer present in NOMIS" do
                                   href: unallocated_prison_prisoners_path(prison))
 
         pom_details = PomDetail.find_by(prison_code: prison.code, nomis_staff_id: removed_pom_staff_id)
-        expect(pom_details).to be_nil
+        expect(pom_details).to be_deleted
       end
     end
   end

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -58,4 +58,24 @@ RSpec.describe PomHelper do
       expect(status(pom)).to eq('deleted')
     end
   end
+
+  describe '#inactive_poms' do
+    let(:active_pom) { double('PomWrapper', inactive?: false) }
+    let(:unavailable_pom) { double('PomWrapper', inactive?: false) }
+    let(:inactive_pom) { double('PomWrapper', inactive?: true) }
+    let(:deleted_pom) { double('PomWrapper', inactive?: false) }
+    let(:poms) { [active_pom, unavailable_pom, inactive_pom, deleted_pom] }
+
+    it 'returns only inactive POMs' do
+      expect(inactive_poms(poms)).to eq([inactive_pom])
+    end
+
+    it 'excludes deleted POMs' do
+      expect(inactive_poms(poms)).not_to include(deleted_pom)
+    end
+
+    it 'excludes active and unavailable POMs' do
+      expect(inactive_poms(poms)).not_to include(active_pom, unavailable_pom)
+    end
+  end
 end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -217,6 +217,25 @@ RSpec.describe Prison do
         expect(result.first.staff_id).to eq(pom1.staff_id)
       end
     end
+
+    context 'when a POM has been soft-deleted' do
+      before do
+        create(:pom_detail, :deleted, prison: prison, nomis_staff_id: pom1.staff_id)
+      end
+
+      it 'excludes the soft-deleted POM by default' do
+        result = prison.get_list_of_poms
+
+        expect(result.map(&:staff_id)).not_to include(pom1.staff_id)
+        expect(result.map(&:staff_id)).to include(pom2.staff_id)
+      end
+
+      it 'includes the soft-deleted POM when include_deleted is true' do
+        result = prison.get_list_of_poms(include_deleted: true)
+
+        expect(result.map(&:staff_id)).to include(pom1.staff_id, pom2.staff_id)
+      end
+    end
   end
 
   describe '#get_removed_poms' do
@@ -274,6 +293,30 @@ RSpec.describe Prison do
       it 'does not return POMs without active primary allocations' do
         removed = prison.get_removed_poms(existing_poms: [pom1])
         expect(removed).to be_empty
+      end
+    end
+
+    context 'when POM is soft-deleted but still has active primary allocations' do
+      let!(:pom_detail2) { create(:pom_detail, :deleted, prison: prison, nomis_staff_id: pom2.staff_id) }
+
+      let!(:allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               primary_pom_nomis_id: pom2.staff_id,
+               nomis_offender_id: offender_no)
+      end
+
+      before do
+        allow(prison).to receive(:allocated).and_return(
+          [MpcOffender.new(prison:, offender:, prison_record:)]
+        )
+      end
+
+      it 'returns the soft-deleted POM so the SPO can re-enter the reallocation journey' do
+        removed = prison.get_removed_poms(existing_poms: [pom1])
+
+        expect(removed.size).to eq(1)
+        expect(removed.first.staff_id).to eq(pom2.staff_id)
       end
     end
   end

--- a/spec/services/nomis_user_roles_service_spec.rb
+++ b/spec/services/nomis_user_roles_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe NomisUserRolesService do
-  let(:prison) { build(:prison) }
+  let(:prison) { create(:prison) }
   let(:nomis_staff_id) { 123_456 }
   let(:spo_username) { 'SPO_USER' }
   let(:pom) { build(:pom, staffId: nomis_staff_id) }
@@ -87,10 +87,9 @@ RSpec.describe NomisUserRolesService do
 
   describe '.remove_pom' do
     let(:event_trigger) { AllocationHistory::INACTIVE_POM }
+    let!(:pom_detail) { create(:pom_detail, :active, prison_code: prison.code, nomis_staff_id: nomis_staff_id) }
 
     before do
-      allow(prison.pom_details).to receive(:destroy_by)
-
       allow(AllocationHistory).to receive(:deallocate_primary_pom)
       allow(AllocationHistory).to receive(:deallocate_secondary_pom)
 
@@ -110,10 +109,10 @@ RSpec.describe NomisUserRolesService do
       )
     end
 
-    it 'removes the POM details' do
+    it 'soft-deletes the POM details' do
       described_class.remove_pom(prison, nomis_staff_id)
 
-      expect(prison.pom_details).to have_received(:destroy_by).with(nomis_staff_id: nomis_staff_id)
+      expect(pom_detail.reload).to be_deleted
     end
 
     it 'expires the staff role' do

--- a/spec/services/reallocation/bulk_reallocation_service_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_service_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Reallocation::BulkReallocationService do
     stub_feature_flag(:rosh_recommendations, enabled: true)
     allocation # ensure it's created
 
+    allow(prison).to receive(:all_policy_offenders).and_return([double(offender_no: offender_no)])
     allow(OffenderService).to receive(:get_offender)
       .with(offender_no, fetch_categories: false, fetch_movements: false).and_return(offender)
     allow(AllocationService).to receive(:create_or_update).and_return(persisted_allocation)
@@ -167,6 +168,7 @@ RSpec.describe Reallocation::BulkReallocationService do
     context 'when the allocation history does not exist (new allocation)' do
       before do
         AllocationHistory.where(nomis_offender_id: offender_no).delete_all
+        allow(NomisUserRolesService).to receive(:remove_pom)
       end
 
       it 'uses allocate_primary_pom as the event' do
@@ -283,29 +285,21 @@ RSpec.describe Reallocation::BulkReallocationService do
       before do
         # Remove the primary allocation so remaining_cases_count is 0
         allocation.update!(primary_pom_nomis_id: target_pom.staff_id)
+        allow(NomisUserRolesService).to receive(:remove_pom)
       end
 
-      let!(:coworking_allocation) do
-        create(:allocation_history,
-               prison: prison.code,
-               nomis_offender_id: 'D4444DD',
-               primary_pom_nomis_id: 99_999,
-               secondary_pom_nomis_id: source_pom.staff_id,
-               secondary_pom_name: 'Old, Pom')
-      end
-
-      it 'deallocates the source POM from all coworking allocations at that prison' do
+      it 'removes the POM from the service' do
         service.call([selected_case], message: 'Moving cases')
 
-        coworking_allocation.reload
-        expect(coworking_allocation.secondary_pom_nomis_id).to be_nil
-        expect(coworking_allocation.secondary_pom_name).to be_nil
-        expect(coworking_allocation.event).to eq('deallocate_secondary_pom')
-        expect(coworking_allocation.event_trigger).to eq('inactive_pom')
+        expect(NomisUserRolesService).to have_received(:remove_pom).with(prison, source_pom.staff_id)
       end
     end
 
     context 'when primary allocations still remain after reallocation' do
+      before do
+        allow(NomisUserRolesService).to receive(:remove_pom)
+      end
+
       let!(:another_primary_allocation) do
         create(:allocation_history,
                prison: prison.code,
@@ -313,20 +307,10 @@ RSpec.describe Reallocation::BulkReallocationService do
                primary_pom_nomis_id: source_pom.staff_id)
       end
 
-      let!(:coworking_allocation) do
-        create(:allocation_history,
-               prison: prison.code,
-               nomis_offender_id: 'G7777GG',
-               primary_pom_nomis_id: 99_999,
-               secondary_pom_nomis_id: source_pom.staff_id,
-               secondary_pom_name: 'Old, Pom')
-      end
-
-      it 'does not deallocate coworking allocations' do
+      it 'does not remove the POM from the service' do
         service.call([selected_case], message: 'Moving cases')
 
-        coworking_allocation.reload
-        expect(coworking_allocation.secondary_pom_nomis_id).to eq(source_pom.staff_id)
+        expect(NomisUserRolesService).not_to have_received(:remove_pom)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1987

Perform the final cleanup and soft-delete the POM upon finalising a bulk reallocation. Deleted POMs will not show up in the inactive POMs tab, but if they still have cases, they will show up in the "attention needed" tab (as in limbo).

Additional copy tweaks.