### PR TITLE
MO-1979 Away from work bulk reallocation

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -107,3 +107,7 @@
     margin-left: govuk-spacing(5);
   }
 }
+
+.app-page-header-actions--align-bottom {
+  align-items: flex-end;
+}

--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -39,27 +39,35 @@ class PomsController < PrisonStaffApplicationController
   end
 
   def edit
-    @errors = {}
+    @edit_pom_form = PomProfileForm.new(
+      status: @pom.status,
+      description: @pom.working_pattern.to_s == '1.0' ? 'FT' : 'PT',
+      working_pattern: @pom.working_pattern.to_s,
+    )
   end
 
   def update
-    pom_detail = @prison.pom_details.find_by!(nomis_staff_id: nomis_staff_id)
-    pom_detail.working_pattern = working_pattern
-    pom_detail.status = edit_pom_params[:status] || pom.status
+    @edit_pom_form = PomProfileForm.new(edit_pom_params.to_h)
 
-    if pom_detail.save
+    if @edit_pom_form.valid?
+      pom_detail = @prison.pom_details.find_by!(nomis_staff_id:)
+      pom_detail.working_pattern = @edit_pom_form.working_pattern_ratio
+      pom_detail.status = @edit_pom_form.status
+      pom_detail.save!
+
       if pom_detail.inactive?
-        AllocationHistory.deallocate_primary_pom(
-          nomis_staff_id, active_prison_id, event_trigger: AllocationHistory::INACTIVE_POM
-        )
-        AllocationHistory.deallocate_secondary_pom(
-          nomis_staff_id, active_prison_id, event_trigger: AllocationHistory::INACTIVE_POM
-        )
+        if FeatureFlags.status_bulk_reallocation.enabled? && pom_detail.has_primary_allocations?
+          redirect_to reallocate_prison_pom_path(active_prison_id, nomis_staff_id:) and return
+        else
+          AllocationHistory.deallocate_pom(
+            nomis_staff_id, active_prison_id, event_trigger: AllocationHistory::INACTIVE_POM
+          )
+        end
       end
+
       redirect_to prison_pom_path(active_prison_id, id: nomis_staff_id),
                   notice: "Profile updated for #{helpers.full_name_ordered(@pom)}"
     else
-      @errors = pom_detail.errors
       render :edit
     end
   end
@@ -85,12 +93,6 @@ private
 
   def load_pom_staff_member
     @pom = StaffMember.new @prison, nomis_staff_id
-  end
-
-  def working_pattern
-    return '1.0' if edit_pom_params[:description] == 'FT'
-
-    edit_pom_params[:working_pattern]
   end
 
   def edit_pom_params

--- a/app/forms/pom_profile_form.rb
+++ b/app/forms/pom_profile_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class PomProfileForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  DESCRIPTIONS = %w[FT PT].freeze
+  WORKING_PATTERNS = (1..9).map { |v| "0.#{v}" }.freeze
+
+  attribute :status, :string
+  attribute :description, :string
+  attribute :working_pattern, :string
+
+  validates :description, inclusion: DESCRIPTIONS
+  validates :working_pattern, inclusion: { in: WORKING_PATTERNS }, if: :part_time?
+  validates :status, inclusion: PomDetail.statuses.keys
+
+  def part_time?
+    description == 'PT'
+  end
+
+  def working_pattern_ratio
+    part_time? ? working_pattern : '1.0'
+  end
+end

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -40,15 +40,17 @@ module PomHelper
   end
 
   def status(pom)
-    # we are now displaying 'Available', instead of 'Active' which is stored in the database
-    pom.status == 'active' ? 'available' : pom.status
+    {
+      'active' => 'available',
+      'inactive' => 'away from work',
+    }.fetch(pom.status, pom.status)
   end
 
   def full_status(pom)
     {
-      active: 'Active: available for new allocations',
-      inactive: 'Inactive',
+      active: 'Available for new allocations',
       unavailable: 'Unavailable for new allocations',
+      inactive: 'Away from work',
       deleted: 'No longer recorded as a POM at this prison',
     }.fetch(pom.status.downcase.to_sym)
   end

--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -154,6 +154,11 @@ class AllocationHistory < ApplicationRecord
     save!
   end
 
+  def self.deallocate_pom(nomis_staff_id, prison, event_trigger: USER)
+    deallocate_primary_pom(nomis_staff_id, prison, event_trigger:)
+    deallocate_secondary_pom(nomis_staff_id, prison, event_trigger:)
+  end
+
   def deallocate_offender_after_release
     deallocate_offender(
       event: AllocationHistory::DEALLOCATE_RELEASED_OFFENDER,

--- a/app/services/nomis_user_roles_service.rb
+++ b/app/services/nomis_user_roles_service.rb
@@ -44,10 +44,7 @@ class NomisUserRolesService
   # @param [Prison] prison
   # @param [Integer] nomis_staff_id
   def self.remove_pom(prison, nomis_staff_id)
-    AllocationHistory.deallocate_primary_pom(
-      nomis_staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
-    )
-    AllocationHistory.deallocate_secondary_pom(
+    AllocationHistory.deallocate_pom(
       nomis_staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
     )
 

--- a/app/services/reallocation/bulk_reallocation_service.rb
+++ b/app/services/reallocation/bulk_reallocation_service.rb
@@ -20,10 +20,18 @@ module Reallocation
     def call(selected_cases, message:)
       reallocated_cases, failed_cases = reallocate_each(selected_cases, message)
 
-      # When no OMIC-eligible primary cases remain, fully remove the POM:
-      # deallocates all leftover allocations, soft-deletes the PomDetail,
-      # and removes their NOMIS role.
-      NomisUserRolesService.remove_pom(prison, source_pom.staff_id) if remaining_cases_count.zero?
+      if remaining_cases_count.zero?
+        if source_pom.in_limbo?
+          # Fully remove the POM: deallocates all leftover allocations,
+          # soft-deletes the PomDetail, and removes their NOMIS role
+          NomisUserRolesService.remove_pom(prison, source_pom.staff_id)
+        else
+          # Deallocate leftover allocations but keep the POM in the service
+          AllocationHistory.deallocate_pom(
+            source_pom.staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
+          )
+        end
+      end
 
       build_result(message, reallocated_cases, failed_cases).tap do |result|
         BulkReallocationNotifier.new(prison:, source_pom:, target_pom:).call(result)

--- a/app/views/poms/_inactive_poms.html.erb
+++ b/app/views/poms/_inactive_poms.html.erb
@@ -4,14 +4,24 @@
     <th class="govuk-table__header" scope="col">POM</th>
     <th class="govuk-table__header" scope="col">POM type</th>
     <th class="govuk-table__header" scope="col">Total cases</th>
+    <% if FeatureFlags.status_bulk_reallocation.enabled? %>
+    <th class="govuk-table__header" scope="col">Action</th>
+    <% end %>
   </tr>
   </thead>
   <tbody class="govuk-table__body">
     <% poms.each_with_index do |pom, i| %>
       <tr class="govuk-table__row pom_row_<%= i %>">
-        <td aria-label="POM" class="govuk-table__cell "><%= link_to full_name_ordered(pom), prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id) %></td>
-        <td aria-label="POM type" class="govuk-table__cell "><%= grade(pom) %></td>
+        <td aria-label="POM" class="govuk-table__cell"><%= link_to full_name_ordered(pom), prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id) %></td>
+        <td aria-label="POM type" class="govuk-table__cell"><%= grade(pom) %></td>
         <td aria-label="Total cases" class="govuk-table__cell govuk-!-font-weight-bold"><%= pom.allocations.count %></td>
+        <% if FeatureFlags.status_bulk_reallocation.enabled? %>
+        <td aria-label="Action" class="govuk-table__cell">
+          <% if pom.has_primary_allocations? %>
+            <%= link_to 'Reallocate cases', reallocate_prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id), class: 'govuk-link' %>
+          <% end %>
+        </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -2,97 +2,46 @@
 
 <%= render :partial => "/shared/backlink", :locals => {:page => @referrer} %>
 
-<div>
-  <%= form_tag prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), method: :put, id: "edit_pom_form" do %>
-    <h1 class="govuk-heading-xl govuk-!-margin-top-4">Edit profile</h1>
-    <h2 class="govuk-heading-l"><%= @pom.first_name.titleize %> <%= @pom.last_name.titleize %></h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@edit_pom_form, as: :edit_pom, url: prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), method: :put,
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { id: "edit_pom_form" }) do |f| %>
 
-    <div class='govuk-!-margin-top-6'>
-      <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          <h1 class="govuk-fieldset__heading">Select working pattern</h1>
-        </legend>
-        <div class="govuk-form-group <% if @errors[:working_pattern].present? %>govuk-form-group--error<% end %>">
-        <% if @errors[:working_pattern].present? %>
-          <span class="govuk-error-message">
-            <%= @errors[:working_pattern].first %>
-          </span>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Edit profile</h1>
+      <h2 class="govuk-heading-l"><%= @pom.full_name_ordered %></h2>
+
+      <div class='govuk-!-margin-top-7'>
+        <%= f.govuk_radio_buttons_fieldset(:description, legend: { text: 'Select working pattern', size: 's', tag: 'h3' }) do %>
+          <%= f.govuk_radio_button :description, 'FT', label: { text: 'Full time' }, link_errors: true %>
+          <%= f.govuk_radio_button :description, 'PT', label: { text: 'Part time' } do %>
+            <%= f.govuk_radio_buttons_fieldset(:working_pattern, legend: { size: 's', text: 'Select how many days per week they will work' }) do %>
+              <% 9.downto(1).each.with_index do |value, index| %>
+                <%= f.govuk_radio_button :working_pattern, "0.#{value}", label: { text: working_pattern_to_days(value) }, link_errors: index.zero? %>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
-
-          <div class="govuk-radios" data-module="govuk-radios">
-            <div class="govuk-form-group">
-              <div class="govuk-radios__item">
-                <%= radio_button_tag("edit_pom[description]", "FT", @pom.working_pattern.to_s == '1.0', id: "working_pattern-ft", class: "govuk-radios__input") %>
-                <%= label_tag "working_pattern-ft", "Full time", class: "govuk-label govuk-radios__label" %>
-              </div>
-              <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="part-time-conditional-1" name="edit_pom[description]" type="radio" value="PT" data-aria-controls="conditional-part-time-conditional-1" <%= 'checked="checked"' if @pom.working_pattern.to_s != '1.0'%>>
-                  <label class="govuk-label govuk-radios__label" for="part-time-conditional-1">
-                    Part time
-                  </label>
-                </div>
-                <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-part-time-conditional-1">
-                  <fieldset class="govuk-fieldset">
-                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Select how many days per week they will work</legend>
-                  <% 9.downto(1).each do |value| %>
-                    <div class="govuk-radios__item">
-                      <%= radio_button_tag("edit_pom[working_pattern]", "0.#{value}", @pom.working_pattern.to_s == "0.#{value}", id: "working_pattern-#{value}", class: "govuk-radios__input") %>
-                      <%= label_tag "working_pattern-#{value}", working_pattern_to_days(value), class: "govuk-label govuk-radios__label" %>
-                    </div>
-                  <% end %>
-                  </fieldset>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-
-    <div class='govuk-!-margin-top-6'>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="-edit_pom-conditional-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h3 class="govuk-fieldset__heading">Select status</h3>
-          </legend>
-          <div class="govuk-radios" data-module="govuk-radios">
-            <div class="govuk-radios__item">
-              <%= radio_button_tag("edit_pom[status]", "active", @pom.active?, id: "status-active", class: "govuk-radios__input") %>
-              <%= label_tag "status-active", "Active", class: "govuk-label govuk-radios__label" %>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-conditional-unavailable" name="edit_pom[status]" type="radio" value="unavailable" data-aria-controls="status-2" <%= 'checked' if @pom.unavailable? %>>
-              <label class="govuk-label govuk-radios__label"
-                     for="status-conditional-unavailable">Active but unavailable for new cases</label>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="status-2">
-              <h4 class="govuk-heading-s">To allocate to this POM you will need to change their status to active.</h4>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-conditional-inactive" name="edit_pom[status]" type="radio" value="inactive" data-aria-controls="status-3"  <%= 'checked' if @pom.inactive? %>>
-              <label class="govuk-label govuk-radios__label"
-                     for="status-conditional-inactive">Inactive</label>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="status-3">
-              <div class="govuk-warning-text">
-                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong class="govuk-warning-text__text">
-                  <span class="govuk-visually-hidden">Warning</span>
-                  If this POMs status becomes inactive their cases will need to be reallocated.
-                </strong>
-              </div>
-            </div>
-          </div>
-        </fieldset>
       </div>
-    </div>
 
-    <div class="govuk-form-group">
-      <button type="submit" class="govuk-button">Save</button>
-      <%= link_to 'Cancel', @referrer, class: 'govuk-link app-cancel-link' %>
-    </div>
+      <div class='govuk-!-margin-top-6'>
+        <%= f.govuk_radio_buttons_fieldset(:status, legend: { text: 'Select status', size: 's', tag: 'h3' }) do %>
+          <%= f.govuk_radio_button :status, :active,
+                label: { text: 'Available for new cases' }, link_errors: true %>
+          <%= f.govuk_radio_button :status, :unavailable,
+                label: { text: 'Unavailable for new cases' },
+                hint: { text: 'Use if this POM is too busy. They will be removed from the list of people you can allocate to.' } %>
+          <%= f.govuk_radio_button :status, :inactive,
+                label: { text: 'Away from work' },
+                hint: { text: 'Use for longer periods of absence. This will remove the POM from the list of people you can allocate to. You will be able to reallocate their cases.' } %>
+        <% end %>
+      </div>
 
-    </form>
-  <% end %>
+      <div class="govuk-form-group">
+        <%= f.govuk_submit 'Save' %>
+        <%= link_to 'Cancel', @referrer, class: 'govuk-link app-cancel-link' %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -28,7 +28,7 @@
     </li>
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#inactive_poms">
-        Inactive staff (<%= inactive_poms(@poms).count %>)
+        Away from work (<%= inactive_poms(@poms).count %>)
       </a>
     </li>
     <% if @removed_poms.any? %>
@@ -70,7 +70,7 @@
   </section>
 
   <section class="govuk-tabs__panel" id="inactive_poms">
-    <h2 class="govuk-heading-l">Inactive staff</h2>
+    <h2 class="govuk-heading-l">Away from work</h2>
     <%= render "inactive_poms", poms: inactive_poms(@poms) %>
   </section>
 

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -4,12 +4,23 @@
 
 <%= render 'layouts/notice', notice: flash[:notice] %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
-  <span class="govuk-caption-xl">
-    <%= pom_level_long(@pom.position) %>
-  </span>
-  <%= full_name_ordered(@pom) %>
-</h1>
+<div class="moj-page-header-actions app-page-header-actions--align-bottom govuk-!-margin-bottom-4 govuk-!-padding-top-0">
+  <div class="moj-page-header-actions__title">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+      <span class="govuk-caption-xl">
+        <%= pom_level_long(@pom.position) %>
+      </span>
+      <%= full_name_ordered(@pom) %>
+    </h1>
+  </div>
+
+  <div class="moj-page-header-actions__actions">
+    <%= link_to 'Edit profile', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), role: 'button',
+                class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                data: { module: 'govuk-button--secondary' } %>
+  </div>
+</div>
+
 <nav class="moj-sub-navigation" aria-label="Sub navigation">
   <ul class="moj-sub-navigation__list">
     <li class="moj-sub-navigation__item">

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -6,6 +6,8 @@ feature_flags:
     staging: true
   limbo_bulk_reallocation:
     staging: true
+  status_bulk_reallocation:
+    staging: true
   rosh_level:
     staging: true
   new_tiers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,15 @@ en:
               inclusion: Select full time or part time
             working_pattern:
               not_a_number: Select how many days they will work
+        pom_profile_form:
+          format: "%{message}"
+          attributes:
+            status:
+              inclusion: Select a status
+            description:
+              inclusion: Select full time or part time
+            working_pattern:
+              inclusion: Select how many days they will work
         early_allocation_date_form:
           format: "%{message}"
           attributes:

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -22,7 +22,7 @@ feature "get poms list", flaky: true do
     expect(page).to have_css(".govuk-tabs__list-item", count: 3)
     expect(page).to have_content("Available probation POMs")
     expect(page).to have_content("Available prison POMs")
-    expect(page).to have_content("Inactive staff")
+    expect(page).to have_content("Away from work")
   end
 
   # This example is a bit misleading. From what I can tell, this offender (G1247VX) _does_ have a valid sentence.

--- a/spec/features/staff/homd_manages_poms_statuses_spec.rb
+++ b/spec/features/staff/homd_manages_poms_statuses_spec.rb
@@ -18,22 +18,24 @@ describe 'HOMD manages POMS statuses' do
 
     # When I re activate the POM
     visit prison_poms_path(prison)
-    within('section', text: 'Inactive staff') { click_on 'Anette Pomme' }
-    within('.govuk-summary-list__row', text: 'Status Inactive') { click_on 'Change' }
-    within('fieldset', text: 'Select status') { choose 'Active' }
+    within('section', text: 'Away from work') { click_on 'Anette Pomme' }
+    within('.govuk-summary-list__row', text: 'Status Away from work') { click_on 'Change' }
+    within('fieldset', text: 'Select status') { choose 'Available for new cases' }
     click_on 'Save'
 
     # Then I see the POM in the active staff section
     visit prison_poms_path(prison)
-    within('section', text: 'Inactive staff') { expect(page).not_to have_content('Anette Pomme') }
+    within('section', text: 'Away from work') { expect(page).not_to have_content('Anette Pomme') }
     within('section', text: 'Available prison POMs') { expect(page).to have_content('Anette Pomme') }
   end
 
-  specify 'HOMD making POM inactive de-allocates any allocated cases' do
+  specify 'HOMD making POM inactive redirects to reallocation journey when feature flag enabled' do
+    stub_feature_flag(:status_bulk_reallocation, enabled: true)
+
     # Given the POM is active
     create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
 
-    # And the POM has cases allcoated to them
+    # And the POM has cases allocated to them
     alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
     create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
     alloc2 = build(:stubbed_offender, nomis_id: 'G1234YY', first_name: 'Allocated', last_name: 'Case2')
@@ -43,16 +45,40 @@ describe 'HOMD manages POMS statuses' do
     # When I make the POM inactive
     visit prison_poms_path(prison)
     within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
-    within('.govuk-summary-list__row', text: 'Status Active') { click_on 'Change' }
-    within('fieldset', text: 'Select status') { choose 'Inactive' }
+    within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
+    within('fieldset', text: 'Select status') { choose 'Away from work' }
     click_on 'Save'
 
-    # Then they appear in the inactive staff section
+    # Then I am redirected to the reallocation journey
+    expect(page).to have_content('Reallocate')
+  end
+
+  specify 'HOMD making POM inactive de-allocates any allocated cases when feature flag disabled' do
+    stub_feature_flag(:status_bulk_reallocation, enabled: false)
+
+    # Given the POM is active
+    create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
+
+    # And the POM has cases allocated to them
+    alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
+    create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+    alloc2 = build(:stubbed_offender, nomis_id: 'G1234YY', first_name: 'Allocated', last_name: 'Case2')
+    create(:allocation_history, nomis_offender_id: 'G1234YY', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+    stub_offenders_for_prison(prison.code, [alloc1, alloc2])
+
+    # When I make the POM inactive
     visit prison_poms_path(prison)
-    within('section', text: 'Inactive staff') { expect(page).to have_content('Anette Pomme') }
+    within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
+    within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
+    within('fieldset', text: 'Select status') { choose 'Away from work' }
+    click_on 'Save'
+
+    # Then they appear in the away from work section
+    visit prison_poms_path(prison)
+    within('section', text: 'Away from work') { expect(page).to have_content('Anette Pomme') }
     within('section', text: 'Available prison POMs') { expect(page).not_to have_content('Anette Pomme') }
 
-    # And the previosly allocated cases are now on the unallocated cases screen
+    # And the previously allocated cases are now on the unallocated cases screen
     visit unallocated_prison_prisoners_path(prison)
     expect(page).to have_content('Case1, Allocated')
     expect(page).to have_content('Case2, Allocated')

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -252,7 +252,7 @@ feature "staff pages" do
       expect(page).to have_content("Manage your staff")
       expect(page).to have_content("Available probation POMs")
       expect(page).to have_content("Available prison POMs")
-      expect(page).to have_content("Inactive staff")
+      expect(page).to have_content("Away from work")
     end
 
     it "can display active probation POMs case mix" do
@@ -285,7 +285,7 @@ feature "staff pages" do
     end
 
     it 'displays the inactive POMs' do
-      click_on('Inactive staff')
+      click_on('Away from work')
 
       expect(page).to have_content('POM')
       expect(page).to have_content('POM type')

--- a/spec/forms/pom_profile_form_spec.rb
+++ b/spec/forms/pom_profile_form_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PomProfileForm, type: :model do
+  subject { described_class.new(status:, description:, working_pattern:) }
+
+  let(:status) { 'active' }
+  let(:description) { 'FT' }
+  let(:working_pattern) { nil }
+
+  describe 'validations' do
+    context 'when status is valid' do
+      PomDetail.statuses.each_key do |s|
+        it "accepts '#{s}'" do
+          subject.status = s
+          subject.valid?
+          expect(subject.errors[:status]).to be_empty
+        end
+      end
+    end
+
+    context 'when status is invalid' do
+      let(:status) { 'unknown' }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors[:status]).to include('Select a status')
+      end
+    end
+
+    context 'when status is blank' do
+      let(:status) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when description is valid' do
+      %w[FT PT].each do |desc|
+        it "accepts '#{desc}'" do
+          subject.description = desc
+          subject.valid?
+          expect(subject.errors[:description]).to be_empty
+        end
+      end
+    end
+
+    context 'when description is invalid' do
+      let(:description) { 'XX' }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors[:description]).to include('Select full time or part time')
+      end
+    end
+
+    context 'when full time' do
+      let(:description) { 'FT' }
+      let(:working_pattern) { nil }
+
+      it 'does not validate working_pattern' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when part time' do
+      let(:description) { 'PT' }
+
+      context 'when working_pattern is blank' do
+        let(:working_pattern) { nil }
+
+        it { is_expected.not_to be_valid }
+
+        it 'has the correct error message' do
+          subject.valid?
+          expect(subject.errors[:working_pattern]).to include('Select how many days they will work')
+        end
+      end
+
+      context 'when working_pattern is invalid' do
+        let(:working_pattern) { '0.0' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when working_pattern is not in range' do
+        let(:working_pattern) { '1.0' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when working_pattern is valid' do
+        let(:working_pattern) { '0.5' }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+
+  describe '#part_time?' do
+    context 'when description is FT' do
+      let(:description) { 'FT' }
+
+      it { is_expected.not_to be_part_time }
+    end
+
+    context 'when description is PT' do
+      let(:description) { 'PT' }
+
+      it { is_expected.to be_part_time }
+    end
+  end
+
+  describe '#working_pattern_ratio' do
+    context 'when full time' do
+      let(:description) { 'FT' }
+
+      it 'returns 1.0' do
+        expect(subject.working_pattern_ratio).to eq('1.0')
+      end
+    end
+
+    context 'when part time' do
+      let(:description) { 'PT' }
+      let(:working_pattern) { '0.5' }
+
+      it 'returns the working pattern value' do
+        expect(subject.working_pattern_ratio).to eq('0.5')
+      end
+    end
+  end
+end

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe PomHelper do
       expect(status(pom)).to eq('available')
     end
 
-    it "does not rename 'inactive' status" do
+    it "renames 'inactive' status to away from work" do
       pom = build(:pom, staffId: 2005,  status: 'inactive')
-      expect(status(pom)).to eq('inactive')
+      expect(status(pom)).to eq('away from work')
     end
 
     it "does not rename 'unavailable' status" do

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -229,6 +229,35 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
           expect(allocation3.primary_pom_nomis_id).to eq(222)
         end
       end
+
+      context 'when deallocating a POM from all roles' do
+        it 'removes them as both primary and secondary from all allocations' do
+          described_class.deallocate_pom(222, prison, event_trigger: AllocationHistory::INACTIVE_POM)
+
+          allocation1.reload
+          allocation3.reload
+
+          # Should remove 222 as secondary from allocation1
+          expect(allocation1.secondary_pom_nomis_id).to be_nil
+          # Should NOT affect primary in allocation1
+          expect(allocation1.primary_pom_nomis_id).to eq(111)
+
+          # Should remove 222 as primary from allocation3
+          expect(allocation3.primary_pom_nomis_id).to be_nil
+          # Should NOT affect secondary in allocation3
+          expect(allocation3.secondary_pom_nomis_id).to eq(555)
+        end
+
+        it 'sets the event_trigger on affected allocations' do
+          described_class.deallocate_pom(222, prison, event_trigger: AllocationHistory::INACTIVE_POM)
+
+          allocation1.reload
+          allocation3.reload
+
+          expect(allocation1.event_trigger).to eq('inactive_pom')
+          expect(allocation3.event_trigger).to eq('inactive_pom')
+        end
+      end
     end
 
     describe 'when an offender moves prison'  do

--- a/spec/services/nomis_user_roles_service_spec.rb
+++ b/spec/services/nomis_user_roles_service_spec.rb
@@ -90,8 +90,7 @@ RSpec.describe NomisUserRolesService do
     let!(:pom_detail) { create(:pom_detail, :active, prison_code: prison.code, nomis_staff_id: nomis_staff_id) }
 
     before do
-      allow(AllocationHistory).to receive(:deallocate_primary_pom)
-      allow(AllocationHistory).to receive(:deallocate_secondary_pom)
+      allow(AllocationHistory).to receive(:deallocate_pom)
 
       allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:list).and_return(pom_list)
       allow(HmppsApi::PrisonApi::PrisonOffenderManagerApi).to receive(:expire_list_cache)
@@ -101,10 +100,7 @@ RSpec.describe NomisUserRolesService do
     it 'deallocates both primary and secondary POMs' do
       described_class.remove_pom(prison, nomis_staff_id)
 
-      expect(AllocationHistory).to have_received(:deallocate_primary_pom).with(
-        nomis_staff_id, prison.code, event_trigger:
-      )
-      expect(AllocationHistory).to have_received(:deallocate_secondary_pom).with(
+      expect(AllocationHistory).to have_received(:deallocate_pom).with(
         nomis_staff_id, prison.code, event_trigger:
       )
     end

--- a/spec/services/reallocation/bulk_reallocation_service_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reallocation::BulkReallocationService do
   let(:offender_no) { 'A1111AA' }
 
   let(:source_pom) do
-    instance_double(StaffMember, staff_id: 10_001, full_name_ordered: 'Old, Pom')
+    instance_double(StaffMember, staff_id: 10_001, full_name_ordered: 'Old, Pom', in_limbo?: false)
   end
 
   let(:target_pom) do
@@ -288,10 +288,35 @@ RSpec.describe Reallocation::BulkReallocationService do
         allow(NomisUserRolesService).to receive(:remove_pom)
       end
 
-      it 'removes the POM from the service' do
-        service.call([selected_case], message: 'Moving cases')
+      context 'when the source POM is in limbo' do
+        before { allow(source_pom).to receive(:in_limbo?).and_return(true) }
 
-        expect(NomisUserRolesService).to have_received(:remove_pom).with(prison, source_pom.staff_id)
+        it 'removes the POM from the service' do
+          service.call([selected_case], message: 'Moving cases')
+
+          expect(NomisUserRolesService).to have_received(:remove_pom).with(prison, source_pom.staff_id)
+        end
+      end
+
+      context 'when the source POM is not in limbo (e.g. inactive)' do
+        before do
+          allow(source_pom).to receive(:in_limbo?).and_return(false)
+          allow(AllocationHistory).to receive(:deallocate_pom)
+        end
+
+        it 'does not remove the POM from the service' do
+          service.call([selected_case], message: 'Moving cases')
+
+          expect(NomisUserRolesService).not_to have_received(:remove_pom)
+        end
+
+        it 'deallocates any leftover allocations' do
+          service.call([selected_case], message: 'Moving cases')
+
+          expect(AllocationHistory).to have_received(:deallocate_pom).with(
+            source_pom.staff_id, prison.code, event_trigger: AllocationHistory::INACTIVE_POM
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1979

New entry-point to the bulk reallocation. Upon marking a POM as "away from work" (internal status `inactive`), we present the bulk reallocation journey if they had any primary cases still allocated.

If SPO drop from the journey and POM still has primary cases allocated, they can re-enter the bulk reallocation fro the "Away from work" staff tab.

Refactored the profile edit page to use the form builder and fixed error handling and layout/markup.