### PR TITLE
MO-1980 POM offboarding bulk reallocation

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -3,9 +3,8 @@
 class PomsController < PrisonStaffApplicationController
   before_action :ensure_spo_user
 
-  before_action :load_pom_staff_member, only: [:show, :edit, :update, :reallocate, :confirm_removal, :destroy]
-  before_action :store_referrer_in_session, only: [:edit]
-  before_action :set_referrer
+  before_action :load_pom_staff_member, except: [:index, :show_non_pom]
+  before_action :ensure_pom_is_editable, only: [:edit, :update]
 
   def index
     @poms = @prison.get_list_of_poms.sort_by(&:full_name_ordered)
@@ -50,6 +49,10 @@ class PomsController < PrisonStaffApplicationController
     @edit_pom_form = PomProfileForm.new(edit_pom_params.to_h)
 
     if @edit_pom_form.valid?
+      if @edit_pom_form.deleting?
+        redirect_to confirm_delete_prison_pom_path(active_prison_id, nomis_staff_id) and return
+      end
+
       pom_detail = @prison.pom_details.find_by!(nomis_staff_id:)
       pom_detail.working_pattern = @edit_pom_form.working_pattern_ratio
       pom_detail.status = @edit_pom_form.status
@@ -83,13 +86,51 @@ class PomsController < PrisonStaffApplicationController
 
   def confirm_removal; end
 
+  def confirm_delete
+    @confirm_delete_form = ConfirmDeletePomForm.new
+  end
+
   def destroy
-    NomisUserRolesService.remove_pom(@prison, nomis_staff_id)
-    redirect_to prison_poms_path(anchor: "#{params[:from]}!top"),
-                notice: "#{@pom.full_name_or_staff_id} removed. If necessary, their cases have been moved to @unallocated_link@."
+    # Legacy flow (limbo poms removal without confirmation form)
+    # TODO: to be removed once we release the new bulk-reallocation feature
+    unless params.key?(:confirm_delete_pom)
+      NomisUserRolesService.remove_pom(@prison, nomis_staff_id)
+      redirect_to prison_poms_path(anchor: 'attention_needed!top'),
+                  notice: "#{@pom.full_name_or_staff_id} removed. If necessary, their cases have been moved to @unallocated_link@."
+      return
+    end
+
+    # New flow (confirm_delete form submission)
+    @confirm_delete_form = ConfirmDeletePomForm.new(confirm_delete_params)
+
+    if @confirm_delete_form.valid?
+      if @confirm_delete_form.confirmed?
+        pom_detail = @prison.pom_details.find_by!(nomis_staff_id:)
+
+        if pom_detail.has_primary_allocations?
+          pom_detail.deleted!
+          redirect_to reallocate_prison_pom_path(active_prison_id, nomis_staff_id:)
+        else
+          NomisUserRolesService.remove_pom(@prison, nomis_staff_id)
+          redirect_to prison_poms_path(active_prison_id),
+                      notice: "#{@pom.full_name_or_staff_id} successfully removed from this service"
+        end
+      else
+        redirect_to edit_prison_pom_path(active_prison_id, nomis_staff_id)
+      end
+    else
+      render :confirm_delete
+    end
   end
 
 private
+
+  def ensure_pom_is_editable
+    unless @pom.editable?
+      redirect_to prison_pom_path(active_prison_id, id: nomis_staff_id),
+                  notice: 'This POM has been removed and their profile cannot be edited.'
+    end
+  end
 
   def load_pom_staff_member
     @pom = StaffMember.new @prison, nomis_staff_id
@@ -97,6 +138,10 @@ private
 
   def edit_pom_params
     params.require(:edit_pom).permit(:working_pattern, :status, :description)
+  end
+
+  def confirm_delete_params
+    params.fetch(:confirm_delete_pom, {}).permit(:confirmation)
   end
 
   def nomis_staff_id

--- a/app/forms/confirm_delete_pom_form.rb
+++ b/app/forms/confirm_delete_pom_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ConfirmDeletePomForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  CONFIRMATIONS = %w[yes no].freeze
+
+  attribute :confirmation, :string
+  validates :confirmation, inclusion: CONFIRMATIONS
+
+  def confirmed?
+    confirmation == 'yes'
+  end
+end

--- a/app/forms/pom_profile_form.rb
+++ b/app/forms/pom_profile_form.rb
@@ -22,4 +22,8 @@ class PomProfileForm
   def working_pattern_ratio
     part_time? ? working_pattern : '1.0'
   end
+
+  def deleting?
+    status == 'deleted'
+  end
 end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -38,6 +38,10 @@ class StaffMember
     staff_detail&.email_address
   end
 
+  def editable?
+    !in_limbo?
+  end
+
   def in_limbo?
     deleted? || !has_pom_role?
   end

--- a/app/views/poms/_overview_tab.html.erb
+++ b/app/views/poms/_overview_tab.html.erb
@@ -50,12 +50,12 @@
             <%= render 'govuk_summary_list_row',
                        key: 'Working pattern',
                        value: format_working_pattern(@pom.working_pattern),
-                       actions: link_to('Change', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), class: 'govuk-link pull-right')
+                       actions: @pom.editable? ? link_to('Change', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), class: 'govuk-link pull-right') : ''
             %>
             <%= render 'govuk_summary_list_row',
                        key: 'Status',
                        value: full_status(@pom),
-                       actions: link_to('Change', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), class: 'govuk-link pull-right')
+                       actions: @pom.editable? ? link_to('Change', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), class: 'govuk-link pull-right') : ''
             %>
           </dl>
         </div>

--- a/app/views/poms/_removed_poms.html.erb
+++ b/app/views/poms/_removed_poms.html.erb
@@ -21,12 +21,17 @@
         </td>
         <td aria-label="Action" class="govuk-table__cell">
           <% if FeatureFlags.limbo_bulk_reallocation.enabled? %>
-            <%= link_to 'Reallocate cases',
-                        confirm_removal_prison_pom_path(@prison.code, pom.staff_id, from: :attention_needed),
-                        class: 'govuk-link govuk-!-font-size-19' %>
+            <% if pom.has_pom_role? %>
+              <%= link_to 'Reallocate cases',
+                          reallocate_prison_pom_path(@prison.code, pom.staff_id),
+                          class: 'govuk-link govuk-!-font-size-19' %>
+            <% else %>
+              <%= link_to 'Reallocate cases',
+                          confirm_removal_prison_pom_path(@prison.code, pom.staff_id),
+                          class: 'govuk-link govuk-!-font-size-19' %>
+            <% end %>
           <% else %>
             <%= form_for(:remove_pom, url: prison_pom_path(@prison.code, pom.staff_id), method: :delete) do |f| %>
-              <%= hidden_field_tag :from, :attention_needed %>
               <%= f.button 'Remove POM', type: 'submit', class: 'app-button--link govuk-link govuk-!-font-size-19' %>
             <% end %>
           <% end %>

--- a/app/views/poms/confirm_delete.html.erb
+++ b/app/views/poms/confirm_delete.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, 'Confirm POM removal – Digital Prison Services' %>
+
+<%= link_to 'Back', edit_prison_pom_path(@prison.code, @pom.staff_id),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@confirm_delete_form, as: :confirm_delete_pom,
+                 url: prison_pom_path(@prison.code, @pom.staff_id),
+                 method: :delete,
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_radio_buttons :confirmation,
+            [OpenStruct.new(value: 'yes', label: 'Yes'), OpenStruct.new(value: 'no', label: 'No')],
+            :value, :label, inline: true, include_hidden: true,
+            legend: { text: "Are you sure you want to remove #{@pom.full_name_ordered} from this service?", size: 'l', tag: 'h1' } %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "Edit profile – Digital Prison Services" %>
 
-<%= render :partial => "/shared/backlink", :locals => {:page => @referrer} %>
+<%= link_to 'Back', prison_pom_path(@prison.code, @pom.staff_id),
+            class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -35,12 +36,17 @@
           <%= f.govuk_radio_button :status, :inactive,
                 label: { text: 'Away from work' },
                 hint: { text: 'Use for longer periods of absence. This will remove the POM from the list of people you can allocate to. You will be able to reallocate their cases.' } %>
+          <% if FeatureFlags.status_bulk_reallocation.enabled? %>
+            <%= f.govuk_radio_button :status, :deleted,
+                  label: { text: "No longer at #{@prison.name}" },
+                  hint: { text: 'Once you have reallocated any cases they have, they will be removed from this service.' } %>
+          <% end %>
         <% end %>
       </div>
 
       <div class="govuk-form-group">
         <%= f.govuk_submit 'Save' %>
-        <%= link_to 'Cancel', @referrer, class: 'govuk-link app-cancel-link' %>
+        <%= link_to 'Cancel', prison_pom_path(@prison.code, @pom.staff_id), class: 'govuk-link app-cancel-link' %>
       </div>
     <% end %>
   </div>

--- a/app/views/poms/index.html.erb
+++ b/app/views/poms/index.html.erb
@@ -48,8 +48,8 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Available probation POMs</h2>
         <p class="govuk-body govuk-!-margin-bottom-8">
-          If someone has left or will be absent for a while, make sure their status is set to inactive by selecting
-          their name below. You will then need to reallocate any cases they have.
+          Change someone’s status by selecting their name below. For example, if they will be away from work for a
+          while, leave the prison or are too busy for new allocations.
         </p>
       </div>
     </div>
@@ -61,8 +61,8 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Available prison POMs</h2>
         <p class="govuk-body govuk-!-margin-bottom-8">
-          If someone has left or will be absent for a while, make sure their status is set to inactive by selecting
-          their name below. You will then need to reallocate any cases they have.
+          Change someone’s status by selecting their name below. For example, if they will be away from work for a
+          while, leave the prison or are too busy for new allocations.
         </p>
       </div>
     </div>

--- a/app/views/poms/reallocate.html.erb
+++ b/app/views/poms/reallocate.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Reallocation summary – Digital Prison Services" %>
 
-<%= link_to 'Back', 'javascript:history.back()',
+<%= link_to 'Back', prison_poms_path(anchor: @pom.in_limbo? ? 'attention_needed!top' : 'inactive_poms!top'),
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">

--- a/app/views/poms/show.html.erb
+++ b/app/views/poms/show.html.erb
@@ -15,9 +15,11 @@
   </div>
 
   <div class="moj-page-header-actions__actions">
-    <%= link_to 'Edit profile', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), role: 'button',
-                class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
-                data: { module: 'govuk-button--secondary' } %>
+    <% if @pom.editable? %>
+      <%= link_to 'Edit profile', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), role: 'button',
+                  class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                  data: { module: 'govuk-button--secondary' } %>
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,11 @@ en:
               inclusion: Select full time or part time
             working_pattern:
               inclusion: Select how many days they will work
+        confirm_delete_pom_form:
+          format: "%{message}"
+          attributes:
+            confirmation:
+              inclusion: Select yes if you want to remove this POM
         early_allocation_date_form:
           format: "%{message}"
           attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
     resources :poms, only: %i[index show edit update destroy], param: :nomis_staff_id do
       member do
         get :confirm_removal
+        get :confirm_delete
         get :reallocate
       end
     end

--- a/spec/controllers/poms_controller_spec.rb
+++ b/spec/controllers/poms_controller_spec.rb
@@ -104,68 +104,70 @@ RSpec.describe PomsController, type: :controller do
     end
   end
 
-  describe 'GET #confirm_removal' do
-    let(:removed_staff_id) { 123_987 }
+  describe 'PUT #update' do
+    let(:updated_staff_id) { 123_456 }
 
     before do
-      create(:pom_detail, :inactive, prison_code: prison.code, nomis_staff_id: removed_staff_id)
-      stub_request(:get, "#{ApiHelper::NOMIS_USER_ROLES_API_HOST}/users/staff/#{removed_staff_id}")
-        .to_return(body: { staffId: removed_staff_id, lastName: 'Example', firstName: 'Mateo' }.to_json)
+      create(:pom_detail, :active, prison_code: prison.code, nomis_staff_id: updated_staff_id)
+      stub_poms(prison.code, [build(:pom, staffId: updated_staff_id, firstName: 'Mateo', lastName: 'Example')])
     end
 
-    it 'renders an intermediate confirmation page before deletion' do
-      get :confirm_removal, params: { prison_id: prison.code, nomis_staff_id: removed_staff_id, from: 'attention_needed' }
+    context 'when status is deleted' do
+      it 'does not save and redirects to confirm delete page' do
+        put :update, params: {
+          prison_id: prison.code,
+          nomis_staff_id: updated_staff_id,
+          edit_pom: { status: 'deleted', description: 'FT', working_pattern: '1.0' },
+        }
 
-      expect(response).to be_successful
-      expect(response.body).to include('Confirm Mateo Example can be removed from this service')
-      expect(response.body).to include('Choose continue to confirm they can be removed from this service once their cases have been reallocated.')
-      expect(response.body).to include(prison_pom_path(prison.code, removed_staff_id))
+        expect(response).to redirect_to(confirm_delete_prison_pom_path(prison.code, updated_staff_id))
+        expect(PomDetail.find_by(nomis_staff_id: updated_staff_id).status).to eq('active')
+      end
     end
   end
 
-  describe 'GET #index' do
-    let(:removed_staff_id) { 123_888 }
-    let(:removed_offender) { build(:nomis_offender) }
-    let(:limbo_bulk_reallocation_enabled) { true }
+  describe 'GET #confirm_delete' do
+    let(:staff_id) { 123_456 }
 
     before do
-      stub_feature_flag(:limbo_bulk_reallocation, enabled: limbo_bulk_reallocation_enabled)
-
-      create(:pom_detail, :inactive, prison_code: prison.code, nomis_staff_id: removed_staff_id)
-      create(:case_information, offender: build(:offender, nomis_offender_id: removed_offender.fetch(:prisonerNumber)))
-      create(:allocation_history,
-             nomis_offender_id: removed_offender.fetch(:prisonerNumber),
-             primary_pom_nomis_id: removed_staff_id,
-             prison: prison.code)
-
-      stub_request(:get, "#{ApiHelper::NOMIS_USER_ROLES_API_HOST}/users/staff/#{removed_staff_id}")
-        .to_return(body: { staffId: removed_staff_id, lastName: 'Example', firstName: 'Mateo' }.to_json)
-      stub_offenders_for_prison(prison.code, [removed_offender])
+      create(:pom_detail, :active, prison_code: prison.code, nomis_staff_id: staff_id)
+      stub_poms(prison.code, [build(:pom, staffId: staff_id, firstName: 'Mateo', lastName: 'Example')])
     end
 
-    context 'when limbo bulk reallocation is enabled' do
-      let(:limbo_bulk_reallocation_enabled) { true }
+    it 'renders the confirmation page' do
+      get :confirm_delete, params: { prison_id: prison.code, nomis_staff_id: staff_id }
 
-      it 'links removed poms to the confirmation page' do
-        get :index, params: { prison_id: prison.code }
+      expect(response).to be_successful
+      expect(response.body).to include('Are you sure you want to remove')
+      expect(response.body).to include('Mateo Example')
+    end
+  end
 
-        expect(response).to be_successful
-        expect(response.body).to include('Reallocate cases')
-        expect(response.body).to include(confirm_removal_prison_pom_path(prison.code, removed_staff_id, from: 'attention_needed'))
-      end
+  describe 'edit/update guard for deleted POMs' do
+    let(:deleted_staff_id) { 123_789 }
+
+    before do
+      create(:pom_detail, :deleted, prison_code: prison.code, nomis_staff_id: deleted_staff_id)
+      stub_request(:get, "#{ApiHelper::NOMIS_USER_ROLES_API_HOST}/users/staff/#{deleted_staff_id}")
+        .to_return(body: { staffId: deleted_staff_id, lastName: 'Removed', firstName: 'Person' }.to_json)
     end
 
-    context 'when limbo bulk reallocation is disabled' do
-      let(:limbo_bulk_reallocation_enabled) { false }
+    it 'redirects from edit with a notice' do
+      get :edit, params: { prison_id: prison.code, nomis_staff_id: deleted_staff_id }
 
-      it 'renders the legacy remove action' do
-        get :index, params: { prison_id: prison.code }
+      expect(response).to redirect_to(prison_pom_path(prison.code, id: deleted_staff_id))
+      expect(flash[:notice]).to eq('This POM has been removed and their profile cannot be edited.')
+    end
 
-        expect(response).to be_successful
-        expect(response.body).to include('Remove POM')
-        expect(response.body).to include(prison_pom_path(prison.code, removed_staff_id))
-        expect(response.body).not_to include(confirm_removal_prison_pom_path(prison.code, removed_staff_id, from: 'attention_needed'))
-      end
+    it 'redirects from update with a notice' do
+      put :update, params: {
+        prison_id: prison.code,
+        nomis_staff_id: deleted_staff_id,
+        edit_pom: { status: 'active', description: 'FT', working_pattern: '1.0' },
+      }
+
+      expect(response).to redirect_to(prison_pom_path(prison.code, id: deleted_staff_id))
+      expect(flash[:notice]).to eq('This POM has been removed and their profile cannot be edited.')
     end
   end
 
@@ -179,12 +181,81 @@ RSpec.describe PomsController, type: :controller do
       allow(NomisUserRolesService).to receive(:remove_pom).with(prison, removed_staff_id).and_return(true)
     end
 
-    it 'removes the pom and redirects back to the attention needed tab' do
-      delete :destroy, params: { prison_id: prison.code, nomis_staff_id: removed_staff_id, from: 'attention_needed' }
+    context 'with legacy flow (no confirmation form)' do
+      it 'removes the pom and redirects back to the attention needed tab' do
+        delete :destroy, params: { prison_id: prison.code, nomis_staff_id: removed_staff_id }
 
-      expect(NomisUserRolesService).to have_received(:remove_pom).with(prison, removed_staff_id)
-      expect(response).to redirect_to(prison_poms_path(anchor: 'attention_needed!top'))
-      expect(flash[:notice]).to eq('Mateo Example removed. If necessary, their cases have been moved to @unallocated_link@.')
+        expect(NomisUserRolesService).to have_received(:remove_pom).with(prison, removed_staff_id)
+        expect(response).to redirect_to(prison_poms_path(anchor: 'attention_needed!top'))
+        expect(flash[:notice]).to eq('Mateo Example removed. If necessary, their cases have been moved to @unallocated_link@.')
+      end
+    end
+
+    context 'with confirm delete flow' do
+      context 'when confirmed yes and POM has no primary allocations' do
+        it 'removes POM and redirects to staff page' do
+          delete :destroy, params: {
+            prison_id: prison.code,
+            nomis_staff_id: removed_staff_id,
+            confirm_delete_pom: { confirmation: 'yes' },
+          }
+
+          expect(NomisUserRolesService).to have_received(:remove_pom).with(prison, removed_staff_id)
+          expect(response).to redirect_to(prison_poms_path(prison.code))
+        end
+      end
+
+      context 'when confirmed yes and POM has primary allocations' do
+        let(:allocated_offender) { build(:nomis_offender) }
+
+        before do
+          create(:case_information, offender: build(:offender, nomis_offender_id: allocated_offender.fetch(:prisonerNumber)))
+          create(:allocation_history,
+                 nomis_offender_id: allocated_offender.fetch(:prisonerNumber),
+                 primary_pom_nomis_id: removed_staff_id,
+                 prison: prison.code)
+          stub_offenders_for_prison(prison.code, [allocated_offender])
+        end
+
+        it 'marks as deleted and redirects to reallocate page' do
+          delete :destroy, params: {
+            prison_id: prison.code,
+            nomis_staff_id: removed_staff_id,
+            confirm_delete_pom: { confirmation: 'yes' },
+          }
+
+          expect(PomDetail.find_by(nomis_staff_id: removed_staff_id).status).to eq('deleted')
+          expect(NomisUserRolesService).not_to have_received(:remove_pom)
+          expect(response).to redirect_to(reallocate_prison_pom_path(prison.code, nomis_staff_id: removed_staff_id))
+        end
+      end
+
+      context 'when confirmed no' do
+        it 'does not change status and redirects to edit page' do
+          delete :destroy, params: {
+            prison_id: prison.code,
+            nomis_staff_id: removed_staff_id,
+            confirm_delete_pom: { confirmation: 'no' },
+          }
+
+          expect(PomDetail.find_by(nomis_staff_id: removed_staff_id).status).to eq('inactive')
+          expect(NomisUserRolesService).not_to have_received(:remove_pom)
+          expect(response).to redirect_to(edit_prison_pom_path(prison.code, removed_staff_id))
+        end
+      end
+
+      context 'when no option selected' do
+        it 're-renders the confirmation page with errors' do
+          delete :destroy, params: {
+            prison_id: prison.code,
+            nomis_staff_id: removed_staff_id,
+            confirm_delete_pom: { confirmation: '' },
+          }
+
+          expect(response).to be_successful
+          expect(response.body).to include('Select yes if you want to remove this POM')
+        end
+      end
     end
   end
 end

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -85,7 +85,7 @@ feature "remove a POM no longer present in NOMIS" do
           expect(page).to have_css('td.govuk-table__cell[aria-label="POM"]', text: 'John Doe')
           expect(page).to have_css('td.govuk-table__cell[aria-label="Last case allocated"]', text: '22 June 2025')
           expect(page).to have_css('td.govuk-table__cell[aria-label="Total cases"]', text: '1')
-          expect(page).to have_link('Reallocate cases', href: confirm_removal_prison_pom_path(prison.code, removed_pom_staff_id, from: :attention_needed))
+          expect(page).to have_link('Reallocate cases', href: confirm_removal_prison_pom_path(prison.code, removed_pom_staff_id))
           expect(page).not_to have_button('Remove POM')
         end
       end
@@ -97,6 +97,36 @@ feature "remove a POM no longer present in NOMIS" do
 
         expect(page).to have_css('h1.govuk-heading-l', text: 'Confirm John Doe can be removed from this service')
         expect(page).to have_link('Continue', href: reallocate_prison_pom_path(prison.code, removed_pom_staff_id))
+      end
+    end
+
+    context 'when a POM with a role is marked as deleted and has cases' do
+      let(:deleted_pom_staff_id) { 789_012 }
+      let(:deleted_pom) { build(:pom, :prison_officer, staffId: deleted_pom_staff_id, firstName: 'JANE', lastName: 'SMITH') }
+      let(:offenders_in_prison) { build_list(:nomis_offender, 1, prisonId: prison.code) }
+
+      before do
+        create(:pom_detail, :deleted, prison_code: prison.code, nomis_staff_id: deleted_pom_staff_id, working_pattern: 1.0)
+
+        stub_poms(prison.code, probation_poms + [deleted_pom])
+        stub_offenders_for_prison(prison.code, offenders_in_prison)
+
+        offenders_in_prison.each do |offender|
+          nomis_offender_id = offender[:prisonerNumber]
+          offender_record = create(:offender, nomis_offender_id:)
+          create(:allocation_history, :primary, prison: prison.code, nomis_offender_id:, primary_pom_nomis_id: deleted_pom_staff_id)
+          create(:case_information, offender: offender_record)
+        end
+
+        visit prison_poms_path(prison_id: prison.code)
+      end
+
+      it 'links directly to the reallocation summary page' do
+        click_link 'Attention needed'
+
+        within('section#attention_needed') do
+          expect(page).to have_link('Reallocate cases', href: reallocate_prison_pom_path(prison.code, deleted_pom_staff_id))
+        end
       end
     end
   end

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -116,9 +116,24 @@ feature "get poms list", flaky: true do
     visit "/prisons/LEI/poms/#{moic_pom_id}/edit"
 
     expect(page).to have_css(".govuk-button", count: 1)
-    expect(page).to have_css(".govuk-radios__item", count: 14)
     expect(page).to have_content("Edit profile")
-    expect(page).to have_content("Working pattern")
-    expect(page).to have_content("Status")
+
+    within('fieldset', text: 'Select working pattern') do
+      expect(page).to have_css(".govuk-radios__item", count: 2)
+      expect(page).to have_content("Full time")
+      expect(page).to have_content("Part time")
+    end
+
+    within('fieldset', text: 'Select how many days per week they will work') do
+      expect(page).to have_css(".govuk-radios__item", count: 9)
+    end
+
+    within('fieldset', text: 'Select status') do
+      expect(page).to have_css(".govuk-radios__item", count: 4)
+      expect(page).to have_content("Available for new cases")
+      expect(page).to have_content("Unavailable for new cases")
+      expect(page).to have_content("Away from work")
+      expect(page).to have_content("No longer at")
+    end
   end
 end

--- a/spec/features/staff/homd_manages_poms_statuses_spec.rb
+++ b/spec/features/staff/homd_manages_poms_statuses_spec.rb
@@ -29,58 +29,120 @@ describe 'HOMD manages POMS statuses' do
     within('section', text: 'Available prison POMs') { expect(page).to have_content('Anette Pomme') }
   end
 
-  specify 'HOMD making POM inactive redirects to reallocation journey when feature flag enabled' do
-    stub_feature_flag(:status_bulk_reallocation, enabled: true)
+  context 'when status_bulk_reallocation is enabled' do
+    before { stub_feature_flag(:status_bulk_reallocation, enabled: true) }
 
-    # Given the POM is active
-    create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
+    specify 'HOMD making POM inactive redirects to reallocation journey' do
+      # Given the POM is active
+      create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
 
-    # And the POM has cases allocated to them
-    alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
-    create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
-    alloc2 = build(:stubbed_offender, nomis_id: 'G1234YY', first_name: 'Allocated', last_name: 'Case2')
-    create(:allocation_history, nomis_offender_id: 'G1234YY', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
-    stub_offenders_for_prison(prison.code, [alloc1, alloc2])
+      # And the POM has cases allocated to them
+      alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
+      create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+      alloc2 = build(:stubbed_offender, nomis_id: 'G1234YY', first_name: 'Allocated', last_name: 'Case2')
+      create(:allocation_history, nomis_offender_id: 'G1234YY', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+      stub_offenders_for_prison(prison.code, [alloc1, alloc2])
 
-    # When I make the POM inactive
-    visit prison_poms_path(prison)
-    within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
-    within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
-    within('fieldset', text: 'Select status') { choose 'Away from work' }
-    click_on 'Save'
+      # When I make the POM inactive
+      visit prison_poms_path(prison)
+      within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
+      within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
+      within('fieldset', text: 'Select status') { choose 'Away from work' }
+      click_on 'Save'
 
-    # Then I am redirected to the reallocation journey
-    expect(page).to have_content('Reallocate')
+      # Then I am redirected to the reallocation journey
+      expect(page).to have_content('Reallocate')
+    end
+
+    context 'when selecting "No longer at prison"' do
+      before do
+        create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
+      end
+
+      def navigate_to_confirm_delete
+        visit prison_poms_path(prison)
+        within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
+        within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
+        within('fieldset', text: 'Select status') { choose "No longer at #{prison.name}" }
+        click_on 'Save'
+      end
+
+      specify 'confirming yes with cases redirects to reallocate page' do
+        alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
+        create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+        stub_offenders_for_prison(prison.code, [alloc1])
+
+        navigate_to_confirm_delete
+
+        expect(page).to have_content("Are you sure you want to remove Anette Pomme from this service?")
+
+        choose 'Yes'
+        click_on 'Continue'
+
+        expect(page).to have_content('Reallocate')
+        expect(PomDetail.find_by(nomis_staff_id: 1234).status).to eq('deleted')
+      end
+
+      specify 'confirming no returns to edit page' do
+        navigate_to_confirm_delete
+
+        choose 'No'
+        click_on 'Continue'
+
+        expect(page).to have_content('Edit profile')
+        expect(PomDetail.find_by(nomis_staff_id: 1234).status).to eq('active')
+      end
+    end
   end
 
-  specify 'HOMD making POM inactive de-allocates any allocated cases when feature flag disabled' do
-    stub_feature_flag(:status_bulk_reallocation, enabled: false)
+  context 'when status_bulk_reallocation is disabled' do
+    before { stub_feature_flag(:status_bulk_reallocation, enabled: false) }
 
-    # Given the POM is active
-    create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
+    specify 'edit page does not show "No longer at prison" option' do
+      # Given the POM is active
+      create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
 
-    # And the POM has cases allocated to them
-    alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
-    create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
-    alloc2 = build(:stubbed_offender, nomis_id: 'G1234YY', first_name: 'Allocated', last_name: 'Case2')
-    create(:allocation_history, nomis_offender_id: 'G1234YY', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
-    stub_offenders_for_prison(prison.code, [alloc1, alloc2])
+      # When I visit the edit page
+      visit prison_poms_path(prison)
+      within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
+      within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
 
-    # When I make the POM inactive
-    visit prison_poms_path(prison)
-    within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
-    within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
-    within('fieldset', text: 'Select status') { choose 'Away from work' }
-    click_on 'Save'
+      # Then I do not see the deleted option
+      within('fieldset', text: 'Select status') do
+        expect(page).to have_content('Available for new cases')
+        expect(page).to have_content('Unavailable for new cases')
+        expect(page).to have_content('Away from work')
+        expect(page).not_to have_content("No longer at #{prison.name}")
+      end
+    end
 
-    # Then they appear in the away from work section
-    visit prison_poms_path(prison)
-    within('section', text: 'Away from work') { expect(page).to have_content('Anette Pomme') }
-    within('section', text: 'Available prison POMs') { expect(page).not_to have_content('Anette Pomme') }
+    specify 'HOMD making POM inactive de-allocates any allocated cases' do
+      # Given the POM is active
+      create(:pom_detail, :active, nomis_staff_id: 1234, prison:)
 
-    # And the previously allocated cases are now on the unallocated cases screen
-    visit unallocated_prison_prisoners_path(prison)
-    expect(page).to have_content('Case1, Allocated')
-    expect(page).to have_content('Case2, Allocated')
+      # And the POM has cases allocated to them
+      alloc1 = build(:stubbed_offender, nomis_id: 'G1234XX', first_name: 'Allocated', last_name: 'Case1')
+      create(:allocation_history, nomis_offender_id: 'G1234XX', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+      alloc2 = build(:stubbed_offender, nomis_id: 'G1234YY', first_name: 'Allocated', last_name: 'Case2')
+      create(:allocation_history, nomis_offender_id: 'G1234YY', primary_pom_nomis_id: 1234, primary_pom_name: 'Anette Pomme', prison: prison.code)
+      stub_offenders_for_prison(prison.code, [alloc1, alloc2])
+
+      # When I make the POM inactive
+      visit prison_poms_path(prison)
+      within('section', text: 'Available prison POMs') { click_on 'Anette Pomme' }
+      within('.govuk-summary-list__row', text: 'Status Available for new allocations') { click_on 'Change' }
+      within('fieldset', text: 'Select status') { choose 'Away from work' }
+      click_on 'Save'
+
+      # Then they appear in the away from work section
+      visit prison_poms_path(prison)
+      within('section', text: 'Away from work') { expect(page).to have_content('Anette Pomme') }
+      within('section', text: 'Available prison POMs') { expect(page).not_to have_content('Anette Pomme') }
+
+      # And the previously allocated cases are now on the unallocated cases screen
+      visit unallocated_prison_prisoners_path(prison)
+      expect(page).to have_content('Case1, Allocated')
+      expect(page).to have_content('Case2, Allocated')
+    end
   end
 end

--- a/spec/forms/confirm_delete_pom_form_spec.rb
+++ b/spec/forms/confirm_delete_pom_form_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ConfirmDeletePomForm, type: :model do
+  subject { described_class.new(confirmation:) }
+
+  describe 'validations' do
+    context 'when confirmation is yes' do
+      let(:confirmation) { 'yes' }
+
+      it { is_expected.to be_valid }
+
+      it 'is confirmed' do
+        expect(subject).to be_confirmed
+      end
+    end
+
+    context 'when confirmation is no' do
+      let(:confirmation) { 'no' }
+
+      it { is_expected.to be_valid }
+
+      it 'is not confirmed' do
+        expect(subject).not_to be_confirmed
+      end
+    end
+
+    context 'when confirmation is blank' do
+      let(:confirmation) { '' }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors[:confirmation]).to include('Select yes if you want to remove this POM')
+      end
+    end
+
+    context 'when confirmation is nil' do
+      let(:confirmation) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/forms/pom_profile_form_spec.rb
+++ b/spec/forms/pom_profile_form_spec.rb
@@ -133,4 +133,12 @@ RSpec.describe PomProfileForm, type: :model do
       end
     end
   end
+
+  describe '#deleting?' do
+    context 'when status is deleted' do
+      let(:status) { 'deleted' }
+
+      it { is_expected.to be_deleting }
+    end
+  end
 end

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -177,6 +177,58 @@ RSpec.describe StaffMember, type: :model do
     end
   end
 
+  describe '#in_limbo?' do
+    before do
+      allow(user).to receive(:pom).and_return(pom)
+    end
+
+    context 'when POM has a role and is not deleted' do
+      let(:pom) { double(:pom) }
+
+      it { expect(user).not_to be_in_limbo }
+    end
+
+    context 'when POM is deleted' do
+      let(:pom) { double(:pom) }
+
+      before { allow(user).to receive(:deleted?).and_return(true) }
+
+      it { expect(user).to be_in_limbo }
+    end
+
+    context 'when POM has no role' do
+      let(:pom) { nil }
+
+      it { expect(user).to be_in_limbo }
+    end
+  end
+
+  describe '#editable?' do
+    before do
+      allow(user).to receive(:pom).and_return(pom)
+    end
+
+    context 'when POM has a role and is not deleted' do
+      let(:pom) { double(:pom) }
+
+      it { expect(user).to be_editable }
+    end
+
+    context 'when POM is deleted' do
+      let(:pom) { double(:pom) }
+
+      before { allow(user).to receive(:deleted?).and_return(true) }
+
+      it { expect(user).not_to be_editable }
+    end
+
+    context 'when POM has no role' do
+      let(:pom) { nil }
+
+      it { expect(user).not_to be_editable }
+    end
+  end
+
   describe '#position' do
     before do
       allow(user).to receive(:pom).and_return(pom)


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1980

New entry-point to the bulk reallocation. Upon marking a POM as "No longer at $prison" (internal status `deleted`), we present confirmation and, then enter the bulk reallocation journey if they had any primary cases still allocated.

If SPO drops from the journey and POM still has primary cases allocated, they can re-enter the bulk reallocation from the "Attention needed" staff tab.

Lots of specs refactor/cleanup now that we have an almost finalised feature and we can link together some previously isolated journeys.