### PR TITLE
MO-1989 Handle `tier.calculation.changed` event

### DIFF
--- a/app/lib/domain_events/handlers/tier_change_handler.rb
+++ b/app/lib/domain_events/handlers/tier_change_handler.rb
@@ -19,6 +19,9 @@ module DomainEvents
         return if new_tier == old_tier
 
         case_info.tier = new_tier
+        case_info.manual_entry = false
+
+        attrs_before = case_info.changed_attributes
 
         if case_info.save
           AuditEvent.publish(
@@ -26,8 +29,8 @@ module DomainEvents
             tags: %w[handler case_information tier changed],
             system_event: true,
             data: {
-              'before' => old_tier,
-              'after' => new_tier
+              'before' => attrs_before,
+              'after' => case_info.slice(attrs_before.keys)
             }
           )
 
@@ -35,7 +38,7 @@ module DomainEvents
                         "version=#{event.version},crn=#{event.crn_number},old_tier=#{old_tier},new_tier=#{new_tier}"
         else
           logger.error "event=domain_event_handle_failure,domain_event_type=#{event.event_type}," \
-            "version=#{event.version},crn=#{event.crn_number}|#{case_info.errors.full_messages.join(',')}"
+            "version=#{event.version},crn=#{event.crn_number},old_tier=#{old_tier},new_tier=#{new_tier}|#{case_info.errors.full_messages.join(',')}"
         end
       end
     end

--- a/app/services/delius_data_import_service.rb
+++ b/app/services/delius_data_import_service.rb
@@ -131,7 +131,7 @@ private
       import_errors = []
       case_info.errors.each do |error|
         DeliusImportError.create!(nomis_offender_id:, error_type: error_type(error.attribute))
-        import_errors << error.attribute
+        import_errors << "#{error.attribute}/#{case_info.send(error.attribute).inspect}"
       end
 
       logger.error(

--- a/config/application.rb
+++ b/config/application.rb
@@ -96,7 +96,7 @@ module OffenderManagementAllocationClient
       'probation-case.registration.added' => 'DomainEvents::Handlers::ProbationChangeHandler',
       'probation-case.registration.deleted' => 'DomainEvents::Handlers::ProbationChangeHandler',
       'probation-case.registration.updated' => 'DomainEvents::Handlers::ProbationChangeHandler',
-      'tier.calculation.complete' => 'DomainEvents::Handlers::TierChangeHandler',
+      'tier.calculation.changed' => 'DomainEvents::Handlers::TierChangeHandler',
       'OFFENDER_MANAGER_CHANGED' => 'DomainEvents::Handlers::ProbationChangeHandler',
       'OFFENDER_OFFICER_CHANGED' => 'DomainEvents::Handlers::ProbationChangeHandler',
       'OFFENDER_DETAILS_CHANGED' => 'DomainEvents::Handlers::ProbationChangeHandler',

--- a/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
   let(:crn) { 'X408769' }
   let(:event) do
     DomainEvents::Event.new(
-      event_type: 'tier.calculation.complete',
+      event_type: 'tier.calculation.changed',
       version: event_version,
-      description: 'Tier calculation complete',
+      description: 'Tier calculation changed',
       detail_url: "https://hmpps-tier.example.org/crn/#{crn}/tier/#{calculation_id}",
       additional_information: { 'calculationId' => calculation_id },
       crn_number: crn,
@@ -40,6 +40,10 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
     context 'when tier has not changed' do
       let(:tier) { 'D' }
 
+      it 'does not update the record' do
+        expect(case_information.reload.tier).to eq('D')
+      end
+
       it 'emits no audit event' do
         expect(AuditEvent).not_to have_received(:publish)
       end
@@ -50,12 +54,44 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
         expect(case_information.reload.tier).to eq('D')
       end
 
+      it 'sets manual_entry to false' do
+        expect(case_information.reload.manual_entry).to be(false)
+      end
+
       it 'emits a log info message' do
         expect(Shoryuken::Logging.logger).to have_received(:info).at_least(2).times
       end
 
-      it 'emits an audit event' do
-        expect(AuditEvent).to have_received(:publish).once
+      it 'emits an audit event with before and after state' do
+        expect(AuditEvent).to have_received(:publish).once.with(
+          nomis_offender_id: case_information.nomis_offender_id,
+          tags: %w[handler case_information tier changed],
+          system_event: true,
+          data: {
+            'before' => { 'tier' => 'A' },
+            'after' => { 'tier' => 'D' }
+          }
+        )
+      end
+
+      context 'when manual_entry was true' do
+        let!(:case_information) { create(:case_information, :manual_entry, crn: crn, tier: tier) }
+
+        it 'sets manual_entry to false' do
+          expect(case_information.reload.manual_entry).to be(false)
+        end
+
+        it 'includes manual_entry in the audit event' do
+          expect(AuditEvent).to have_received(:publish).once.with(
+            nomis_offender_id: case_information.nomis_offender_id,
+            tags: %w[handler case_information tier changed],
+            system_event: true,
+            data: {
+              'before' => { 'tier' => 'A', 'manual_entry' => true },
+              'after' => { 'tier' => 'D', 'manual_entry' => false }
+            }
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1989

We are switching to this event that is more appropriate for us as we only care about changes in tier, whereas previous event is too noisy as it is triggered even if the end result is the same (no tier level change).

Improved some logging.