### PR TITLE
Minor improvements to the early alloc email job

### DIFF
--- a/app/jobs/suitable_for_early_allocation_email_job.rb
+++ b/app/jobs/suitable_for_early_allocation_email_job.rb
@@ -9,25 +9,28 @@ class SuitableForEarlyAllocationEmailJob < ApplicationJob
   EQUIP_URL = 'https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777'
 
   def perform(offender_no)
-    allocation = AllocationHistory.where(nomis_offender_id: offender_no).first
+    allocation = AllocationHistory.active.find_by(nomis_offender_id: offender_no)
     return if allocation.nil?
 
-    prisoner = OffenderService.get_offender(offender_no)
+    prisoner = OffenderService.get_offender(
+      offender_no, fetch_complexities: false, fetch_categories: false, fetch_movements: false
+    )
     return if prisoner.nil?
-
-    # Skip if the offender has transferred but the allocation hasn't been updated yet
-    if allocation.prison != prisoner.prison_id
-      logger.info("job=suitable_for_early_allocation_email_job,nomis_offender_id=#{offender_no}," \
-                  "event=skipped_transfer|Offender prison (#{prisoner.prison_id}) does not match allocation prison (#{allocation.prison})")
-      return
-    end
 
     if prisoner.within_early_allocation_window?
       already_emailed = EmailHistory.sent_within_current_sentence(prisoner, EmailHistory::SUITABLE_FOR_EARLY_ALLOCATION)
 
       if already_emailed.empty?
+        # Skip if the offender has transferred but the allocation hasn't been updated yet
+        if allocation.prison != prisoner.prison_id
+          logger.info("job=suitable_for_early_allocation_email_job,nomis_offender_id=#{offender_no}," \
+                        "event=skipped_transfer|Offender prison (#{prisoner.prison_id}) does not match allocation prison (#{allocation.prison})")
+          return
+        end
+
         prison = Prison.find(prisoner.prison_id)
         pom = prison.get_single_pom(allocation.primary_pom_nomis_id)
+
         EarlyAllocationMailer.with(
           email: pom.email_address,
           prisoner_name: prisoner.full_name,

--- a/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
+++ b/spec/jobs/suitable_for_early_allocation_email_job_spec.rb
@@ -18,16 +18,15 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
   before do
     case_info = create(:case_information, offender: build(:offender, nomis_offender_id: api_offender.offender_no))
     offender = build(:mpc_offender, prison: prison, offender: case_info.offender, prison_record: api_offender)
-    allow(OffenderService).to receive(:get_offender).and_return(offender)
+    allow(OffenderService).to receive(:get_offender)
+      .with(api_offender.offender_no, fetch_complexities: false, fetch_categories: false, fetch_movements: false)
+      .and_return(offender)
   end
 
   context 'when offender is not allocated to a POM' do
     let(:release_date) { Time.zone.today + 17.months }
 
     it 'does not send email' do
-      create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                created_within_referral_window: false, nomis_offender_id: api_offender.offender_no)
-
       expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
       described_class.perform_now(api_offender.offender_no)
     end
@@ -43,7 +42,6 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
       let(:other_prison) { create(:prison) }
 
       before do
-        # Simulate transfer: offender is now at a different prison than the allocation
         transferred_api_offender = build(:hmpps_api_offender, prisonId: other_prison.code,
                                                               sentence: attributes_for(:sentence_detail,
                                                                                        :determinate,
@@ -54,127 +52,100 @@ RSpec.describe SuitableForEarlyAllocationEmailJob, type: :job do
                                                                                        tariffDate: nil))
         case_info = CaseInformation.find_by(nomis_offender_id: api_offender.offender_no)
         transferred_offender = build(:mpc_offender, prison: other_prison, offender: case_info.offender, prison_record: transferred_api_offender)
-        allow(OffenderService).to receive(:get_offender).and_return(transferred_offender)
+        allow(OffenderService).to receive(:get_offender)
+          .with(api_offender.offender_no, fetch_complexities: false, fetch_categories: false, fetch_movements: false)
+          .and_return(transferred_offender)
       end
 
       it 'does not send email' do
-        create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                  created_within_referral_window: false, nomis_offender_id: api_offender.offender_no)
-
         expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
         described_class.perform_now(api_offender.offender_no)
       end
     end
 
-    context 'when form created outside of the referral window (more than 18 months to release)' do
-      context 'when form outcome is ineligible' do
-        let(:release_date) { Time.zone.today + 28.months }
+    context 'when offender not found in NOMIS' do
+      let(:release_date) { Time.zone.today + 17.months }
 
-        it 'does not send email' do
-          create(:early_allocation, :ineligible, created_within_referral_window: false, nomis_offender_id: api_offender.offender_no)
+      before do
+        allow(OffenderService).to receive(:get_offender)
+          .with(api_offender.offender_no, fetch_complexities: false, fetch_categories: false, fetch_movements: false)
+          .and_return(nil)
+      end
 
-          expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+      it 'does not send email' do
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now(api_offender.offender_no)
+      end
+    end
+
+    context 'when offender has more than 18 months of sentence remaining' do
+      let(:release_date) { Time.zone.today + 19.months }
+
+      it 'does not send email' do
+        expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
+        described_class.perform_now(api_offender.offender_no)
+      end
+    end
+
+    context 'when offender is within the early allocation window' do
+      before do
+        allow_any_instance_of(Prison).to receive(:get_single_pom).and_return(pom)
+      end
+
+      context 'when no previous early allocation reminder email has been sent' do
+        let(:release_date) { Time.zone.today + 18.months }
+
+        it 'sends the email' do
+          mailer = double(:mailer)
+          expect(EarlyAllocationMailer).to receive(:with)
+            .with(
+              email: pom.email_address,
+              prisoner_name: api_offender.full_name,
+              prisoner_number: api_offender.offender_no,
+              prison_name: prison.name,
+              start_page_link: "http://localhost:3000/prisons/#{api_offender.prison_id}/prisoners/#{api_offender.offender_no}/early_allocations",
+              equip_guidance_link: described_class::EQUIP_URL
+            )
+            .and_return(double(review_early_allocation: mailer))
+          expect(mailer).to receive(:deliver_now)
           described_class.perform_now(api_offender.offender_no)
         end
       end
 
-      context 'when offender not found in NOMIS' do
+      context 'when an email was already sent during the current sentence' do
         let(:release_date) { Time.zone.today + 17.months }
 
         before do
-          allow(OffenderService).to receive(:get_offender).and_return(nil)
+          create(:email_history, :suitable_early_allocation, nomis_offender_id: api_offender.offender_no)
         end
 
         it 'does not send email' do
-          create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                    created_within_referral_window: false, nomis_offender_id:  api_offender.offender_no)
-
           expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-          described_class.perform_now(api_offender.offender_no)
+          expect { described_class.perform_now(api_offender.offender_no) }.not_to change(EmailHistory, :count)
         end
       end
 
-      context 'when offender has more than 18 months of sentence remaining' do
-        let(:release_date) { Time.zone.today + 19.months }
+      context 'when an email was sent before the current sentence started' do
+        let(:release_date) { Time.zone.today + 17.months }
 
-        it 'does not send email' do
-          create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                    created_within_referral_window: false, nomis_offender_id:  api_offender.offender_no)
-
-          expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-          described_class.perform_now(api_offender.offender_no)
-        end
-      end
-
-      context 'when offender has 18 months or less of sentence remaining' do
         before do
-          allow_any_instance_of(Prison).to receive(:get_single_pom).and_return(pom)
+          create(:email_history, :suitable_early_allocation, nomis_offender_id: api_offender.offender_no, created_at: Time.zone.today - 3.years)
         end
 
-        context 'when no previous Early Allocation reminder email sent for this offender' do
-          let(:release_date) { Time.zone.today + 18.months }
-
-          it 'sends email' do
-            create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                      created_within_referral_window: false, nomis_offender_id:  api_offender.offender_no)
-
-            mailer = double(:mailer)
-            expect(EarlyAllocationMailer).to receive(:with)
-                                         .with(
-                                           email: pom.email_address,
-                                           prisoner_name: api_offender.full_name,
-                                           prisoner_number: api_offender.offender_no,
-                                           prison_name: prison.name,
-                                           start_page_link: "http://localhost:3000/prisons/#{api_offender.prison_id}/prisoners/#{api_offender.offender_no}/early_allocations",
-                                           equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
-                                         )
-                                         .and_return(double(review_early_allocation: mailer))
-            expect(mailer).to receive(:deliver_now)
-            described_class.perform_now(api_offender.offender_no)
-          end
-        end
-
-        context 'when there are previous Early Allocation reminders emails sent for this offenders' do
-          let(:release_date) { Time.zone.today + 17.months }
-
-          context 'when the email relates to the current sentence' do
-            before do
-              create(:email_history, :suitable_early_allocation, nomis_offender_id: api_offender.offender_no)
-            end
-
-            it 'does not send email if email previously sent' do
-              create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                        created_within_referral_window: false, nomis_offender_id:  api_offender.offender_no)
-
-              expect_any_instance_of(EarlyAllocationMailer).not_to receive(:review_early_allocation)
-              expect { described_class.perform_now(api_offender.offender_no) }.not_to change(EmailHistory, :count)
-            end
-          end
-
-          context 'when the email relates to the offenders previous sentence' do
-            before do
-              create(:email_history, :suitable_early_allocation, nomis_offender_id: api_offender.offender_no, created_at: Time.zone.today - 3.years)
-            end
-
-            it 'does send email' do
-              create(:early_allocation, created_at: Time.zone.today - 9.months, updated_at: Time.zone.today - 9.months,
-                                        created_within_referral_window: false, nomis_offender_id:  api_offender.offender_no)
-
-              mailer = double(:mailer)
-              expect(EarlyAllocationMailer).to receive(:with)
-                                                 .with(
-                                                   email: pom.email_address,
-                                                   prisoner_name: api_offender.full_name,
-                                                   prisoner_number: api_offender.offender_no,
-                                                   prison_name: prison.name,
-                                                   start_page_link: "http://localhost:3000/prisons/#{api_offender.prison_id}/prisoners/#{api_offender.offender_no}/early_allocations",
-                                                   equip_guidance_link: "https://equip-portal.rocstac.com/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3A9A63E167DE4B400EA07F81A9271E1944&dgm=4F984B45CBC447B1A304B2FFECABB777"
-                                                 )
-                                                 .and_return(double(review_early_allocation: mailer))
-              expect(mailer).to receive(:deliver_now)
-              described_class.perform_now(api_offender.offender_no)
-            end
-          end
+        it 'sends the email' do
+          mailer = double(:mailer)
+          expect(EarlyAllocationMailer).to receive(:with)
+            .with(
+              email: pom.email_address,
+              prisoner_name: api_offender.full_name,
+              prisoner_number: api_offender.offender_no,
+              prison_name: prison.name,
+              start_page_link: "http://localhost:3000/prisons/#{api_offender.prison_id}/prisoners/#{api_offender.offender_no}/early_allocations",
+              equip_guidance_link: described_class::EQUIP_URL
+            )
+            .and_return(double(review_early_allocation: mailer))
+          expect(mailer).to receive(:deliver_now)
+          described_class.perform_now(api_offender.offender_no)
         end
       end
     end


### PR DESCRIPTION
Scope allocations by active, as we must have a `primary_pom_nomis_id` present down the line in order to obtain the POM from the API.

Do not call unnecessary APIs to fetch data we don't need in this job (complexities, categories, etc.)

Move the prison transfer check to the point where it actually skips the email if we had sent one.