### PR TITLE
MO-1992 Handle reallocations to same co-worker POM

### DIFF
--- a/app/assets/javascripts/reallocation_select_all.js
+++ b/app/assets/javascripts/reallocation_select_all.js
@@ -1,7 +1,7 @@
 document.addEventListener('turbolinks:load', function() {
   document.querySelectorAll('[data-reallocation-case-selection]').forEach(function(form) {
     const selectAll = form.querySelector('[data-reallocation-select-all]');
-    const checkboxes = Array.from(form.querySelectorAll('[data-reallocation-case-checkbox]'));
+    const checkboxes = Array.from(form.querySelectorAll('[data-reallocation-case-checkbox]:not(:disabled)'));
     const continueButton = form.querySelector('[data-reallocation-continue-button]');
 
     if (!selectAll || checkboxes.length === 0) {

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -91,6 +91,10 @@ $purble: govuk-colour("purple");
 
 // Reallocation cases table
 //
+.reallocation-cases-table__recommended-column {
+  max-width: 180px;
+}
+
 .reallocation-cases-table__select-column {
   width: 50px;
 }

--- a/app/controllers/reallocations/selection_controller.rb
+++ b/app/controllers/reallocations/selection_controller.rb
@@ -68,7 +68,9 @@ module Reallocations
 
     def selected_cases_from_params
       offender_ids = Array(params[:nomis_offender_ids]).compact_blank
-      primary_allocations.select { offender_ids.include?(it.nomis_offender_id) }
+      primary_allocations
+        .select { offender_ids.include?(it.nomis_offender_id) }
+        .reject { it.secondary_pom_nomis_id == @new_pom.staff_id }
     end
   end
 end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -23,7 +23,7 @@ class AllocatedOffender
            :pom_tasks, :com_allocation_days_overdue, :handover_date, to: :@offender
   delegate :last_name, to: :offender, prefix: true
   delegate :updated_at, :nomis_offender_id, :primary_pom_allocated_at, :prison, :primary_pom_nomis_id, :primary_pom_name,
-           to: :@allocation
+           :secondary_pom_nomis_id, to: :@allocation
   delegate :full_name_ordered, to: :staff_member, prefix: true
 
   COMPLEXITIES = { 'high' => 3, 'medium' => 2, 'low' => 1 }.freeze

--- a/app/views/reallocations/_caseload_table.html.erb
+++ b/app/views/reallocations/_caseload_table.html.erb
@@ -35,6 +35,7 @@
   </thead>
   <tbody class="govuk-table__body">
     <% collection.each_with_index do |allocation, allocation_counter| %>
+      <% coworker_conflict = (allocation.secondary_pom_nomis_id == target_pom.staff_id) %>
       <tr class="govuk-table__row offender_row_<%= allocation_counter %>">
         <td aria-label="Select case" class="govuk-table__cell govuk-!-padding-top-2 reallocation-cases-table__select-cell reallocation-cases-table__select-column">
           <fieldset class="govuk-fieldset">
@@ -42,9 +43,16 @@
               <div class="govuk-checkboxes__item reallocation-cases-table__select-checkbox">
                 <%= check_box_tag 'nomis_offender_ids[]', allocation.nomis_offender_id, false,
                                   id: "case-#{allocation.nomis_offender_id}",
-                                  class: 'govuk-checkboxes__input', data: { reallocation_case_checkbox: true } %>
+                                  class: 'govuk-checkboxes__input', disabled: coworker_conflict,
+                                  data: { reallocation_case_checkbox: (true unless coworker_conflict) } %>
                 <%= label_tag "case-#{allocation.nomis_offender_id}", '', class: 'govuk-label govuk-checkboxes__label' do %>
-                  <span class="govuk-visually-hidden">Select <%= allocation.full_name %> to reallocate</span>
+                  <span class="govuk-visually-hidden">
+                    <% if coworker_conflict %>
+                      Cannot select <%= allocation.full_name %>: <%= target_pom.first_name %> already allocated as co-working POM
+                    <% else %>
+                      Select <%= allocation.full_name %> to reallocate
+                    <% end %>
+                  </span>
                 <% end %>
               </div>
             </div>
@@ -62,8 +70,10 @@
             <%= allocation.nomis_offender_id %>
           </span>
         </td>
-        <td aria-label="Recommended POM type" class="govuk-table__cell">
-          <%= allocation.recommended_pom_type == RecommendationService::PRISON_POM ? 'Prison POM' : 'Probation POM' %>
+        <td aria-label="Recommended POM type" class="govuk-table__cell reallocation-cases-table__recommended-column">
+          <%= highlight_conditionally('alert', "#{target_pom.first_name} already allocated as co-working POM", -> { coworker_conflict }) do %>
+            <%= allocation.recommended_pom_type == RecommendationService::PRISON_POM ? 'Prison POM' : 'Probation POM' %>
+          <% end %>
         </td>
         <td aria-label="POM role needed" class="govuk-table__cell">
           <%= pom_responsibility_label(allocation) %>

--- a/app/views/reallocations/caseload.html.erb
+++ b/app/views/reallocations/caseload.html.erb
@@ -25,10 +25,12 @@
                locals: { title: 'Choose cases to reallocate', pom: @pom, new_pom: @new_pom } %>
   </div>
 
+  <% selectable_count = @allocations.count { it.secondary_pom_nomis_id != @new_pom.staff_id } %>
+
   <div class="govuk-grid-column-full govuk-!-margin-top-6">
     <%= form_tag(caseload_prison_reallocation_path(@prison.code, @pom.staff_id, @new_pom.staff_id),
                  method: :post, data: { reallocation_case_selection: true }) do %>
-      <%= render 'caseload_table', collection: @allocations %>
+      <%= render 'caseload_table', collection: @allocations, target_pom: @new_pom %>
 
       <div class="govuk-form-group govuk-!-margin-top-6 govuk-!-margin-bottom-6 reallocation-cases-table__select-all">
         <fieldset class="govuk-fieldset">
@@ -37,7 +39,7 @@
               <%= check_box_tag :select_all_cases, '1', false, id: 'nomis-offender-ids-all',
                                 class: 'govuk-checkboxes__input', data: { reallocation_select_all: true } %>
               <%= label_tag 'nomis-offender-ids-all',
-                            "Select all cases (#{@allocations.size})",
+                            "Select all cases (#{selectable_count})",
                             class: 'govuk-label govuk-checkboxes__label govuk-!-font-weight-bold' %>
             </div>
           </div>

--- a/spec/controllers/reallocations/selection_controller_spec.rb
+++ b/spec/controllers/reallocations/selection_controller_spec.rb
@@ -159,6 +159,61 @@ RSpec.describe Reallocations::SelectionController, type: :controller do
         expect(response.body).to include('Complexity level')
       end
     end
+
+    context 'when the target POM is already the co-working POM on a case' do
+      let(:coworker_offender_no) { 'G9999CC' }
+      let(:coworker_offender) do
+        build(
+          :nomis_offender,
+          :inside_omic_policy,
+          prisonId: prison.code,
+          prisonerNumber: coworker_offender_no,
+          firstName: 'Charlie',
+          lastName: 'Brown',
+          sentence: attributes_for(:sentence_detail, conditionalReleaseDate: '2028-06-01', releaseDate: '2029-06-01')
+        )
+      end
+      let(:offenders_in_prison) { [offender, coworker_offender] }
+
+      before do
+        create(:case_information, tier: 'B', offender: build(:offender, nomis_offender_id: coworker_offender_no))
+        create(
+          :allocation_history,
+          prison: prison.code,
+          nomis_offender_id: coworker_offender_no,
+          primary_pom_nomis_id: old_pom.staffId,
+          primary_pom_name: old_pom.full_name,
+          secondary_pom_nomis_id: new_pom.staffId,
+          secondary_pom_name: new_pom.full_name
+        )
+        stub_oasys_assessments(coworker_offender_no)
+      end
+
+      it 'renders a disabled checkbox for the conflicting case' do
+        perform_request
+
+        page = Nokogiri::HTML(response.body)
+        conflicting_checkbox = page.at_css("#case-#{coworker_offender_no}")
+        normal_checkbox = page.at_css("#case-#{offender_no}")
+
+        expect(conflicting_checkbox).not_to be_nil
+        expect(conflicting_checkbox['disabled']).to eq('disabled')
+        expect(normal_checkbox).not_to be_nil
+        expect(normal_checkbox['disabled']).to be_nil
+      end
+
+      it 'shows the "already allocated as co-working POM" highlight for the conflicting case' do
+        perform_request
+
+        expect(response.body).to include('already allocated as co-working POM')
+      end
+
+      it 'adjusts the select-all count to exclude the conflicting case' do
+        perform_request
+
+        expect(response.body).to include('Select all cases (1)')
+      end
+    end
   end
 
   describe '#create' do
@@ -199,6 +254,44 @@ RSpec.describe Reallocations::SelectionController, type: :controller do
         post :create, params: params
 
         expect(response).to redirect_to(override_prison_reallocation_path(prison, old_pom.staffId, new_pom.staffId, override_offender_no))
+      end
+    end
+
+    context 'when a selected case has the target POM as co-worker (form manipulation)' do
+      let(:coworker_offender_no) { 'G9999CC' }
+      let(:coworker_offender) do
+        build(
+          :nomis_offender,
+          :inside_omic_policy,
+          prisonId: prison.code,
+          prisonerNumber: coworker_offender_no,
+          firstName: 'Charlie',
+          lastName: 'Brown',
+          sentence: attributes_for(:sentence_detail, conditionalReleaseDate: '2028-06-01', releaseDate: '2029-06-01')
+        )
+      end
+      let(:offenders_in_prison) { [offender, coworker_offender] }
+      let(:nomis_offender_ids) { [coworker_offender_no] }
+
+      before do
+        create(:case_information, tier: 'B', offender: build(:offender, nomis_offender_id: coworker_offender_no))
+        create(
+          :allocation_history,
+          prison: prison.code,
+          nomis_offender_id: coworker_offender_no,
+          primary_pom_nomis_id: old_pom.staffId,
+          primary_pom_name: old_pom.full_name,
+          secondary_pom_nomis_id: new_pom.staffId,
+          secondary_pom_name: new_pom.full_name
+        )
+        stub_oasys_assessments(coworker_offender_no)
+      end
+
+      it 'rejects the conflicting case and redirects with an alert' do
+        post :create, params: params
+
+        expect(response).to redirect_to(caseload_prison_reallocation_path(prison, old_pom.staffId, new_pom.staffId))
+        expect(flash[:alert]).to eq('Choose at least one case to reallocate.')
       end
     end
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1992

A POM can't be both the primary and secondary (co-worker) on the same case. There was an edge case where it could be possible on the bulk reallocation to select a target POM that had already some of the cases being reallocated as co-worker, thus giving an error.

Agreed with UCD to present these cases but disable the checkbox and also place a copy in the row to say the target POM is the co-worker on that case.