### PR TITLE
Add additional audit trail to DB records

### DIFF
--- a/app/controllers/prisoners_controller.rb
+++ b/app/controllers/prisoners_controller.rb
@@ -3,6 +3,7 @@
 class PrisonersController < PrisonsApplicationController
   before_action :ensure_spo_user, except: [:show, :image, :search]
 
+  before_action :load_prisoner_or_redirect, only: [:show, :review_case_details]
   before_action :load_all_offenders, only: [:allocated, :missing_information, :unallocated, :search]
   before_action :load_reallocation_alert, only: [:unallocated]
 
@@ -30,10 +31,6 @@ class PrisonersController < PrisonsApplicationController
   end
 
   def review_case_details
-    @prisoner = OffenderService.get_offender(params[:prisoner_id])
-
-    return redirect_to '/404' if @prisoner.nil?
-
     @alerts = @prisoner.active_alert_labels
     @mappa = @prisoner.mappa_details
     @rosh = @prisoner.rosh_summary
@@ -60,12 +57,6 @@ class PrisonersController < PrisonsApplicationController
   end
 
   def show
-    @prisoner = OffenderService.get_offender(params[:id])
-
-    return redirect_to '/404' if @prisoner.nil?
-
-    return render 'show_outside_omic_policy' unless @prisoner.inside_omic_policy?
-
     @tasks = @prisoner.pom_tasks
 
     if (allocation = AllocationHistory.find_by(nomis_offender_id: @prisoner.offender_no))
@@ -93,6 +84,18 @@ class PrisonersController < PrisonsApplicationController
   end
 
 private
+
+  def load_prisoner_or_redirect
+    offender_id = params[:prisoner_id] || params[:id]
+    @prisoner = OffenderService.get_offender(offender_id)
+
+    if @prisoner.nil?
+      redirect_to '/404'
+    elsif !@prisoner.inside_omic_policy?
+      Rails.logger.warn("event=outside_omic_policy,nomis_offender_id=#{offender_id},prison_id=#{@prison.code}")
+      render 'show_outside_omic_policy'
+    end
+  end
 
   def load_all_offenders
     @missing_info = @prison.missing_info

--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AllocationHistory < ApplicationRecord
+  include Auditable
+
   self.table_name = 'allocation_history'
 
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
@@ -22,8 +24,6 @@ class AllocationHistory < ApplicationRecord
   MANUAL_CHANGE = 3
   LEGAL_STATUS_CHANGED = 4
   INACTIVE_POM = 5
-
-  AUDIT_EXCLUDED_KEYS = %w[id nomis_offender_id message override_detail suitability_detail].freeze
 
   # IMPORTANT:
   # Dirty changes are reset every time the model saves, not just when a transaction is closed.
@@ -233,26 +233,12 @@ private
     end
   end
 
-  def save_audit_event
-    return unless previous_changes.any?
+  def audit_event_tags
+    %w[record allocation changed].freeze
+  end
 
-    before_changes = previous_changes.transform_values(&:first)
-    after_changes  = previous_changes.transform_values(&:last)
-
-    [before_changes, after_changes].each do |changes_hash|
-      AUDIT_EXCLUDED_KEYS.each { changes_hash.delete(it) }
-    end
-
-    AuditEvent.publish(
-      nomis_offender_id:,
-      tags: %w[record allocation changed],
-      system_event: PaperTrail.request.whodunnit.blank?,
-      username: PaperTrail.request.whodunnit,
-      data: {
-        'before' => before_changes,
-        'after' => after_changes
-      }
-    )
+  def audit_excluded_keys
+    %w[id nomis_offender_id message override_detail suitability_detail].freeze
   end
 
   def publish_allocation_changed_event

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 class CaseInformation < ApplicationRecord
+  include Auditable
+
   self.table_name = 'case_information'
+
+  has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
 
   MAPPA_LEVELS = [0, 1, 2, 3].freeze
   TIER_LEVELS = %w[A B C D].freeze
   EXTENDED_TIER_LEVELS = %w[E F G].freeze
   ROSH_LEVELS = %w[VERY_HIGH HIGH MEDIUM LOW].freeze
 
-  has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
+  after_commit :save_audit_event, if: :manual_entry?
 
   belongs_to :offender, foreign_key: :nomis_offender_id, inverse_of: :case_information
 
@@ -49,5 +53,13 @@ private
 
   def rosh_level_feature_enabled?
     FeatureFlags.rosh_level.enabled?
+  end
+
+  def audit_event_tags
+    %w[record case_information changed].freeze
+  end
+
+  def audit_excluded_keys
+    %w[id nomis_offender_id].freeze
   end
 end

--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Auditable
+  extend ActiveSupport::Concern
+
+private
+
+  def save_audit_event
+    return unless previous_changes.any?
+
+    before_changes = previous_changes.transform_values(&:first)
+    after_changes  = previous_changes.transform_values(&:last)
+
+    [before_changes, after_changes].each do |changes_hash|
+      audit_excluded_keys.each { changes_hash.delete(it) }
+    end
+
+    AuditEvent.publish(
+      nomis_offender_id: (nomis_offender_id if has_attribute?(:nomis_offender_id)),
+      tags: audit_event_tags,
+      system_event: PaperTrail.request.whodunnit.blank?,
+      username: PaperTrail.request.whodunnit,
+      data: audit_additional_data.merge(
+        'before' => before_changes,
+        'after' => after_changes
+      )
+    )
+  end
+
+  # Override in including models to exclude specific keys from the audit diff
+  def audit_excluded_keys
+    []
+  end
+
+  # Override in including models to merge additional identifying data
+  def audit_additional_data
+    {}
+  end
+end

--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class EarlyAllocation < ApplicationRecord
+  include Auditable
+
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
 
   before_save :record_outcome
+  after_commit :save_audit_event
 
   belongs_to :offender,
              primary_key: :nomis_offender_id,
@@ -95,5 +98,13 @@ private
     return self.outcome = 'ineligible' if ineligible?
 
     self.outcome = 'discretionary'
+  end
+
+  def audit_event_tags
+    %w[record early_allocation changed].freeze
+  end
+
+  def audit_excluded_keys
+    %w[id nomis_offender_id reason other_reason].freeze
   end
 end

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class PomDetail < ApplicationRecord
+  include Auditable
+
   has_paper_trail
 
   FULL_TIME_HOURS_PER_WEEK = 37.5
+
+  after_commit :save_audit_event
 
   enum :status, {
     active: 'active',
@@ -41,5 +45,15 @@ class PomDetail < ApplicationRecord
 
   def hours_per_week
     working_pattern * FULL_TIME_HOURS_PER_WEEK
+  end
+
+private
+
+  def audit_event_tags
+    %w[record pom_detail changed].freeze
+  end
+
+  def audit_additional_data
+    { 'nomis_staff_id' => nomis_staff_id, 'prison_code' => prison_code }
   end
 end

--- a/app/views/debugging/timeline/_audit_event.html.erb
+++ b/app/views/debugging/timeline/_audit_event.html.erb
@@ -4,7 +4,7 @@
   <td class="govuk-table__cell" style="display: flex; flex-direction: column; margin-bottom: -1px;">
     <span>
       <strong class="govuk-tag govuk-tag--purple">audit event</strong>
-      <span><%= audit_event.tags.join(' ') %></span>
+      <span><%= audit_event.tags.join(' &middot; ').html_safe %></span>
     </span>
 
     <details class="govuk-details govuk-!-margin-top-3 govuk-!-margin-bottom-2">
@@ -18,11 +18,11 @@
             <dd class="govuk-summary-list__value"><%= audit_event.system_event %></dd>
           </div>
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Username / Name</dt>
-            <dd class="govuk-summary-list__value"><%= audit_event.username %> / <%= audit_event.user_human_name %></dd>
+            <dt class="govuk-summary-list__key">Username</dt>
+            <dd class="govuk-summary-list__value"><%= audit_event.username %></dd>
           </div>
         </dl>
-        <pre><%= JSON.pretty_generate(audit_event.data) %></pre>
+        <pre><%= audit_event.data.to_yaml %></pre>
       </div>
     </details>
   </td>

--- a/app/views/manage/audit_events/index.html.erb
+++ b/app/views/manage/audit_events/index.html.erb
@@ -47,7 +47,7 @@
           <% if audit_event.system_event? %>
             <em>System</em>
           <% else %>
-            <%= audit_event.user_human_name %> (<%= audit_event.username %>)
+            <%= audit_event.username %>
           <% end %>
         </td>
         <td class="govuk-table__cell">

--- a/spec/controllers/case_information_controller_spec.rb
+++ b/spec/controllers/case_information_controller_spec.rb
@@ -41,6 +41,29 @@ RSpec.describe CaseInformationController, type: :controller do
       end
     end
 
+    it 'publishes an audit event on successful create' do
+      allow(AuditEvent).to receive(:publish).and_call_original
+
+      post :create, params: {
+        prison_id: prison.code,
+        prisoner_id: offender_no,
+        commit: 'Save',
+        case_information: {
+          tier: 'A',
+          rosh_level: 'HIGH',
+          enhanced_resourcing: 'true'
+        }
+      }
+
+      expect(AuditEvent).to have_received(:publish).once.with(
+        hash_including(
+          nomis_offender_id: offender_no,
+          tags: %w[record case_information changed],
+          system_event: false
+        )
+      )
+    end
+
     it 'redirects to the review-case page when saving and allocating' do
       post :create, params: {
         prison_id: prison.code,
@@ -297,6 +320,33 @@ RSpec.describe CaseInformationController, type: :controller do
                tier: 'B',
                rosh_level: 'LOW',
                enhanced_resourcing: false)
+      end
+
+      it 'publishes an audit event on successful update' do
+        allow(AuditEvent).to receive(:publish).and_call_original
+
+        put :update, params: {
+          prison_id: prison.code,
+          prisoner_id: offender_no,
+          from: 'review_case',
+          case_information: {
+            tier: 'A',
+            rosh_level: 'HIGH',
+            enhanced_resourcing: 'true'
+          }
+        }
+
+        expect(AuditEvent).to have_received(:publish).once.with(
+          hash_including(
+            nomis_offender_id: offender_no,
+            tags: %w[record case_information changed],
+            system_event: false,
+            data: hash_including(
+              'before' => hash_including('tier' => 'B', 'rosh_level' => 'LOW'),
+              'after' => hash_including('tier' => 'A', 'rosh_level' => 'HIGH')
+            )
+          )
+        )
       end
 
       it 'redirects back to review case details when from is review_case' do

--- a/spec/controllers/prisoners_controller_spec.rb
+++ b/spec/controllers/prisoners_controller_spec.rb
@@ -697,4 +697,58 @@ RSpec.describe PrisonersController, type: :controller do
       end
     end
   end
+
+  describe '#load_prisoner_or_redirect' do
+    let(:prison) { create(:prison) }
+
+    before do
+      stub_sso_data(prison.code)
+    end
+
+    describe '#show' do
+      context 'when the offender does not exist' do
+        before { stub_nil_offender }
+
+        it 'redirects to 404' do
+          get :show, params: { prison_id: prison.code, id: 'NONEXIST' }
+          expect(response).to redirect_to('/404')
+        end
+      end
+
+      context 'when the offender is outside OMIC policy' do
+        let(:offender) { build(:nomis_offender, :outside_omic_policy, prisonId: prison.code) }
+        let(:offender_no) { offender.fetch(:prisonerNumber) }
+
+        before { stub_offender(offender) }
+
+        it 'renders the outside OMIC policy page' do
+          get :show, params: { prison_id: prison.code, id: offender_no }
+          expect(response).to render_template('show_outside_omic_policy')
+        end
+      end
+    end
+
+    describe '#review_case_details' do
+      context 'when the offender does not exist' do
+        before { stub_nil_offender }
+
+        it 'redirects to 404' do
+          get :review_case_details, params: { prison_id: prison.code, prisoner_id: 'NONEXIST' }
+          expect(response).to redirect_to('/404')
+        end
+      end
+
+      context 'when the offender is outside OMIC policy' do
+        let(:offender) { build(:nomis_offender, :outside_omic_policy, prisonId: prison.code) }
+        let(:offender_no) { offender.fetch(:prisonerNumber) }
+
+        before { stub_offender(offender) }
+
+        it 'renders the outside OMIC policy page' do
+          get :review_case_details, params: { prison_id: prison.code, prisoner_id: offender_no }
+          expect(response).to render_template('show_outside_omic_policy')
+        end
+      end
+    end
+  end
 end

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -629,8 +629,6 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
   end
 
   describe '#save_audit_event' do
-    let(:audit_excluded_keys) { described_class::AUDIT_EXCLUDED_KEYS }
-
     let(:prison) { create(:prison) }
     let!(:allocation) { create(:allocation_history, prison: prison.code, nomis_offender_id:) }
 
@@ -643,7 +641,7 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
       PaperTrail.request.whodunnit = nil
     end
 
-    it 'removes sensitive or unnecessary fields from audit data when present' do
+    it 'publishes an audit event with correct tags and excludes sensitive fields' do
       allocation.update!(
         message: 'sensitive note',
         override_detail: 'override details',
@@ -669,18 +667,6 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
           }
         )
       end
-    end
-
-    it 'marks system events when whodunnit is blank' do
-      PaperTrail.request.whodunnit = nil
-
-      allocation.update!(allocated_at_tier: 'B')
-
-      expect(AuditEvent).to have_received(:publish).once.with(
-        hash_including(
-          system_event: true, username: nil
-        )
-      )
     end
   end
 end

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -204,4 +204,51 @@ describe CaseInformation do
       expect(build(:case_information, tier: nil, rosh_level: 'HIGH').complete_for_allocation?).to be(false)
     end
   end
+
+  describe '#save_audit_event' do
+    before do
+      PaperTrail.request.whodunnit = 'SPO_USER'
+    end
+
+    after do
+      PaperTrail.request.whodunnit = nil
+    end
+
+    context 'when the record is a manual entry' do
+      let(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
+
+      it 'publishes an audit event with the correct tags and offender id' do
+        expect { case_info }.to change(AuditEvent, :count).by(1)
+
+        audit = AuditEvent.order(:created_at).last
+        aggregate_failures do
+          expect(audit.nomis_offender_id).to eq(case_info.nomis_offender_id)
+          expect(audit.tags).to eq(%w[record case_information changed])
+        end
+      end
+
+      it 'records before and after changes on update' do
+        case_info
+        last_audit = AuditEvent.order(:created_at).last
+
+        case_info.update!(tier: 'A', rosh_level: 'HIGH')
+
+        audit = AuditEvent.where.not(id: last_audit.id).order(:created_at).last
+        aggregate_failures do
+          expect(audit.data['before']).to include('tier' => 'B', 'rosh_level' => 'LOW')
+          expect(audit.data['after']).to include('tier' => 'A', 'rosh_level' => 'HIGH')
+        end
+      end
+    end
+
+    context 'when the record is not a manual entry' do
+      let(:case_info) { create(:case_information, manual_entry: false, tier: 'B') }
+
+      it 'does not publish an audit event' do
+        case_info
+
+        expect { case_info.update!(tier: 'A') }.not_to change(AuditEvent, :count)
+      end
+    end
+  end
 end

--- a/spec/models/concerns/auditable_spec.rb
+++ b/spec/models/concerns/auditable_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Auditable do
+  before do
+    PaperTrail.request.whodunnit = 'TEST_USER'
+    stub_feature_flag(:rosh_level, enabled: true)
+  end
+
+  after do
+    PaperTrail.request.whodunnit = nil
+  end
+
+  describe 'with an offender-linked model (CaseInformation)' do
+    let!(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
+
+    it 'sets nomis_offender_id from the record' do
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.nomis_offender_id).to eq(case_info.nomis_offender_id)
+    end
+
+    it 'does not include extra data keys beyond before/after' do
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.data.keys).to contain_exactly('before', 'after')
+    end
+  end
+
+  describe 'with a non-offender-linked model (PomDetail)' do
+    let!(:prison) { create(:prison) }
+    let!(:pom_detail) { create(:pom_detail, prison: prison) }
+
+    it 'sets nomis_offender_id to nil' do
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.nomis_offender_id).to be_nil
+    end
+
+    it 'includes additional data from audit_additional_data' do
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.data['nomis_staff_id']).to eq(pom_detail.nomis_staff_id)
+        expect(audit.data['prison_code']).to eq(prison.code)
+        expect(audit.data).to have_key('before')
+        expect(audit.data).to have_key('after')
+      end
+    end
+  end
+
+  describe 'system_event flag' do
+    let!(:prison) { create(:prison) }
+
+    it 'is false when whodunnit is present' do
+      create(:pom_detail, prison: prison)
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.system_event).to be(false)
+    end
+
+    it 'is true when whodunnit is blank' do
+      PaperTrail.request.whodunnit = nil
+      create(:pom_detail, prison: prison)
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.system_event).to be(true)
+    end
+  end
+
+  describe 'excluded keys' do
+    let!(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
+
+    it 'strips excluded keys from before and after' do
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.data['before']).not_to have_key('id')
+        expect(audit.data['before']).not_to have_key('nomis_offender_id')
+        expect(audit.data['after']).not_to have_key('id')
+        expect(audit.data['after']).not_to have_key('nomis_offender_id')
+      end
+    end
+  end
+
+  describe 'no-op when nothing changed' do
+    let!(:prison) { create(:prison) }
+    let!(:pom_detail) { create(:pom_detail, prison: prison) }
+
+    it 'does not publish when save produces no changes' do
+      expect { pom_detail.save! }.not_to change(AuditEvent, :count)
+    end
+  end
+end

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -179,4 +179,40 @@ RSpec.describe EarlyAllocation, type: :model do
       end
     end
   end
+
+  describe '#save_audit_event' do
+    before do
+      PaperTrail.request.whodunnit = 'SPO_USER'
+    end
+
+    after do
+      PaperTrail.request.whodunnit = nil
+    end
+
+    it 'publishes an audit event on create with correct tags and outcome' do
+      expect { create(:early_allocation) }.to change(AuditEvent, :count).by(1)
+
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.tags).to eq(%w[record early_allocation changed])
+        expect(audit.data['after']).to include('outcome' => 'eligible')
+      end
+    end
+
+    it 'records community decision changes on update' do
+      early_allocation = create(:early_allocation, :discretionary)
+      last_audit = AuditEvent.order(:created_at).last
+
+      early_allocation.update!(community_decision: true,
+                               updated_by_firstname: 'Jane',
+                               updated_by_lastname: 'Smith')
+
+      audit = AuditEvent.where.not(id: last_audit.id).order(:created_at).last
+      aggregate_failures do
+        expect(audit.nomis_offender_id).to eq(early_allocation.nomis_offender_id)
+        expect(audit.data['before']).to include('community_decision' => nil)
+        expect(audit.data['after']).to include('community_decision' => true)
+      end
+    end
+  end
 end

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -64,4 +64,39 @@ RSpec.describe PomDetail, type: :model do
       expect(pom_detail.has_primary_allocations?).to be false
     end
   end
+
+  describe '#save_audit_event' do
+    before do
+      PaperTrail.request.whodunnit = 'SPO_USER'
+    end
+
+    after do
+      PaperTrail.request.whodunnit = nil
+    end
+
+    it 'publishes an audit event with correct tags and additional data' do
+      pom_detail = create(:pom_detail, prison: prison)
+
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.nomis_offender_id).to be_nil
+        expect(audit.tags).to eq(%w[record pom_detail changed])
+        expect(audit.data['nomis_staff_id']).to eq(pom_detail.nomis_staff_id)
+        expect(audit.data['prison_code']).to eq(prison.code)
+      end
+    end
+
+    it 'records before and after changes on update' do
+      pom_detail = create(:pom_detail, prison: prison, status: 'active', working_pattern: 1.0)
+      last_audit = AuditEvent.order(:created_at).last
+
+      pom_detail.update!(status: 'inactive', working_pattern: 0.8)
+
+      audit = AuditEvent.where.not(id: last_audit.id).order(:created_at).last
+      aggregate_failures do
+        expect(audit.data['before']).to include('status' => 'active', 'working_pattern' => 1.0)
+        expect(audit.data['after']).to include('status' => 'inactive', 'working_pattern' => 0.8)
+      end
+    end
+  end
 end

--- a/spec/services/delius_data_import_service_spec.rb
+++ b/spec/services/delius_data_import_service_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe DeliusDataImportService do
   end
 
   shared_examples 'audit event' do
-    let(:audit_event) { AuditEvent.last }
+    let(:audit_event) { AuditEvent.tags('process_delius_data_job').order(:created_at).last }
 
     it 'creates an audit event with the expected data and tags' do
       expect {
         service.process(nomis_offender_id)
-      }.to change(AuditEvent, :count).by(1)
+      }.to change { AuditEvent.tags('process_delius_data_job').count }.by(1)
 
       expect(audit_event.data['before']).to eq(expected_data['before'])
       expect(audit_event.data['after']).to eq(expected_data['after'])


### PR DESCRIPTION
This is an ongoing tasks and will probably add some more in the future, as it is helpful for the debugging page / timeline and understanding certain actions in the service.

Also, added a missing OMIC gate check in the `review_case_details` page, and DRY code.