### PR TITLE
MO-1996 Reset handover tasks if case leaves window

### DIFF
--- a/app/controllers/handover_progress_checklists_controller.rb
+++ b/app/controllers/handover_progress_checklists_controller.rb
@@ -30,9 +30,7 @@ private
 
   def ensure_handover_in_progress
     return redirect_to('/401') if offender_released?
-
-    return if CalculatedHandoverDate.by_handover_in_progress(offender_ids: [nomis_offender_id]).exists?
-    return if CalculatedHandoverDate.by_upcoming_handover(offender_ids: [nomis_offender_id]).exists?
+    return if CalculatedHandoverDate.in_handover_window?(nomis_offender_id)
 
     redirect_to '/401'
   end

--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -4,21 +4,34 @@ class RecalculateHandoverDateJob < ApplicationJob
   queue_as :default
 
   def perform(nomis_offender_id)
-    offender = OffenderService.get_offender(nomis_offender_id)
-    if offender&.inside_omic_policy?
-      recalculate_dates_for(offender)
-    end
+    @nomis_offender = OffenderService.get_offender(nomis_offender_id)
+    return unless nomis_offender&.inside_omic_policy?
+
+    recalculate_dates_for_offender
   end
 
 private
 
-  def recalculate_dates_for(nomis_offender)
+  attr_reader :nomis_offender, :db_offender, :record, :com_email_eligible
+
+  def recalculate_dates_for_offender
+    save_handover_calculation
+
+    # Side effects that depend on the committed state but should not
+    # prevent the core recalculation from persisting. Each runs independently
+    # so a failure in one does not block the others.
+    safely { publish_event }
+    safely { maybe_reset_handover_checklist }
+    safely { request_supporting_com }
+    safely { assign_com_email }
+  end
+
+  # The only DB-mutating part: saves the recalculated handover date and audit event atomically.
+  def save_handover_calculation
     ApplicationRecord.transaction do
-      # we have to go direct to handover data to avoid being blocked when COM is responsible
       handover = HandoverDateService.handover(nomis_offender)
-      db_offender = Offender.find_by! nomis_offender_id: nomis_offender.offender_no
-      case_info = db_offender.case_information
-      record = db_offender.calculated_handover_date.presence || db_offender.build_calculated_handover_date
+      @db_offender = Offender.find_by! nomis_offender_id: nomis_offender.offender_no
+      @record = db_offender.calculated_handover_date.presence || db_offender.build_calculated_handover_date
       handover_before = record.attributes.except('id', 'created_at', 'updated_at')
       record.assign_attributes(
         responsibility: handover.responsibility,
@@ -26,13 +39,6 @@ private
         handover_date: handover.handover_date,
         reason: handover.reason,
       )
-      if handover.community_responsible? &&
-        handover.reason.to_sym == :determinate_short &&
-        nomis_offender.ldu_email_address.present? &&
-        nomis_offender.allocated_com_name.blank?
-
-        assign_com_email(db_offender:, nomis_offender:, case_info:)
-      end
 
       if record.changed?
         record.offender_attributes_to_archive = nomis_offender.attributes_to_archive
@@ -52,43 +58,70 @@ private
         )
       end
 
-      publish_event(record)
-
-      request_supporting_com record, nomis_offender
+      @com_email_eligible = handover.community_responsible? &&
+                            handover.reason.to_sym == :determinate_short &&
+                            nomis_offender.ldu_email_address.present? &&
+                            nomis_offender.allocated_com_name.blank?
     end
   end
 
-  def publish_event(record)
-    # Don't push if the dates haven't changed
-    if record.saved_change_to_start_date? || record.saved_change_to_handover_date?
-      event = DomainEvents::EventFactory.build_handover_event(host: Rails.configuration.allocation_manager_host,
-                                                              noms_number: record.nomis_offender_id)
-      event.publish(job: 'recalculate_handover_date')
+  def publish_event
+    return unless record.saved_change_to_start_date? || record.saved_change_to_handover_date?
+
+    event = DomainEvents::EventFactory.build_handover_event(
+      host: Rails.configuration.allocation_manager_host,
+      noms_number: record.nomis_offender_id
+    )
+    event.publish(job: 'recalculate_handover_date')
+  end
+
+  # Reset all checklist tasks if the case has moved out of the handover window.
+  # This ensures that if the case re-enters the window later, the POM starts fresh.
+  def maybe_reset_handover_checklist
+    return unless record.saved_change_to_responsibility? || record.saved_change_to_handover_date?
+
+    checklist = HandoverProgressChecklist.find_by(nomis_offender_id: record.nomis_offender_id)
+    return unless checklist
+
+    return if CalculatedHandoverDate.in_handover_window?(record.nomis_offender_id)
+
+    # Blank whodunnit so both PaperTrail and Auditable record this as system-initiated,
+    # even when the job runs synchronously within a user request (e.g. parole review).
+    PaperTrail.request(whodunnit: nil) do
+      checklist.update!(
+        reviewed_oasys: false,
+        contacted_com: false,
+        attended_handover_meeting: false,
+        sent_handover_report: false
+      )
     end
   end
 
-  def request_supporting_com(record, nomis_offender)
+  def request_supporting_com
     reason_change = %w[indeterminate indeterminate_open]
     responsibility_change = [CalculatedHandoverDate::CUSTODY_ONLY, CalculatedHandoverDate::CUSTODY_WITH_COM]
 
-    if record.saved_change_to_reason == reason_change &&
+    return unless record.saved_change_to_reason == reason_change &&
       record.saved_change_to_responsibility == responsibility_change &&
       nomis_offender.ldu_email_address.present? &&
       nomis_offender.allocated_com_name.blank?
 
-      CommunityMailer.with(
-        prisoner_name: nomis_offender.full_name,
-        prisoner_number: nomis_offender.offender_no,
-        prisoner_crn: nomis_offender.crn,
-        prison_name: PrisonService.name_for(nomis_offender.prison_id),
-        ldu_email: nomis_offender.ldu_email_address,
-        email_history_name: nomis_offender.ldu_name
-      ).open_prison_supporting_com_needed.deliver_later
-    end
+    CommunityMailer.with(
+      prisoner_name: nomis_offender.full_name,
+      prisoner_number: nomis_offender.offender_no,
+      prisoner_crn: nomis_offender.crn,
+      prison_name: PrisonService.name_for(nomis_offender.prison_id),
+      ldu_email: nomis_offender.ldu_email_address,
+      email_history_name: nomis_offender.ldu_name
+    ).open_prison_supporting_com_needed.deliver_later
   end
 
-  # TODO: This should probably be a shceduled job - we are effectivly using this like a cron every 2 days
-  def assign_com_email(db_offender:, nomis_offender:, case_info:)
+  # TODO: This should probably be a scheduled job — we are effectively using this like a cron every 2 days
+  def assign_com_email
+    return unless com_email_eligible
+
+    case_info = db_offender.case_information
+
     # There is frequently bad data on staging/dev, thus this check
     return if case_info.nil? || case_info.crn.blank?
 
@@ -105,5 +138,15 @@ private
         crn_number: case_info.crn,
       ).assign_com_less_than_10_months.deliver_later
     end
+  end
+
+  def safely
+    yield
+  rescue StandardError => e
+    Rails.logger.error(
+      'event=recalculate_handover_side_effect_failed,' \
+      "nomis_offender_id=#{nomis_offender.offender_no}," \
+      "error=#{e.class}|#{e.message}"
+    )
   end
 end

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -139,6 +139,11 @@ class CalculatedHandoverDate < ApplicationRecord
         .where.not(handover_date: nil)
     end
 
+    def in_handover_window?(nomis_offender_id)
+      by_handover_in_progress(offender_ids: [nomis_offender_id]).exists? ||
+        by_upcoming_handover(offender_ids: [nomis_offender_id]).exists?
+    end
+
     def by_com_allocation_overdue(offender_ids:, relative_to_date: Time.zone.now.to_date)
       relation
         .by_handover_in_progress(offender_ids: offender_ids)

--- a/lib/tasks/recalculate_handover_dates.rake
+++ b/lib/tasks/recalculate_handover_dates.rake
@@ -6,11 +6,16 @@ task recalculate_handover_dates: :environment do
 
   Rails.logger.info('Queueing RecalculateHandoverDateJob for all offenders')
 
-  Prison.all.find_each do |prison|
-    prison.offenders.each do |offender|
-      RecalculateHandoverDateJob.perform_later(offender.offender_no)
-    end
-    Rails.logger.info("RecalculateHandoverDateJob #{prison.name} Queued #{prison.offenders.count} Jobs")
+  Prison.active.find_each do |prison|
+    offender_ids = prison.offenders.map(&:offender_no)
+
+    ActiveJob.perform_all_later(
+      offender_ids.map { RecalculateHandoverDateJob.new(it) }
+    )
+
+    Rails.logger.info(
+      "event=recalculate_handover_dates,prison=#{prison.code},queued=#{offender_ids.size}"
+    )
   end
 
   Rails.logger.info('RecalculateHandoverDateJob all done')

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -221,20 +221,207 @@ describe RecalculateHandoverDateJob do
   end
 
   context 'when offender details are valid but case info is unusable for COM assignment' do
-    it 'does not send an assign COM email if case info is nil' do
-      described_class.new.send(
-        :assign_com_email, db_offender: double, nomis_offender: double, case_info: nil
-      )
+    before do
+      the_responsibility_is_recorded_as(CalculatedHandoverDate.com(reason: :determinate_short))
+      the_responsibility_will_be_calculated_as(CalculatedHandoverDate.com(reason: :determinate_short))
+    end
 
+    it 'does not send an assign COM email if case info is nil' do
+      the_case_information_is(local_delivery_unit: build(:local_delivery_unit, email_address: 'ldu@email.com'))
+      CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id).destroy!
+      recalculate_handover_dates
       expect(assign_com_email).not_to have_received(:deliver_later)
     end
 
     it 'does not send an assign COM email if case info CRN is blank' do
-      described_class.new.send(
-        :assign_com_email, db_offender: double, nomis_offender: double, case_info: double(crn: nil)
-      )
-
+      the_case_information_is(crn: '', local_delivery_unit: build(:local_delivery_unit, email_address: 'ldu@email.com'))
+      recalculate_handover_dates
       expect(assign_com_email).not_to have_received(:deliver_later)
+    end
+  end
+
+  describe 'handover checklist reset' do
+    context 'when responsibility changes and the case leaves the handover window' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        # Recalculation moves responsibility back to custody (far future handover)
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 1.year.from_now.to_date,
+            start_date: 10.months.from_now.to_date
+          )
+        )
+      end
+
+      it 'resets all checklist tasks to false' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true,
+          attended_handover_meeting: true,
+          sent_handover_report: false
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: false,
+          contacted_com: false,
+          attended_handover_meeting: false,
+          sent_handover_report: false
+        )
+      end
+
+      it 'creates a PaperTrail version for the reset' do
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        expect { recalculate_handover_dates }
+          .to change { PaperTrail::Version.where(item_type: 'HandoverProgressChecklist').count }.by(1)
+
+        version = PaperTrail::Version.where(item_type: 'HandoverProgressChecklist').last
+        expect(version.whodunnit).to be_nil
+      end
+
+      it 'publishes a system audit event for the reset' do
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        expect(handover_change_event).to receive(:publish).with(
+          hash_including(
+            nomis_offender_id: offender.nomis_offender_id,
+            system_event: true,
+            tags: %w[record handover_progress_checklist changed]
+          )
+        )
+
+        recalculate_handover_dates
+      end
+
+      it 'records as system-initiated even when triggered within a user session' do
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        # Simulate perform_now called from a controller action (e.g. parole review)
+        PaperTrail.request.whodunnit = 'SOME_USER'
+
+        expect(handover_change_event).to receive(:publish).with(
+          hash_including(system_event: true, username: nil)
+        )
+
+        recalculate_handover_dates
+
+        version = PaperTrail::Version.where(item_type: 'HandoverProgressChecklist').last
+        expect(version.whodunnit).to be_nil
+      end
+
+      it 'does not delete the checklist record' do
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        expect { recalculate_handover_dates }
+          .not_to change(HandoverProgressChecklist, :count)
+      end
+    end
+
+    context 'when responsibility changes but the case remains in the handover window' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 1.week.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        # Recalculation moves to community responsible (in progress)
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 1.week.ago.to_date
+          )
+        )
+      end
+
+      it 'does not reset checklist tasks' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+      end
+    end
+
+    context 'when there is no change to responsibility or handover date' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date
+          )
+        )
+      end
+
+      it 'does not reset checklist tasks' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1996

If a case leaves the handover window and had some of their checklist tasks already completed, we have to clear these checks so whenever/if the case re-enters the handover window again, it has all their corresponding tasks awaiting completion.

Also some refactoring and improvement of the recalculation job and rake task along the way.