### PR TITLE
MO-1945 Trigger handover recalculations via events

### DIFF
--- a/app/jobs/debounced_recalculate_handover_date_job.rb
+++ b/app/jobs/debounced_recalculate_handover_date_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class DebouncedRecalculateHandoverDateJob < ApplicationJob
+  queue_as :debounce
+
+  # Best-effort only: if this fails the daily sweep will catch up within 24h
+  sidekiq_options retry: 0
+
+  def perform(nomis_offender_id, debounce_key:, debounce_token:)
+    return unless debounce_token_match?(nomis_offender_id, debounce_key, debounce_token)
+
+    job = RecalculateHandoverDateJob.perform_later(nomis_offender_id)
+
+    logger.info(
+      "job=debounced_recalculate_handover_date_job,event=enqueued,nomis_offender_id=#{nomis_offender_id},job_id=#{job.job_id}"
+    )
+  end
+
+private
+
+  def debounce_token_match?(nomis_offender_id, debounce_key, debounce_token)
+    cached_token = Rails.cache.read(debounce_key)
+    cached_token.nil? || cached_token == debounce_token
+  rescue StandardError => e
+    # If cache is unavailable for whatever reason, skip rather than risk running
+    # without debounce protection, as the daily sweep will catch up within 24h
+    logger.warn("job=debounced_recalculate_handover_date_job,event=cache_error,nomis_offender_id=#{nomis_offender_id}|#{e.message}")
+    false
+  end
+end

--- a/app/lib/domain_events/handlers/prisoner_updated_handler.rb
+++ b/app/lib/domain_events/handlers/prisoner_updated_handler.rb
@@ -1,16 +1,42 @@
 class DomainEvents::Handlers::PrisonerUpdatedHandler
+  DEBOUNCE_KEY_PREFIX = 'domain_events:prisoner_updated_handover'.freeze
+  DEBOUNCE_WINDOW = 1.hour
+
   def handle(event)
     nomis_offender_id = event.additional_information.fetch('nomsNumber')
 
     Shoryuken::Logging.logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type},nomis_offender_id=#{nomis_offender_id}"
 
     changes = event.additional_information.fetch('categoriesChanged')
-    if changes.include?('STATUS')
+
+    if changes.include?('STATUS') && AllocationHistory.active.exists?(nomis_offender_id:)
       # The status of the prisoner has changed, so one of: status, inOutStatus, csra,
       # category, legalStatus, imprisonmentStatus, imprisonmentStatusDescription, recall
       ProcessPrisonerStatusJob.perform_later(nomis_offender_id)
     end
 
+    if changes.include?('SENTENCE')
+      debounce_handover_recalculation(nomis_offender_id)
+    end
+
     Shoryuken::Logging.logger.info "event=domain_event_handle_success,domain_event_type=#{event.event_type},nomis_offender_id=#{nomis_offender_id}"
+  end
+
+private
+
+  def debounce_handover_recalculation(nomis_offender_id)
+    # Quick check to avoid creating cache entries and debounced jobs for offenders
+    # we don't manage as the event fires for every prisoner change across NOMIS
+    return unless CalculatedHandoverDate.exists?(nomis_offender_id:)
+
+    debounce_key = "#{DEBOUNCE_KEY_PREFIX}:#{nomis_offender_id}"
+    debounce_token = SecureRandom.uuid
+    Rails.cache.write(debounce_key, debounce_token, expires_in: 2.hours)
+
+    DebouncedRecalculateHandoverDateJob.set(wait: DEBOUNCE_WINDOW).perform_later(
+      nomis_offender_id,
+      debounce_key:,
+      debounce_token:,
+    )
   end
 end

--- a/spec/jobs/debounced_recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/debounced_recalculate_handover_date_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe DebouncedRecalculateHandoverDateJob, type: :job do
+  let(:nomis_offender_id) { 'A1234BC' }
+  let(:debounce_key) { "domain_events:prisoner_updated_handover:#{nomis_offender_id}" }
+  let(:job_logger) { instance_double(ActiveSupport::Logger, info: nil, warn: nil) }
+
+  let(:enqueued_job) { instance_double(RecalculateHandoverDateJob, job_id: 'job-123') }
+
+  before do
+    allow(RecalculateHandoverDateJob).to receive(:perform_later).and_return(enqueued_job)
+  end
+
+  context 'when the offender has an existing calculated handover date' do
+    it 'enqueues RecalculateHandoverDateJob when the debounce token matches' do
+      debounce_token = SecureRandom.uuid
+      Rails.cache.write(debounce_key, debounce_token)
+
+      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+
+      expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
+    end
+
+    it 'enqueues RecalculateHandoverDateJob when the debounce key is missing or expired' do
+      debounce_token = SecureRandom.uuid
+
+      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+
+      expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
+    end
+
+    it 'skips when the debounce token does not match the cache' do
+      Rails.cache.write(debounce_key, SecureRandom.uuid)
+      debounce_token = SecureRandom.uuid
+
+      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+
+      expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
+    end
+
+    it 'skips and logs a warning when reading from the cache raises an error' do
+      debounce_token = SecureRandom.uuid
+      allow(Rails.cache).to receive(:read).with(debounce_key).and_raise(StandardError, 'boom')
+      allow_any_instance_of(described_class).to receive(:logger).and_return(job_logger)
+
+      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+
+      expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
+      expect(job_logger).to have_received(:warn).with(
+        'job=debounced_recalculate_handover_date_job,event=cache_error,nomis_offender_id=A1234BC|boom'
+      )
+    end
+  end
+end

--- a/spec/lib/domain_events/handlers/prisoner_updated_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/prisoner_updated_handler_spec.rb
@@ -1,42 +1,95 @@
 RSpec.describe DomainEvents::Handlers::PrisonerUpdatedHandler do
   subject!(:handler) { described_class.new }
 
+  let(:nomis_offender_id) { 'T1111XX' }
+  let(:debounced_job_proxy) { instance_double(ActiveJob::ConfiguredJob, perform_later: nil) }
+
   before do
     allow(ProcessPrisonerStatusJob).to receive(:perform_later)
+    allow(DebouncedRecalculateHandoverDateJob).to receive(:set).and_return(debounced_job_proxy)
     allow(CaseInformation).to receive(:find_by_nomis_offender_id).and_return(double(:case_information))
   end
 
-  it 'does not process legal status changes unless categoriesChanged includes STATUS' do
-    event = DomainEvents::Event.new(
+  def build_event(categories_changed:)
+    DomainEvents::Event.new(
       event_type: 'prisoner-offender-search.prisoner.updated',
       version: 1,
       description: 'A prisoner record has been updated',
       detail_url: 'https://example.org/irrelevant',
       additional_information: {
-        'nomsNumber' => 'T1111XX',
-        'categoriesChanged' => %w[SENTENCE],
+        'nomsNumber' => nomis_offender_id,
+        'categoriesChanged' => categories_changed,
       },
       external_event: true,
     )
-    handler.handle(event)
-
-    expect(ProcessPrisonerStatusJob).not_to have_received(:perform_later)
   end
 
-  it 'process legal status changes when categoriesChanged includes STATUS' do
-    event = DomainEvents::Event.new(
-      event_type: 'prisoner-offender-search.prisoner.updated',
-      version: 1,
-      description: 'A prisoner record has been updated',
-      detail_url: 'https://example.org/irrelevant',
-      additional_information: {
-        'nomsNumber' => 'T1111XX',
-        'categoriesChanged' => %w[PERSONAL_DETAILS STATUS],
-      },
-      external_event: true,
-    )
-    handler.handle(event)
+  describe 'legal status processing' do
+    it 'does not process legal status changes unless categoriesChanged includes STATUS' do
+      handler.handle(build_event(categories_changed: %w[SENTENCE]))
 
-    expect(ProcessPrisonerStatusJob).to have_received(:perform_later)
+      expect(ProcessPrisonerStatusJob).not_to have_received(:perform_later)
+    end
+
+    context 'when the offender has an active allocation' do
+      before { create(:allocation_history, :with_prison, nomis_offender_id:) }
+
+      it 'processes legal status changes when categoriesChanged includes STATUS' do
+        handler.handle(build_event(categories_changed: %w[PERSONAL_DETAILS STATUS]))
+
+        expect(ProcessPrisonerStatusJob).to have_received(:perform_later)
+      end
+    end
+
+    it 'does not process legal status changes for offenders without an active allocation' do
+      handler.handle(build_event(categories_changed: %w[STATUS]))
+
+      expect(ProcessPrisonerStatusJob).not_to have_received(:perform_later)
+    end
+  end
+
+  describe 'debounced handover recalculation' do
+    context 'when the offender has an existing calculated handover date' do
+      before do
+        offender = create(:offender, nomis_offender_id:)
+        create(:calculated_handover_date, offender:)
+      end
+
+      it 'triggers debounced recalculation when categoriesChanged includes SENTENCE' do
+        handler.handle(build_event(categories_changed: %w[SENTENCE]))
+
+        expect(DebouncedRecalculateHandoverDateJob).to have_received(:set).with(wait: 1.hour)
+      end
+
+      it 'does not trigger debounced recalculation for non-SENTENCE categories' do
+        handler.handle(build_event(categories_changed: %w[STATUS LOCATION PERSONAL_DETAILS]))
+
+        expect(DebouncedRecalculateHandoverDateJob).not_to have_received(:set)
+      end
+
+      context 'when the offender also has an active allocation' do
+        before { create(:allocation_history, :with_prison, nomis_offender_id:) }
+
+        it 'triggers both status processing and debounced recalculation for STATUS and SENTENCE' do
+          handler.handle(build_event(categories_changed: %w[STATUS SENTENCE]))
+
+          expect(ProcessPrisonerStatusJob).to have_received(:perform_later)
+          expect(DebouncedRecalculateHandoverDateJob).to have_received(:set).with(wait: 1.hour)
+        end
+      end
+
+      it 'writes a debounce token to the cache' do
+        handler.handle(build_event(categories_changed: %w[SENTENCE]))
+
+        cached_token = Rails.cache.read("domain_events:prisoner_updated_handover:#{nomis_offender_id}")
+        expect(cached_token).to be_present
+      end
+    end
+
+    it 'does not trigger debounced recalculation for offenders without an existing handover date' do
+      handler.handle(build_event(categories_changed: %w[SENTENCE]))
+
+      expect(DebouncedRecalculateHandoverDateJob).not_to have_received(:set)
+    end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1945

Work related to MO-1996 and MO-1993.

We need more frequency with regards to handover recalculations where, in worst case scenario it could take up to 24h for the sweep job to run and catch these.

We can use sentence events to decide if we should enqueue a recalculation. These are debounced similarly to how we did for Delius imports but with a way longer debounce window (1h) to give plenty of time to avoid flip-flopping sentences etc.