### PR TITLE
Handle missing POM in co-worker removal flow

### DIFF
--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -45,7 +45,7 @@ class CoworkingController < PrisonsApplicationController
     @prisoner = offender(@allocation.nomis_offender_id)
 
     if @allocation.primary_pom_nomis_id
-      @primary_pom = @prison.find_pom(@allocation.primary_pom_nomis_id)
+      @primary_pom = @prison.get_single_pom(@allocation.primary_pom_nomis_id, safe: true)
     end
   end
 

--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -45,7 +45,7 @@ class CoworkingController < PrisonsApplicationController
     @prisoner = offender(@allocation.nomis_offender_id)
 
     if @allocation.primary_pom_nomis_id
-      @primary_pom = @prison.get_single_pom(@allocation.primary_pom_nomis_id)
+      @primary_pom = @prison.find_pom(@allocation.primary_pom_nomis_id)
     end
   end
 

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -21,23 +21,19 @@ class Prison < ApplicationRecord
     include_deleted ? result : result.reject(&:deleted?)
   end
 
-  def get_single_pom(nomis_staff_id)
+  def get_single_pom(nomis_staff_id, safe: false)
     raise ArgumentError, 'Prison#get_single_pom(nil)' if nomis_staff_id.nil?
 
-    pom = find_pom(nomis_staff_id)
+    pom = get_list_of_poms(staff_id: nomis_staff_id, include_deleted: true).first
     if pom.nil?
-      raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{code}"
+      if safe
+        Rails.logger.warn("event=pom_not_found,staff_id=#{nomis_staff_id},prison=#{code}")
+      else
+        raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{code}"
+      end
     end
 
     pom
-  end
-
-  # Like get_single_pom but returns nil instead of raising when the POM
-  # cannot be found (e.g. they have left the prison or lost their role).
-  def find_pom(nomis_staff_id)
-    return nil if nomis_staff_id.nil?
-
-    get_list_of_poms(staff_id: nomis_staff_id, include_deleted: true).first
   end
 
   def get_removed_poms(existing_poms:)

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -24,12 +24,20 @@ class Prison < ApplicationRecord
   def get_single_pom(nomis_staff_id)
     raise ArgumentError, 'Prison#get_single_pom(nil)' if nomis_staff_id.nil?
 
-    pom = get_list_of_poms(staff_id: nomis_staff_id, include_deleted: true).first
+    pom = find_pom(nomis_staff_id)
     if pom.nil?
       raise StandardError, "Failed to find POM ##{nomis_staff_id} at #{code}"
     end
 
     pom
+  end
+
+  # Like get_single_pom but returns nil instead of raising when the POM
+  # cannot be found (e.g. they have left the prison or lost their role).
+  def find_pom(nomis_staff_id)
+    return nil if nomis_staff_id.nil?
+
+    get_list_of_poms(staff_id: nomis_staff_id, include_deleted: true).first
   end
 
   def get_removed_poms(existing_poms:)

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -73,7 +73,7 @@ class EmailService
     end
 
     def pom_for(allocation, pom_nomis_id)
-      Prison.find(allocation.prison).find_pom(pom_nomis_id)
+      Prison.find(allocation.prison).get_single_pom(pom_nomis_id, safe: true)
     end
 
     def current_responsibility(offender)

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -4,7 +4,7 @@ class EmailService
   class << self
     def send_email(message:, allocation:, pom_nomis_id:, further_info: {}, notify_previous_pom: true)
       pom = pom_for(allocation, pom_nomis_id)
-      return if pom.email_address.blank?
+      return if pom.nil? || pom.email_address.blank?
 
       send_deallocation_email(pom:, allocation:, further_info:) if notify_previous_pom
       deliver_new_allocation_email(pom:, message:, allocation:, further_info:)
@@ -13,6 +13,8 @@ class EmailService
     def send_coworking_primary_email(message:, allocation:)
       pom_nomis_id = allocation.primary_pom_nomis_id
       pom = pom_for(allocation, pom_nomis_id)
+      return if pom.nil?
+
       offender = offender_for allocation
       coworking_pom_name = allocation.secondary_pom_name
       if pom.email_address.present?
@@ -30,6 +32,8 @@ class EmailService
 
     def send_secondary_email(pom_firstname:, pom_nomis_id:, message:, allocation:)
       pom = pom_for(allocation, pom_nomis_id)
+      return if pom.nil?
+
       offender = offender_for allocation
 
       if pom.email_address.present?
@@ -48,7 +52,7 @@ class EmailService
 
     def send_cowork_deallocation_email(allocation:, pom_nomis_id:, secondary_pom_name:)
       pom = pom_for(allocation, pom_nomis_id)
-      return if pom.email_address.blank?
+      return if pom.nil? || pom.email_address.blank?
 
       offender = offender_for allocation
 
@@ -69,7 +73,7 @@ class EmailService
     end
 
     def pom_for(allocation, pom_nomis_id)
-      Prison.find(allocation.prison).get_single_pom(pom_nomis_id)
+      Prison.find(allocation.prison).find_pom(pom_nomis_id)
     end
 
     def current_responsibility(offender)

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -125,6 +125,16 @@ RSpec.describe EmailService do
                                                        secondary_pom_name: coworking_allocation.secondary_pom_name)
       }.not_to change(enqueued_jobs, :size)
     end
+
+    it "does not crash when the primary POM cannot be found at the prison" do
+      stub_inexistent_filtered_pom(prison_code, coworking_deallocation.primary_pom_nomis_id)
+
+      expect {
+        described_class.send_cowork_deallocation_email(allocation: coworking_deallocation,
+                                                       pom_nomis_id: coworking_deallocation.primary_pom_nomis_id,
+                                                       secondary_pom_name: coworking_allocation.secondary_pom_name)
+      }.not_to change(enqueued_jobs, :size)
+    end
   end
 
   context 'when offender has been released' do

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -60,6 +60,35 @@ describe PrisonOffenderManagerService do
     end
   end
 
+  describe '#find_pom' do
+    context 'when the POM exists' do
+      before(:each) do
+        stub_filtered_pom(prison.code, poms.first)
+      end
+
+      it 'returns the POM' do
+        pom = prison.find_pom(staff_id)
+        expect(pom.staff_id).to eq(staff_id)
+      end
+    end
+
+    context 'when the POM does not exist' do
+      before(:each) do
+        stub_inexistent_filtered_pom(prison.code, 1234)
+      end
+
+      it 'returns nil' do
+        expect(prison.find_pom(1234)).to be_nil
+      end
+    end
+
+    context 'when given nil' do
+      it 'returns nil' do
+        expect(prison.find_pom(nil)).to be_nil
+      end
+    end
+  end
+
   describe 'fetch_pom_name' do
     it 'fetches the ordered POM name from NOMIS' do
       expect(described_class.fetch_pom_name(staff_id)).to eq('Po Moic')

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -57,34 +57,14 @@ describe PrisonOffenderManagerService do
           prison.get_single_pom(1234)
         }.to raise_exception(StandardError, /^Failed to find POM/)
       end
-    end
-  end
 
-  describe '#find_pom' do
-    context 'when the POM exists' do
-      before(:each) do
-        stub_filtered_pom(prison.code, poms.first)
-      end
+      context 'with safe: true' do
+        it "returns nil and logs a warning" do
+          allow(Rails.logger).to receive(:warn)
 
-      it 'returns the POM' do
-        pom = prison.find_pom(staff_id)
-        expect(pom.staff_id).to eq(staff_id)
-      end
-    end
-
-    context 'when the POM does not exist' do
-      before(:each) do
-        stub_inexistent_filtered_pom(prison.code, 1234)
-      end
-
-      it 'returns nil' do
-        expect(prison.find_pom(1234)).to be_nil
-      end
-    end
-
-    context 'when given nil' do
-      it 'returns nil' do
-        expect(prison.find_pom(nil)).to be_nil
+          expect(prison.get_single_pom(1234, safe: true)).to be_nil
+          expect(Rails.logger).to have_received(:warn).with(/event=pom_not_found,staff_id=1234,prison=LEI/)
+        end
       end
     end
   end


### PR DESCRIPTION
When a POM leaves a prison but their allocation record remains, `get_single_pom` raises an error. Added a nil-safe alternative and use it in the confirm_removal action and emails to prevent 500 errors when viewing or completing these edge cases co-worker removals.