### PR TITLE
Add additional logging to the debounce recalc job

### DIFF
--- a/app/jobs/debounced_recalculate_handover_date_job.rb
+++ b/app/jobs/debounced_recalculate_handover_date_job.rb
@@ -20,7 +20,10 @@ private
 
   def debounce_token_match?(nomis_offender_id, debounce_key, debounce_token)
     cached_token = Rails.cache.read(debounce_key)
-    cached_token.nil? || cached_token == debounce_token
+    return true if cached_token.nil? || cached_token == debounce_token
+
+    logger.info("job=debounced_recalculate_handover_date_job,event=skipped,nomis_offender_id=#{nomis_offender_id}")
+    false
   rescue StandardError => e
     # If cache is unavailable for whatever reason, skip rather than risk running
     # without debounce protection, as the daily sweep will catch up within 24h

--- a/spec/jobs/debounced_recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/debounced_recalculate_handover_date_job_spec.rb
@@ -9,46 +9,53 @@ RSpec.describe DebouncedRecalculateHandoverDateJob, type: :job do
 
   before do
     allow(RecalculateHandoverDateJob).to receive(:perform_later).and_return(enqueued_job)
+    allow_any_instance_of(described_class).to receive(:logger).and_return(job_logger)
   end
 
-  context 'when the offender has an existing calculated handover date' do
-    it 'enqueues RecalculateHandoverDateJob when the debounce token matches' do
-      debounce_token = SecureRandom.uuid
-      Rails.cache.write(debounce_key, debounce_token)
+  it 'enqueues RecalculateHandoverDateJob when the debounce token matches' do
+    debounce_token = SecureRandom.uuid
+    Rails.cache.write(debounce_key, debounce_token)
 
-      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+    described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
 
-      expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
-    end
+    expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
+    expect(job_logger).to have_received(:info).with(
+      "job=debounced_recalculate_handover_date_job,event=enqueued,nomis_offender_id=#{nomis_offender_id},job_id=job-123"
+    )
+  end
 
-    it 'enqueues RecalculateHandoverDateJob when the debounce key is missing or expired' do
-      debounce_token = SecureRandom.uuid
+  it 'enqueues RecalculateHandoverDateJob when the debounce key is missing or expired' do
+    debounce_token = SecureRandom.uuid
 
-      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+    described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
 
-      expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
-    end
+    expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
+    expect(job_logger).to have_received(:info).with(
+      "job=debounced_recalculate_handover_date_job,event=enqueued,nomis_offender_id=#{nomis_offender_id},job_id=job-123"
+    )
+  end
 
-    it 'skips when the debounce token does not match the cache' do
-      Rails.cache.write(debounce_key, SecureRandom.uuid)
-      debounce_token = SecureRandom.uuid
+  it 'skips when the debounce token does not match the cache' do
+    Rails.cache.write(debounce_key, SecureRandom.uuid)
+    debounce_token = SecureRandom.uuid
 
-      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+    described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
 
-      expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
-    end
+    expect(job_logger).to have_received(:info).with(
+      "job=debounced_recalculate_handover_date_job,event=skipped,nomis_offender_id=#{nomis_offender_id}"
+    )
+    expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
+  end
 
-    it 'skips and logs a warning when reading from the cache raises an error' do
-      debounce_token = SecureRandom.uuid
-      allow(Rails.cache).to receive(:read).with(debounce_key).and_raise(StandardError, 'boom')
-      allow_any_instance_of(described_class).to receive(:logger).and_return(job_logger)
+  it 'skips and logs a warning when reading from the cache raises an error' do
+    debounce_token = SecureRandom.uuid
+    allow(Rails.cache).to receive(:read).with(debounce_key).and_raise(StandardError, 'boom')
 
-      described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
+    described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
 
-      expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
-      expect(job_logger).to have_received(:warn).with(
-        'job=debounced_recalculate_handover_date_job,event=cache_error,nomis_offender_id=A1234BC|boom'
-      )
-    end
+    expect(job_logger).to have_received(:warn).with(
+      "job=debounced_recalculate_handover_date_job,event=cache_error,nomis_offender_id=#{nomis_offender_id}|boom"
+    )
+    expect(RecalculateHandoverDateJob).not_to have_received(:perform_later)
   end
 end


### PR DESCRIPTION
This aligns the logging with the similar pattern we already have in the Delius job and makes it easier to see how many skipped (events in quick succession) we skip.

Reorg some tests.