### PR TITLE
MO-1993 Handling of checks reset and date stamp

### DIFF
--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -22,6 +22,7 @@ private
     # so a failure in one does not block the others.
     safely { publish_event }
     safely { maybe_reset_handover_checklist }
+    safely { maybe_stamp_handover_episode }
     safely { request_supporting_com }
     safely { assign_com_email }
   end
@@ -75,15 +76,21 @@ private
     event.publish(job: 'recalculate_handover_date')
   end
 
-  # Reset all checklist tasks if the case has moved out of the handover window.
-  # This ensures that if the case re-enters the window later, the POM starts fresh.
+  # Reset all checklist tasks when the handover episode has ended, meaning either:
+  # - responsibility reverted to custody-only (e.g. sentence recalculation), or
+  # - a date change moved the case off all handover lists while already custody-only.
+  # Does not trigger on date adjustments that keep the case on a handover list,
+  # and does not trigger when responsibility moves forward (e.g. upcoming -> in-progress).
   def maybe_reset_handover_checklist
-    return unless record.saved_change_to_responsibility? || record.saved_change_to_handover_date?
+    responsibility_reverted = record.saved_change_to_responsibility? && record.responsibility == CalculatedHandoverDate::CUSTODY_ONLY
+    dates_moved_off_lists = record.saved_change_to_handover_date? &&
+                            record.responsibility == CalculatedHandoverDate::CUSTODY_ONLY &&
+                            !CalculatedHandoverDate.in_handover_window?(record.nomis_offender_id)
+
+    return unless responsibility_reverted || dates_moved_off_lists
 
     checklist = HandoverProgressChecklist.find_by(nomis_offender_id: record.nomis_offender_id)
     return unless checklist
-
-    return if CalculatedHandoverDate.in_handover_window?(record.nomis_offender_id)
 
     # Blank whodunnit so both PaperTrail and Auditable record this as system-initiated,
     # even when the job runs synchronously within a user request (e.g. parole review).
@@ -92,8 +99,32 @@ private
         reviewed_oasys: false,
         contacted_com: false,
         attended_handover_meeting: false,
-        sent_handover_report: false
+        sent_handover_report: false,
+        handover_episode_started_at: nil,
       )
+    end
+  end
+
+  # Stamp the handover episode start date when responsibility shifts away from
+  # custody-only (i.e. the handover has formally begun). This date is frozen for
+  # the duration of the episode and used to determine which task version applies.
+  def maybe_stamp_handover_episode
+    return if record.responsibility == CalculatedHandoverDate::CUSTODY_ONLY
+    return if record.handover_date.nil?
+
+    # Blank whodunnit so both PaperTrail and Auditable record this as system-initiated,
+    # even when the job runs synchronously within a user request (e.g. parole review).
+    PaperTrail.request(whodunnit: nil) do
+      checklist = HandoverProgressChecklist.find_by(nomis_offender_id: record.nomis_offender_id)
+
+      if checklist
+        checklist.update!(handover_episode_started_at: Date.current) if checklist.handover_episode_started_at.nil?
+      else
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: record.nomis_offender_id,
+          handover_episode_started_at: Date.current,
+        )
+      end
     end
   end
 

--- a/app/presenters/sar/handover_progress_checklist.rb
+++ b/app/presenters/sar/handover_progress_checklist.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sar
+  class HandoverProgressChecklist < BaseSarPresenter
+    class << self
+      def omitted_attributes
+        [:handover_episode_started_at]
+      end
+    end
+  end
+end

--- a/db/migrate/20260713120000_add_handover_episode_started_at.rb
+++ b/db/migrate/20260713120000_add_handover_episode_started_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHandoverEpisodeStartedAt < ActiveRecord::Migration[7.2]
+  def change
+    add_column :handover_progress_checklists, :handover_episode_started_at, :date, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -371,7 +371,8 @@ CREATE TABLE public.handover_progress_checklists (
     attended_handover_meeting boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone,
     updated_at timestamp(6) without time zone,
-    sent_handover_report boolean DEFAULT false NOT NULL
+    sent_handover_report boolean DEFAULT false NOT NULL,
+    handover_episode_started_at date
 );
 
 
@@ -1346,6 +1347,7 @@ ALTER TABLE ONLY public.offender_email_sent
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260713120000'),
 ('20260409113634'),
 ('20260217152514'),
 ('20260213115546'),

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -241,7 +241,7 @@ describe RecalculateHandoverDateJob do
   end
 
   describe 'handover checklist reset' do
-    context 'when responsibility changes and the case leaves the handover window' do
+    context 'when responsibility reverts to custody-only and the case leaves the window entirely' do
       before do
         the_responsibility_is_recorded_as(
           CalculatedHandoverDate.new(
@@ -263,13 +263,14 @@ describe RecalculateHandoverDateJob do
         )
       end
 
-      it 'resets all checklist tasks to false' do
+      it 'resets all checklist tasks to false and clears handover_episode_started_at' do
         checklist = HandoverProgressChecklist.create!(
           nomis_offender_id: offender.nomis_offender_id,
           reviewed_oasys: true,
           contacted_com: true,
           attended_handover_meeting: true,
-          sent_handover_report: false
+          sent_handover_report: false,
+          handover_episode_started_at: 2.weeks.ago.to_date
         )
 
         recalculate_handover_dates
@@ -279,7 +280,8 @@ describe RecalculateHandoverDateJob do
           reviewed_oasys: false,
           contacted_com: false,
           attended_handover_meeting: false,
-          sent_handover_report: false
+          sent_handover_report: false,
+          handover_episode_started_at: nil
         )
       end
 
@@ -386,6 +388,131 @@ describe RecalculateHandoverDateJob do
       end
     end
 
+    context 'when responsibility reverts to custody-only but the case lands in upcoming' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        # Recalculation moves responsibility back to custody, but new handover_date is within 56 days
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 4.weeks.from_now.to_date,
+            start_date: 4.weeks.from_now.to_date
+          )
+        )
+      end
+
+      it 'resets checklist tasks and clears handover_episode_started_at' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true,
+          attended_handover_meeting: true,
+          handover_episode_started_at: 6.weeks.ago.to_date
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: false,
+          contacted_com: false,
+          attended_handover_meeting: false,
+          sent_handover_report: false,
+          handover_episode_started_at: nil
+        )
+      end
+    end
+
+    context 'when a date change moves a case in upcoming off all lists (still custody-only)' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 3.weeks.from_now.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        # Recalculation pushes handover_date far into the future (beyond 56 days)
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 1.year.from_now.to_date,
+            start_date: 10.months.from_now.to_date
+          )
+        )
+      end
+
+      it 'resets checklist tasks and clears handover_episode_started_at' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: false,
+          contacted_com: false,
+          attended_handover_meeting: false,
+          sent_handover_report: false,
+          handover_episode_started_at: nil
+        )
+      end
+    end
+
+    context 'when a date change keeps the case in upcoming (still custody-only)' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 3.weeks.from_now.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        # Recalculation shifts handover_date slightly but still within 56 days
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 5.weeks.from_now.to_date,
+            start_date: 5.weeks.from_now.to_date
+          )
+        )
+      end
+
+      it 'does not reset checklist tasks' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+      end
+    end
+
     context 'when there is no change to responsibility or handover date' do
       before do
         the_responsibility_is_recorded_as(
@@ -421,6 +548,270 @@ describe RecalculateHandoverDateJob do
           reviewed_oasys: true,
           contacted_com: true
         )
+      end
+    end
+
+    context 'when in-progress and only handover_date shifts slightly (responsibility unchanged)' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 1.week.ago.to_date,
+            start_date: 5.weeks.ago.to_date
+          )
+        )
+      end
+
+      it 'does not reset checklist tasks' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true,
+          handover_episode_started_at: 6.weeks.ago.to_date
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: true,
+          contacted_com: true,
+          handover_episode_started_at: 6.weeks.ago.to_date
+        )
+      end
+    end
+
+    context 'when in upcoming and nothing changes (stable)' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 3.weeks.from_now.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 3.weeks.from_now.to_date
+          )
+        )
+      end
+
+      it 'does not reset checklist tasks' do
+        checklist = HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist).to have_attributes(
+          reviewed_oasys: true,
+          contacted_com: true
+        )
+      end
+    end
+  end
+
+  describe 'handover episode stamping' do
+    context 'when responsibility shifts and no checklist exists' do
+      before do
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date
+          )
+        )
+      end
+
+      it 'creates a checklist and stamps handover_episode_started_at with today' do
+        recalculate_handover_dates
+
+        checklist = HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)
+        expect(checklist).to be_present
+        expect(checklist.handover_episode_started_at).to eq(Date.current)
+      end
+
+      it 'creates a PaperTrail version for the stamp' do
+        expect { recalculate_handover_dates }
+          .to change { PaperTrail::Version.where(item_type: 'HandoverProgressChecklist').count }.by(1)
+
+        version = PaperTrail::Version.where(item_type: 'HandoverProgressChecklist').last
+        expect(version.whodunnit).to be_nil
+      end
+
+      it 'publishes a system audit event for the stamp' do
+        expect(handover_change_event).to receive(:publish).with(
+          hash_including(
+            nomis_offender_id: offender.nomis_offender_id,
+            system_event: true,
+            tags: %w[record handover_progress_checklist changed]
+          )
+        )
+
+        recalculate_handover_dates
+      end
+
+      it 'records as system-initiated even when triggered within a user session' do
+        PaperTrail.request.whodunnit = 'SOME_USER'
+
+        recalculate_handover_dates
+
+        version = PaperTrail::Version.where(item_type: 'HandoverProgressChecklist').last
+        expect(version.whodunnit).to be_nil
+      end
+    end
+
+    context 'when responsibility has shifted and checklist already has a stamp' do
+      before do
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date
+          )
+        )
+      end
+
+      it 'does not overwrite the existing stamp' do
+        original_date = 3.weeks.ago.to_date
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          handover_episode_started_at: original_date
+        )
+
+        recalculate_handover_dates
+
+        checklist = HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)
+        expect(checklist.handover_episode_started_at).to eq(original_date)
+      end
+    end
+
+    context 'when responsibility is still custody-only' do
+      before do
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 1.year.from_now.to_date,
+            start_date: 10.months.from_now.to_date
+          )
+        )
+      end
+
+      it 'does not stamp the checklist' do
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          handover_episode_started_at: nil
+        )
+
+        recalculate_handover_dates
+
+        checklist = HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)
+        expect(checklist.handover_episode_started_at).to be_nil
+      end
+    end
+
+    context 'when case is in upcoming handover window but responsibility has not yet shifted' do
+      before do
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 3.weeks.from_now.to_date,
+            start_date: 3.weeks.from_now.to_date
+          )
+        )
+      end
+
+      it 'does not stamp the checklist' do
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          handover_episode_started_at: nil
+        )
+
+        recalculate_handover_dates
+
+        checklist = HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)
+        expect(checklist.handover_episode_started_at).to be_nil
+      end
+    end
+
+    context 'when a case exits the window and re-enters' do
+      it 'gets a new stamp on re-entry' do
+        # Case is in the window with an existing stamp
+        the_responsibility_is_recorded_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 2.weeks.ago.to_date,
+            start_date: 6.weeks.ago.to_date,
+            last_calculated_at: 1.day.ago
+          )
+        )
+
+        HandoverProgressChecklist.create!(
+          nomis_offender_id: offender.nomis_offender_id,
+          reviewed_oasys: true,
+          handover_episode_started_at: 6.weeks.ago.to_date
+        )
+
+        # Recalculate to move out of window
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::CUSTODY_ONLY,
+            reason: :determinate,
+            handover_date: 1.year.from_now.to_date,
+            start_date: 10.months.from_now.to_date
+          )
+        )
+        recalculate_handover_dates
+
+        checklist = HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)
+        expect(checklist.handover_episode_started_at).to be_nil
+
+        # Recalculate to re-enter the window
+        the_responsibility_will_be_calculated_as(
+          CalculatedHandoverDate.new(
+            responsibility: CalculatedHandoverDate::COMMUNITY_RESPONSIBLE,
+            reason: :determinate,
+            handover_date: 1.week.ago.to_date,
+            start_date: 5.weeks.ago.to_date
+          )
+        )
+        recalculate_handover_dates
+
+        checklist.reload
+        expect(checklist.handover_episode_started_at).to eq(Date.current)
       end
     end
   end

--- a/spec/services/sar_offender_data_service_spec.rb
+++ b/spec/services/sar_offender_data_service_spec.rb
@@ -250,6 +250,14 @@ RSpec.describe SarOffenderDataService do
           end
         end
 
+        context 'with handover progress checklist' do
+          let(:handover_progress_checklist) { result[:handoverProgressChecklist] }
+
+          it 'omits some attributes' do
+            expect(handover_progress_checklist.keys).not_to include('handoverEpisodeStartedAt')
+          end
+        end
+
         context 'with early allocation' do
           let(:early_allocation) { result[:earlyAllocations].last }
 

--- a/spec/services/subject_access_request_template_service_spec.rb
+++ b/spec/services/subject_access_request_template_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SubjectAccessRequestTemplateService do
 
   describe 'DB schema change guard' do
     # Keep this updated once any potential SAR drifting is asserted
-    let(:reviewed_version) { '20260409_113634' }
+    let(:reviewed_version) { '20260713_120000' }
 
     let(:current_version) { ActiveRecord::Base.connection_pool.migration_context.current_version }
     let(:message) do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1993

A follow-up to PR #2859 to refine the reset handling (as it has been confirmed reset should also happen when moving from in progress back to upcoming as a consequence of responsibility being reverted).

And set the date stamping that will let us implement the second part of the "simplified" enhanced handovers after the cutoff date (we need an immutable stamp to know if it is before or after X date for this to work thus the new DB attribute).

A separate PR will be raised soon to move from feature flag to cutoff date.