### PR TITLE
MO-1997 Prevent local rosh level from drifting

### DIFF
--- a/app/services/delius_data_import_service.rb
+++ b/app/services/delius_data_import_service.rb
@@ -149,6 +149,11 @@ private
     # updated by `TierChangeHandler` (leaving both updates causes a race condition)
     tier = case_info.persisted? ? case_info.tier : map_tier(probation_record.fetch(:tier))
 
+    # Preserve manually-entered rosh for one import cycle, then let blank
+    # nDelius rosh clear it to avoid drift
+    rosh_level = probation_record.dig(:rosh, :level).presence ||
+                  (case_info.manual_entry? ? case_info.rosh_level : nil)
+
     case_info.tap do |ci|
       ci.assign_attributes(
         manual_entry: false,
@@ -163,7 +168,7 @@ private
         probation_service: ldu_record&.country || 'England',
         active_vlo: probation_record.fetch(:vlo_assigned),
         mappa_level: probation_record.fetch(:mappa_level),
-        rosh_level: probation_record.dig(:rosh, :level).presence || case_info.rosh_level,
+        rosh_level: rosh_level,
         rosh_start_date: probation_record.dig(:rosh, :start_date),
       )
     end

--- a/spec/services/delius_data_import_service_spec.rb
+++ b/spec/services/delius_data_import_service_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe DeliusDataImportService do
       end
     end
 
-    context 'when the existing rosh level is already present' do
+    context 'when the existing rosh level is already present and manual_entry is true' do
       let!(:c1) do
         create(:case_information, :manual_entry,
                offender: build(:offender, nomis_offender_id: nomis_offender_id),
@@ -259,10 +259,16 @@ RSpec.describe DeliusDataImportService do
       context 'when probation rosh is nil' do
         let(:rosh_level) { nil }
 
-        it 'preserves the existing rosh level' do
+        it 'preserves the existing rosh level during the transition' do
           service.process(nomis_offender_id)
 
           expect(c1.reload.rosh_level).to eq('LOW')
+        end
+
+        it 'clears manual_entry because the nDelius link now exists' do
+          service.process(nomis_offender_id)
+
+          expect(c1.reload.manual_entry).to be(false)
         end
       end
 
@@ -273,6 +279,32 @@ RSpec.describe DeliusDataImportService do
           service.process(nomis_offender_id)
 
           expect(c1.reload.rosh_level).to eq('HIGH')
+        end
+
+        it 'clears manual_entry' do
+          service.process(nomis_offender_id)
+
+          expect(c1.reload.manual_entry).to be(false)
+        end
+      end
+    end
+
+    context 'when the existing rosh level is present and manual_entry is false' do
+      let!(:c1) do
+        create(:case_information,
+               offender: build(:offender, nomis_offender_id: nomis_offender_id),
+               manual_entry: false,
+               tier: 'B',
+               rosh_level: 'LOW')
+      end
+
+      context 'when probation rosh is nil' do
+        let(:rosh_level) { nil }
+
+        it 'clears the rosh level to avoid drifting from nDelius' do
+          service.process(nomis_offender_id)
+
+          expect(c1.reload.rosh_level).to be_nil
         end
       end
     end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1997

When nDelius returns a blank `rosh_level`, we were always preserving the local DB value, even after `manual_entry` had been set to false. This meant a stale rosh could persist indefinitely and drift from nDelius (which is our authoritative source).

This change makes it behave more like the rest of the attributes, while still consider a manual rosh for a while (but not forever).