### PR TITLE
MO-1994 Remove coworking recommendations

### DIFF
--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -39,6 +39,13 @@ module PomHelper
     "#{pom.position_description.split(' ').first} POM"
   end
 
+  def sortable_grade(pom, recommended_pom_type)
+    return grade(pom) unless recommended_pom_type
+
+    prefix = recommended_pom_type == pom.position ? '0' : '1'
+    "#{prefix} #{grade(pom)}"
+  end
+
   def status(pom)
     {
       'active' => 'available',

--- a/app/views/allocation_staff/index.html.erb
+++ b/app/views/allocation_staff/index.html.erb
@@ -41,6 +41,7 @@
   </div>
 </div>
 
+<% unless @coworking %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m govuk-!-margin-top-5">
@@ -51,6 +52,7 @@
     </div>
   </div>
 </div>
+<% end %>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-5">
   <div class="govuk-grid-column-two-thirds">
@@ -81,7 +83,8 @@
       Choose a POM
     </h2>
     <p class="govuk-body">
-      <%= t(@prisoner.recommended_pom_type, scope: 'recommendation_service.guidance', name: @prisoner.full_name_ordered) %>
+      <%= t(@coworking ? 'NOREC' : @prisoner.recommended_pom_type,
+            scope: 'recommendation_service.guidance', name: @prisoner.full_name_ordered) %>
     </p>
   </div>
 </div>
@@ -90,7 +93,7 @@
   <%= render 'shared/pom_selection_table',
              journey: :allocation,
              available_poms: @available_poms,
-             recommended_pom_type: @prisoner.recommended_pom_type,
+             recommended_pom_type: (@prisoner.recommended_pom_type unless @coworking),
              current_pom_id: @current_pom&.staff_id,
              previous_pom_ids: @previous_poms.map(&:staff_id),
              coworking: @coworking %>

--- a/app/views/shared/_pom_selection_table.html.erb
+++ b/app/views/shared/_pom_selection_table.html.erb
@@ -21,10 +21,10 @@
   <caption class="govuk-visually-hidden">Available POMs to allocate</caption>
   <thead class="govuk-table__head">
     <tr>
-      <th class="govuk-table__header" scope="col" aria-sort="ascending" style="width: 200px;">
+      <th class="govuk-table__header" scope="col" aria-sort="<%= recommended_pom_type.nil? ? 'ascending' : 'none' %>" style="width: 200px;">
         POM
       </th>
-      <th class="govuk-table__header" scope="col" aria-sort="none" style="width: 200px;">
+      <th class="govuk-table__header" scope="col" aria-sort="<%= recommended_pom_type.nil? ? 'none' : 'ascending' %>" style="width: 200px;">
         POM type
       </th>
       <th class="govuk-table__header" scope="col" aria-sort="none" style="width: 140px;">
@@ -68,7 +68,7 @@
             <br/><span class="govuk-!-font-weight-bold">Previously allocated</span>
           <% end %>
         </td>
-        <td aria-label="POM role" class="govuk-table__cell" data-sort-value="<%= grade(pom) %>">
+        <td aria-label="POM role" class="govuk-table__cell" data-sort-value="<%= sortable_grade(pom, recommended_pom_type) %>">
           <%= highlight_conditionally('notice', 'recommended', -> { recommended_pom_type == pom.position }) do %>
             <%= grade(pom) %>
           <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,3 +300,4 @@ en:
     guidance:
       PRO: "You can choose an available prison POM below or allocate to a probation POM, for example if a particular POM has worked with %{name} before."
       PO: "You can choose an available probation POM below or allocate to a prison POM, for example if a particular POM has worked with %{name} before."
+      NOREC: "Choose an available POM below."

--- a/spec/controllers/allocation_staff_controller_spec.rb
+++ b/spec/controllers/allocation_staff_controller_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe AllocationStaffController, type: :controller do
             expect(response.body).to include('Unavailable POMs')
           end
 
-          it 'renders the shared client-side sortable POM table' do
+          it 'renders the shared client-side sortable POM table sorted by POM type when a recommendation exists' do
             expect(response_body).to include('data-module="moj-sortable-table"')
             expect(page.css('#available-poms thead th a')).to be_empty
             expect(sortable_headers.map { |header| header['aria-sort'] }).to eq(
-              %w[ascending none none none none none none none]
+              %w[none ascending none none none none none none]
             )
             expect(response_body).to include(alice.full_name_ordered)
             expect(page.at_css("a[href='#{new_prison_prisoner_staff_build_allocation_path(prison_code, offender_no, alice.staff_id)}']").text)

--- a/spec/controllers/allocation_staff_controller_spec.rb
+++ b/spec/controllers/allocation_staff_controller_spec.rb
@@ -137,6 +137,9 @@ RSpec.describe AllocationStaffController, type: :controller do
         context 'when choosing a co-working POM' do
           render_views
           let(:tier) { 'B' }
+          let(:response_body) { response.body }
+          let(:page) { Nokogiri::HTML(response_body) }
+          let(:sortable_headers) { page.css('#available-poms thead th[aria-sort]') }
 
           before do
             create(:allocation_history,
@@ -149,11 +152,25 @@ RSpec.describe AllocationStaffController, type: :controller do
           end
 
           it 'links each POM name to the co-working confirmation page' do
-            page = Nokogiri::HTML(response.body)
-
             expect(response).to be_successful
             expect(page.at_css("a[href='#{prison_confirm_coworking_allocation_path(prison_code, offender_no, poms.last.staff_id, poms.first.staff_id)}']").text)
               .to eq(poms.first.full_name_ordered)
+          end
+
+          it 'sorts by POM name rather than POM type because co-working has no recommendation' do
+            expect(sortable_headers.map { it['aria-sort'] }).to eq(
+              %w[ascending none none none none none none none]
+            )
+          end
+
+          it 'does not show the recommendation section' do
+            expect(response_body).not_to include('POM recommended')
+          end
+
+          it 'shows the generic guidance without a POM type recommendation' do
+            expect(response_body).to include(
+              I18n.t('NOREC', scope: 'recommendation_service.guidance', name: assigns(:prisoner).full_name_ordered)
+            )
           end
         end
 

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -59,6 +59,42 @@ RSpec.describe PomHelper do
     end
   end
 
+  describe '#sortable_grade' do
+    let(:prison_pom) { double('POM', position_description: 'Prison Officer', position: RecommendationService::PRISON_POM) }
+    let(:probation_pom) { double('POM', position_description: 'Probation Officer', position: RecommendationService::PROBATION_POM) }
+
+    context 'when there is no recommendation' do
+      it 'returns the plain grade' do
+        expect(sortable_grade(prison_pom, nil)).to eq('Prison POM')
+        expect(sortable_grade(probation_pom, nil)).to eq('Probation POM')
+      end
+    end
+
+    context 'when prison POM is recommended' do
+      let(:recommended_pom_type) { RecommendationService::PRISON_POM }
+
+      it 'prefixes 0 for matching POMs' do
+        expect(sortable_grade(prison_pom, recommended_pom_type)).to eq('0 Prison POM')
+      end
+
+      it 'prefixes 1 for non-matching POMs' do
+        expect(sortable_grade(probation_pom, recommended_pom_type)).to eq('1 Probation POM')
+      end
+    end
+
+    context 'when probation POM is recommended' do
+      let(:recommended_pom_type) { RecommendationService::PROBATION_POM }
+
+      it 'prefixes 0 for matching POMs' do
+        expect(sortable_grade(probation_pom, recommended_pom_type)).to eq('0 Probation POM')
+      end
+
+      it 'prefixes 1 for non-matching POMs' do
+        expect(sortable_grade(prison_pom, recommended_pom_type)).to eq('1 Prison POM')
+      end
+    end
+  end
+
   describe '#inactive_poms' do
     let(:active_pom) { double('PomWrapper', inactive?: false) }
     let(:unavailable_pom) { double('PomWrapper', inactive?: false) }

--- a/spec/views/allocation_staff/index.html.erb_spec.rb
+++ b/spec/views/allocation_staff/index.html.erb_spec.rb
@@ -48,6 +48,47 @@ RSpec.describe "allocation_staff/index", type: :view do
     end
   end
 
+  it 'sorts by POM type column by default when a recommendation exists' do
+    headers = page.all('#available-poms thead th[aria-sort]')
+    pom_name_header = headers[0]
+    pom_type_header = headers[1]
+
+    expect(pom_name_header[:'aria-sort']).to eq('none')
+    expect(pom_type_header[:'aria-sort']).to eq('ascending')
+  end
+
+  it 'assigns data-sort-value that puts recommended POM type first' do
+    pom_type_cells = page.all('#available-poms tbody td[aria-label="POM role"]')
+    sort_values = pom_type_cells.map { |cell| cell[:'data-sort-value'] }
+
+    expect(sort_values).to all(match(/\A[01] /))
+  end
+
+  context 'when there is no recommendation' do
+    before do
+      allow(RecommendationService).to receive(:recommended_pom_type).and_return(nil)
+    end
+
+    it 'sorts by POM name column by default' do
+      headers = page.all('#available-poms thead th[aria-sort]')
+      pom_name_header = headers[0]
+      pom_type_header = headers[1]
+
+      expect(pom_name_header[:'aria-sort']).to eq('ascending')
+      expect(pom_type_header[:'aria-sort']).to eq('none')
+    end
+
+    it 'assigns plain grade as data-sort-value without prefix' do
+      pom_type_cells = page.all('#available-poms tbody td[aria-label="POM role"]')
+      sort_values = pom_type_cells.map { |cell| cell[:'data-sort-value'] }
+
+      sort_values.each do |value|
+        expect(value).not_to match(/\A[01] /)
+        expect(value).to match(/POM\z/)
+      end
+    end
+  end
+
   context 'when a prison POM is recommended' do
     before do
       allow(RecommendationService).to receive(:recommended_pom_type).and_return(RecommendationService::PRISON_POM)

--- a/spec/views/reallocations/index.html.erb_spec.rb
+++ b/spec/views/reallocations/index.html.erb_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe 'reallocations/index', type: :view do
     end
   end
 
+  it 'sorts by POM name column by default because there is no recommendation' do
+    render
+
+    headers = page.all('#available-poms thead th[aria-sort]')
+    pom_name_header = headers[0]
+    pom_type_header = headers[1]
+
+    expect(pom_name_header[:'aria-sort']).to eq('ascending')
+    expect(pom_type_header[:'aria-sort']).to eq('none')
+  end
+
   context 'when there is a selection error' do
     before do
       flash[:alert] = 'Choose at least one POM to compare workloads'


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1994

It was confirmed co-worker allocation journey shouldn't recommend a POM type. Copy has been either removed or changed.

Also, fixed a sorting issue raised by UCD. If we recommend a prison POM then those should be at the top and if we recommend a probation POM then those should be at the top. If there is no recommendation (like coworking) we keep sorting by POM name as before.