### PR TITLE
Cleanup stint data after offender release

### DIFF
--- a/app/models/offender.rb
+++ b/app/models/offender.rb
@@ -39,7 +39,7 @@ class Offender < ApplicationRecord
 
   has_many :victim_liaison_officers, foreign_key: :nomis_offender_id, inverse_of: :offender, dependent: :destroy
 
-  has_one :handover_progress_checklist, foreign_key: :nomis_offender_id
+  has_one :handover_progress_checklist, foreign_key: :nomis_offender_id, dependent: :destroy
 
   delegate :handover_progress_complete?, to: :handover_progress_checklist, allow_nil: true
 

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -83,28 +83,22 @@ private
     true
   end
 
-  def self.release_offender(offender_no, from_agency)
-    Rails.logger.info("[MOVEMENT] Processing release for #{offender_no}")
+  def self.release_offender(nomis_offender_id, from_agency)
+    Rails.logger.info("[MOVEMENT] Processing release for #{nomis_offender_id}")
 
-    alloc = AllocationHistory.active.find_by(nomis_offender_id: offender_no)
+    alloc = AllocationHistory.active.find_by(nomis_offender_id:)
     alloc.deallocate_offender_after_release if alloc
 
-    destroy_case_information(offender_no)
+    destroy_offender_stint_data(nomis_offender_id)
 
-    HmppsApi::ComplexityApi.inactivate(offender_no) if PrisonService.womens_prison?(from_agency)
+    HmppsApi::ComplexityApi.inactivate(nomis_offender_id) if PrisonService.womens_prison?(from_agency)
   end
 
-private
-
-  def self.destroy_case_information(offender_no)
-    case_information = CaseInformation.find_by(nomis_offender_id: offender_no)
-    return unless case_information
-
-    # Preserve destroy callbacks and PaperTrail history for case information.
-    # Use a savepoint if an outer transaction exists so a failed destroy rolls
-    # back cleanly rather than leaving that wider transaction unusable.
-    CaseInformation.transaction(requires_new: true) do
-      case_information.destroy!
+  def self.destroy_offender_stint_data(nomis_offender_id)
+    [CaseInformation, CalculatedHandoverDate, HandoverProgressChecklist, Responsibility].each do |model|
+      model.find_by(nomis_offender_id:)&.destroy!
+    rescue StandardError => e
+      Rails.logger.error("[MOVEMENT] Failed to destroy #{model} for #{nomis_offender_id}: #{e.class} - #{e.message}")
     end
   end
 

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -142,6 +142,9 @@ describe MovementService, type: :feature do
   describe "processing an offender release" do
     let!(:case_info) { create(:case_information, offender: build(:offender, nomis_offender_id: 'G7266VD')) }
     let!(:allocation) { create(:allocation_history, prison: 'LEI', nomis_offender_id: 'G7266VD') }
+    let!(:calculated_handover_date) { create(:calculated_handover_date, offender: case_info.offender) }
+    let!(:handover_progress_checklist) { create(:handover_progress_checklist, offender: case_info.offender) }
+    let!(:responsibility) { create(:responsibility, offender: case_info.offender) }
 
     def pom_tester(valid_release)
       mailer = double(:mailer)
@@ -173,16 +176,20 @@ describe MovementService, type: :feature do
           expect(HmppsApi::ComplexityApi).not_to receive(:inactivate).with(valid_release.offender_no)
           expect(processed).to be true
           expect(CaseInformation.where(nomis_offender_id: valid_release.offender_no)).to be_empty
+          expect(CalculatedHandoverDate.where(nomis_offender_id: valid_release.offender_no)).to be_empty
+          expect(HandoverProgressChecklist.where(nomis_offender_id: valid_release.offender_no)).to be_empty
+          expect(Responsibility.where(nomis_offender_id: valid_release.offender_no)).to be_empty
           expect(updated_allocation.event_trigger).to eq 'offender_released'
           expect(updated_allocation.prison).to eq 'LEI'
         end
 
-        it 'deallocates before destroying case information so destroy failures do not block the release update' do
+        it 'continues processing even if a destroy fails' do
           allow_any_instance_of(CaseInformation).to receive(:destroy!).and_raise(ActiveRecord::StatementInvalid, 'boom')
 
-          expect { processed }.to raise_error(ActiveRecord::StatementInvalid, 'boom')
+          expect { processed }.not_to raise_error
           expect(updated_allocation.reload.event_trigger).to eq 'offender_released'
           expect(CaseInformation.where(nomis_offender_id: valid_release.offender_no)).not_to be_empty
+          expect(CalculatedHandoverDate.where(nomis_offender_id: valid_release.offender_no)).to be_empty
         end
       end
 


### PR DESCRIPTION
We had some leftovers not needed to keep upon offender release, and in fact could cause trouble under certain circumstances if the same offender re-enters custody (like the responsibility override, that would be preserved).