### PR TITLE
MO-2005 Allow blank rosh case reallocations

### DIFF
--- a/app/controllers/allocation_staff_controller.rb
+++ b/app/controllers/allocation_staff_controller.rb
@@ -19,7 +19,9 @@ class AllocationStaffController < PrisonsApplicationController
     @current_pom = poms[allocation&.primary_pom_nomis_id]
     @current_coworker = poms[allocation&.secondary_pom_nomis_id]
     @recent_pom_history = AllocationService.recent_pom_history(allocation)
+
     @coworking = coworking?
+    @recommended_pom_type = recommended_pom_type
 
     @available_poms = available_poms.sort_by(&:full_name_ordered)
   end
@@ -104,6 +106,10 @@ private
 
   def coworking?
     params[:coworking].present? && params[:coworking] == 'true'
+  end
+
+  def recommended_pom_type
+    @prisoner.recommended_pom_type unless @coworking || !RecommendationService.recommendation_available?(@prisoner)
   end
 
   def check_compare_success_route

--- a/app/controllers/build_allocations_controller.rb
+++ b/app/controllers/build_allocations_controller.rb
@@ -57,7 +57,7 @@ class BuildAllocationsController < PrisonsApplicationController
         created_by_username: current_user,
         allocated_at_tier: @prisoner.tier,
         allocated_at_rosh: FeatureFlags.rosh_recommendations.enabled? ? @prisoner.rosh_level : nil,
-        recommended_pom_type: recommended_pom_type_code == RecommendationService::PRISON_POM ? 'prison' : 'probation',
+        recommended_pom_type: RecommendationService::POM_TYPE_LABELS.fetch(recommended_pom_type_code),
         prison: @prison.code,
         message: allocation_params[:message],
         override_reasons: override.override_reasons.presence,
@@ -122,7 +122,8 @@ private
 
   def override_needed?
     recommended_pom_type_code == RecommendationService::PRISON_POM && @pom.probation_officer? ||
-      recommended_pom_type_code == RecommendationService::PROBATION_POM && @pom.prison_officer?
+      recommended_pom_type_code == RecommendationService::PROBATION_POM && @pom.prison_officer? ||
+      recommended_pom_type_code == RecommendationService::NO_RECOMMENDATION
   end
 
   def recommended_pom_type_code

--- a/app/forms/override_form.rb
+++ b/app/forms/override_form.rb
@@ -9,7 +9,7 @@ class OverrideForm
   attribute :suitability_detail, :string
 
   validates :override_reasons,
-            presence: { message: 'Select one or more reasons for not accepting the recommendation' }
+            presence: { message: 'Select at least one reason' }
 
   validates :more_detail,
             presence: { message: 'Please provide extra detail when Other is selected' },

--- a/app/helpers/offender_helper.rb
+++ b/app/helpers/offender_helper.rb
@@ -55,22 +55,6 @@ module OffenderHelper
     end
   end
 
-  def recommended_pom_type_label(offender)
-    if RecommendationService.recommended_pom_type(offender) == RecommendationService::PRISON_POM
-      'Prison'
-    else
-      'Probation'
-    end
-  end
-
-  def complex_reason_label(offender)
-    if RecommendationService.recommended_pom_type(offender) == RecommendationService::PRISON_POM
-      'Assessed as not suitable for a prison POM'
-    else
-      'Assessed as suitable for a prison POM despite probation POM recommendation'
-    end
-  end
-
   def probation_field(offender, field)
     offender.public_send field if offender.probation_record.present?
   end

--- a/app/helpers/override_helper.rb
+++ b/app/helpers/override_helper.rb
@@ -2,14 +2,12 @@
 
 module OverrideHelper
   def display_override_pom(allocation)
-    if allocation.recommended_pom_type &&
-      allocation.recommended_pom_type == 'prison'
+    if allocation.recommended_pom_type == 'prison'
       'Probation POM allocated instead of recommended prison POM'
-    elsif allocation.recommended_pom_type &&
-      allocation.recommended_pom_type == 'probation'
+    elsif allocation.recommended_pom_type == 'probation'
       'Prison POM allocated instead of recommended probation POM'
     else
-      'Prisoner not allocated to recommended POM'
+      'POM allocated without a recommendation'
     end
   end
 
@@ -33,19 +31,17 @@ private
     if allocation.recommended_pom_type.present?
       tag.p("- No available #{allocation.recommended_pom_type} POMs")
     else
-      tag.p('- No available recommended POMs')
+      tag.p('- No available POMs of the other type')
     end
   end
 
   def suitability_detail(allocation)
-    if allocation.recommended_pom_type.present?
-      if allocation.recommended_pom_type == 'prison'
-        tag.p('- Assessed as not suitable for a prison POM')
-      else
-        tag.p('- Assessed as suitable for a prison POM despite probation POM recommendation')
-      end
+    if allocation.recommended_pom_type == 'prison'
+      tag.p('- Assessed as not suitable for a prison POM')
+    elsif allocation.recommended_pom_type == 'probation'
+      tag.p('- Assessed as not suitable for a probation POM')
     else
-      tag.p('- Assessed as suitable for allocated POM despite recommendation')
+      tag.p('- Assessed as suitable for the allocated POM type')
     end + tag.p(allocation.suitability_detail, class: 'app-override-reason--detail')
   end
 end

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -39,6 +39,10 @@ module PomHelper
     "#{pom.position_description.split(' ').first} POM"
   end
 
+  def opposite_pom_type(pom)
+    pom.probation_officer? ? 'prison' : 'probation'
+  end
+
   def sortable_grade(pom, recommended_pom_type)
     return grade(pom) unless recommended_pom_type
 

--- a/app/services/reallocation/bulk_reallocation_service.rb
+++ b/app/services/reallocation/bulk_reallocation_service.rb
@@ -113,7 +113,7 @@ module Reallocation
     end
 
     def recommended_pom_type_for(offender)
-      offender.recommended_pom_type == RecommendationService::PRISON_POM ? 'prison' : 'probation'
+      RecommendationService::POM_TYPE_LABELS.fetch(offender.recommended_pom_type)
     end
 
     def offender_for(nomis_offender_id)

--- a/app/services/recommendation_service.rb
+++ b/app/services/recommendation_service.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class RecommendationService
-  # yes this looks backwards. However the string 'PRO' already existed in NOMIS for 'PRISON_OFFICER'
-  # so 'PO' was chosen for 'Probation Officer'
   PRISON_POM = 'PRO'
   PROBATION_POM = 'PO'
+  NO_RECOMMENDATION = 'NOREC'
 
   POM_TYPE_LABELS = {
     PRISON_POM => 'prison',
     PROBATION_POM => 'probation',
+    NO_RECOMMENDATION => nil,
   }.freeze
 
   class << self
@@ -21,6 +21,10 @@ class RecommendationService
       strategy.recommended_pom_type_reason(offender)
     end
     # rubocop:enable Rails/Delegate
+
+    def recommendation_available?(offender)
+      recommended_pom_type(offender) != NO_RECOMMENDATION
+    end
 
     def reason(key, **options)
       I18n.t(key, scope: 'recommendation_service.reasons', **options).html_safe

--- a/app/services/recommendation_service/rosh_strategy.rb
+++ b/app/services/recommendation_service/rosh_strategy.rb
@@ -7,6 +7,7 @@ class RecommendationService
     def self.recommended_pom_type(offender)
       return PRISON_POM if offender.immigration_case? || !offender.pom_responsible?
       return PROBATION_POM if offender.tier == 'A' || HIGH_ROSH_LEVELS.include?(offender.rosh_level)
+      return NO_RECOMMENDATION if offender.rosh_level.blank?
 
       PRISON_POM
     end
@@ -18,8 +19,9 @@ class RecommendationService
       return RecommendationService.reason(:immigration_case) if offender.immigration_case?
       return RecommendationService.reason(:supporting_role, name:) unless offender.pom_responsible?
       return RecommendationService.reason(:tier_based, name:, tier: 'A', pom_type:) if offender.tier == 'A'
+      return RecommendationService.reason(:missing_rosh) if offender.rosh_level.blank?
 
-      rosh_level = offender.rosh_level.to_s.humanize.downcase.presence || 'N/A'
+      rosh_level = offender.rosh_level.humanize.downcase
       RecommendationService.reason(:rosh_based, name:, rosh_level:, pom_type:)
     end
   end

--- a/app/views/allocation_staff/index.html.erb
+++ b/app/views/allocation_staff/index.html.erb
@@ -42,13 +42,20 @@
 </div>
 
 <% unless @coworking %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m govuk-!-margin-top-5">
-      <%= recommended_pom_type_label(@prisoner) %> POM recommended
-    </h2>
-    <div class="govuk-inset-text">
-      <p><%= RecommendationService.recommended_pom_type_reason(@prisoner) %>.</p>
+<div class="govuk-grid-row govuk-!-margin-top-2">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @recommended_pom_type %>
+      <h2 class="govuk-heading-m">
+        <%= pom_level(@recommended_pom_type) %> recommended
+      </h2>
+    <% else %>
+      <h2 class="govuk-heading-m">
+        No POM type recommendation
+      </h2>
+      <p>We cannot recommend which POM type should be allocated to work with this person because they have no ROSH on NDelius.</p>
+    <% end %>
+    <div class="govuk-inset-text govuk-!-margin-top-0">
+      <p><%= RecommendationService.recommended_pom_type_reason(@prisoner) %></p>
     </div>
   </div>
 </div>
@@ -79,11 +86,11 @@
       </div>
     <% end %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-6">
+    <h2 class="govuk-heading-m govuk-!-margin-top-4">
       Choose a POM
     </h2>
     <p class="govuk-body">
-      <%= t(@coworking ? 'NOREC' : @prisoner.recommended_pom_type,
+      <%= t(@recommended_pom_type || RecommendationService::NO_RECOMMENDATION,
             scope: 'recommendation_service.guidance', name: @prisoner.full_name_ordered) %>
     </p>
   </div>
@@ -93,7 +100,7 @@
   <%= render 'shared/pom_selection_table',
              journey: :allocation,
              available_poms: @available_poms,
-             recommended_pom_type: (@prisoner.recommended_pom_type unless @coworking),
+             recommended_pom_type: @recommended_pom_type,
              current_pom_id: @current_pom&.staff_id,
              previous_pom_ids: @previous_poms.map(&:staff_id),
              coworking: @coworking %>

--- a/app/views/case_history/allocation/_primary_pom_event.html.erb
+++ b/app/views/case_history/allocation/_primary_pom_event.html.erb
@@ -1,8 +1,8 @@
 <% description = capture do %>
   Prisoner <%= variant %> to <%= allocation.primary_pom_name.titleize %> - <%= format_email(allocation.primary_pom_email) %>
   <br/>Tier: <%= allocation.allocated_at_tier %>
-  <% if allocation.allocated_at_rosh.present? %>
-  <br/>ROSH: <%= allocation.allocated_at_rosh.humanize %>
+  <% if FeatureFlags.rosh_recommendations.enabled? %>
+  <br/>ROSH: <%= allocation.allocated_at_rosh.present? ? allocation.allocated_at_rosh.humanize : 'N/A' %>
   <% end %>
   <% if allocation.override_reasons.present? %>
     <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-3"><%= display_override_pom(allocation) %></p>

--- a/app/views/reallocations/_caseload_table.html.erb
+++ b/app/views/reallocations/_caseload_table.html.erb
@@ -72,7 +72,11 @@
         </td>
         <td aria-label="Recommended POM type" class="govuk-table__cell reallocation-cases-table__recommended-column">
           <%= highlight_conditionally('alert', "#{target_pom.first_name} already allocated as co-working POM", -> { coworker_conflict }) do %>
-            <%= allocation.recommended_pom_type == RecommendationService::PRISON_POM ? 'Prison POM' : 'Probation POM' %>
+            <%= case allocation.recommended_pom_type
+                when RecommendationService::PRISON_POM then 'Prison POM'
+                when RecommendationService::PROBATION_POM then 'Probation POM'
+                else safe_join(['No POM type', tag.br, 'recommendation', tag.br, '– missing ROSH'])
+                end %>
           <% end %>
         </td>
         <td aria-label="POM role needed" class="govuk-table__cell">

--- a/app/views/shared/_override_reasons_form.html.erb
+++ b/app/views/shared/_override_reasons_form.html.erb
@@ -1,12 +1,12 @@
 <%= form.govuk_check_boxes_fieldset :override_reasons, multiple: false, legend: nil,
                                     hint: { text: 'Choose all that apply' } do %>
   <%= form.govuk_check_box :override_reasons, 'suitability', link_errors: true,
-                           label: { text: complex_reason_label(offender) } do %>
+                           label: { text: "Assessed as not suitable for a #{opposite_pom_type(pom)} POM" } do %>
     <%= form.govuk_text_area :suitability_detail, link_errors: true, rows: 2,
                              label: { text: 'Enter reason' } %>
   <% end %>
   <%= form.govuk_check_box :override_reasons, 'no_staff',
-                           label: { text: "No available #{recommended_pom_type_label(offender).downcase} POMs" } %>
+                           label: { text: "No available #{opposite_pom_type(pom)} POMs" } %>
   <%= form.govuk_check_box :override_reasons, 'continuity',
                            label: { text: "#{pom.full_name_ordered} has worked with #{offender.full_name_ordered} before" } %>
   <%= form.govuk_check_box :override_reasons, 'other',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,10 +293,11 @@ en:
 
   recommendation_service:
     reasons:
-      immigration_case: "This is an immigration case, so should be given to a <strong>prison POM</strong>"
-      supporting_role: "%{name} needs a POM in a supporting role, so should be allocated to a <strong>prison POM</strong>"
-      tier_based: "%{name} is tier %{tier}, so we recommend allocating to a <strong>%{pom_type} POM</strong>"
-      rosh_based: "%{name} has a %{rosh_level} ROSH, so we recommend allocating to a <strong>%{pom_type} POM</strong>"
+      immigration_case: "This is an immigration case, so should be given to a <strong>prison POM</strong>."
+      supporting_role: "%{name} needs a POM in a supporting role, so should be allocated to a <strong>prison POM</strong>."
+      tier_based: "%{name} is tier %{tier}, so we recommend allocating to a <strong>%{pom_type} POM</strong>."
+      rosh_based: "%{name} has a %{rosh_level} ROSH, so we recommend allocating to a <strong>%{pom_type} POM</strong>."
+      missing_rosh: "Check their risk on NDelius and OASys and then allocate to the appropriate POM. You will be asked to record a reason for selecting the POM type you choose."
     guidance:
       PRO: "You can choose an available prison POM below or allocate to a probation POM, for example if a particular POM has worked with %{name} before."
       PO: "You can choose an available probation POM below or allocate to a prison POM, for example if a particular POM has worked with %{name} before."

--- a/spec/controllers/allocation_staff_controller_spec.rb
+++ b/spec/controllers/allocation_staff_controller_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe AllocationStaffController, type: :controller do
 
           it 'shows the generic guidance without a POM type recommendation' do
             expect(response_body).to include(
-              I18n.t('NOREC', scope: 'recommendation_service.guidance', name: assigns(:prisoner).full_name_ordered)
+              I18n.t(RecommendationService::NO_RECOMMENDATION, scope: 'recommendation_service.guidance', name: assigns(:prisoner).full_name_ordered)
             )
           end
         end

--- a/spec/controllers/build_allocations_controller_spec.rb
+++ b/spec/controllers/build_allocations_controller_spec.rb
@@ -171,10 +171,10 @@ RSpec.describe BuildAllocationsController, type: :controller do
         }
       end
 
-      it 're-renders the override step successfully' do
+      it 're-renders the override step with validation errors' do
         expect(response).to have_http_status(:ok)
         expect(assigns(:pom)).to be_present
-        expect(assigns(:override).errors[:override_reasons]).to include('Select one or more reasons for not accepting the recommendation')
+        expect(assigns(:override).errors[:override_reasons]).to be_present
       end
     end
 
@@ -239,6 +239,41 @@ RSpec.describe BuildAllocationsController, type: :controller do
           allocation = AllocationHistory.find_by!(nomis_offender_id: offender_no)
 
           expect(allocation.allocated_at_rosh).to be_nil
+        end
+      end
+
+      context 'when RoSH is missing and tier is not A' do
+        before do
+          CaseInformation.find_by(nomis_offender_id: offender_no).update!(rosh_level: nil, tier: 'B')
+          AllocationHistory.where(nomis_offender_id: offender_no).delete_all
+        end
+
+        it 'requires the override step' do
+          get :new, params: {
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            staff_id: pom.staffId
+          }
+
+          expect(response).to redirect_to(
+            prison_prisoner_staff_build_allocation_path(prison.code, offender_no, pom.staffId, 'override')
+          )
+        end
+
+        it 'stores nil recommended_pom_type' do
+          stub_user('user', pom.staffId)
+          session[:allocation_override] = { override_reasons: ['suitability'], suitability_detail: 'Reason given' }
+
+          put :update, params: {
+            allocation_form: { message: notes },
+            prison_id: prison.code,
+            prisoner_id: offender_no,
+            staff_id: pom.staffId,
+            id: 'allocate'
+          }
+
+          allocation = AllocationHistory.find_by!(nomis_offender_id: offender_no)
+          expect(allocation.recommended_pom_type).to be_nil
         end
       end
     end

--- a/spec/features/allocation/homd_allocates_poms_spec.rb
+++ b/spec/features/allocation/homd_allocates_poms_spec.rb
@@ -48,7 +48,7 @@ describe 'HOMD allocates cases to POMS' do
     click_on 'Continue'
 
     within('.govuk-error-summary') do
-      expect(page).to have_content('Select one or more reasons for not accepting the recommendation')
+      expect(page).to have_content('Select at least one reason')
     end
   end
 

--- a/spec/forms/override_form_spec.rb
+++ b/spec/forms/override_form_spec.rb
@@ -14,7 +14,7 @@ describe OverrideForm do
   it 'a reason for overriding must be given' do
     override = described_class.new(override_reasons: nil)
     expect(override).not_to be_valid
-    expect(override.errors[:override_reasons]).to match_array(['Select one or more reasons for not accepting the recommendation'])
+    expect(override.errors[:override_reasons]).to match_array(['Select at least one reason'])
   end
 
   it 'more details must be given when overriding due to another reason' do

--- a/spec/helpers/offender_helper_spec.rb
+++ b/spec/helpers/offender_helper_spec.rb
@@ -93,45 +93,6 @@ RSpec.describe OffenderHelper do
     end
   end
 
-  describe '#recommended_pom_type_label' do
-    it "returns 'Prison' if RecommendService is PRISON_POM" do
-      allow(RecommendationService).to receive(:recommended_pom_type).and_return(RecommendationService::PRISON_POM)
-      offender = OpenStruct.new(immigration_case?: true, nps_case?: false, responsibility: nil)
-
-      expect(helper.recommended_pom_type_label(offender)).to eq('Prison')
-    end
-
-    it "returns 'Probation' if RecommendService is PROBATION_POM" do
-      allow(RecommendationService).to receive(:recommended_pom_type).and_return(RecommendationService::PROBATION_POM)
-      offender = OpenStruct.new(immigration_case?: false, nps_case?: true, tier: 'A', responsibility: nil)
-
-      expect(helper.recommended_pom_type_label(offender)).to eq('Probation')
-    end
-  end
-
-  describe '#complex_reason_label' do
-    context 'when a prison POM' do
-      # we need to set up this test to return a Prison POM recommendation; we are using an
-      # Immigration case as they are always recommended to Prison POMs
-      let(:offender) { OpenStruct.new(immigration_case?: true, nps_case?: false) }
-
-      it "can get for a prison owned offender" do
-        expect(helper.complex_reason_label(offender)).to eq('Assessed as not suitable for a prison POM')
-      end
-    end
-
-    context 'when a probation POM' do
-      let(:api_offender) { build(:hmpps_api_offender, sentence: attributes_for(:sentence_detail, :indeterminate)) }
-      let(:offender) do
-        build(:mpc_offender, prison: prison, prison_record: api_offender, offender: build(:case_information, tier: 'A').offender)
-      end
-
-      it "can get for a probation owned offender" do
-        expect(helper.complex_reason_label(offender)).to eq('Assessed as suitable for a prison POM despite probation POM recommendation')
-      end
-    end
-  end
-
   describe '#format_allocation' do
     subject do
       helper.format_allocation(offender: offender, pom: pom, view_context: view_context)

--- a/spec/helpers/override_helper_spec.rb
+++ b/spec/helpers/override_helper_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe OverrideHelper do
       expect(display_override_pom(allocation_one)).to eq('Probation POM allocated instead of recommended prison POM')
     end
 
-    it 'displays generic message if POM type not present' do
-      expect(display_override_pom(allocation_two)).to eq('Prisoner not allocated to recommended POM')
+    it 'displays message when no recommendation was available' do
+      expect(display_override_pom(allocation_two)).to eq('POM allocated without a recommendation')
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe OverrideHelper do
     end
 
     it 'displays a generic message if reason is POM type not available, and the POM type is not present' do
-      expect(display_override_details("no_staff", allocation_two)).to include('No available recommended POMs')
+      expect(display_override_details("no_staff", allocation_two)).to include('No available POMs of the other type')
     end
 
     it 'displays that the prisoner was not suitable for a prison POM when prison was recommended' do
@@ -54,14 +54,14 @@ RSpec.describe OverrideHelper do
     end
 
     it 'displays that the prisoner was suitable for a prison POM when probation was recommended' do
-      expect(display_override_details("suitability", allocation_three)).to match(/Assessed as suitable for a prison POM\s+despite probation POM recommendation/)
+      expect(display_override_details("suitability", allocation_three)).to match(/Assessed as not suitable for a probation POM/)
       expect(display_override_details("suitability", allocation_three)).to include('Needs continuity')
     end
 
-    it 'displays a generic suitability message for the allocated POM if the recommendation is not present' do
+    it 'displays a generic suitability message when no recommendation was available' do
       allocation_two.suitability_detail = 'Needs continuity'
 
-      expect(display_override_details("suitability", allocation_two)).to match(/Assessed as suitable for allocated POM despite recommendation/)
+      expect(display_override_details("suitability", allocation_two)).to match(/Assessed as suitable for the allocated POM type/)
       expect(display_override_details("suitability", allocation_two)).to include('Needs continuity')
     end
 

--- a/spec/services/reallocation/bulk_reallocation_service_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Reallocation::BulkReallocationService do
       offender_no: offender_no,
       tier: 'A',
       rosh_level: 'HIGH',
-      recommended_pom_type: 'probation',
+      recommended_pom_type: RecommendationService::PROBATION_POM,
       full_name_ordered: 'Zephyr, Alice',
       pom_responsible?: true,
       com_responsible?: false,

--- a/spec/services/recommendation_service/rosh_strategy_spec.rb
+++ b/spec/services/recommendation_service/rosh_strategy_spec.rb
@@ -62,12 +62,25 @@ describe RecommendationService::RoshStrategy do
   context 'with no ROSH level' do
     let(:rosh_level) { nil }
 
-    it 'recommends a prison POM' do
-      expect(described_class.recommended_pom_type(offender)).to eq(RecommendationService::PRISON_POM)
+    it 'returns NO_RECOMMENDATION' do
+      expect(described_class.recommended_pom_type(offender)).to eq(RecommendationService::NO_RECOMMENDATION)
     end
 
-    it 'gives the reason with N/A' do
-      expect(described_class.recommended_pom_type_reason(offender)).to include('has a N/A ROSH', 'prison POM')
+    it 'gives the missing RoSH reason' do
+      expect(described_class.recommended_pom_type_reason(offender)).to include('Check their risk on NDelius')
+    end
+  end
+
+  context 'with no ROSH level but tier A' do
+    let(:rosh_level) { nil }
+    let(:tier) { 'A' }
+
+    it 'still recommends a probation POM' do
+      expect(described_class.recommended_pom_type(offender)).to eq(RecommendationService::PROBATION_POM)
+    end
+
+    it 'gives the tier A reason' do
+      expect(described_class.recommended_pom_type_reason(offender)).to include('tier A')
     end
   end
 

--- a/spec/services/recommendation_service_spec.rb
+++ b/spec/services/recommendation_service_spec.rb
@@ -32,5 +32,19 @@ describe RecommendationService do
       expect(described_class::RoshStrategy).to receive(:recommended_pom_type_reason).with(offender).and_call_original
       described_class.recommended_pom_type_reason(offender)
     end
+
+    describe '.recommendation_available?' do
+      it 'returns true when a recommendation exists' do
+        expect(described_class.recommendation_available?(offender)).to be(true)
+      end
+
+      context 'when RoSH is missing and tier is not A' do
+        let(:case_info) { build(:case_information, tier: 'B', rosh_level: nil) }
+
+        it 'returns false' do
+          expect(described_class.recommendation_available?(offender)).to be(false)
+        end
+      end
+    end
   end
 end

--- a/spec/views/allocation_staff/index.html.erb_spec.rb
+++ b/spec/views/allocation_staff/index.html.erb_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "allocation_staff/index", type: :view do
     assign(:available_poms, poms.map { |p| StaffMember.new(prison, p.staff_id) })
     assign(:prison_poms, [])
     assign(:recent_pom_history, recent_pom_history)
+    assign(:recommended_pom_type, offender.recommended_pom_type)
   end
 
   it 'renders the allocation-specific wrapper around the shared POM selection table' do
@@ -67,6 +68,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   context 'when there is no recommendation' do
     before do
       allow(RecommendationService).to receive(:recommended_pom_type).and_return(nil)
+      assign(:recommended_pom_type, nil)
     end
 
     it 'sorts by POM name column by default' do
@@ -92,6 +94,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   context 'when a prison POM is recommended' do
     before do
       allow(RecommendationService).to receive(:recommended_pom_type).and_return(RecommendationService::PRISON_POM)
+      assign(:recommended_pom_type, RecommendationService::PRISON_POM)
     end
 
     it 'shows the correct guidance' do
@@ -104,6 +107,7 @@ RSpec.describe "allocation_staff/index", type: :view do
   context 'when a probation POM is recommended' do
     before do
       allow(RecommendationService).to receive(:recommended_pom_type).and_return(RecommendationService::PROBATION_POM)
+      assign(:recommended_pom_type, RecommendationService::PROBATION_POM)
     end
 
     it 'shows the correct guidance' do

--- a/spec/views/build_allocations/override.html.erb_spec.rb
+++ b/spec/views/build_allocations/override.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'build_allocations/override', type: :view do
     OverrideForm.new(override_reasons: ['other']).tap(&:valid?)
   end
   let(:pom) do
-    instance_double(StaffMember, full_name_ordered: 'Jessica King', position: 'PO')
+    instance_double(StaffMember, full_name_ordered: 'Jessica King', position: 'PO', probation_officer?: true)
   end
   let(:prisoner) do
     instance_double(

--- a/spec/views/case_history/allocation/primary_pom_partials_spec.rb
+++ b/spec/views/case_history/allocation/primary_pom_partials_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'case_history/allocation primary POM partials', type: :view do
       expect(page).to have_css('.moj-timeline__description', text: 'Prisoner reallocated to John Smith')
       expect(page).to have_css('.moj-timeline__description', text: '(email address not found)')
       expect(page).to have_css('.moj-timeline__description', text: 'Tier: B')
-      expect(page).not_to have_css('.moj-timeline__description', text: 'ROSH:')
+      expect(page).to have_css('.moj-timeline__description', text: 'ROSH: N/A')
       expect(page).not_to have_css('.app-override-reasons')
     end
   end

--- a/spec/views/reallocations/override.html.erb_spec.rb
+++ b/spec/views/reallocations/override.html.erb_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'reallocations/override', type: :view do
       expect(page).to have_css('.govuk-error-summary')
       expect(page).to have_css('.govuk-hint', text: 'Choose all that apply')
       expect(page).to have_link(
-        'Select one or more reasons for not accepting the recommendation',
+        'Select at least one reason',
         href: '#override-form-override-reasons-field-error'
       )
       expect(page).to have_css('input#override-form-override-reasons-field-error')


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2005

When a case is re-allocated to a different POM, sometimes the RoSH has been updated to a blank value. Therefore we cannot make a recommendation if the case is not Tier A.

The content on several screens have been updated as per UCD to reflect this lack of recommendation, as well as forcing going through the override screen for these cases.