### PR TITLE
Add additional contextual tags to the audit

### DIFF
--- a/app/controllers/parole_reviews_controller.rb
+++ b/app/controllers/parole_reviews_controller.rb
@@ -9,7 +9,7 @@ class ParoleReviewsController < PrisonsApplicationController
     @parole_review.update(parole_review_params)
 
     if @parole_review.valid?(:manual_update)
-      RecalculateHandoverDateJob.perform_now(@offender.offender_no)
+      RecalculateHandoverDateJob.perform_now(@offender.offender_no, trigger_method: 'parole_review')
       redirect_to prison_prisoner_path(prison: @prison, id: @offender.offender_no)
     else
       render :edit

--- a/app/jobs/debounced_recalculate_handover_date_job.rb
+++ b/app/jobs/debounced_recalculate_handover_date_job.rb
@@ -9,7 +9,7 @@ class DebouncedRecalculateHandoverDateJob < ApplicationJob
   def perform(nomis_offender_id, debounce_key:, debounce_token:)
     return unless debounce_token_match?(nomis_offender_id, debounce_key, debounce_token)
 
-    job = RecalculateHandoverDateJob.perform_later(nomis_offender_id)
+    job = RecalculateHandoverDateJob.perform_later(nomis_offender_id, trigger_method: 'event')
 
     logger.info(
       "job=debounced_recalculate_handover_date_job,event=enqueued,nomis_offender_id=#{nomis_offender_id},job_id=#{job.job_id}"

--- a/app/jobs/recalculate_handover_date_job.rb
+++ b/app/jobs/recalculate_handover_date_job.rb
@@ -3,8 +3,9 @@
 class RecalculateHandoverDateJob < ApplicationJob
   queue_as :default
 
-  def perform(nomis_offender_id)
+  def perform(nomis_offender_id, trigger_method: 'manual')
     @nomis_offender = OffenderService.get_offender(nomis_offender_id)
+    @trigger_method = trigger_method
 
     return if nomis_offender.nil?
     return if nomis_offender.case_information.nil? || !nomis_offender.inside_omic_policy?
@@ -14,7 +15,7 @@ class RecalculateHandoverDateJob < ApplicationJob
 
 private
 
-  attr_reader :nomis_offender, :db_offender, :record, :com_email_eligible
+  attr_reader :nomis_offender, :db_offender, :record, :com_email_eligible, :trigger_method
 
   def recalculate_dates_for_offender
     save_handover_calculation
@@ -50,7 +51,7 @@ private
 
         AuditEvent.publish(
           nomis_offender_id: handover_after['nomis_offender_id'],
-          tags: %w[job recalculate_handover_date handover changed],
+          tags: ['job', 'recalculate_handover_date', 'handover', 'changed', trigger_method],
           system_event: true,
           data: {
             'before' => handover_before,

--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -234,7 +234,7 @@ private
   end
 
   def audit_event_tags
-    %w[record allocation changed].freeze
+    ['record', 'allocation', 'changed', event].freeze
   end
 
   def audit_excluded_keys

--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -101,7 +101,7 @@ private
   end
 
   def audit_event_tags
-    %w[record early_allocation changed].freeze
+    ['record', 'early_allocation', 'changed', outcome].freeze
   end
 
   def audit_excluded_keys

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -50,7 +50,7 @@ class PomDetail < ApplicationRecord
 private
 
   def audit_event_tags
-    %w[record pom_detail changed].freeze
+    ['record', 'pom_detail', 'changed', status].freeze
   end
 
   def audit_additional_data

--- a/app/services/early_allocation_service.rb
+++ b/app/services/early_allocation_service.rb
@@ -48,7 +48,7 @@ class EarlyAllocationService
             }
           )
         end
-        RecalculateHandoverDateJob.perform_now(offender.nomis_offender_id)
+        RecalculateHandoverDateJob.perform_now(offender.nomis_offender_id, trigger_method: 'early_allocation')
       end
     end
 

--- a/lib/tasks/recalculate_handover_dates.rake
+++ b/lib/tasks/recalculate_handover_dates.rake
@@ -10,7 +10,7 @@ task recalculate_handover_dates: :environment do
     offender_ids = prison.offenders.map(&:offender_no)
 
     ActiveJob.perform_all_later(
-      offender_ids.map { RecalculateHandoverDateJob.new(it) }
+      offender_ids.map { RecalculateHandoverDateJob.new(it, trigger_method: 'batch') }
     )
 
     Rails.logger.info(

--- a/spec/controllers/parole_reviews_controller_spec.rb
+++ b/spec/controllers/parole_reviews_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ParoleReviewsController, type: :controller do
       end
 
       it 'enqueues the job and redirects to the offender' do
-        expect(RecalculateHandoverDateJob).to receive(:perform_now).with(offender.offender_no)
+        expect(RecalculateHandoverDateJob).to receive(:perform_now).with(offender.offender_no, trigger_method: 'parole_review')
         patch :update, params: {
           prison_id: prison, prisoner_id: offender.offender_no, id: parole_review.review_id, parole_review: valid_params
         }

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -128,7 +128,7 @@ feature "early allocation", :disable_early_allocation_event, type: :feature do
 
             expect(EarlyAllocationService).to have_received(:send_early_allocation).with(
               CalculatedEarlyAllocationStatus.find_by_nomis_offender_id(nomis_offender_id))
-            expect(RecalculateHandoverDateJob).to have_received(:perform_now).with(nomis_offender_id)
+            expect(RecalculateHandoverDateJob).to have_received(:perform_now).with(nomis_offender_id, trigger_method: 'early_allocation')
           end
 
           scenario 'displaying the PDF' do

--- a/spec/jobs/debounced_recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/debounced_recalculate_handover_date_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DebouncedRecalculateHandoverDateJob, type: :job do
 
     described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
 
-    expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
+    expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id, trigger_method: 'event')
     expect(job_logger).to have_received(:info).with(
       "job=debounced_recalculate_handover_date_job,event=enqueued,nomis_offender_id=#{nomis_offender_id},job_id=job-123"
     )
@@ -29,7 +29,7 @@ RSpec.describe DebouncedRecalculateHandoverDateJob, type: :job do
 
     described_class.perform_now(nomis_offender_id, debounce_key:, debounce_token:)
 
-    expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id)
+    expect(RecalculateHandoverDateJob).to have_received(:perform_later).with(nomis_offender_id, trigger_method: 'event')
     expect(job_logger).to have_received(:info).with(
       "job=debounced_recalculate_handover_date_job,event=enqueued,nomis_offender_id=#{nomis_offender_id},job_id=job-123"
     )

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -79,7 +79,7 @@ describe RecalculateHandoverDateJob do
         {
           nomis_offender_id: offender.nomis_offender_id,
           system_event: true,
-          tags: %w[job recalculate_handover_date handover changed],
+          tags: %w[job recalculate_handover_date handover changed manual],
           data: {
             'before' => {
               'handover_date' => nil,

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -652,7 +652,7 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
       expect(AuditEvent).to have_received(:publish).once do |payload|
         expect(payload).to include(
           nomis_offender_id: allocation.nomis_offender_id,
-          tags: %w[record allocation changed],
+          tags: %w[record allocation changed allocate_primary_pom],
           system_event: false,
           username: 'HOMD_USER',
           data: {

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe EarlyAllocation, type: :model do
 
       audit = AuditEvent.order(:created_at).last
       aggregate_failures do
-        expect(audit.tags).to eq(%w[record early_allocation changed])
+        expect(audit.tags).to eq(%w[record early_allocation changed eligible])
         expect(audit.data['after']).to include('outcome' => 'eligible')
       end
     end

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe PomDetail, type: :model do
       audit = AuditEvent.order(:created_at).last
       aggregate_failures do
         expect(audit.nomis_offender_id).to be_nil
-        expect(audit.tags).to eq(%w[record pom_detail changed])
+        expect(audit.tags).to eq(%w[record pom_detail changed active])
         expect(audit.data['nomis_staff_id']).to eq(pom_detail.nomis_staff_id)
         expect(audit.data['prison_code']).to eq(prison.code)
       end

--- a/spec/services/early_allocation_service_spec.rb
+++ b/spec/services/early_allocation_service_spec.rb
@@ -63,7 +63,7 @@ describe EarlyAllocationService do
       end
 
       it 'invokes job to recalculate handover date in case that changed too' do
-        expect(RecalculateHandoverDateJob).to have_received(:perform_now).with(nomis_offender_id)
+        expect(RecalculateHandoverDateJob).to have_received(:perform_now).with(nomis_offender_id, trigger_method: 'early_allocation')
       end
 
       it 'audits the change', :aggregate_failures do
@@ -88,7 +88,7 @@ describe EarlyAllocationService do
       end
 
       it 'invokes job to recalculate handover date in case that changed too' do
-        expect(RecalculateHandoverDateJob).to have_received(:perform_now).with(nomis_offender_id)
+        expect(RecalculateHandoverDateJob).to have_received(:perform_now).with(nomis_offender_id, trigger_method: 'early_allocation')
       end
 
       it 'audits the change', :aggregate_failures do


### PR DESCRIPTION
Allows for better filtering in the debugging page.

Particularly useful for the handover recalculation as it can be triggered via several methods and it follows the pattern we have in other places like delius import.