### PR TITLE
MO-2003 Skip bulk reallocation interstitial page

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -79,6 +79,7 @@ class PomsController < PrisonStaffApplicationController
     unless @pom.inactive? || @pom.in_limbo?
       # TODO: maybe design a nicer informational page?
       redirect_to prison_pom_path, notice: 'Only inactive POMs are eligible for bulk case reallocation.'
+      return
     end
 
     pom_allocations_summary

--- a/app/controllers/reallocations/selection_controller.rb
+++ b/app/controllers/reallocations/selection_controller.rb
@@ -12,6 +12,7 @@ module Reallocations
 
     def index
       @available_poms = active_poms.sort_by(&:full_name_ordered)
+      @from_tab = params[:from] == 'tab'
     end
 
     # NOTE: do not remove this override, it is here for explicitness

--- a/app/helpers/pom_helper.rb
+++ b/app/helpers/pom_helper.rb
@@ -77,4 +77,14 @@ module PomHelper
   def inactive_poms(poms)
     poms.select(&:inactive?)
   end
+
+  def pom_staff_list_tab_path(pom, prison_code = nil)
+    anchor = pom.in_limbo? ? 'attention_needed!top' : 'inactive_poms!top'
+
+    if prison_code
+      prison_poms_path(prison_code, anchor:)
+    else
+      prison_poms_path(anchor:)
+    end
+  end
 end

--- a/app/views/poms/_inactive_poms.html.erb
+++ b/app/views/poms/_inactive_poms.html.erb
@@ -18,7 +18,7 @@
         <% if FeatureFlags.bulk_reallocation.enabled? %>
         <td aria-label="Action" class="govuk-table__cell">
           <% if pom.has_primary_allocations? %>
-            <%= link_to 'Reallocate cases', reallocate_prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id), class: 'govuk-link' %>
+            <%= link_to 'Reallocate cases', prison_reallocation_path(@prison.code, pom.staff_id, from: 'tab'), class: 'govuk-link' %>
           <% end %>
         </td>
         <% end %>

--- a/app/views/poms/_removed_poms.html.erb
+++ b/app/views/poms/_removed_poms.html.erb
@@ -23,7 +23,7 @@
           <% if FeatureFlags.bulk_reallocation.enabled? %>
             <% if pom.has_pom_role? %>
               <%= link_to 'Reallocate cases',
-                          reallocate_prison_pom_path(@prison.code, pom.staff_id),
+                          prison_reallocation_path(@prison.code, pom.staff_id, from: 'tab'),
                           class: 'govuk-link govuk-!-font-size-19' %>
             <% else %>
               <%= link_to 'Reallocate cases',

--- a/app/views/poms/confirm_delete.html.erb
+++ b/app/views/poms/confirm_delete.html.erb
@@ -15,7 +15,8 @@
       <%= f.govuk_collection_radio_buttons :confirmation,
             [OpenStruct.new(value: 'yes', label: 'Yes'), OpenStruct.new(value: 'no', label: 'No')],
             :value, :label, inline: true, include_hidden: true,
-            legend: { text: "Are you sure you want to remove #{@pom.full_name_ordered} from this service?", size: 'l', tag: 'h1' } %>
+            legend: { text: "Are you sure you want to remove #{@pom.full_name_ordered} from this service?", size: 'l', tag: 'h1' },
+            hint: { text: 'If you choose yes, you will have the option to reallocate their cases in bulk.' } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/poms/confirm_removal.html.erb
+++ b/app/views/poms/confirm_removal.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Confirm POM removal – Digital Prison Services' %>
 
-<%= link_to 'Back', prison_poms_path(anchor: 'attention_needed!top'),
+<%= link_to 'Back', pom_staff_list_tab_path(@pom),
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">
@@ -20,7 +20,7 @@
 
     <div class="govuk-button-group">
       <%= link_to 'Continue', reallocate_prison_pom_path(@prison.code, @pom.staff_id), role: 'button', class: 'govuk-button' %>
-      <%= link_to 'Cancel', prison_poms_path(anchor: 'attention_needed!top'), class: 'govuk-link' %>
+      <%= link_to 'Cancel', pom_staff_list_tab_path(@pom), class: 'govuk-link' %>
     </div>
   </div>
 </div>

--- a/app/views/poms/confirm_removal.html.erb
+++ b/app/views/poms/confirm_removal.html.erb
@@ -15,11 +15,12 @@
     </p>
 
     <p class="govuk-body govuk-!-margin-bottom-6">
-      Choose continue to confirm they can be removed from this service once their cases have been reallocated.
+      Choose continue to confirm they can be removed from this service. You will then have the option to reallocate
+      their cases in bulk.
     </p>
 
     <div class="govuk-button-group">
-      <%= link_to 'Continue', reallocate_prison_pom_path(@prison.code, @pom.staff_id), role: 'button', class: 'govuk-button' %>
+      <%= link_to 'Continue', prison_reallocation_path(@prison.code, @pom.staff_id, from: 'tab'), role: 'button', class: 'govuk-button' %>
       <%= link_to 'Cancel', pom_staff_list_tab_path(@pom), class: 'govuk-link' %>
     </div>
   </div>

--- a/app/views/poms/reallocate.html.erb
+++ b/app/views/poms/reallocate.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Reallocation summary – Digital Prison Services" %>
 
-<%= link_to 'Back', prison_poms_path(anchor: @pom.in_limbo? ? 'attention_needed!top' : 'inactive_poms!top'),
+<%= link_to 'Back', pom_staff_list_tab_path(@pom),
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">
@@ -78,10 +78,10 @@
       <%= link_to 'Continue', prison_reallocation_path, role: 'button', class: 'govuk-button' %>
 
       <% if @pom.in_limbo? %>
-        <%= link_to 'Reallocate cases later', prison_poms_path(anchor: 'attention_needed!top'),
+        <%= link_to 'Reallocate cases later', pom_staff_list_tab_path(@pom),
                     role: 'button', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button--secondary' } %>
       <% else %>
-        <%= link_to 'Skip this', prison_poms_path(anchor: 'inactive_poms!top'),
+        <%= link_to 'Skip this', pom_staff_list_tab_path(@pom),
                     role: 'button', class: 'govuk-button govuk-button--secondary', data: { module: 'govuk-button--secondary' } %>
       <% end %>
     </div>

--- a/app/views/reallocations/confirmation.html.erb
+++ b/app/views/reallocations/confirmation.html.erb
@@ -65,15 +65,15 @@
       </p>
 
       <div class="govuk-button-group">
-        <%= link_to 'Reallocate cases now', prison_reallocation_path, class: 'govuk-button' %>
-        <%= link_to 'Back to staff list', prison_poms_path(@prison.code, anchor: 'attention_needed!top'), class: 'govuk-button govuk-button--secondary' %>
+        <%= link_to 'Reallocate cases now', prison_reallocation_path(from: 'tab'), class: 'govuk-button' %>
+        <%= link_to 'Back to staff list', pom_staff_list_tab_path(@pom, @prison.code), class: 'govuk-button govuk-button--secondary' %>
       </div>
     <% else %>
       <p class="govuk-body">
         <%= @pom.full_name_ordered %> has no more cases and has been removed from this service.
       </p>
 
-      <%= link_to 'Back to staff list', prison_poms_path(@prison.code, anchor: 'attention_needed!top'), class: 'govuk-button' %>
+      <%= link_to 'Back to staff list', pom_staff_list_tab_path(@pom, @prison.code), class: 'govuk-button' %>
     <% end %>
   </div>
 </div>

--- a/app/views/reallocations/index.html.erb
+++ b/app/views/reallocations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Choose a POM – Digital Prison Services" %>
 
-<%= link_to 'Back', reallocate_prison_pom_path,
+<%= link_to 'Back', @from_tab ? pom_staff_list_tab_path(@pom) : reallocate_prison_pom_path,
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -96,7 +96,7 @@ feature "remove a POM no longer present in NOMIS" do
         end
 
         expect(page).to have_css('h1.govuk-heading-l', text: 'Confirm John Doe can be removed from this service')
-        expect(page).to have_link('Continue', href: reallocate_prison_pom_path(prison.code, removed_pom_staff_id))
+        expect(page).to have_link('Continue', href: prison_reallocation_path(prison.code, removed_pom_staff_id, from: 'tab'))
       end
     end
 

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -121,11 +121,11 @@ feature "remove a POM no longer present in NOMIS" do
         visit prison_poms_path(prison_id: prison.code)
       end
 
-      it 'links directly to the reallocation summary page' do
+      it 'links directly to the POM selection page, skipping the summary' do
         click_link 'Attention needed'
 
         within('section#attention_needed') do
-          expect(page).to have_link('Reallocate cases', href: reallocate_prison_pom_path(prison.code, deleted_pom_staff_id))
+          expect(page).to have_link('Reallocate cases', href: prison_reallocation_path(prison.code, deleted_pom_staff_id, from: 'tab'))
         end
       end
     end

--- a/spec/helpers/pom_helper_spec.rb
+++ b/spec/helpers/pom_helper_spec.rb
@@ -114,4 +114,16 @@ RSpec.describe PomHelper do
       expect(inactive_poms(poms)).not_to include(active_pom, unavailable_pom)
     end
   end
+
+  describe '#pom_staff_list_tab_path' do
+    it 'returns the inactive POMs tab for a non-limbo POM' do
+      pom = double('POM', in_limbo?: false)
+      expect(pom_staff_list_tab_path(pom, 'LEI')).to eq(prison_poms_path('LEI', anchor: 'inactive_poms!top'))
+    end
+
+    it 'returns the attention needed tab for a limbo POM' do
+      pom = double('POM', in_limbo?: true)
+      expect(pom_staff_list_tab_path(pom, 'LEI')).to eq(prison_poms_path('LEI', anchor: 'attention_needed!top'))
+    end
+  end
 end

--- a/spec/views/reallocations/index.html.erb_spec.rb
+++ b/spec/views/reallocations/index.html.erb_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'reallocations/index', type: :view do
   let(:all_pom_records) { [source_pom_record] + available_pom_records }
   let(:source_pom) { StaffMember.new(prison, source_pom_record.staff_id) }
   let(:available_poms) { available_pom_records.map { |pom| StaffMember.new(prison, pom.staff_id) } }
+  let(:from_tab) { false }
 
   before do
     stub_poms(prison.code, all_pom_records)
@@ -36,6 +37,7 @@ RSpec.describe 'reallocations/index', type: :view do
     assign(:available_poms, available_poms)
     assign(:prison_poms, available_poms.select(&:prison_officer?))
     assign(:probation_poms, available_poms.select(&:probation_officer?))
+    assign(:from_tab, from_tab)
   end
 
   it 'renders the reallocation-specific wrapper around the shared POM selection table' do
@@ -93,6 +95,20 @@ RSpec.describe 'reallocations/index', type: :view do
         expect(page).to have_css('#pom-selection-error')
         expect(page).to have_link('Choose at least one POM to compare workloads', href: '#pom-selection-error')
       end
+    end
+  end
+
+  context 'when navigated from a tab link' do
+    let(:from_tab) { true }
+
+    before do
+      PomDetail.find_by!(prison_code: prison.code, nomis_staff_id: source_pom.staff_id).update!(status: 'inactive')
+    end
+
+    it 'renders the back link to the POM list tabs instead of the summary page' do
+      render
+
+      expect(page).to have_link('Back', href: prison_poms_path(prison.code, anchor: 'inactive_poms!top'))
     end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2003

As per UCD, when using the reallocate cases link from either Attention needed or Away from work tabs, take the user to the "Choose a POM" screen directly (and skip the Reallocate X cases screen).

Keep the interstitial when updating the POM status through the edit profile page.

Also added a missing hint text as per https://dsdmoj.atlassian.net/browse/MO-2002
And a copy change as per https://dsdmoj.atlassian.net/browse/MO-2015