### PR TITLE
MO-2014 Only send bulk realloc summary emails

### DIFF
--- a/app/services/reallocation/bulk_reallocation_notifier.rb
+++ b/app/services/reallocation/bulk_reallocation_notifier.rb
@@ -2,37 +2,23 @@
 
 module Reallocation
   class BulkReallocationNotifier
-    attr_reader :prison, :source_pom, :target_pom, :email_service, :mailer
+    attr_reader :prison, :source_pom, :target_pom, :mailer
 
-    def initialize(prison:, source_pom:, target_pom:, email_service: EmailService, mailer: PomMailer)
+    def initialize(prison:, source_pom:, target_pom:, mailer: PomMailer)
       @prison = prison
       @source_pom = source_pom
       @target_pom = target_pom
-      @email_service = email_service
       @mailer = mailer
     end
 
     def call(result)
       return if result.reallocated_cases.empty?
 
-      deliver_individual_emails(result)
       deliver_allocations_created_email(result)
       deliver_allocations_removed_email(result)
     end
 
   private
-
-    def deliver_individual_emails(result)
-      result.reallocated_cases.each do |reallocated_case|
-        email_service.send_email(
-          allocation: reallocated_case.allocation,
-          message: result.message,
-          pom_nomis_id: reallocated_case.allocation.primary_pom_nomis_id,
-          further_info: reallocated_case.further_info,
-          notify_previous_pom: false,
-        )
-      end
-    end
 
     def deliver_allocations_created_email(result)
       return if target_pom.email_address.blank?

--- a/app/services/reallocation/bulk_reallocation_result.rb
+++ b/app/services/reallocation/bulk_reallocation_result.rb
@@ -12,7 +12,7 @@ module Reallocation
       end
     end
 
-    ReallocatedCase = Struct.new(:allocation, :selected_case, :further_info, :email_context, keyword_init: true) do
+    ReallocatedCase = Struct.new(:allocation, :selected_case, :email_context, keyword_init: true) do
       def confirmation_attributes
         {
           full_name: selected_case.full_name,

--- a/app/services/reallocation/bulk_reallocation_service.rb
+++ b/app/services/reallocation/bulk_reallocation_service.rb
@@ -103,7 +103,6 @@ module Reallocation
       BulkReallocationResult::ReallocatedCase.new(
         allocation: persisted_allocation,
         selected_case: selected_case,
-        further_info: notification_context,
         email_context: email_context,
       )
     end

--- a/spec/services/reallocation/bulk_reallocation_notifier_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_notifier_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
       prison: prison,
       source_pom: source_pom,
       target_pom: target_pom,
-      email_service: email_service,
       mailer: mailer,
     )
   end
@@ -20,7 +19,6 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
   let(:target_pom) do
     instance_double(StaffMember, staff_id: 10_002, full_name_ordered: 'New Pom', email_address: 'new.pom@example.com')
   end
-  let(:email_service) { class_double(EmailService, send_email: nil) }
   let(:mailer) { class_double(PomMailer) }
   let(:created_email) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
   let(:removed_email) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
@@ -30,7 +28,6 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
     Reallocation::BulkReallocationResult::ReallocatedCase.new(
       allocation: allocation,
       selected_case: instance_double(AllocatedOffender, full_name: 'Zephyr, Alice', nomis_offender_id: 'G1234AA'),
-      further_info: { com_name: 'John Smith' },
       email_context: {
         offender_name: 'Alice Zephyr',
         prisoner_number: 'G1234AA',
@@ -71,13 +68,6 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
 
     notifier.call(result)
 
-    expect(email_service).to have_received(:send_email).with(
-      allocation: allocation,
-      message: 'Bulk move',
-      pom_nomis_id: target_pom.staff_id,
-      further_info: { com_name: 'John Smith' },
-      notify_previous_pom: false,
-    )
     expect(created_email).to have_received(:deliver_later).with(no_args)
     expect(removed_email).to have_received(:deliver_later).with(no_args)
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2014

For each case that was reallocated in the bulk reallocation journey, the service sent an individual reallocation email. It also sent an email summarising all the cases that had been reallocated.

As per UCD, only the summary email will be sent, skipping the individual emails.