### PR TITLE
MO-2017 Away from work table empty state

### DIFF
--- a/app/views/caseload/parole_cases.html.erb
+++ b/app/views/caseload/parole_cases.html.erb
@@ -7,7 +7,7 @@
 <% if @pom.blank? || @parole_cases.empty? %>
   <h2 class="govuk-heading-l">No cases approaching parole </h2>
 <% else %>
-  <table class="govuk-table responsive tablesorter">
+  <table class="govuk-table responsive">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col" <%= sort_aria('last_name') %>>

--- a/app/views/caseload_global/_caseload_table.html.erb
+++ b/app/views/caseload_global/_caseload_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table responsive tablesorter">
+<table class="govuk-table responsive">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <%= render header_partial, anchor: (defined?(selected_filter) ? selected_filter : nil) %>

--- a/app/views/parole_cases/index.html.erb
+++ b/app/views/parole_cases/index.html.erb
@@ -11,7 +11,7 @@
                 :data => @offenders,
             }) %>
 
-      <table class="govuk-table responsive tablesorter">
+      <table class="govuk-table responsive">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col" <%= sort_aria('last_name') %>>

--- a/app/views/poms/_inactive_poms.html.erb
+++ b/app/views/poms/_inactive_poms.html.erb
@@ -1,18 +1,25 @@
-<table class="govuk-table responsive tablesorter">
-  <thead class="govuk-table__head">
-  <tr class="govuk-table__row">
-    <th class="govuk-table__header" scope="col">POM</th>
-    <th class="govuk-table__header" scope="col">POM type</th>
-    <th class="govuk-table__header" scope="col">Total cases</th>
-    <% if FeatureFlags.bulk_reallocation.enabled? %>
-    <th class="govuk-table__header" scope="col">Action</th>
-    <% end %>
-  </tr>
-  </thead>
-  <tbody class="govuk-table__body">
+<% if poms.empty? %>
+  <p class="govuk-body govuk-!-margin-bottom-2">
+    No POMs away from work.
+  </p>
+<% else %>
+  <table class="govuk-table responsive">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">POM</th>
+      <th class="govuk-table__header" scope="col">POM type</th>
+      <th class="govuk-table__header" scope="col">Total cases</th>
+      <% if FeatureFlags.bulk_reallocation.enabled? %>
+      <th class="govuk-table__header" scope="col">Action</th>
+      <% end %>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
     <% poms.each_with_index do |pom, i| %>
       <tr class="govuk-table__row pom_row_<%= i %>">
-        <td aria-label="POM" class="govuk-table__cell"><%= link_to full_name_ordered(pom), prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id) %></td>
+        <td aria-label="POM" class="govuk-table__cell">
+          <%= link_to full_name_ordered(pom), prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id) %>
+        </td>
         <td aria-label="POM type" class="govuk-table__cell"><%= grade(pom) %></td>
         <td aria-label="Total cases" class="govuk-table__cell govuk-!-font-weight-bold"><%= pom.allocations.count %></td>
         <% if FeatureFlags.bulk_reallocation.enabled? %>
@@ -24,5 +31,6 @@
         <% end %>
       </tr>
     <% end %>
-  </tbody>
-</table>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/prisoners/allocated.html.erb
+++ b/app/views/prisoners/allocated.html.erb
@@ -35,7 +35,7 @@
               :data => @offenders,
           }) %>
 
-  <table class="govuk-table responsive tablesorter">
+  <table class="govuk-table responsive">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" <%= sort_aria('last_name') %>>

--- a/app/views/prisoners/missing_information.html.erb
+++ b/app/views/prisoners/missing_information.html.erb
@@ -22,7 +22,7 @@
 <section id="awaiting-information">
   <%= render partial: 'shared/pagination', locals: { data: @offenders } %>
 
-  <table class="govuk-table responsive tablesorter">
+  <table class="govuk-table responsive">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" <%= sort_aria('last_name') %>>

--- a/app/views/prisoners/search.html.erb
+++ b/app/views/prisoners/search.html.erb
@@ -18,7 +18,7 @@
             :data => @offenders,
           }) %>
 
-    <table class="govuk-table responsive tablesorter govuk-!-margin-top-4">
+    <table class="govuk-table responsive govuk-!-margin-top-4">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Case</th>

--- a/app/views/prisoners/search_global.html.erb
+++ b/app/views/prisoners/search_global.html.erb
@@ -33,7 +33,7 @@
               :url_params => { anchor: 'caseload-results' }
             }) %>
 
-      <table class="govuk-table responsive tablesorter govuk-!-margin-top-4">
+      <table class="govuk-table responsive govuk-!-margin-top-4">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Case</th>
@@ -90,7 +90,7 @@
               :url_params => { anchor: 'global-results' }
             }) %>
 
-      <table class="govuk-table responsive tablesorter govuk-!-margin-top-4">
+      <table class="govuk-table responsive govuk-!-margin-top-4">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Case</th>

--- a/app/views/prisoners/unallocated.html.erb
+++ b/app/views/prisoners/unallocated.html.erb
@@ -40,7 +40,7 @@
               :data => @offenders,
           }) %>
 
-  <table class="govuk-table responsive tablesorter">
+  <table class="govuk-table responsive">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" <%= sort_aria('last_name') %>>

--- a/app/views/shared/_caseload_table.html.erb
+++ b/app/views/shared/_caseload_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table responsive tablesorter">
+<table class="govuk-table responsive">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <%= render header_partial, anchor: (defined?(selected_filter) ? selected_filter : nil)  %>

--- a/app/views/shared/_parole_table.html.erb
+++ b/app/views/shared/_parole_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table responsive tablesorter">
+<table class="govuk-table responsive">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" <%= sort_aria('last_name') %>>

--- a/spec/controllers/poms_controller_spec.rb
+++ b/spec/controllers/poms_controller_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe PomsController, type: :controller do
       expect(response).to be_successful
 
       expect(inactive_poms.count).to eq(1)
+      expect(response.body).not_to include('No POMs away from work.')
+
       active_poms_list = active_poms.map do |pom|
         {
           staff_id: pom.staff_id,
@@ -101,6 +103,19 @@ RSpec.describe PomsController, type: :controller do
                                                                 "C",
                                                                 "C",
                                                                 "D"])
+    end
+  end
+
+  context 'when there are no inactive POMs' do
+    before do
+      PomDetail.where(status: 'inactive').destroy_all
+      stub_offenders_for_prison(prison.code, a_offenders + b_offenders + c_offenders + d_offenders)
+    end
+
+    it 'shows the empty state message in the away from work tab' do
+      get :index, params: { prison_id: prison.code }
+      expect(response).to be_successful
+      expect(response.body).to include('No POMs away from work.')
     end
   end
 

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -284,12 +284,18 @@ feature "staff pages" do
       end
     end
 
-    it 'displays the inactive POMs' do
+    it 'displays inactive POMs in the Away from work tab' do
+      PomDetail.find_by!(nomis_staff_id: prison_poms.first.staffId).update!(status: 'inactive')
+
+      visit prison_poms_path(female_prison)
       click_on('Away from work')
 
-      expect(page).to have_content('POM')
-      expect(page).to have_content('POM type')
-      expect(page).to have_content('Total cases')
+      within('#inactive_poms') do
+        expect(page).to have_content('POM')
+        expect(page).to have_content('POM type')
+        expect(page).to have_content('Total cases')
+        expect(page).to have_content(prison_poms.first.full_name_ordered)
+      end
     end
 
     it 'can view a POM' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2017

If no POMs are away from work, we remove the table and display the empty state message 'No POMs away from work'.

Also, small markup and unused css class cleanup.