### PR TITLE
MO-2018 Show ghost POMs in attention needed tab

### DIFF
--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -23,6 +23,18 @@ class PomDetail < ApplicationRecord
 
   belongs_to :prison, foreign_key: :prison_code, inverse_of: :pom_details
 
+  def self.find_or_create_as_system!(prison_code:, nomis_staff_id:, status: 'active', working_pattern: 0.0)
+    find_by(prison_code:, nomis_staff_id:) ||
+      PaperTrail.request(whodunnit: nil) do
+        find_or_create_by!(prison_code:, nomis_staff_id:) do |pd|
+          pd.working_pattern = working_pattern
+          pd.status = status
+        end
+      end
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(prison_code:, nomis_staff_id:)
+  end
+
   # @return [Array<MpcOffender>] Allocated offenders for this POM
   def allocations
     @allocations ||= begin

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -128,22 +128,17 @@ private
 
   # Creates a deleted `PomDetail` so existing flows (bulk reallocation,
   # NomisUserRolesService.remove_pom) work seamlessly
-  def find_or_create_ghost_pom(nomis_staff_id)
-    pom_detail = pom_details.find_or_create_by!(nomis_staff_id:) do |pd|
-      pd.working_pattern = 0.0
-      pd.status = 'deleted'
-      Rails.logger.info("event=ghost_pom_created,staff_id=#{nomis_staff_id},prison=#{code}")
-    end
-    StaffMember.new(self, nomis_staff_id, pom_detail)
-  rescue ActiveRecord::RecordNotUnique
-    StaffMember.new(self, nomis_staff_id, pom_details.find_by!(nomis_staff_id:))
+  def find_or_create_ghost_pom(staff_id)
+    pom_detail = PomDetail.find_or_create_as_system!(
+      prison_code: code, nomis_staff_id: staff_id, status: 'deleted'
+    )
+    Rails.logger.info("event=ghost_pom_created,staff_id=#{staff_id},prison=#{code}") if pom_detail.previously_new_record?
+
+    StaffMember.new(self, staff_id, pom_detail)
   end
 
   def get_pom_detail(details, pom)
-    details.detect { |d| d.nomis_staff_id == pom.staff_id } ||
-      PomDetail.find_or_create_by!(prison_code: code, nomis_staff_id: pom.staff_id) do |pd|
-        pd.hours_per_week = 0 # TODO: decide if we want to use `pom.hours_per_week` (NOMIS hours)
-        pd.status = 'active'
-      end
+    details.detect { it.nomis_staff_id == pom.staff_id } ||
+      PomDetail.find_or_create_as_system!(prison_code: code, nomis_staff_id: pom.staff_id)
   end
 end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -37,11 +37,28 @@ class Prison < ApplicationRecord
   end
 
   def get_removed_poms(existing_poms:)
-    removed_poms = pom_details.where.not(nomis_staff_id: existing_poms.map(&:staff_id))
+    existing_pom_ids = existing_poms.map(&:staff_id)
 
-    removed_poms.filter(&:has_primary_allocations?).map do |pom_detail|
-      StaffMember.new(self, pom_detail.nomis_staff_id, pom_detail)
-    end
+    relevant_allocations = limbo_allocations_for(existing_pom_ids)
+    return [] if relevant_allocations.none?
+
+    # POMs that have a `PomDetail` but are no longer in NOMIS
+    removed_pom_details = pom_details.where.not(nomis_staff_id: existing_pom_ids)
+    staff_ids_with_allocations = relevant_allocations
+      .where(primary_pom_nomis_id: removed_pom_details.select(:nomis_staff_id))
+      .distinct.pluck(:primary_pom_nomis_id)
+
+    removed_poms = removed_pom_details
+      .where(nomis_staff_id: staff_ids_with_allocations)
+      .map { StaffMember.new(self, it.nomis_staff_id, it) }
+
+    # "Ghost" POMs: have active allocations but no `PomDetail` record
+    known_pom_ids = existing_pom_ids + pom_details.pluck(:nomis_staff_id)
+    ghost_pom_ids = relevant_allocations
+      .where.not(primary_pom_nomis_id: known_pom_ids)
+      .distinct.pluck(:primary_pom_nomis_id)
+
+    removed_poms + ghost_pom_ids.map { find_or_create_ghost_pom(it) }
   end
 
   def active?
@@ -95,6 +112,31 @@ private
 
   def summary
     @summary ||= AllocationsSummary.new(self)
+  end
+
+  # Returns allocations for POMs not in the active list, scoped to offenders
+  # still at this prison. Returns an empty relation if there are no candidates
+  # (avoids the expensive `allocated` call when unnecessary)
+  def limbo_allocations_for(existing_pom_ids)
+    candidates = AllocationHistory.active_allocations_for_prison(code)
+      .where.not(primary_pom_nomis_id: existing_pom_ids)
+
+    return AllocationHistory.none unless candidates.exists?
+
+    candidates.where(nomis_offender_id: allocated.map(&:offender_no))
+  end
+
+  # Creates a deleted `PomDetail` so existing flows (bulk reallocation,
+  # NomisUserRolesService.remove_pom) work seamlessly
+  def find_or_create_ghost_pom(nomis_staff_id)
+    pom_detail = pom_details.find_or_create_by!(nomis_staff_id:) do |pd|
+      pd.working_pattern = 0.0
+      pd.status = 'deleted'
+      Rails.logger.info("event=ghost_pom_created,staff_id=#{nomis_staff_id},prison=#{code}")
+    end
+    StaffMember.new(self, nomis_staff_id, pom_detail)
+  rescue ActiveRecord::RecordNotUnique
+    StaffMember.new(self, nomis_staff_id, pom_details.find_by!(nomis_staff_id:))
   end
 
   def get_pom_detail(details, pom)

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -125,7 +125,7 @@ private
 
   # Attempt to forward-populate the PomDetail table for new records
   def default_pom_detail(prison, staff_id)
-    prison.pom_details.find_by(nomis_staff_id: staff_id) || prison.pom_details.create!(working_pattern: 0.0, status: 'active', nomis_staff_id: staff_id)
+    PomDetail.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id: staff_id)
   end
 
   # This may raise a 404 for no longer existing NOMIS accounts (should be rare).

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -65,6 +65,45 @@ RSpec.describe PomDetail, type: :model do
     end
   end
 
+  describe '.find_or_create_as_system!' do
+    let(:nomis_staff_id) { 555_555 }
+
+    it 'creates a PomDetail with default attributes' do
+      pom_detail = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:)
+
+      expect(pom_detail).to be_persisted
+      expect(pom_detail.status).to eq('active')
+      expect(pom_detail.working_pattern).to eq(0.0)
+    end
+
+    it 'accepts custom status and working_pattern' do
+      pom_detail = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:, status: 'deleted', working_pattern: 0.5)
+
+      expect(pom_detail.status).to eq('deleted')
+      expect(pom_detail.working_pattern).to eq(0.5)
+    end
+
+    it 'returns the existing record if one already exists' do
+      existing = create(:pom_detail, prison:, nomis_staff_id:, status: 'active')
+
+      result = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:, status: 'deleted')
+
+      expect(result.id).to eq(existing.id)
+      expect(result.status).to eq('active')
+    end
+
+    it 'records as system-initiated even during a user session' do
+      PaperTrail.request.whodunnit = 'SPO_USER'
+
+      described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:)
+
+      version = PaperTrail::Version.where(item_type: 'PomDetail').last
+      expect(version.whodunnit).to be_nil
+    ensure
+      PaperTrail.request.whodunnit = nil
+    end
+  end
+
   describe '#save_audit_event' do
     before do
       PaperTrail.request.whodunnit = 'SPO_USER'

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -319,5 +319,101 @@ RSpec.describe Prison do
         expect(removed.first.staff_id).to eq(pom2.staff_id)
       end
     end
+
+    context 'when a ghost POM has allocations but no PomDetail record' do
+      let(:ghost_staff_id) { 999_999 }
+
+      let!(:allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               primary_pom_nomis_id: ghost_staff_id,
+               nomis_offender_id: offender_no)
+      end
+
+      before do
+        allow(prison).to receive(:allocated).and_return(
+          [MpcOffender.new(prison:, offender:, prison_record:)]
+        )
+      end
+
+      it 'returns the ghost POM as needing attention' do
+        removed = prison.get_removed_poms(existing_poms: [pom1, pom2])
+
+        expect(removed.size).to eq(1)
+        expect(removed.first).to be_a(StaffMember)
+        expect(removed.first.staff_id).to eq(ghost_staff_id)
+      end
+
+      it 'creates a PomDetail with deleted status for the ghost POM' do
+        expect { prison.get_removed_poms(existing_poms: [pom1, pom2]) }
+          .to change { PomDetail.where(prison_code: prison.code, nomis_staff_id: ghost_staff_id).count }.from(0).to(1)
+
+        pom_detail = PomDetail.find_by(prison_code: prison.code, nomis_staff_id: ghost_staff_id)
+        expect(pom_detail.status).to eq('deleted')
+        expect(pom_detail.working_pattern).to eq(0.0)
+      end
+
+      it 'does not create duplicate PomDetails on repeated calls' do
+        prison.get_removed_poms(existing_poms: [pom1, pom2])
+        expect { prison.get_removed_poms(existing_poms: [pom1, pom2]) }
+          .not_to(change { PomDetail.where(prison_code: prison.code, nomis_staff_id: ghost_staff_id).count })
+      end
+    end
+
+    context 'when a ghost POM has allocations but the offender has left the prison' do
+      let(:ghost_staff_id) { 999_999 }
+
+      let!(:allocation) do
+        create(:allocation_history,
+               prison: prison.code,
+               primary_pom_nomis_id: ghost_staff_id,
+               nomis_offender_id: offender_no)
+      end
+
+      before do
+        # No offenders at the prison
+        allow(prison).to receive(:allocated).and_return([])
+      end
+
+      it 'does not return the ghost POM because their cases are no longer at this prison' do
+        removed = prison.get_removed_poms(existing_poms: [pom1, pom2])
+        expect(removed).to be_empty
+      end
+    end
+
+    context 'when both removed and ghost POMs have allocations' do
+      let(:ghost_staff_id) { 999_999 }
+      let(:offender_no_2) { 'T0000B' }
+      let(:offender_2) { double(offender_no: offender_no_2) }
+      let(:prison_record_2) { double(offender_no: offender_no_2) }
+
+      let!(:allocation_removed) do
+        create(:allocation_history,
+               prison: prison.code,
+               primary_pom_nomis_id: pom2.staff_id,
+               nomis_offender_id: offender_no)
+      end
+
+      let!(:allocation_ghost) do
+        create(:allocation_history,
+               prison: prison.code,
+               primary_pom_nomis_id: ghost_staff_id,
+               nomis_offender_id: offender_no_2)
+      end
+
+      before do
+        allow(prison).to receive(:allocated).and_return([
+          MpcOffender.new(prison:, offender:, prison_record:),
+          MpcOffender.new(prison:, offender: offender_2, prison_record: prison_record_2),
+        ])
+      end
+
+      it 'returns both removed and ghost POMs without duplicates' do
+        removed = prison.get_removed_poms(existing_poms: [pom1])
+
+        expect(removed.size).to eq(2)
+        expect(removed.map(&:staff_id)).to contain_exactly(pom2.staff_id, ghost_staff_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2018

POMs who have active case allocations but no corresponding `PomDetail` record in our database are invisible to the "Attention needed" tab on the staff page. This creates a limbo state where cases are stuck and the SPO has no clear path to resolve them.

This PR extends the detection of limbo POMs to these ghosts so they also appear in the list.

DRY the handling of PomDetail, however there is a further ticket in the backlog to actually stop pulling/creating POM records automatically (forward-populate), that will clean up much of that code:
https://dsdmoj.atlassian.net/browse/MO-1892