### PR TITLE
MO-2025 Fix conditional message in Notify emails

### DIFF
--- a/app/mailers/pom_mailer.rb
+++ b/app/mailers/pom_mailer.rb
@@ -85,14 +85,14 @@ class PomMailer < ApplicationMailer
 
   def bulk_allocations_created
     set_template('5516c944-2e2c-4227-b08f-2084b799d12a')
-    set_personalisation(**params.slice(:pom_name, :old_pom_name, :message, :allocations, :url))
+    set_personalisation(**params.slice(:pom_name, :old_pom_name, :message, :has_message, :allocations, :url))
 
     mail(to: params[:pom_email])
   end
 
   def bulk_allocations_removed
     set_template('2c5b87eb-9e1e-4ca6-a011-3b9b01532a2f')
-    set_personalisation(**params.slice(:pom_name, :new_pom_name, :message, :allocations, :url))
+    set_personalisation(**params.slice(:pom_name, :new_pom_name, :message, :has_message, :allocations, :url))
 
     mail(to: params[:pom_email])
   end

--- a/app/services/reallocation/bulk_reallocation_notifier.rb
+++ b/app/services/reallocation/bulk_reallocation_notifier.rb
@@ -28,6 +28,7 @@ module Reallocation
         pom_email: target_pom.email_address,
         old_pom_name: source_pom.full_name_ordered,
         message: result.message,
+        has_message: notify_boolean(result.message.present?),
         allocations: result.allocations_for_email,
         url: caseload_url_for(target_pom),
       ).bulk_allocations_created.deliver_later
@@ -41,6 +42,7 @@ module Reallocation
         pom_email: source_pom.email_address,
         new_pom_name: target_pom.full_name_ordered,
         message: result.message,
+        has_message: notify_boolean(result.message.present?),
         allocations: result.allocations_for_email,
         url: caseload_url_for(source_pom),
       ).bulk_allocations_removed.deliver_later
@@ -48,6 +50,11 @@ module Reallocation
 
     def caseload_url_for(pom)
       Rails.application.routes.url_helpers.prison_staff_caseload_url(prison.code, pom.staff_id)
+    end
+
+    # Notify expects yes/no for conditional template placeholders
+    def notify_boolean(value)
+      value ? 'yes' : 'no'
     end
   end
 end

--- a/spec/mailers/pom_mailer_spec.rb
+++ b/spec/mailers/pom_mailer_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe PomMailer, type: :mailer do
         pom_email: 'new.pom@example.com',
         old_pom_name: 'Old Pom',
         message: 'Bulk move',
+        has_message: 'yes',
         allocations: [
           'Alice Zephyr (G1234AA) – responsible',
           'Bob Amber (G5678BB) – supporting'
@@ -173,6 +174,7 @@ RSpec.describe PomMailer, type: :mailer do
           pom_name: params[:pom_name],
           old_pom_name: params[:old_pom_name],
           message: 'Bulk move',
+          has_message: 'yes',
           allocations: params[:allocations],
           url: params[:url]
         )
@@ -181,12 +183,14 @@ RSpec.describe PomMailer, type: :mailer do
     context 'when no optional message has been added to the email' do
       it 'personalises the email with an empty message' do
         params[:message] = ''
+        params[:has_message] = 'no'
 
         expect(mail.govuk_notify_personalisation)
           .to eq(
             pom_name: params[:pom_name],
             old_pom_name: params[:old_pom_name],
             message: '',
+            has_message: 'no',
             allocations: params[:allocations],
             url: params[:url]
           )
@@ -201,6 +205,7 @@ RSpec.describe PomMailer, type: :mailer do
         pom_email: 'old.pom@example.com',
         new_pom_name: 'New Pom',
         message: 'Bulk move',
+        has_message: 'yes',
         allocations: [
           'Alice Zephyr (G1234AA) – responsible',
           'Bob Amber (G5678BB) – supporting'
@@ -226,6 +231,7 @@ RSpec.describe PomMailer, type: :mailer do
           pom_name: params[:pom_name],
           new_pom_name: params[:new_pom_name],
           message: 'Bulk move',
+          has_message: 'yes',
           allocations: params[:allocations],
           url: params[:url]
         )
@@ -234,12 +240,14 @@ RSpec.describe PomMailer, type: :mailer do
     context 'when no optional message has been added to the email' do
       it 'personalises the email with an empty message' do
         params[:message] = ''
+        params[:has_message] = 'no'
 
         expect(mail.govuk_notify_personalisation)
           .to eq(
             pom_name: params[:pom_name],
             new_pom_name: params[:new_pom_name],
             message: '',
+            has_message: 'no',
             allocations: params[:allocations],
             url: params[:url]
           )

--- a/spec/services/reallocation/bulk_reallocation_notifier_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_notifier_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
       pom_email: 'new.pom@example.com',
       old_pom_name: 'Old Pom',
       message: 'Bulk move',
+      has_message: 'yes',
       allocations: ['Alice Zephyr (G1234AA) – responsible'],
       url: 'http://localhost:3000/prisons/LEI/staff/10002/caseload'
     ).and_return(instance_double(PomMailer, bulk_allocations_created: created_email))
@@ -62,6 +63,7 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
       pom_email: 'old.pom@example.com',
       new_pom_name: 'New Pom',
       message: 'Bulk move',
+      has_message: 'yes',
       allocations: ['Alice Zephyr (G1234AA) – responsible'],
       url: 'http://localhost:3000/prisons/LEI/staff/10001/caseload'
     ).and_return(instance_double(PomMailer, bulk_allocations_removed: removed_email))
@@ -79,6 +81,7 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
       pom_email: 'old.pom@example.com',
       new_pom_name: 'New Pom',
       message: 'Bulk move',
+      has_message: 'yes',
       allocations: ['Alice Zephyr (G1234AA) – responsible'],
       url: 'http://localhost:3000/prisons/LEI/staff/10001/caseload'
     ).and_return(instance_double(PomMailer, bulk_allocations_removed: removed_email))
@@ -96,6 +99,7 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
       pom_email: 'new.pom@example.com',
       old_pom_name: 'Old Pom',
       message: 'Bulk move',
+      has_message: 'yes',
       allocations: ['Alice Zephyr (G1234AA) – responsible'],
       url: 'http://localhost:3000/prisons/LEI/staff/10002/caseload'
     ).and_return(instance_double(PomMailer, bulk_allocations_created: created_email))
@@ -104,5 +108,31 @@ RSpec.describe Reallocation::BulkReallocationNotifier do
 
     expect(created_email).to have_received(:deliver_later).with(no_args)
     expect(mailer).not_to have_received(:with).with(hash_including(pom_email: nil))
+  end
+
+  context 'when no optional message is provided' do
+    let(:result) do
+      Reallocation::BulkReallocationResult.new(
+        source_pom_id: source_pom.staff_id,
+        target_pom_id: target_pom.staff_id,
+        message: '',
+        reallocated_cases: [reallocated_case],
+        failed_cases: [],
+        remaining_cases_count: 3,
+      )
+    end
+
+    it 'passes has_message as no' do
+      allow(mailer).to receive(:with)
+        .with(hash_including(message: '', has_message: 'no'))
+        .and_return(
+          instance_double(PomMailer, bulk_allocations_created: created_email),
+          instance_double(PomMailer, bulk_allocations_removed: removed_email),
+        )
+
+      notifier.call(result)
+
+      expect(mailer).to have_received(:with).with(hash_including(message: '', has_message: 'no')).twice
+    end
   end
 end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2025

In the bulk reallocation summary emails there is an optional SPO message. The template needs to conditionally show a sentence depending whether there is message or not.