### PR TITLE
Additional error handling and more log/context

### DIFF
--- a/app/controllers/reallocations/base_controller.rb
+++ b/app/controllers/reallocations/base_controller.rb
@@ -83,7 +83,11 @@ module Reallocations
         "event=bulk_reallocation_error,prison_id=#{@prison.code},source_pom_id=#{@pom&.staff_id}," \
         "target_pom_id=#{@new_pom&.staff_id},path=#{request.fullpath}|#{error.message}"
       )
-      Rails.error.report(error, severity: :error, source: 'bulk_reallocation')
+      Rails.error.report(error, severity: :error, source: 'bulk_reallocation', context: {
+        prison_id: @prison.code,
+        source_pom_id: @pom&.staff_id,
+        target_pom_id: @new_pom&.staff_id,
+      })
       render 'reallocations/error', status: :internal_server_error
     end
   end

--- a/app/services/hmpps_api/nomis_user_roles_api.rb
+++ b/app/services/hmpps_api/nomis_user_roles_api.rb
@@ -48,6 +48,10 @@ module HmppsApi
     end
 
     # See: https://nomis-user-roles-api-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/staff-member-resource/setJobClassification
+    #
+    # Note: NOMIS will return 500 if `toDate` is before `fromDate`, which happens
+    # when trying to expire a role on the same day it was created (this should not
+    # be a problem in production, but it happens sometimes during QA/testing)
     def self.expire_staff_role(pom)
       client.put(
         "/agency/#{pom.agency_id}/staff-members/#{pom.staff_id}/staff-role/POM",

--- a/app/services/nomis_user_roles_service.rb
+++ b/app/services/nomis_user_roles_service.rb
@@ -50,6 +50,12 @@ class NomisUserRolesService
 
     prison.pom_details.find_by(nomis_staff_id:)&.deleted!
 
+    expire_nomis_role!(prison, nomis_staff_id)
+
+    true
+  end
+
+  def self.expire_nomis_role!(prison, nomis_staff_id)
     pom = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(
       prison.code, staff_id: nomis_staff_id
     ).first
@@ -61,7 +67,15 @@ class NomisUserRolesService
       # list endpoint until any previous cached request expires (which could take 1h)
       HmppsApi::PrisonApi::PrisonOffenderManagerApi.expire_list_cache(prison.code)
     end
-
-    true
+  rescue StandardError => e
+    Rails.logger.error(
+      "event=nomis_role_removal_failed,prison_id=#{prison.code},staff_id=#{nomis_staff_id},from_date=#{pom&.from_date}|#{e.message}"
+    )
+    Rails.error.report(e, severity: :warning, source: 'nomis_role_removal', context: {
+      prison_id: prison.code,
+      staff_id: nomis_staff_id,
+      from_date: pom&.from_date,
+    })
   end
+  private_class_method :expire_nomis_role!
 end

--- a/spec/controllers/reallocations/journey_controller_spec.rb
+++ b/spec/controllers/reallocations/journey_controller_spec.rb
@@ -201,4 +201,43 @@ RSpec.describe Reallocations::JourneyController, type: :controller do
       end
     end
   end
+
+  describe '#handle_unexpected_error' do
+    let(:error) { StandardError.new('something went wrong') }
+
+    before do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.error).to receive(:report)
+      allow(controller).to receive(:render)
+
+      controller.instance_variable_set(:@prison, prison)
+      controller.instance_variable_set(:@pom, double(staff_id: old_pom.staffId))
+      controller.instance_variable_set(:@new_pom, double(staff_id: new_pom.staffId))
+
+      controller.send(:handle_unexpected_error, error)
+    end
+
+    it 'logs a structured error event' do
+      expect(Rails.logger).to have_received(:error).with(
+        /event=bulk_reallocation_error.*prison_id=#{prison.code}.*source_pom_id=#{old_pom.staffId}/
+      )
+    end
+
+    it 'reports to Rails error reporter with context' do
+      expect(Rails.error).to have_received(:report).with(
+        error,
+        severity: :error,
+        source: 'bulk_reallocation',
+        context: hash_including(
+          prison_id: prison.code,
+          source_pom_id: old_pom.staffId,
+          target_pom_id: new_pom.staffId,
+        ),
+      )
+    end
+
+    it 'renders the error page with 500 status' do
+      expect(controller).to have_received(:render).with('reallocations/error', status: :internal_server_error)
+    end
+  end
 end

--- a/spec/services/nomis_user_roles_service_spec.rb
+++ b/spec/services/nomis_user_roles_service_spec.rb
@@ -169,5 +169,55 @@ RSpec.describe NomisUserRolesService do
         expect(HmppsApi::PrisonApi::PrisonOffenderManagerApi).not_to have_received(:expire_list_cache)
       end
     end
+
+    context 'when the NOMIS role expiry fails' do
+      before do
+        allow(HmppsApi::NomisUserRolesApi).to receive(:expire_staff_role)
+          .and_raise(Faraday::ServerError, 'the server responded with status 500')
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.error).to receive(:report)
+      end
+
+      it 'still deallocates the POM' do
+        described_class.remove_pom(prison, nomis_staff_id)
+
+        expect(AllocationHistory).to have_received(:deallocate_pom).with(
+          nomis_staff_id, prison.code, event_trigger:
+        )
+      end
+
+      it 'still soft-deletes the POM details' do
+        described_class.remove_pom(prison, nomis_staff_id)
+
+        expect(pom_detail.reload).to be_deleted
+      end
+
+      it 'logs a structured error event' do
+        described_class.remove_pom(prison, nomis_staff_id)
+
+        expect(Rails.logger).to have_received(:error).with(
+          /event=nomis_role_removal_failed.*staff_id=#{nomis_staff_id}.*from_date=/
+        )
+      end
+
+      it 'reports to Rails error reporter with context' do
+        described_class.remove_pom(prison, nomis_staff_id)
+
+        expect(Rails.error).to have_received(:report).with(
+          an_instance_of(Faraday::ServerError),
+          severity: :warning,
+          source: 'nomis_role_removal',
+          context: hash_including(
+            prison_id: prison.code,
+            staff_id: nomis_staff_id,
+            from_date: pom.from_date,
+          ),
+        )
+      end
+
+      it 'does not raise' do
+        expect { described_class.remove_pom(prison, nomis_staff_id) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/services/reallocation/bulk_reallocation_service_spec.rb
+++ b/spec/services/reallocation/bulk_reallocation_service_spec.rb
@@ -170,7 +170,6 @@ RSpec.describe Reallocation::BulkReallocationService do
     context 'when the allocation history does not exist (new allocation)' do
       before do
         AllocationHistory.where(nomis_offender_id: offender_no).delete_all
-        allow(NomisUserRolesService).to receive(:remove_pom)
       end
 
       it 'uses allocate_primary_pom as the event' do


### PR DESCRIPTION
Some additional error handling and adding more Sentry context to diagnose issues.

Mostly covers the known-issue of trying to expire a role on the same day it was created (NOMIS will give an error). This exception should not bubble up.