### PR TITLE
Extend audit to record destroys

### DIFF
--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -234,7 +234,7 @@ private
   end
 
   def audit_event_tags
-    ['record', 'allocation', 'changed', event].freeze
+    ['record', 'allocation', event].freeze
   end
 
   def audit_excluded_keys

--- a/app/models/calculated_handover_date.rb
+++ b/app/models/calculated_handover_date.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CalculatedHandoverDate < ApplicationRecord
+  include Auditable
+
   CUSTODY_ONLY = 'CustodyOnly'
   CUSTODY_WITH_COM = 'CustodyWithCom'
   COMMUNITY_RESPONSIBLE = 'Community'
@@ -43,6 +45,10 @@ class CalculatedHandoverDate < ApplicationRecord
   }.stringify_keys.freeze
 
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id, offender_attributes_to_archive: :offender_attributes_to_archive }
+
+  # Create/update audit events are published ad-hoc in `RecalculateHandoverDateJob`
+  # with richer context (e.g. nomis_offender_state). Only destroy needs the concern
+  after_commit :save_audit_event, on: :destroy
 
   belongs_to :offender,
              primary_key: :nomis_offender_id,
@@ -155,5 +161,11 @@ class CalculatedHandoverDate < ApplicationRecord
 
   def history
     History.new(self)
+  end
+
+private
+
+  def audit_event_tags
+    %w[record calculated_handover_date].freeze
   end
 end

--- a/app/models/case_information.rb
+++ b/app/models/case_information.rb
@@ -12,7 +12,9 @@ class CaseInformation < ApplicationRecord
   EXTENDED_TIER_LEVELS = %w[E F G].freeze
   ROSH_LEVELS = %w[VERY_HIGH HIGH MEDIUM LOW].freeze
 
-  after_commit :save_audit_event, if: :manual_entry?
+  # Create/update audit events for non-manual records are published ad-hoc
+  # in `DeliusDataImportService`. Destroys always need auditing regardless
+  after_commit :save_audit_event, if: -> { manual_entry? || destroyed? }
 
   belongs_to :offender, foreign_key: :nomis_offender_id, inverse_of: :case_information
 
@@ -56,6 +58,6 @@ private
   end
 
   def audit_event_tags
-    %w[record case_information changed].freeze
+    %w[record case_information].freeze
   end
 end

--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -8,18 +8,27 @@ module Auditable
 private
 
   def save_audit_event
-    return unless previous_changes.any?
+    excluded = AUDIT_EXCLUDED_KEYS + audit_excluded_keys
 
-    before_changes = previous_changes.transform_values(&:first)
-    after_changes  = previous_changes.transform_values(&:last)
+    if destroyed?
+      before_changes = attributes.except(*excluded)
+      after_changes  = {}
+    else
+      return unless previous_changes.any?
 
-    [before_changes, after_changes].each do |changes_hash|
-      (AUDIT_EXCLUDED_KEYS + audit_excluded_keys).each { changes_hash.delete(it) }
+      before_changes = previous_changes.transform_values(&:first)
+      after_changes  = previous_changes.transform_values(&:last)
+
+      [before_changes, after_changes].each do |changes_hash|
+        excluded.each { changes_hash.delete(it) }
+      end
     end
+
+    action_tag = destroyed? ? 'destroyed' : 'changed'
 
     AuditEvent.publish(
       nomis_offender_id: (nomis_offender_id if has_attribute?(:nomis_offender_id)),
-      tags: audit_event_tags,
+      tags: [*audit_event_tags, action_tag],
       system_event: PaperTrail.request.whodunnit.blank?,
       username: PaperTrail.request.whodunnit,
       data: audit_additional_data.merge(

--- a/app/models/early_allocation.rb
+++ b/app/models/early_allocation.rb
@@ -101,7 +101,7 @@ private
   end
 
   def audit_event_tags
-    ['record', 'early_allocation', 'changed', outcome].freeze
+    ['record', 'early_allocation', outcome].freeze
   end
 
   def audit_excluded_keys

--- a/app/models/handover_progress_checklist.rb
+++ b/app/models/handover_progress_checklist.rb
@@ -55,6 +55,6 @@ private
   end
 
   def audit_event_tags
-    %w[record handover_progress_checklist changed].freeze
+    %w[record handover_progress_checklist].freeze
   end
 end

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -62,7 +62,7 @@ class PomDetail < ApplicationRecord
 private
 
   def audit_event_tags
-    ['record', 'pom_detail', 'changed', status].freeze
+    ['record', 'pom_detail', status].freeze
   end
 
   def audit_additional_data

--- a/app/models/responsibility.rb
+++ b/app/models/responsibility.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Responsibility < ApplicationRecord
+  include Auditable
+
   has_paper_trail meta: { nomis_offender_id: :nomis_offender_id }
 
-  after_commit :publish_audit_event, on: %i[create destroy]
+  after_commit :save_audit_event
 
   belongs_to :offender,
              primary_key: :nomis_offender_id,
@@ -62,13 +64,11 @@ class Responsibility < ApplicationRecord
 
 private
 
-  def publish_audit_event
-    AuditEvent.publish(
-      nomis_offender_id:,
-      tags: %w[record responsibility override] << (destroyed? ? 'removed' : 'created'),
-      system_event: PaperTrail.request.whodunnit.blank?,
-      username: PaperTrail.request.whodunnit,
-      data: attributes.slice('value', 'reason')
-    )
+  def audit_event_tags
+    %w[record responsibility override].freeze
+  end
+
+  def audit_excluded_keys
+    %w[reason_text created_at updated_at].freeze
   end
 end

--- a/spec/jobs/recalculate_handover_date_job_spec.rb
+++ b/spec/jobs/recalculate_handover_date_job_spec.rb
@@ -242,7 +242,7 @@ describe RecalculateHandoverDateJob do
     it 'does not emit any events' do
       recalculate_handover_dates
       expect(handover_event).not_to have_received(:publish)
-      expect(handover_change_event).not_to have_received(:publish)
+      expect(handover_change_event).not_to have_received(:publish).with(hash_including(tags: include('recalculate_handover_date')))
     end
   end
 

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -652,7 +652,7 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
       expect(AuditEvent).to have_received(:publish).once do |payload|
         expect(payload).to include(
           nomis_offender_id: allocation.nomis_offender_id,
-          tags: %w[record allocation changed allocate_primary_pom],
+          tags: %w[record allocation allocate_primary_pom changed],
           system_event: false,
           username: 'HOMD_USER',
           data: {

--- a/spec/models/calculated_handover_date_spec.rb
+++ b/spec/models/calculated_handover_date_spec.rb
@@ -215,4 +215,28 @@ RSpec.describe CalculatedHandoverDate do
       end
     end
   end
+
+  describe '#save_audit_event' do
+    before { PaperTrail.request.whodunnit = nil }
+
+    let!(:record) { create(:calculated_handover_date, offender: offender) }
+
+    it 'publishes an audit event on destroy' do
+      expect { record.destroy! }.to change(AuditEvent, :count).by(1)
+
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.tags).to include('destroyed')
+        expect(audit.data['before']).to include('responsibility' => record.responsibility, 'reason' => record.reason)
+        expect(audit.data['after']).to eq({})
+      end
+    end
+
+    it 'does not publish an audit event on create or update' do
+      expect(AuditEvent.where(tags: '{record,calculated_handover_date,changed}')).to be_empty
+
+      record.update!(reason: 'determinate')
+      expect(AuditEvent.where(tags: '{record,calculated_handover_date,changed}')).to be_empty
+    end
+  end
 end

--- a/spec/models/case_information_spec.rb
+++ b/spec/models/case_information_spec.rb
@@ -217,16 +217,6 @@ describe CaseInformation do
     context 'when the record is a manual entry' do
       let(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
 
-      it 'publishes an audit event with the correct tags and offender id' do
-        expect { case_info }.to change(AuditEvent, :count).by(1)
-
-        audit = AuditEvent.order(:created_at).last
-        aggregate_failures do
-          expect(audit.nomis_offender_id).to eq(case_info.nomis_offender_id)
-          expect(audit.tags).to eq(%w[record case_information changed])
-        end
-      end
-
       it 'records before and after changes on update' do
         case_info
         last_audit = AuditEvent.order(:created_at).last
@@ -239,15 +229,33 @@ describe CaseInformation do
           expect(audit.data['after']).to include('tier' => 'A', 'rosh_level' => 'HIGH')
         end
       end
+
+      it 'publishes an audit event on destroy' do
+        case_info
+
+        expect { case_info.destroy! }.to change(AuditEvent, :count).by(1)
+
+        audit = AuditEvent.order(:created_at).last
+        expect(audit.tags).to include('destroyed')
+      end
     end
 
     context 'when the record is not a manual entry' do
       let(:case_info) { create(:case_information, manual_entry: false, tier: 'B') }
 
-      it 'does not publish an audit event' do
+      it 'does not publish an audit event on update' do
         case_info
 
         expect { case_info.update!(tier: 'A') }.not_to change(AuditEvent, :count)
+      end
+
+      it 'publishes an audit event on destroy' do
+        case_info
+
+        expect { case_info.destroy! }.to change(AuditEvent, :count).by(1)
+
+        audit = AuditEvent.order(:created_at).last
+        expect(audit.tags).to include('destroyed')
       end
     end
   end

--- a/spec/models/concerns/auditable_spec.rb
+++ b/spec/models/concerns/auditable_spec.rb
@@ -85,4 +85,52 @@ RSpec.describe Auditable do
       expect { pom_detail.save! }.not_to change(AuditEvent, :count)
     end
   end
+
+  describe 'on destroy' do
+    let!(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
+
+    it 'publishes an audit event' do
+      expect { case_info.destroy! }.to change(AuditEvent, :count).by(1)
+    end
+
+    it 'records the destroyed attributes as before and an empty after' do
+      case_info.destroy!
+      audit = AuditEvent.order(:created_at).last
+
+      aggregate_failures do
+        expect(audit.data['before']).not_to have_key('id')
+        expect(audit.data['before']).not_to have_key('nomis_offender_id')
+        expect(audit.data['before']['tier']).to eq('B')
+        expect(audit.data['after']).to eq({})
+      end
+    end
+
+    it 'sets nomis_offender_id from the destroyed record' do
+      offender_id = case_info.nomis_offender_id
+      case_info.destroy!
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.nomis_offender_id).to eq(offender_id)
+    end
+
+    it "replaces the 'changed' tag with 'destroyed'" do
+      case_info.destroy!
+      audit = AuditEvent.order(:created_at).last
+
+      aggregate_failures do
+        expect(audit.tags).to include('destroyed')
+        expect(audit.tags).not_to include('changed')
+        expect(audit.tags).to include('record', 'case_information')
+      end
+    end
+  end
+
+  describe 'tags on create and update' do
+    let!(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
+
+    it "uses 'changed' tag on create" do
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.tags).to include('changed')
+      expect(audit.tags).not_to include('destroyed')
+    end
+  end
 end

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe EarlyAllocation, type: :model do
 
       audit = AuditEvent.order(:created_at).last
       aggregate_failures do
-        expect(audit.tags).to eq(%w[record early_allocation changed eligible])
+        expect(audit.tags).to eq(%w[record early_allocation eligible changed])
         expect(audit.data['after']).to include('outcome' => 'eligible')
       end
     end

--- a/spec/models/handover_progress_checklist_spec.rb
+++ b/spec/models/handover_progress_checklist_spec.rb
@@ -179,16 +179,6 @@ RSpec.describe HandoverProgressChecklist do
       PaperTrail.request.whodunnit = nil
     end
 
-    it 'publishes an audit event with correct tags and offender id on create' do
-      checklist = described_class.create!(offender: offender, reviewed_oasys: true, contacted_com: true)
-
-      audit = AuditEvent.order(:created_at).last
-      aggregate_failures do
-        expect(audit.nomis_offender_id).to eq(checklist.nomis_offender_id)
-        expect(audit.tags).to eq(%w[record handover_progress_checklist changed])
-      end
-    end
-
     it 'records before and after changes on update' do
       checklist = described_class.create!(offender: offender)
       last_audit = AuditEvent.order(:created_at).last

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -113,16 +113,11 @@ RSpec.describe PomDetail, type: :model do
       PaperTrail.request.whodunnit = nil
     end
 
-    it 'publishes an audit event with correct tags and additional data' do
-      pom_detail = create(:pom_detail, prison: prison)
+    it 'includes the dynamic status tag' do
+      create(:pom_detail, prison: prison, status: 'active')
 
       audit = AuditEvent.order(:created_at).last
-      aggregate_failures do
-        expect(audit.nomis_offender_id).to be_nil
-        expect(audit.tags).to eq(%w[record pom_detail changed active])
-        expect(audit.data['nomis_staff_id']).to eq(pom_detail.nomis_staff_id)
-        expect(audit.data['prison_code']).to eq(prison.code)
-      end
+      expect(audit.tags).to include('active')
     end
 
     it 'records before and after changes on update' do

--- a/spec/models/responsibility_spec.rb
+++ b/spec/models/responsibility_spec.rb
@@ -60,13 +60,8 @@ RSpec.describe Responsibility, type: :model do
     it { is_expected.to be_valid }
   end
 
-  describe 'audit events' do
-    let(:audit_payloads) { [] }
-
+  describe '#save_audit_event' do
     before do
-      allow(AuditEvent).to receive(:publish) do |**payload|
-        audit_payloads << payload
-      end
       PaperTrail.request.whodunnit = 'HOMD_USER'
     end
 
@@ -74,37 +69,33 @@ RSpec.describe Responsibility, type: :model do
       PaperTrail.request.whodunnit = nil
     end
 
-    it 'publishes an audit event when a responsibility override is created' do
-      create(:responsibility, offender: offender)
+    it 'only includes value and reason in the audit data on create' do
+      responsibility = create(:responsibility, offender: offender)
 
-      expect(AuditEvent).to have_received(:publish).once
-      expect(audit_payloads.last).to include(
-        nomis_offender_id: offender.nomis_offender_id,
-        tags: %w[record responsibility override created],
-        system_event: false,
-        username: 'HOMD_USER',
-        data: {
-          'value' => Responsibility::PROBATION,
-          'reason' => 'less_than_10_months_to_serve',
-        }
-      )
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.data['after'].keys).to contain_exactly('value', 'reason')
+        expect(audit.data['after']).to eq(
+          'value' => responsibility.value,
+          'reason' => responsibility.reason
+        )
+      end
     end
 
-    it 'publishes an audit event when a responsibility override is removed' do
+    it 'only includes value and reason in the audit data on destroy' do
       responsibility = create(:responsibility, offender: offender)
 
       responsibility.destroy!
 
-      expect(audit_payloads.last).to include(
-        nomis_offender_id: offender.nomis_offender_id,
-        tags: %w[record responsibility override removed],
-        system_event: false,
-        username: 'HOMD_USER',
-        data: {
-          'value' => Responsibility::PROBATION,
-          'reason' => 'less_than_10_months_to_serve',
-        }
-      )
+      audit = AuditEvent.order(:created_at).last
+      aggregate_failures do
+        expect(audit.data['before'].keys).to contain_exactly('value', 'reason')
+        expect(audit.data['before']).to eq(
+          'value' => responsibility.value,
+          'reason' => responsibility.reason
+        )
+        expect(audit.data['after']).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
On destroy, logs the full record attributes as "before", with an empty "after", instead of silently skipping (although we still had papertrail for these).

Concern now owns the action tag and appends 'changed' or 'destroyed' to the tags automatically, so models only declare identity tags.

DRY the tests.