### PR TITLE
Scale down additional targets in non-prod envs

### DIFF
--- a/helm_deploy/offender-management-allocation-manager/Chart.yaml
+++ b/helm_deploy/offender-management-allocation-manager/Chart.yaml
@@ -11,7 +11,7 @@ version: 1.0.0
 
 dependencies:
   - name: generic-service
-    version: ~3.12
+    version: ~3.17
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: ~1.17

--- a/helm_deploy/offender-management-allocation-manager/values.yaml
+++ b/helm_deploy/offender-management-allocation-manager/values.yaml
@@ -27,7 +27,7 @@ custom_templates_config:
 cronjobs:
   process_movements:
     enabled: true
-    schedule: 45 6 * * 1-5
+    schedule: 52 6 * * 1-5
     command: bundle exec rake movements:process
   recalculate_handover_dates:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,6 +20,11 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
+    additionalScaleTargets:
+      - name: offender-management-events-consumer
+        startupReplicas: 1
+      - name: offender-management-jobs-processor
+        startupReplicas: 1
 
   env:
     ENV_NAME: preprod

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -24,6 +24,11 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
+    additionalScaleTargets:
+      - name: offender-management-events-consumer
+        startupReplicas: 1
+      - name: offender-management-jobs-processor
+        startupReplicas: 1
 
   env:
     ENV_NAME: staging


### PR DESCRIPTION
During the night (and weekends) we scale down already the main application pods, but with a recently released improvement to the [Helm chart](https://github.com/ministryofjustice/hmpps-helm-charts/pull/261), we can also scale down additional deployments like jobs processor.

Move the process movements cronjob schedule a few minutes in staging/preprod so it triggers after the scaling up.