### PR TITLE
Scheduled downtime tweaks

### DIFF
--- a/helm_deploy/offender-management-allocation-manager/values.yaml
+++ b/helm_deploy/offender-management-allocation-manager/values.yaml
@@ -104,6 +104,19 @@ generic-service:
   ingress:
     enabled: true
 
+  # Scheduled downtime can be used in non-production environments to save costs
+  # Override per environment (do not enable in production!)
+  scheduledDowntime:
+    enabled: false
+    shutdown: '45 21 * * 1-5'
+    additionalScaleTargets:
+      - name: offender-management-jobs-processor
+        startupReplicas: 1
+      - name: offender-management-events-consumer
+        startupReplicas: 1
+      - name: offender-management-prometheus-exporter
+        startupReplicas: 1
+
   # https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml
   allowlist:
     groups:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,11 +20,6 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-    additionalScaleTargets:
-      - name: offender-management-events-consumer
-        startupReplicas: 1
-      - name: offender-management-jobs-processor
-        startupReplicas: 1
 
   env:
     ENV_NAME: preprod

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -24,11 +24,6 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-    additionalScaleTargets:
-      - name: offender-management-events-consumer
-        startupReplicas: 1
-      - name: offender-management-jobs-processor
-        startupReplicas: 1
 
   env:
     ENV_NAME: staging


### PR DESCRIPTION
Follow-up to PR #2896.

Add prometheus exporter to the scheduled downtime. DRY config.