### PR TITLE
MO-1892 Stop forward populating POMs - part 1

### DIFF
--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -17,7 +17,14 @@ class Prison < ApplicationRecord
 
     details = pom_details.where(nomis_staff_id: poms.map(&:staff_id))
 
-    result = poms.map { |pom| PomWrapper.new(pom, get_pom_detail(details, pom)) }
+    result = poms.filter_map do |pom|
+      pom_detail = details.detect { it.nomis_staff_id == pom.staff_id }
+      if pom_detail.nil?
+        Rails.logger.warn("event=pom_not_onboarded,staff_id=#{pom.staff_id},prison=#{code}")
+        next
+      end
+      PomWrapper.new(pom, pom_detail)
+    end
     include_deleted ? result : result.reject(&:deleted?)
   end
 
@@ -135,10 +142,5 @@ private
     Rails.logger.info("event=ghost_pom_created,staff_id=#{staff_id},prison=#{code}") if pom_detail.previously_new_record?
 
     StaffMember.new(self, staff_id, pom_detail)
-  end
-
-  def get_pom_detail(details, pom)
-    details.detect { it.nomis_staff_id == pom.staff_id } ||
-      PomDetail.find_or_create_as_system!(prison_code: code, nomis_staff_id: pom.staff_id)
   end
 end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -3,11 +3,10 @@
 # This object represents a staff member who may or my not be a POM. It is up to the caller to check
 # and do something interesting if they are not a POM at a specific prison.
 class StaffMember
-  # maybe this method shouldn't be here?
   attr_reader :staff_id, :prison
 
   delegate :position_description, :probation_officer?, :prison_officer?, to: :pom, allow_nil: true
-  delegate :working_pattern, :status, :active?, :unavailable?, :inactive?, :deleted?, to: :@pom_detail
+  delegate :working_pattern, :status, :active?, :unavailable?, :inactive?, :deleted?, to: :@pom_detail, allow_nil: true
 
   def initialize(prison, staff_id, pom_detail = default_pom_detail(prison, staff_id))
     @prison = prison
@@ -120,10 +119,11 @@ private
 
   def fetch_pom
     poms = HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(prison.code)
-    poms.detect { |pom| pom.staff_id == staff_id }
+    poms.detect { it.staff_id == staff_id }
   end
 
   # Attempt to forward-populate the PomDetail table for new records
+  # TODO: this auto-creation is now temporary and due to be removed
   def default_pom_detail(prison, staff_id)
     PomDetail.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id: staff_id)
   end

--- a/spec/controllers/allocation_staff_controller_spec.rb
+++ b/spec/controllers/allocation_staff_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AllocationStaffController, type: :controller do
   let(:offender_no) { offender.fetch(:prisonerNumber) }
 
   before do
-    stub_poms(prison_code, poms)
+    stub_onboarded_poms(prison_code, poms)
     stub_offender(offender)
     stub_movements_for offender_no, [attributes_for(:movement)]
   end

--- a/spec/controllers/build_allocations_controller_spec.rb
+++ b/spec/controllers/build_allocations_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BuildAllocationsController, type: :controller do
 
   before do
     stub_feature_flag(:rosh_recommendations, enabled: true)
-    stub_poms(prison.code, poms)
+    stub_onboarded_poms(prison, poms)
     stub_signed_in_pom(prison.code, pom.staffId, 'Alice')
     stub_sso_data(prison.code)
     stub_offender(offender)

--- a/spec/controllers/coworking_controller_spec.rb
+++ b/spec/controllers/coworking_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CoworkingController, :allocation, type: :controller do
   let(:new_secondary_pom) { build(:pom) }
 
   before do
+    stub_onboarded_poms(prison, [primary_pom, new_secondary_pom])
     stub_sso_data(prison)
     stub_offender(offender)
     create(:case_information, offender: build(:offender, nomis_offender_id: offender_no))

--- a/spec/controllers/early_allocations_controller_spec.rb
+++ b/spec/controllers/early_allocations_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe EarlyAllocationsController, type: :controller do
     allow(OffenderService).to receive(:get_offender).and_raise(NotImplementedError)
     allow(OffenderService).to receive(:get_offender).with(nomis_offender_id).and_return(mpc_offender)
 
-    stub_poms(prison, poms)
+    stub_onboarded_poms(prison, poms)
     stub_filtered_pom(prison, first_pom)
     stub_offenders_for_prison(prison, [offender])
     allow(EarlyAllocationService).to receive(:process_eligibility_change)

--- a/spec/controllers/prisoners_controller_spec.rb
+++ b/spec/controllers/prisoners_controller_spec.rb
@@ -644,7 +644,7 @@ RSpec.describe PrisonersController, type: :controller do
     before do
       stub_sso_data(prison.code)
       stub_offenders_for_prison(prison.code, [offender])
-      stub_poms(prison.code, [pom_record])
+      stub_onboarded_poms(prison, [pom_record])
       create(:case_information, offender: build(:offender, nomis_offender_id: offender.fetch(:prisonerNumber)))
       create(:allocation_history, nomis_offender_id: offender.fetch(:prisonerNumber), prison: prison.code, primary_pom_nomis_id: pom_record.staff_id)
     end

--- a/spec/features/active_caseload_enforcement_feature_spec.rb
+++ b/spec/features/active_caseload_enforcement_feature_spec.rb
@@ -18,8 +18,8 @@ RSpec.feature 'Active caseload enforcement' do
     create(:prison, code: 'RSI')
 
     signin_spo_user(%w[LEI RSI])
-    stub_poms('LEI', [pom])
-    stub_poms('RSI', [pom])
+    stub_onboarded_poms('LEI', [pom])
+    stub_onboarded_poms('RSI', [pom])
     stub_offenders_for_prison('LEI', [])
 
     stub_dps_header_footer

--- a/spec/features/allocation/homd_allocates_poms_spec.rb
+++ b/spec/features/allocation/homd_allocates_poms_spec.rb
@@ -13,7 +13,7 @@ describe 'HOMD allocates cases to POMS' do
   before do
     stub_bank_holidays
     stub_signin_spo(build(:homd))
-    stub_poms(prison.code, poms)
+    stub_onboarded_poms(prison, poms)
     stub_offenders_for_prison(prison.code, [offender])
   end
 
@@ -99,7 +99,7 @@ describe 'HOMD allocates cases to POMS' do
 
   specify 'HOMD does not see current primary or co-working POMs when selecting a new POM' do
     extra_pom = build(:pom, :prison_officer, staffId: 2222, firstName: 'Extra', lastName: 'Pom')
-    stub_poms(prison.code, poms + [extra_pom])
+    stub_onboarded_poms(prison, poms + [extra_pom])
 
     create(
       :allocation_history,

--- a/spec/features/case_history_spec.rb
+++ b/spec/features/case_history_spec.rb
@@ -337,7 +337,7 @@ feature 'Case History' do
       stub_offenders_for_prison(open_prison.code, [nomis_offender])
       stub_movements_for nomis_offender.fetch(:prisonerNumber), offender_movements
       signin_spo_user([open_prison.code])
-      stub_poms(open_prison.code, [pom])
+      stub_onboarded_poms(open_prison, [pom])
       stub_pom pom
     end
 

--- a/spec/features/complexity_level_feature_spec.rb
+++ b/spec/features/complexity_level_feature_spec.rb
@@ -14,7 +14,7 @@ feature 'complexity level feature' do
 
     stub_offenders_for_prison(womens_prison.code, offenders)
     stub_signin_spo(spo, [womens_prison.code])
-    stub_poms(womens_prison.code, [pom, spo])
+    stub_onboarded_poms(womens_prison, [pom, spo])
     stub_keyworker(offender_no)
     stub_community_offender(offender_no, build(:community_data))
     allow_any_instance_of(MpcOffender).to receive(:rosh_summary).and_return(RoshSummary.missing)

--- a/spec/features/coworking_feature_spec.rb
+++ b/spec/features/coworking_feature_spec.rb
@@ -32,8 +32,7 @@ feature 'Co-working' do
   let(:prisoner_name_forwards) { "#{offender.fetch(:firstName)} #{offender.fetch(:lastName)}" }
 
   before(:each) do
-    stub_poms(prison.code, poms)
-    poms.each { |pom| stub_filtered_pom(prison.code, pom) }
+    stub_onboarded_poms(prison, poms)
 
     stub_offenders_for_prison prison.code, [offender]
     stub_signin_spo poms.last, [prison.code]

--- a/spec/features/early_allocation_18month_feature_spec.rb
+++ b/spec/features/early_allocation_18month_feature_spec.rb
@@ -13,7 +13,7 @@ feature 'early allocation when crossing 18 month threshold' do
     before do
       stub_offenders_for_prison(prison.code, [nomis_offender])
       stub_movements_for nomis_offender.fetch(:prisonerNumber), attributes_for_list(:movement, 1, toAgency: prison.code)
-      stub_filtered_pom(prison.code, user)
+      stub_onboarded_poms(prison, [user])
 
       create(:case_information, offender: build(:offender, nomis_offender_id: offender_no,
                                                            early_allocations: [build(:early_allocation, prison: prison.code,

--- a/spec/features/early_allocation_feature_spec.rb
+++ b/spec/features/early_allocation_feature_spec.rb
@@ -20,8 +20,7 @@ feature "early allocation", :disable_early_allocation_event, type: :feature do
 
     stub_offenders_for_prison(prison, [nomis_offender])
     stub_user(username, nomis_staff_id)
-    stub_poms(prison, [pom])
-    stub_filtered_pom(prison, pom)
+    stub_onboarded_poms(prison, [pom])
     stub_keyworker(nomis_offender_id)
 
     signin_pom_user([prison])

--- a/spec/features/handover/homd_views_handover_summary_spec.rb
+++ b/spec/features/handover/homd_views_handover_summary_spec.rb
@@ -18,7 +18,7 @@ describe "HOMD views handover summary for a Prison" do
       'emily' => build(:pom),
       'frank' => build(:pom)
     }.tap do |poms|
-      stub_poms(prison.code, poms.values)
+      stub_onboarded_poms(prison, poms.values)
     end
   end
 

--- a/spec/features/handover/pom_views_handover_caseload_spec.rb
+++ b/spec/features/handover/pom_views_handover_caseload_spec.rb
@@ -16,7 +16,7 @@ describe "POM views their handover caseload" do
   let(:pom) { build(:pom) }
 
   before do
-    stub_poms(prison.code, [pom])
+    stub_onboarded_poms(prison, [pom])
     stub_pom_user(pom)
     signin_pom_user([prison.code], pom.staff_id)
   end

--- a/spec/features/inactive_pom_feature_spec.rb
+++ b/spec/features/inactive_pom_feature_spec.rb
@@ -11,7 +11,7 @@ feature 'Inactive POM' do
     let(:nomis_offender) { [build(:nomis_offender, prisonId: prison_code, prisonerNumber: nomis_offender_id)] }
 
     before do
-      stub_poms(prison_code, [active_pom])
+      stub_onboarded_poms(prison, [active_pom])
       stub_signin_spo(active_pom, prison_code)
       stub_offenders_for_prison(prison.code, nomis_offender)
 

--- a/spec/features/parole_set_hearing_outcome_date_feature_spec.rb
+++ b/spec/features/parole_set_hearing_outcome_date_feature_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Parole set hearing outcome date', type: :feature do
   before do
     stub_keyworker(offender_no)
     stub_signin_spo(pom, [prison_code])
-    stub_poms(prison_code, [pom])
+    stub_onboarded_poms(prison_code, [pom])
     stub_offender(nomis_offender)
 
     visit prison_prisoner_path(prison_code, offender_no)

--- a/spec/features/pom_caseload_feature_spec.rb
+++ b/spec/features/pom_caseload_feature_spec.rb
@@ -86,7 +86,7 @@ feature "view POM's caseload" do
         other_pom
       ]
 
-    stub_poms(prison.code, poms)
+    stub_onboarded_poms(prison, poms)
     signin_pom_user [prison.code]
 
     # Add attributes to moved_offenders to make them ROTLs - needed in conjunction with the ROTL movements

--- a/spec/features/pom_onboarding_feature_spec.rb
+++ b/spec/features/pom_onboarding_feature_spec.rb
@@ -16,7 +16,7 @@ feature 'POM onboarding' do
     let(:search_response) { { totalElements: 0, content: [] } }
 
     before do
-      stub_poms(prison.code, existing_poms)
+      stub_onboarded_poms(prison, existing_poms)
 
       stub_request(:get, search_endpoint)
         .to_return(status: 200, body: search_response.to_json)
@@ -282,7 +282,7 @@ feature 'POM onboarding' do
         )
 
         # for the confirmation page
-        stub_filtered_pom(prison.code, pom)
+        stub_onboarded_poms(prison, [pom])
       end
 
       it 'creates the staff job classification and shows a confirmation page' do

--- a/spec/features/prisoner_info_spec.rb
+++ b/spec/features/prisoner_info_spec.rb
@@ -46,7 +46,7 @@ describe 'View a prisoner profile page' do
     let(:pom) { build(:pom, staffId: 1234, firstName: 'A', lastName: 'Pom') }
 
     before do
-      stub_poms(prison.code, [pom])
+      stub_onboarded_poms(prison, [pom])
       create(:allocation_history, nomis_offender_id: 'G1234AB', primary_pom_nomis_id: 1234, primary_pom_name: 'A Pom', prison: prison.code)
       local_delivery_unit = create(:local_delivery_unit, name: 'An LDU', email_address: 'test@example.com')
       CaseInformation.find_by(nomis_offender_id: 'G1234AB').update(local_delivery_unit:, team_name: 'Team X', com_name: 'Bob Smith')

--- a/spec/features/responsibility/homd_overrides_responsibilities_spec.rb
+++ b/spec/features/responsibility/homd_overrides_responsibilities_spec.rb
@@ -8,7 +8,7 @@ describe 'HOMD overrides responsibilities' do
   before do
     stub_bank_holidays
     stub_signin_spo(homd_user)
-    stub_poms(prison.code, [pom, homd_user])
+    stub_onboarded_poms(prison, [pom, homd_user])
   end
 
   specify 'HOMD removes community responsibility override returning case to calculated responsibility of POM' do

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -5,7 +5,7 @@ feature 'Search for offenders' do
     prison = create(:prison, code: prison_code)
     pom = build(:pom)
 
-    stub_poms(prison.code, [pom])
+    stub_onboarded_poms(prison, [pom])
     stub_pom_user(pom)
     stub_signin_spo(build(:homd))
 

--- a/spec/features/show_poms_feature_spec.rb
+++ b/spec/features/show_poms_feature_spec.rb
@@ -11,8 +11,8 @@ feature "get poms list", flaky: true do
 
   before do
     signin_spo_user
-    create(:pom_detail, :inactive, prison_code: 'LEI', nomis_staff_id: inactive_pom.staff_id)
-    stub_poms('LEI', [active_probation_pom, moic_pom, inactive_pom])
+    stub_onboarded_poms('LEI', [active_probation_pom, moic_pom, inactive_pom])
+    PomDetail.find_by!(prison_code: 'LEI', nomis_staff_id: inactive_pom.staff_id).inactive!
   end
 
   it "shows the page" do

--- a/spec/features/staff_feature_spec.rb
+++ b/spec/features/staff_feature_spec.rb
@@ -226,7 +226,7 @@ feature "staff pages" do
     before do
       stub_signin_spo spo, [female_prison]
       stub_offenders_for_prison(female_prison, offenders_in_prison << nomis_offender)
-      stub_poms(female_prison, poms)
+      stub_onboarded_poms(female_prison, poms)
 
       offenders_in_prison.map { |o| o.fetch(:prisonerNumber) }.each do |nomis_id|
         stub_keyworker(nomis_id)

--- a/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
+++ b/spec/jobs/handover_follow_up_job/follow_up_email_details_spec.rb
@@ -21,7 +21,7 @@ describe HandoverFollowUpJob::FollowUpEmailDetails do
 
   describe "the details used in sending the CommunityMailer email" do
     before do
-      stub_poms(prison.code, [pom])
+      stub_onboarded_poms(prison, [pom])
       stub_filtered_pom(prison.code, pom)
     end
 

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -179,11 +179,15 @@ RSpec.describe Prison do
     let(:duplicate_pom1) { build(:pom, staffId: pom1.staff_id) }
     let(:non_pom) { build(:pom, position: 'STAFF') }
 
+    # Both POMs have been onboarded through our service
+    let!(:pom1_detail) { create(:pom_detail, :active, prison: prison, nomis_staff_id: pom1.staff_id) }
+    let!(:pom2_detail) { create(:pom_detail, :active, prison: prison, nomis_staff_id: pom2.staff_id) }
+
     before do
       stub_poms(prison.code, [pom1, pom2, duplicate_pom1, non_pom])
     end
 
-    it 'returns a list of wrapped POMs' do
+    it 'returns a list of wrapped POMs for onboarded staff' do
       result = prison.get_list_of_poms
 
       expect(result.size).to eq(2)
@@ -191,18 +195,50 @@ RSpec.describe Prison do
       expect(result.map(&:staff_id)).to match_array([pom1.staff_id, pom2.staff_id])
     end
 
-    it 'creates POM details for new POMs' do
+    it 'does not create PomDetail records for POMs seen in NOMIS' do
+      prison2 = create(:prison)
+      new_pom = build(:pom)
+      stub_poms(prison2.code, [new_pom])
+
       expect {
-        prison.get_list_of_poms
-      }.to change(PomDetail, :count).by(2)
+        prison2.get_list_of_poms
+      }.not_to change(PomDetail, :count)
     end
 
-    it 'uses working pattern details pulled from the POM' do
+    it 'uses local PomDetail data for status and working pattern' do
       result = prison.get_list_of_poms
 
       expect(result.map(&:status)).to all(eq('active'))
-      expect(result[0].working_pattern).to eq(0.0)
-      expect(result[1].working_pattern).to eq(0.0)
+      expect(result.map(&:working_pattern)).to all(eq(pom1_detail.working_pattern))
+    end
+
+    context 'when a POM has a NOMIS role but has not been onboarded through our service' do
+      let(:unonboarded_pom) { build(:pom) }
+
+      before do
+        stub_poms(prison.code, [pom1, pom2, unonboarded_pom])
+      end
+
+      it 'excludes the un-onboarded POM from results' do
+        result = prison.get_list_of_poms
+
+        expect(result.map(&:staff_id)).to match_array([pom1.staff_id, pom2.staff_id])
+        expect(result.map(&:staff_id)).not_to include(unonboarded_pom.staff_id)
+      end
+
+      it 'does not create a PomDetail for the un-onboarded POM' do
+        expect {
+          prison.get_list_of_poms
+        }.not_to change(PomDetail, :count)
+      end
+
+      it 'logs a warning for the un-onboarded POM' do
+        allow(Rails.logger).to receive(:warn)
+        prison.get_list_of_poms
+        expect(Rails.logger).to have_received(:warn).with(
+          "event=pom_not_onboarded,staff_id=#{unonboarded_pom.staff_id},prison=#{prison.code}"
+        )
+      end
     end
 
     context 'when fetching a specific POM' do
@@ -220,7 +256,7 @@ RSpec.describe Prison do
 
     context 'when a POM has been soft-deleted' do
       before do
-        create(:pom_detail, :deleted, prison: prison, nomis_staff_id: pom1.staff_id)
+        pom1_detail.deleted!
       end
 
       it 'excludes the soft-deleted POM by default' do

--- a/spec/models/staff_member_spec.rb
+++ b/spec/models/staff_member_spec.rb
@@ -326,4 +326,52 @@ RSpec.describe StaffMember, type: :model do
       expect(user.total_allocations_count).to eq(2)
     end
   end
+
+  describe 'when pom_detail is nil' do
+    let(:user_without_detail) { described_class.new(prison, staff_id, nil) }
+
+    it 'returns nil for status' do
+      expect(user_without_detail.status).to be_nil
+    end
+
+    it 'returns nil for working_pattern' do
+      expect(user_without_detail.working_pattern).to be_nil
+    end
+
+    it 'returns nil for active?' do
+      expect(user_without_detail.active?).to be_nil
+    end
+
+    it 'returns nil for deleted?' do
+      expect(user_without_detail.deleted?).to be_nil
+    end
+
+    it 'returns nil for unavailable?' do
+      expect(user_without_detail.unavailable?).to be_nil
+    end
+
+    it 'returns nil for inactive?' do
+      expect(user_without_detail.inactive?).to be_nil
+    end
+
+    context 'when POM has a NOMIS role' do
+      before do
+        allow(user_without_detail).to receive(:fetch_pom).and_return(double(:pom))
+      end
+
+      it 'is not in limbo (has role, not deleted)' do
+        expect(user_without_detail).not_to be_in_limbo
+      end
+    end
+
+    context 'when POM has no NOMIS role' do
+      before do
+        allow(user_without_detail).to receive(:fetch_pom).and_return(nil)
+      end
+
+      it 'is in limbo (no role)' do
+        expect(user_without_detail).to be_in_limbo
+      end
+    end
+  end
 end

--- a/spec/services/email_service_spec.rb
+++ b/spec/services/email_service_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe EmailService do
     PomDetail.create(nomis_staff_id: 485_637, working_pattern: 1.0, status: 'inactive')
     create(:case_information, offender: build(:offender, nomis_offender_id: 'G2911GD'))
     stub_offender(offender)
-    stub_poms(prison_code, [andrien, leigh])
+    stub_onboarded_poms(prison_code, [andrien, leigh])
     stub_filtered_pom(prison_code, andrien)
   end
 

--- a/spec/services/prison_offender_manager_service_spec.rb
+++ b/spec/services/prison_offender_manager_service_spec.rb
@@ -16,9 +16,8 @@ describe PrisonOffenderManagerService do
   end
 
   before(:each) do
-    PomDetail.create(prison_code: 'LEI', nomis_staff_id: other_staff_id, working_pattern: 1.0, status: 'inactive')
-
-    stub_poms(prison.code, poms)
+    stub_onboarded_poms(prison, poms)
+    prison.pom_details.find_by!(nomis_staff_id: other_staff_id).inactive!
   end
 
   describe '#get_list_of_poms' do

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -82,6 +82,20 @@ module ApiHelper
     end
   end
 
+  # Use this helper when the spec expects the returned NOMIS POMs to be
+  # onboarded and therefore visible in service lists.
+  def stub_onboarded_poms(prison, poms, status: 'active', working_pattern: 1.0)
+    prison_code = prison.is_a?(Prison) ? prison.code : prison
+    prison_record = prison.is_a?(Prison) ? prison : Prison.find_by!(code: prison_code)
+
+    stub_poms(prison_code, poms)
+
+    poms.each do |pom|
+      pom_detail = PomDetail.find_or_initialize_by(prison_code: prison_record.code, nomis_staff_id: pom.staff_id)
+      pom_detail.update!(status:, working_pattern:)
+    end
+  end
+
   def stub_filtered_pom(prison, pom)
     pom.agencyId = prison
 

--- a/spec/support/shared_contexts/reallocation_controller_setup.rb
+++ b/spec/support/shared_contexts/reallocation_controller_setup.rb
@@ -32,13 +32,12 @@ RSpec.shared_context 'with reallocation controller defaults' do
   let(:override_offender_no) { override_offender.fetch(:prisonerNumber) }
 
   before do
-    stub_poms(prison.code, poms)
+    stub_onboarded_poms(prison, poms)
     stub_signed_in_spo_pom(prison.code, 99_999, 'spo-user')
     stub_offenders_for_prison(prison.code, offenders_in_prison)
     offenders_in_prison.each { |prisoner| stub_oasys_assessments(prisoner.fetch(:prisonerNumber)) }
 
-    create(:pom_detail, :inactive, prison_code: prison.code, nomis_staff_id: old_pom.staffId)
-    create(:pom_detail, :active, prison_code: prison.code, nomis_staff_id: new_pom.staffId)
+    prison.pom_details.find_by!(nomis_staff_id: old_pom.staffId).inactive!
     create_reallocation_case(offender_no, tier: 'A')
   end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1892

First part of a wider piece of work to stop forward populating local `PomDetail` records whenever we see a new POM coming back from NOMIS (as we have now an in-service onboarding feature).

Big majority of changed files are just specs that need to use a new `stub_onboarded_poms` helper (as we are not autocreating DB records anymore).

A follow-up PR will continue the work.