### PR TITLE
MO-1892 Cleanup task for auto-created pom details

### DIFF
--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -24,11 +24,9 @@ private
       end
     end
 
-    action_tag = destroyed? ? 'destroyed' : 'changed'
-
     AuditEvent.publish(
       nomis_offender_id: (nomis_offender_id if has_attribute?(:nomis_offender_id)),
-      tags: [*audit_event_tags, action_tag],
+      tags: [*audit_event_tags, audit_action_tag],
       system_event: PaperTrail.request.whodunnit.blank?,
       username: PaperTrail.request.whodunnit,
       data: audit_additional_data.merge(
@@ -46,5 +44,12 @@ private
   # Override in including models to merge additional identifying data
   def audit_additional_data
     {}
+  end
+
+  def audit_action_tag
+    return 'destroyed' if destroyed?
+    return 'created'   if previous_changes.key?('id')
+
+    'changed'
   end
 end

--- a/app/models/pom_detail.rb
+++ b/app/models/pom_detail.rb
@@ -23,7 +23,7 @@ class PomDetail < ApplicationRecord
 
   belongs_to :prison, foreign_key: :prison_code, inverse_of: :pom_details
 
-  def self.find_or_create_as_system!(prison_code:, nomis_staff_id:, status: 'active', working_pattern: 0.0)
+  def self.find_or_create_as_system!(prison_code:, nomis_staff_id:, status:, working_pattern:)
     find_by(prison_code:, nomis_staff_id:) ||
       PaperTrail.request(whodunnit: nil) do
         find_or_create_by!(prison_code:, nomis_staff_id:) do |pd|
@@ -62,7 +62,7 @@ class PomDetail < ApplicationRecord
 private
 
   def audit_event_tags
-    ['record', 'pom_detail', status].freeze
+    ['record', 'pom_detail', "status_#{status}"].freeze
   end
 
   def audit_additional_data

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -137,7 +137,7 @@ private
   # NomisUserRolesService.remove_pom) work seamlessly
   def find_or_create_ghost_pom(staff_id)
     pom_detail = PomDetail.find_or_create_as_system!(
-      prison_code: code, nomis_staff_id: staff_id, status: 'deleted'
+      prison_code: code, nomis_staff_id: staff_id, status: 'deleted', working_pattern: 0.0
     )
     Rails.logger.info("event=ghost_pom_created,staff_id=#{staff_id},prison=#{code}") if pom_detail.previously_new_record?
 

--- a/app/services/nomis_user_roles_service.rb
+++ b/app/services/nomis_user_roles_service.rb
@@ -43,10 +43,6 @@ class NomisUserRolesService
     # list endpoint until any previous cached request expires (which could take 1h)
     HmppsApi::PrisonApi::PrisonOffenderManagerApi.expire_list_cache(prison.code)
 
-    # This should not be neccessary if we decide to use NOMIS working hours
-    # upon reading the list of POMS.
-    # For now, we are not doing that so we need to create the PomDetail here
-    # as part of the onboarding to save the correct hours.
     prison.pom_details.find_or_initialize_by(nomis_staff_id:).tap do |pd|
       pd.update!(created_by:, status: 'active', hours_per_week: config[:hours_per_week])
     end

--- a/lib/pom_details_cleaner.rb
+++ b/lib/pom_details_cleaner.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class PomDetailsCleaner
+  BATCH_SIZE = 1_000
+
+  def initialize(prison_code: nil, output: $stdout)
+    @prison_code = prison_code.presence
+    @output = output
+  end
+
+  def call
+    prisons.each { |prison| delete_for_prison!(prison) }
+  end
+
+private
+
+  attr_reader :prison_code, :output
+
+  def prisons
+    return [Prison.find_by!(code: prison_code)] if prison_code.present?
+
+    Prison.order(code: :asc).to_a
+  end
+
+  def delete_for_prison!(prison)
+    scope = prison.pom_details.where(status: 'active', working_pattern: 0.0)
+    candidate_ids = scope.distinct.pluck(:nomis_staff_id)
+
+    if candidate_ids.empty?
+      output.puts "[PomDetails] #{prison.code}: no active zero-working-pattern PomDetails found"
+      return
+    end
+
+    nomis_staff_ids = nomis_staff_ids_for(prison.code)
+    if nomis_staff_ids.nil?
+      output.puts "[PomDetails] #{prison.code}: skipped because NOMIS lookup failed"
+      return
+    end
+
+    keep_ids = candidate_ids & nomis_staff_ids.to_a
+    delete_ids = candidate_ids - keep_ids
+
+    if delete_ids.empty?
+      output.puts "[PomDetails] #{prison.code}: no deletions; all #{candidate_ids.size} candidates are still returned by NOMIS"
+      return
+    end
+
+    deleted_count = 0
+    delete_ids.each_slice(BATCH_SIZE) do |batch_ids|
+      deleted_count += scope.where(nomis_staff_id: batch_ids).delete_all
+    end
+
+    output.puts "[PomDetails] Deleted #{deleted_count} PomDetails for #{prison.code}"
+    output.puts "[PomDetails] Skipped #{keep_ids.size} PomDetails still returned by NOMIS for #{prison.code}: #{keep_ids.join(', ')}" if keep_ids.any?
+  end
+
+  def nomis_staff_ids_for(prison_code)
+    HmppsApi::PrisonApi::PrisonOffenderManagerApi.list(prison_code)
+      .select { |pom| pom.prison_officer? || pom.probation_officer? }
+      .map(&:staff_id)
+      .to_set
+  rescue StandardError => e
+    output.puts "[PomDetails] NOMIS check failed for #{prison_code}: #{e.class}: #{e.message}"
+    nil
+  end
+end

--- a/lib/tasks/pom_details.rake
+++ b/lib/tasks/pom_details.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'pom_details_cleaner'
+
+namespace :pom_details do
+  desc 'Delete active zero-working-pattern PomDetails. Usage: rake pom_details:delete_auto_created or rake pom_details:delete_auto_created[FDI]'
+  task :delete_auto_created, [:prison_code] => :environment do |_task, args|
+    PomDetailsCleaner.new(prison_code: args[:prison_code].presence || ENV['PRISON_CODE']).call
+  end
+end

--- a/spec/controllers/case_information_controller_spec.rb
+++ b/spec/controllers/case_information_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CaseInformationController, type: :controller do
       expect(AuditEvent).to have_received(:publish).once.with(
         hash_including(
           nomis_offender_id: offender_no,
-          tags: %w[record case_information changed],
+          tags: %w[record case_information created],
           system_event: false
         )
       )

--- a/spec/models/concerns/auditable_spec.rb
+++ b/spec/models/concerns/auditable_spec.rb
@@ -127,9 +127,18 @@ RSpec.describe Auditable do
   describe 'tags on create and update' do
     let!(:case_info) { create(:case_information, :manual_entry, tier: 'B', rosh_level: 'LOW', enhanced_resourcing: false) }
 
-    it "uses 'changed' tag on create" do
+    it "uses 'created' tag on create" do
+      audit = AuditEvent.order(:created_at).last
+      expect(audit.tags).to include('created')
+      expect(audit.tags).not_to include('changed')
+      expect(audit.tags).not_to include('destroyed')
+    end
+
+    it "uses 'changed' tag on update" do
+      case_info.update!(tier: 'C')
       audit = AuditEvent.order(:created_at).last
       expect(audit.tags).to include('changed')
+      expect(audit.tags).not_to include('created')
       expect(audit.tags).not_to include('destroyed')
     end
   end

--- a/spec/models/early_allocation_spec.rb
+++ b/spec/models/early_allocation_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe EarlyAllocation, type: :model do
 
       audit = AuditEvent.order(:created_at).last
       aggregate_failures do
-        expect(audit.tags).to eq(%w[record early_allocation eligible changed])
+        expect(audit.tags).to eq(%w[record early_allocation eligible created])
         expect(audit.data['after']).to include('outcome' => 'eligible')
       end
     end

--- a/spec/models/pom_detail_spec.rb
+++ b/spec/models/pom_detail_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe PomDetail, type: :model do
   describe '.find_or_create_as_system!' do
     let(:nomis_staff_id) { 555_555 }
 
-    it 'creates a PomDetail with default attributes' do
-      pom_detail = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:)
+    it 'creates a PomDetail with the given attributes' do
+      pom_detail = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:, status: 'active', working_pattern: 0.0)
 
       expect(pom_detail).to be_persisted
       expect(pom_detail.status).to eq('active')
@@ -86,7 +86,7 @@ RSpec.describe PomDetail, type: :model do
     it 'returns the existing record if one already exists' do
       existing = create(:pom_detail, prison:, nomis_staff_id:, status: 'active')
 
-      result = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:, status: 'deleted')
+      result = described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:, status: 'deleted', working_pattern: 0.0)
 
       expect(result.id).to eq(existing.id)
       expect(result.status).to eq('active')
@@ -95,7 +95,7 @@ RSpec.describe PomDetail, type: :model do
     it 'records as system-initiated even during a user session' do
       PaperTrail.request.whodunnit = 'SPO_USER'
 
-      described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:)
+      described_class.find_or_create_as_system!(prison_code: prison.code, nomis_staff_id:, status: 'active', working_pattern: 0.0)
 
       version = PaperTrail::Version.where(item_type: 'PomDetail').last
       expect(version.whodunnit).to be_nil
@@ -117,7 +117,7 @@ RSpec.describe PomDetail, type: :model do
       create(:pom_detail, prison: prison, status: 'active')
 
       audit = AuditEvent.order(:created_at).last
-      expect(audit.tags).to include('active')
+      expect(audit.tags).to include('status_active')
     end
 
     it 'records before and after changes on update' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1892

Follow-up to previous PRs #2901 and #2902.

Creates a task that will cleanup forward-populated POMs that have been auto-created, their working pattern remains at 0.0, and their role in NOMIS is no longer returned.

Also a few minor tweaks to clarify audit tags.