### PR TITLE
MO-2039 HOMD and POM routes consistency

### DIFF
--- a/app/controllers/coworking_controller.rb
+++ b/app/controllers/coworking_controller.rb
@@ -72,7 +72,7 @@ class CoworkingController < PrisonsApplicationController
       notice = nil
     end
 
-    redirect_to helpers.prisoner_path_for_role(current_user_is_spo?, @prison, prisoner), notice:
+    redirect_to helpers.prisoner_path_for_role(@prison, prisoner), notice:
   end
 
 private

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -17,9 +17,13 @@ module SearchHelper
     end
   end
 
-  def prisoner_path_for_role(is_spo, prison, offender)
-    if is_spo && offender.active_allocation
-      prison_prisoner_allocation_path(prison.code, prisoner_id: offender.offender_no)
+  def prisoner_path_for_role(prison, offender)
+    if current_user_is_spo?
+      if offender.active_allocation
+        prison_prisoner_allocation_path(prison.code, prisoner_id: offender.offender_no)
+      else
+        prison_prisoner_review_case_details_path(prison.code, offender.offender_no)
+      end
     else
       prison_prisoner_path(prison.code, offender.offender_no)
     end

--- a/app/models/allocated_offender.rb
+++ b/app/models/allocated_offender.rb
@@ -34,6 +34,10 @@ class AllocatedOffender
     @offender = offender
   end
 
+  def active_allocation
+    @allocation
+  end
+
   # check for changes in the last week where the target value
   # (item[1] in the array) is our staff_id
   def new_case?

--- a/app/views/allocations/show.html.erb
+++ b/app/views/allocations/show.html.erb
@@ -141,7 +141,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell govuk-!-width-one-half">POM</td>
       <td class="govuk-table__cell table_cell__left_align govuk-!-width-one-half">
-        <%= link_to @pom.full_name, prison_pom_path(@prison.code, @pom.staff_id), class: "govuk-link" %>
+        <%= link_to @pom.full_name, prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), class: "govuk-link" %>
         <%= link_to 'Reallocate', prison_prisoner_review_case_details_path(@prison.code, @prisoner.offender_no), class: "govuk-link pull-right" %>
       </td>
     </tr>
@@ -153,7 +153,7 @@
           <%= link_to 'Allocate', prison_prisoner_review_case_details_path(@prison.code, @prisoner.offender_no, coworking: true), class: "govuk-link pull-right" %>
         <% else %>
           <%= link_to_if @coworker.has_pom_role?, @coworker.full_name.presence || 'Unknown',
-                         prison_pom_path(@prison.code, @coworker.staff_id), class: "govuk-link" %>
+                         prison_pom_path(@prison.code, nomis_staff_id: @coworker.staff_id), class: "govuk-link" %>
           <%= link_to 'Remove', prison_coworking_confirm_removal_path(@prison.code, @prisoner.offender_no), class: "govuk-link pull-right" %>
         <% end %>
       </td>

--- a/app/views/caseload/parole_cases.html.erb
+++ b/app/views/caseload/parole_cases.html.erb
@@ -34,7 +34,7 @@
       <% @parole_cases.each_with_index do |offender, i| %>
         <tr class="govuk-table__row offender_row_<%= i %>">
           <td aria-label="Prisoner name" class="govuk-table__cell ">
-            <a href="<%= prison_prisoner_path(@prison.code, offender.offender_no) %>"><%= offender.full_name %></a>
+            <%= link_to offender.full_name, prison_prisoner_path(@prison.code, offender.offender_no) %>
             <br/>
             <span class='govuk-hint govuk-!-margin-bottom-0'>
               <%= offender.offender_no %>

--- a/app/views/coworking/confirm_removal.html.erb
+++ b/app/views/coworking/confirm_removal.html.erb
@@ -13,6 +13,6 @@
 <%= form_tag(prison_coworking_path(@prison.code, @prisoner.offender_no), method: :delete) do %>
   <div class="govuk-form-group">
     <button type="submit" class="govuk-button">Confirm</button>
-    <%= link_to 'Cancel', prisoner_path_for_role(@is_spo, @prison, @prisoner), class: 'govuk-link app-cancel-link' %>
+    <%= link_to 'Cancel', prisoner_path_for_role(@prison, @prisoner), class: 'govuk-link app-cancel-link' %>
   </div>
 <% end %>

--- a/app/views/handovers/_case_list.html.erb
+++ b/app/views/handovers/_case_list.html.erb
@@ -24,7 +24,7 @@
 
   <% handover_cases.each do |handover_case| %>
     <tr class="govuk-table__row allocated-offender">
-      <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: handover_case.offender, anchor: local_assigns[:anchor] %>
+      <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: handover_case.offender, pom_view: @pom_view, anchor: local_assigns[:anchor] %>
       
       <% unless @pom_view %>
         <%= render 'handovers/cells/staff_member', staff_member: handover_case.staff_member %>

--- a/app/views/handovers/cells/_prisoner_details.html.erb
+++ b/app/views/handovers/cells/_prisoner_details.html.erb
@@ -1,5 +1,6 @@
 <td class="govuk-table__cell prisoner-details">
-  <%= link_to offender.full_name, prison_prisoner_path(prison_id, offender.offender_no),
+  <%= link_to offender.full_name,
+              pom_view ? prison_prisoner_path(prison_id, offender.offender_no) : prison_prisoner_allocation_path(prison_id, prisoner_id: offender.offender_no),
               class: 'govuk-link', data: { 'sort-value' => offender.last_name} %>
   <br>
   <span class="govuk-hint govuk-!-margin-bottom-0 offender-no"><%= offender.offender_no %></span>

--- a/app/views/handovers/cells/_staff_member.html.erb
+++ b/app/views/handovers/cells/_staff_member.html.erb
@@ -1,5 +1,5 @@
 <td class="govuk-table__cell staff-member">
   <%= link_to(staff_member.full_name_ordered,
-              prison_pom_path(@prison, staff_member.staff_id),
+              prison_pom_path(@prison.code, nomis_staff_id: staff_member.staff_id),
               class: 'govuk-link govuk-link--no-visited-state') %>
 </td>

--- a/app/views/poms/_removed_poms.html.erb
+++ b/app/views/poms/_removed_poms.html.erb
@@ -27,11 +27,11 @@
                           class: 'govuk-link govuk-!-font-size-19' %>
             <% else %>
               <%= link_to 'Reallocate cases',
-                          confirm_removal_prison_pom_path(@prison.code, pom.staff_id),
+                          confirm_removal_prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id),
                           class: 'govuk-link govuk-!-font-size-19' %>
             <% end %>
           <% else %>
-            <%= form_for(:remove_pom, url: prison_pom_path(@prison.code, pom.staff_id), method: :delete) do |f| %>
+            <%= form_for(:remove_pom, url: prison_pom_path(@prison.code, nomis_staff_id: pom.staff_id), method: :delete) do |f| %>
               <%= f.button 'Remove POM', type: 'submit', class: 'app-button--link govuk-link govuk-!-font-size-19' %>
             <% end %>
           <% end %>

--- a/app/views/poms/confirm_delete.html.erb
+++ b/app/views/poms/confirm_delete.html.erb
@@ -1,12 +1,12 @@
 <% content_for :title, 'Confirm POM removal – Digital Prison Services' %>
 
-<%= link_to 'Back', edit_prison_pom_path(@prison.code, @pom.staff_id),
+<%= link_to 'Back', edit_prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id),
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@confirm_delete_form, as: :confirm_delete_pom,
-                 url: prison_pom_path(@prison.code, @pom.staff_id),
+                 url: prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id),
                  method: :delete,
                  builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
 

--- a/app/views/poms/edit.html.erb
+++ b/app/views/poms/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Edit profile – Digital Prison Services" %>
 
-<%= link_to 'Back', prison_pom_path(@prison.code, @pom.staff_id),
+<%= link_to 'Back', prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id),
             class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
 
 <div class="govuk-grid-row">
@@ -49,7 +49,7 @@
 
       <div class="govuk-form-group">
         <%= f.govuk_submit 'Save' %>
-        <%= link_to 'Cancel', prison_pom_path(@prison.code, @pom.staff_id), class: 'govuk-link app-cancel-link' %>
+        <%= link_to 'Cancel', prison_pom_path(@prison.code, nomis_staff_id: @pom.staff_id), class: 'govuk-link app-cancel-link' %>
       </div>
     <% end %>
   </div>

--- a/app/views/prisoners/_search_results_table.html.erb
+++ b/app/views/prisoners/_search_results_table.html.erb
@@ -1,0 +1,56 @@
+<%= render partial: 'shared/pagination', locals: { data: offenders, url_params: local_assigns[:url_params] || {} } %>
+
+<% missing_info_ids = @missing_info.map(&:offender_no) %>
+<% unallocated_ids = @unallocated.map(&:offender_no) %>
+
+<table class="govuk-table responsive govuk-!-margin-top-4">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col">Case</th>
+    <th class="govuk-table__header" scope="col">POM</th>
+    <th class="govuk-table__header" scope="col">POM role</th>
+    <th class="govuk-table__header sorter-false" scope="col">Location</th>
+    <th class="govuk-table__header sorter-false" scope="col">Earliest release date</th>
+    <th class="govuk-table__header sorter-false" scope="col">Tier</th>
+    <% if @is_spo %>
+      <th class="govuk-table__header" scope="col">Action</th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% offenders.each_with_index do |offender, i| %>
+    <tr class="govuk-table__row allocated_offender_row_<%= i %>">
+      <td aria-label="Prisoner name" class="govuk-table__cell">
+        <%= link_to_unless(missing_info_ids.include?(offender.offender_no), highlight(offender.full_name, @q),
+                           prisoner_path_for_role(@prison, offender)) { highlight(offender.full_name, @q) } %>
+        <br/><%= highlight(offender.offender_no, @q) %>
+      </td>
+      <td aria-label="POM" class="govuk-table__cell"><%= offender.formatted_pom_name || 'None allocated' %></td>
+      <td aria-label="POM role" class="govuk-table__cell"> <%= offender.probation_record.present? ? pom_responsibility_label(offender) : 'None allocated' %> </td>
+      <td aria-label="Location" class="govuk-table__cell"><%= offender.location %></td>
+      <td aria-label="Earliest release date" class="govuk-table__cell">
+        <% if offender.earliest_release.present? %>
+          <%= offender.earliest_release[:type] %>: <br/>
+          <%= format_date(offender.earliest_release[:date], replacement: 'Unknown') %>
+        <% else %>
+          Unknown
+        <% end %>
+      </td>
+      <td aria-label="Tier" class="govuk-table__cell"><%= probation_field(offender, :tier) || 'No tier found' %></td>
+      <% if @is_spo %>
+        <td aria-label="Action" class="govuk-table__cell">
+          <% if missing_info_ids.include?(offender.offender_no) %>
+            <%= link_to 'Add missing details', new_prison_prisoner_case_information_path(@prison.code, offender.offender_no) %>
+          <% elsif unallocated_ids.include?(offender.offender_no) %>
+            <%= link_to 'Allocate', prison_prisoner_staff_index_path(@prison.code, offender.offender_no) %>
+          <% else %>
+            -
+          <% end %>
+        </td>
+      <% end %>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<%= render partial: 'shared/pagination', locals: { data: offenders, url_params: local_assigns[:url_params] || {} } %>

--- a/app/views/prisoners/allocated.html.erb
+++ b/app/views/prisoners/allocated.html.erb
@@ -101,7 +101,7 @@
           <%= offender.tier %>
         </td>
         <td aria-label="POM" class="govuk-table__cell">
-          <%= link_to offender.formatted_pom_name, prison_pom_path(@prison.code, offender.allocated_pom_nomis_id), class: "govuk-link" %>
+          <%= link_to offender.formatted_pom_name, prison_pom_path(@prison.code, nomis_staff_id: offender.allocated_pom_nomis_id), class: "govuk-link" %>
         </td>
         <td aria-label="Allocation date" class="govuk-table__cell"><%= format_date(offender.allocation_date) %></td>
       </tr>

--- a/app/views/prisoners/search.html.erb
+++ b/app/views/prisoners/search.html.erb
@@ -36,7 +36,7 @@
       <% @offenders.each_with_index do |offender, i| %>
         <tr class="govuk-table__row allocated_offender_row_<%= i %>">
           <td aria-label="Prisoner name" class="govuk-table__cell">
-            <%= link_to(highlight(offender.full_name, @q), prisoner_path_for_role(@is_spo, @prison, offender)) %>
+            <%= link_to(highlight(offender.full_name, @q), prisoner_path_for_role(@prison, offender)) %>
             <br/><%= highlight(offender.offender_no, @q) %>
           </td>
           <td aria-label="POM" class="govuk-table__cell"><%= offender.formatted_pom_name || 'None allocated' %></td>

--- a/app/views/prisoners/search.html.erb
+++ b/app/views/prisoners/search.html.erb
@@ -12,65 +12,6 @@
       Search again
     </p>
   <% else %>
-    <%= render(
-          :partial => 'shared/pagination',
-          :locals => {
-            :data => @offenders,
-          }) %>
-
-    <table class="govuk-table responsive govuk-!-margin-top-4">
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">Case</th>
-        <th class="govuk-table__header" scope="col">POM</th>
-        <th class="govuk-table__header" scope="col">POM role</th>
-        <th class="govuk-table__header sorter-false" scope="col">Location</th>
-        <th class="govuk-table__header sorter-false" scope="col">Earliest release date</th>
-        <th class="govuk-table__header sorter-false" scope="col">Tier</th>
-        <% if @is_spo %>
-        <th class="govuk-table__header" scope="col">Action</th>
-        <% end %>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      <% @offenders.each_with_index do |offender, i| %>
-        <tr class="govuk-table__row allocated_offender_row_<%= i %>">
-          <td aria-label="Prisoner name" class="govuk-table__cell">
-            <%= link_to(highlight(offender.full_name, @q), prisoner_path_for_role(@prison, offender)) %>
-            <br/><%= highlight(offender.offender_no, @q) %>
-          </td>
-          <td aria-label="POM" class="govuk-table__cell"><%= offender.formatted_pom_name || 'None allocated' %></td>
-          <td aria-label="POM role" class="govuk-table__cell"> <%= offender.probation_record.present? ? pom_responsibility_label(offender) : 'None allocated' %> </td>
-          <td aria-label="Location" class="govuk-table__cell"><%= offender.location %></td>
-          <td aria-label="Date of birth" class="govuk-table__cell">
-            <% if offender.earliest_release.present? %>
-              <%= offender.earliest_release[:type] %>: <br/>
-              <%= format_date(offender.earliest_release[:date], replacement: "Unknown") %>
-            <% else %>
-              Unknown
-            <% end %>
-          </td>
-          <td aria-label="Tier" class="govuk-table__cell"><%= probation_field(offender, :tier) || 'No tier found' %></td>
-          <% if @is_spo %>
-          <td aria-label="Action" class="govuk-table__cell">
-            <% if @missing_info.map(&:offender_no).include?(offender.offender_no) %>
-              <%= link_to "Add missing details", new_prison_prisoner_case_information_path(@prison.code, offender.offender_no) %>
-            <% elsif @unallocated.map(&:offender_no).include?(offender.offender_no) %>
-              <%= link_to 'Allocate', prison_prisoner_staff_index_path(@prison.code, offender.offender_no) %>
-            <% else %>
-                -
-            <% end %>
-          </td>
-          <% end %>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-
-    <%= render(
-          :partial => 'shared/pagination',
-          :locals => {
-            :data => @offenders,
-          }) %>
+    <%= render 'prisoners/search_results_table', offenders: @offenders %>
   <% end %>
 </div>

--- a/app/views/prisoners/search_global.html.erb
+++ b/app/views/prisoners/search_global.html.erb
@@ -83,70 +83,8 @@
       <h2 class="govuk-heading-l">
         <%= @offenders.length %> <%= 'more' if @user_allocations.length > 0 %> <%= 'result'.pluralize(@offenders.length) %> from this prison
       </h2>
-      <%= render(
-            :partial => 'shared/pagination',
-            :locals => {
-              :data => @offenders,
-              :url_params => { anchor: 'global-results' }
-            }) %>
 
-      <table class="govuk-table responsive govuk-!-margin-top-4">
-        <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col">Case</th>
-          <th class="govuk-table__header" scope="col">POM</th>
-          <th class="govuk-table__header" scope="col">POM role</th>
-          <th class="govuk-table__header sorter-false" scope="col">Location</th>
-          <th class="govuk-table__header sorter-false" scope="col">Earliest release date</th>
-          <th class="govuk-table__header sorter-false" scope="col">Tier</th>
-          <% if @is_spo %>
-            <th class="govuk-table__header" scope="col">Action</th>
-          <% end %>
-        </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-        <% @offenders.each_with_index do |offender, i| %>
-          <tr class="govuk-table__row allocated_offender_row_<%= i %>">
-            <td aria-label="Prisoner name" class="govuk-table__cell">
-              <%= link_to_unless(@missing_info.map(&:offender_no).include?(offender.offender_no),
-                                 highlight(offender.full_name, @q),
-                                 prisoner_path_for_role(@prison, offender)) { highlight(offender.full_name, @q) } %>
-              <br/><%= highlight(offender.offender_no, @q) %>
-            </td>
-            <td aria-label="POM" class="govuk-table__cell"><%= offender.formatted_pom_name || 'None allocated' %></td>
-            <td aria-label="POM role" class="govuk-table__cell"> <%= offender.probation_record.present? ? pom_responsibility_label(offender) : 'None allocated' %> </td>
-            <td aria-label="Location" class="govuk-table__cell"><%= offender.location %></td>
-            <td aria-label="Date of birth" class="govuk-table__cell">
-              <% if offender.earliest_release.present? %>
-                <%= offender.earliest_release[:type] %>: <br/>
-                <%= format_date(offender.earliest_release[:date], replacement: "Unknown") %>
-              <% else %>
-                Unknown
-              <% end %>
-            </td>
-            <td aria-label="Tier" class="govuk-table__cell"><%= probation_field(offender, :tier) || 'No tier found' %></td>
-            <% if @is_spo %>
-              <td aria-label="Action" class="govuk-table__cell">
-                <% if @missing_info.map(&:offender_no).include?(offender.offender_no) %>
-                  <%= link_to "Add missing details", new_prison_prisoner_case_information_path(@prison.code, offender.offender_no) %>
-                <% elsif @unallocated.map(&:offender_no).include?(offender.offender_no) %>
-                  <%= link_to 'Allocate', prison_prisoner_staff_index_path(@prison.code, offender.offender_no) %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
-      <%= render(
-            :partial => 'shared/pagination',
-            :locals => {
-              :data => @offenders,
-              :url_params => { anchor: 'global-results' }
-            }) %>
-
+      <%= render 'prisoners/search_results_table', offenders: @offenders, url_params: { anchor: 'global-results' } %>
     <% end %>
 
   </div>

--- a/app/views/prisoners/search_global.html.erb
+++ b/app/views/prisoners/search_global.html.erb
@@ -47,7 +47,7 @@
         <% @user_allocations.each_with_index do |offender, i| %>
           <tr class="govuk-table__row allocated_offender_row_<%= i %>">
             <td aria-label="Prisoner name" class="govuk-table__cell">
-              <%= link_to(highlight(offender.full_name, @q), prisoner_path_for_role(@is_spo, @prison, offender)) %>
+              <%= link_to(highlight(offender.full_name, @q), prisoner_path_for_role(@prison, offender)) %>
               <br/><%= highlight(offender.offender_no, @q) %>
             </td>
             <td aria-label="POM role" class="govuk-table__cell"> <%= offender.probation_record.present? ? pom_responsibility_label(offender) : '-' %> </td>
@@ -108,7 +108,9 @@
         <% @offenders.each_with_index do |offender, i| %>
           <tr class="govuk-table__row allocated_offender_row_<%= i %>">
             <td aria-label="Prisoner name" class="govuk-table__cell">
-              <%= link_to(highlight(offender.full_name, @q), prisoner_path_for_role(@is_spo, @prison, offender)) %>
+              <%= link_to_unless(@missing_info.map(&:offender_no).include?(offender.offender_no),
+                                 highlight(offender.full_name, @q),
+                                 prisoner_path_for_role(@prison, offender)) { highlight(offender.full_name, @q) } %>
               <br/><%= highlight(offender.offender_no, @q) %>
             </td>
             <td aria-label="POM" class="govuk-table__cell"><%= offender.formatted_pom_name || 'None allocated' %></td>

--- a/app/views/shared/_parole_table.html.erb
+++ b/app/views/shared/_parole_table.html.erb
@@ -25,7 +25,7 @@
     <% @parole_cases.each_with_index do |offender, i| %>
       <tr class="govuk-table__row offender_row_<%= i %>">
         <td aria-label="Prisoner name" class="govuk-table__cell ">
-          <a href="<%= prison_prisoner_path(@prison.code, offender.offender_no) %>"><%= offender.full_name %></a>
+          <%= link_to offender.full_name, prisoner_path_for_role(@prison, offender) %>
           <br/>
           <span class='govuk-hint govuk-!-margin-bottom-0'>
             <%= offender.offender_no %>

--- a/spec/features/remove_pom_feature_spec.rb
+++ b/spec/features/remove_pom_feature_spec.rb
@@ -47,13 +47,13 @@ feature "remove a POM no longer present in NOMIS" do
       end
 
       # Goes to the Manage your staff page
-      visit prison_poms_path(prison_id: prison.code)
+      visit prison_poms_path(prison.code)
     end
   end
 
   shared_examples 'without an attention needed tab' do
     it 'does not show the attention needed tab' do
-      visit prison_poms_path(prison_id: prison.code)
+      visit prison_poms_path(prison.code)
 
       expect(page).not_to have_css('a.govuk-tabs__tab', text: 'Attention needed')
     end
@@ -118,7 +118,7 @@ feature "remove a POM no longer present in NOMIS" do
           create(:case_information, offender: offender_record)
         end
 
-        visit prison_poms_path(prison_id: prison.code)
+        visit prison_poms_path(prison.code)
       end
 
       it 'links directly to the POM selection page, skipping the summary' do

--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -23,6 +23,8 @@ feature 'Search for offenders' do
   end
 
   it 'Can search from the dashboard' do
+    create(:case_information, offender: build(:offender, nomis_offender_id: 'T0000AA'))
+
     visit root_path
     fill_in 'Find a case', with: 'Cal'
     click_on 'Search'
@@ -30,8 +32,11 @@ feature 'Search for offenders' do
     expect(page).to have_current_path(search_prison_prisoners_path(prison_code), ignore_query: true)
     expect(all('[aria-label="Prisoner name"]').map(&:text)).to eq(['Mccoy, California T0000AA', 'Agnes, Cally T0000AB', 'Callins, Bridget T0000AE'])
 
-    click_on 'Mccoy, California'
-    expect(page).to have_title "View case information"
+    # Offender with case information is linked
+    expect(page).to have_link('Mccoy, California', href: prison_prisoner_review_case_details_path(prison_code, 'T0000AA'))
+    # Offenders without case information are shown as plain text
+    expect(page).not_to have_link('Agnes, Cally')
+    expect(page).to have_content('Agnes, Cally')
   end
 
   it 'Can search from the Allocations summary page' do

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -40,17 +40,17 @@ RSpec.describe SearchHelper do
     end
 
     context 'when user is not an SPO' do
-      let(:is_spo) { false }
+      def current_user_is_spo? = false
 
       it 'returns the prisoner path' do
         expect(
-          prisoner_path_for_role(is_spo, prison, offender)
+          prisoner_path_for_role(prison, offender)
         ).to eq(prison_prisoner_path(prison.code, offender.offender_no))
       end
     end
 
     context 'when user is an SPO' do
-      let(:is_spo) { true }
+      def current_user_is_spo? = true
 
       context 'with an active allocation' do
         before do
@@ -59,7 +59,7 @@ RSpec.describe SearchHelper do
 
         it 'returns the allocation path' do
           expect(
-            prisoner_path_for_role(is_spo, prison, offender)
+            prisoner_path_for_role(prison, offender)
           ).to eq(prison_prisoner_allocation_path(prison.code, prisoner_id: offender.offender_no))
         end
       end
@@ -69,10 +69,10 @@ RSpec.describe SearchHelper do
           allow(offender).to receive(:active_allocation).and_return(nil)
         end
 
-        it 'returns the prisoner path' do
+        it 'returns the review case details path' do
           expect(
-            prisoner_path_for_role(is_spo, prison, offender)
-          ).to eq(prison_prisoner_path(prison.code, offender.offender_no))
+            prisoner_path_for_role(prison, offender)
+          ).to eq(prison_prisoner_review_case_details_path(prison.code, offender.offender_no))
         end
       end
     end

--- a/spec/views/handovers/cells/_prisoner_details.html.erb_spec.rb
+++ b/spec/views/handovers/cells/_prisoner_details.html.erb_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe 'handovers/cells/_prisoner_details' do
+  let(:prison_id) { 'LEI' }
+  let(:offender) do
+    double(full_name: 'Doe, John', last_name: 'Doe', offender_no: 'A1234BC')
+  end
+
+  describe 'when rendered for a POM' do
+    before do
+      render 'handovers/cells/prisoner_details', prison_id: prison_id, offender: offender, pom_view: true
+    end
+
+    it 'links to the prisoner page' do
+      expect(partial).to have_link('Doe, John', href: prison_prisoner_path(prison_id, 'A1234BC'))
+    end
+
+    it 'displays the offender number' do
+      expect(rendered).to include('A1234BC')
+    end
+
+    it 'sets the sort value to the last name' do
+      expect(partial).to have_css('[data-sort-value="Doe"]')
+    end
+  end
+
+  describe 'when rendered for an SPO/HOMD' do
+    before do
+      render 'handovers/cells/prisoner_details', prison_id: prison_id, offender: offender, pom_view: false
+    end
+
+    it 'links to the prisoner allocation page' do
+      expect(partial).to have_link('Doe, John', href: prison_prisoner_allocation_path(prison_id, prisoner_id: 'A1234BC'))
+    end
+
+    it 'displays the offender number' do
+      expect(rendered).to include('A1234BC')
+    end
+
+    it 'sets the sort value to the last name' do
+      expect(partial).to have_css('[data-sort-value="Doe"]')
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2039

Ensure HOMDs and POMs are seeing the correct version of the PiP profile.
This unify the behaviour across the service:

SPO + allocated → allocation info page
SPO + not allocated → review case details page
Non-SPO (POM) → prisoner profile page

Also DRY the search results table, and using named argument in the prison_pom_path helper.