### PR TITLE
MO-2039 Ensure SPO view in staff-level handovers

### DIFF
--- a/app/controllers/poms_controller.rb
+++ b/app/controllers/poms_controller.rb
@@ -28,7 +28,7 @@ class PomsController < PrisonStaffApplicationController
       @overdue_com_allocations = @handover_cases.com_allocation_overdue
     end
 
-    @pom_view = true
+    @pom_view = false
   end
 
   # This is for the situation where the user is no longer a POM

--- a/app/views/handovers/_case_list.html.erb
+++ b/app/views/handovers/_case_list.html.erb
@@ -7,12 +7,13 @@
 <% end %>
 
 <% handover_cases = local_assigns[:handover_data] || @filtered_handover_cases %>
+<% hide_pom_column = local_assigns.fetch(:hide_pom_column, @pom_view) %>
 
 <%= handover_list_table(table_class: [table_class] + ['govuk-!-margin-top-7'],
                         anchor: local_assigns[:anchor],
                         headers: [
                           { sort: 'offender_last_name', body: 'Prisoner details' },
-                          @pom_view ? nil : { sort: 'staff_member_full_name_ordered', body: 'POM' },
+                          hide_pom_column ? nil : { sort: 'staff_member_full_name_ordered', body: 'POM' },
                           local_assigns[:hide_com_details] ? nil : { sort: 'allocated_com_name', body: 'COM details' },
                           { sort: 'handover_date', body: 'COM responsible' },
                           { sort: 'earliest_release_date', body: 'Earliest release date' },
@@ -26,7 +27,7 @@
     <tr class="govuk-table__row allocated-offender">
       <%= render 'handovers/cells/prisoner_details', prison_id: @prison_id, offender: handover_case.offender, pom_view: @pom_view, anchor: local_assigns[:anchor] %>
       
-      <% unless @pom_view %>
+      <% unless hide_pom_column %>
         <%= render 'handovers/cells/staff_member', staff_member: handover_case.staff_member %>
       <% end %>
 

--- a/app/views/poms/_handover_tab.html.erb
+++ b/app/views/poms/_handover_tab.html.erb
@@ -40,7 +40,8 @@
               no_cases_message: 'No upcoming handovers at the moment',
               hide_com_details: true,
               show_handover_date_highlight: :due_soon,
-              hide_record_progress_link: true %>
+              hide_record_progress_link: true,
+              hide_pom_column: true %>
       </div>
 
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="in-progress-handovers">
@@ -55,7 +56,8 @@
               no_cases_message: 'No in-progress handovers at the moment',
               hide_com_details: false,
               show_handover_date_highlight: nil,
-              hide_record_progress_link: true %>
+              hide_record_progress_link: true,
+              hide_pom_column: true %>
       </div>
 
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="overdue-tasks">
@@ -70,7 +72,8 @@
               no_cases_message: 'No overdue tasks at the moment',
               hide_com_details: false,
               show_handover_date_highlight: nil,
-              hide_record_progress_link: true %>
+              hide_record_progress_link: true,
+              hide_pom_column: true %>
       </div>
 
       <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="overdue-com-allocations">
@@ -86,7 +89,8 @@
               hide_com_details: true,
               com_allocation_view: true,
               show_handover_date_highlight: nil,
-              hide_record_progress_link: true %>
+              hide_record_progress_link: true,
+              hide_pom_column: true %>
       </div>
     </div>
   </div>

--- a/spec/features/handover/homd_views_handover_summary_spec.rb
+++ b/spec/features/handover/homd_views_handover_summary_spec.rb
@@ -43,6 +43,14 @@ describe "HOMD views handover summary for a Prison" do
     expect(page).to have_content("Upcoming handovers (1)")
     expect(page).to have_content(offender_with_upcoming_handover.nomis_offender_id)
     expect(page).not_to have_content(another_offender_with_upcoming_handover_but_different_pom.nomis_offender_id)
+
+    # Offender links go to the allocation page, not the prisoner profile
+    within 'tr', text: offender_with_upcoming_handover.nomis_offender_id do
+      expect(page).to have_link(href: prison_prisoner_allocation_path(prison.code, prisoner_id: offender_with_upcoming_handover.nomis_offender_id))
+    end
+
+    # POM column is hidden since we're already viewing this POM's cases
+    expect(page).not_to have_css('th', text: 'POM')
   end
 
   specify 'HOMD can view in progress handovers' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2039

Additional work to previous PR #2905 to ensure an SPO/HOMD viewing either the top level handover page, or the staff-scoped one, has links to the allocation instead of prisoner profile, and the view is consistent.