### PR TITLE
Improve admin audit search page

### DIFF
--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -17,4 +17,8 @@
 nav.govuk-pagination {
   margin-top: 2em;
   margin-bottom: 2em;
+
+  &--end {
+    justify-content: flex-end;
+  }
 }

--- a/app/controllers/manage/audit_events_controller.rb
+++ b/app/controllers/manage/audit_events_controller.rb
@@ -2,8 +2,10 @@ class Manage::AuditEventsController < ApplicationController
   before_action :authenticate_user, :ensure_admin_user
 
   def index
-    @nomis_offender_id = params[:nomis_offender_id]
+    @nomis_offender_id = params[:nomis_offender_id]&.strip
+    @username = params[:whodunnit]&.strip
     @tags = params.fetch(:tags, '').strip.split(/[^\w.=]+/)
+
     query = AuditEvent.order(created_at: :desc)
 
     if @nomis_offender_id.present?
@@ -14,6 +16,14 @@ class Manage::AuditEventsController < ApplicationController
       query = query.tags(*@tags)
     end
 
-    @audit_events = query.page params[:page]
+    if @username.present?
+      query = if @username.casecmp('system').zero?
+                query.where(system_event: true)
+              else
+                query.where(username: @username)
+              end
+    end
+
+    @audit_events = query.page(params[:page]).without_count
   end
 end

--- a/app/views/manage/audit_events/_pagination.html.erb
+++ b/app/views/manage/audit_events/_pagination.html.erb
@@ -1,0 +1,35 @@
+<% current_page_number = audit_events.current_page %>
+<% has_prev = current_page_number > 1 %>
+<% has_next = audit_events.length == audit_events.limit_value %>
+<% pagination_params = request.query_parameters.slice(:nomis_offender_id, :tags, :whodunnit) %>
+
+<% if has_prev || has_next %>
+  <nav class="govuk-pagination govuk-pagination--end" role="navigation" aria-label="Pagination">
+    <% if has_prev %>
+      <div class="govuk-pagination__prev">
+        <%= link_to url_for(pagination_params.merge(page: current_page_number - 1)),
+                    class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state', rel: 'prev' do %>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+          </svg>
+          <span class="govuk-pagination__link-title">
+            Previous<span class="govuk-visually-hidden"> page</span>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+    <% if has_next %>
+      <div class="govuk-pagination__next">
+        <%= link_to url_for(pagination_params.merge(page: current_page_number + 1)),
+                    class: 'govuk-link govuk-pagination__link govuk-link--no-visited-state', rel: 'next' do %>
+          <span class="govuk-pagination__link-title">
+            Next<span class="govuk-visually-hidden"> page</span>
+          </span>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+        <% end %>
+      </div>
+    <% end %>
+  </nav>
+<% end %>

--- a/app/views/manage/audit_events/index.html.erb
+++ b/app/views/manage/audit_events/index.html.erb
@@ -4,30 +4,47 @@
   Log of Audit Events
 </h2>
 
-<div class="search-box govuk-grid-row">
+<div class="search-box">
   <%= form_tag(manage_audit_events_path, method: :get) do %>
-    <div class="govuk-form-group">
-      <label class="govuk-label" for="nomis_offender_id">
-        Prisoner number/NOMS no/case number (looks like X1111XX)
-      </label>
-      <input class="govuk-input" id="nomis_offender_id" name="nomis_offender_id" type="text" value="<%= @nomis_offender_id %>" autofocus>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="nomis_offender_id">
+            Prisoner number (looks like X1111XX)
+          </label>
+          <input class="govuk-input" id="nomis_offender_id" name="nomis_offender_id" type="text" value="<%= @nomis_offender_id %>" autofocus autocomplete="off">
+        </div>
+      </div>
+
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="tags">
+            Tags (comma or space separated)
+          </label>
+          <input class="govuk-input" id="tags" name="tags" type="text" value="<%= @tags.join(' ') %>" autocomplete="off">
+        </div>
+      </div>
+
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="whodunnit">
+            User (or "system" for system events)
+          </label>
+          <input class="govuk-input" id="whodunnit" name="whodunnit" type="text" value="<%= @username %>" autocomplete="off">
+        </div>
+      </div>
     </div>
 
-    <div class="govuk-form-group">
-    <label class="govuk-label" for="tags">
-        Tags (comma or space separated)
-      </label>
-      <input class="govuk-input" id="tags" name="tags" type="text" value="<%= @tags.join(' ') %>">
-
-      <input id="search-button" type="submit" class="govuk-button" value="    Search    "/>
-    </div>
+    <input id="search-button" type="submit" class="govuk-button" value="Search" style="margin-left: 0;"/>
   <% end %>
 </div>
 
-<%= render partial: 'shared/pagination', locals: { data: @audit_events } %>
+<% filtering = @nomis_offender_id.present? || @tags.present? || @username.present? %>
+
+<%= render partial: 'manage/audit_events/pagination', locals: { audit_events: @audit_events } %>
 
 <table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m">All</caption>
+  <caption class="govuk-table__caption govuk-table__caption--m"><%= filtering ? 'Search results' : 'Most recent events' %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Time</th>
@@ -40,7 +57,11 @@
   <tbody class="govuk-table__body">
     <% @audit_events.each do |audit_event| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= format_time_readably(audit_event.created_at) %></td>
+        <td class="govuk-table__cell">
+          <time datetime="<%= audit_event.created_at.iso8601 %>" title="<%= audit_event.created_at.iso8601(3) %>">
+            <%= format_time_readably(audit_event.created_at) %>
+          </time>
+        </td>
         <td class="govuk-table__cell"><%= audit_event.nomis_offender_id || 'N/A' %></td>
         <td class="govuk-table__cell govuk-body-s"><%= audit_event.tags.join('<br>').html_safe %></td>
         <td class="govuk-table__cell">
@@ -67,4 +88,4 @@
   </tbody>
 </table>
 
-<%= render partial: 'shared/pagination', locals: { data: @audit_events } %>
+<%= render partial: 'manage/audit_events/pagination', locals: { audit_events: @audit_events } %>

--- a/db/migrate/20260811114112_add_index_to_audit_events_on_username.rb
+++ b/db/migrate/20260811114112_add_index_to_audit_events_on_username.rb
@@ -1,0 +1,7 @@
+class AddIndexToAuditEventsOnUsername < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :audit_events, :username, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1191,6 +1191,13 @@ CREATE INDEX index_audit_events_on_tags ON public.audit_events USING gin (tags);
 
 
 --
+-- Name: index_audit_events_on_username; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_audit_events_on_username ON public.audit_events USING btree (username);
+
+
+--
 -- Name: index_calculated_handover_dates_on_nomis_offender_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1346,6 +1353,7 @@ ALTER TABLE ONLY public.offender_email_sent
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260811114112'),
 ('20260714160140'),
 ('20260713120000'),
 ('20260409113634'),

--- a/spec/services/subject_access_request_template_service_spec.rb
+++ b/spec/services/subject_access_request_template_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SubjectAccessRequestTemplateService do
 
   describe 'DB schema change guard' do
     # Keep this updated once any potential SAR drifting is asserted
-    let(:reviewed_version) { '20260714_160140' }
+    let(:reviewed_version) { '20260811_114112' }
 
     let(:current_version) { ActiveRecord::Base.connection_pool.migration_context.current_version }
     let(:message) do


### PR DESCRIPTION
The audit page was veeery slow, particularly on first load, because it had to do a full count. Removed the count in the queries as we don't really care for that (we keep next/previous links).

Added index to username column, and ability to filter by this in the search.

Other minor styling tweaks.