### PR TITLE
MO-2042 Include soft-deleted in POM onboard search

### DIFF
--- a/app/services/nomis_user_roles_service.rb
+++ b/app/services/nomis_user_roles_service.rb
@@ -11,9 +11,12 @@ class NomisUserRolesService
     results = response.fetch('content', [])
     total_elements = response.fetch('totalElements', 0)
 
-    # We remove existing POMs from the search results
-    existing_pom_ids = prison.get_list_of_poms(include_deleted: true).map(&:staff_id)
+    # Exclude POMs who already appear in the staff lists (active, unavailable,
+    # or inactive) as SPOs manage those via status changes, not re-onboarding.
+    # Only deleted POMs should be eligible for re-onboarding via search.
+    existing_pom_ids = prison.pom_details.not_deleted.pluck(:nomis_staff_id)
     filtered_results = results.reject { |result| existing_pom_ids.include?(result['staffId']) }
+
     total_elements -= (results.size - filtered_results.size)
 
     [filtered_results, total_elements]

--- a/spec/services/nomis_user_roles_service_spec.rb
+++ b/spec/services/nomis_user_roles_service_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe NomisUserRolesService do
 
     before do
       allow(HmppsApi::NomisUserRolesApi).to receive(:get_users).and_return(api_response)
-      allow(prison).to receive(:get_list_of_poms).and_return([double(staff_id: 222)])
     end
 
     it 'calls the NOMIS API with correct parameters' do
@@ -35,48 +34,61 @@ RSpec.describe NomisUserRolesService do
       )
     end
 
-    it 'filters out existing POMs and adjusts total count' do
+    it 'filters out active POMs and adjusts total count' do
+      create(:pom_detail, :active, prison: prison, nomis_staff_id: 222)
+
       results, total = described_class.search_staff(prison, filter)
 
       expect(results).to contain_exactly({ 'staffId' => 111 }, { 'staffId' => 333 })
       expect(total).to eq(2)
     end
 
-    context 'when a POM has been soft-deleted but still has their NOMIS role' do
-      before do
-        # POM 333 is soft-deleted locally but their NOMIS role has not yet been
-        # expired (e.g. cases still pending reallocation). They should still be
-        # excluded from the search results to prevent re-onboarding mid-removal
-        allow(prison).to receive(:get_list_of_poms)
-          .with(include_deleted: true)
-          .and_return([double(staff_id: 222), double(staff_id: 333)])
-      end
+    context 'when a POM has an unavailable status' do
+      it 'excludes them from results' do
+        create(:pom_detail, :unavailable, prison: prison, nomis_staff_id: 222)
 
-      it 'excludes the soft-deleted POM from results' do
         results, total = described_class.search_staff(prison, filter)
 
-        expect(results).to contain_exactly({ 'staffId' => 111 })
-        expect(total).to eq(1)
+        expect(results).to contain_exactly({ 'staffId' => 111 }, { 'staffId' => 333 })
+        expect(total).to eq(2)
       end
     end
 
-    context 'when a POM has been fully removed (role expired in NOMIS)' do
-      before do
-        # POM 222 was previously removed and their NOMIS role has been expired,
-        # so `get_list_of_poms` no longer returns them. They will appear in the
-        # search results so they can be re-onboarded
-        allow(prison).to receive(:get_list_of_poms)
-          .with(include_deleted: true)
-          .and_return([])
-      end
+    context 'when a POM has an inactive status' do
+      it 'excludes them from results' do
+        create(:pom_detail, :inactive, prison: prison, nomis_staff_id: 333)
 
-      it 'includes the fully removed POM in results' do
+        results, total = described_class.search_staff(prison, filter)
+
+        expect(results).to contain_exactly({ 'staffId' => 111 }, { 'staffId' => 222 })
+        expect(total).to eq(2)
+      end
+    end
+
+    context 'when a POM has been deleted' do
+      it 'includes them in results so they can be re-onboarded' do
+        create(:pom_detail, :deleted, prison: prison, nomis_staff_id: 222)
+
         results, total = described_class.search_staff(prison, filter)
 
         expect(results).to contain_exactly(
           { 'staffId' => 111 }, { 'staffId' => 222 }, { 'staffId' => 333 }
         )
         expect(total).to eq(3)
+      end
+    end
+
+    context 'when multiple POMs have mixed statuses' do
+      it 'only excludes non-deleted POMs' do
+        create(:pom_detail, :active, prison: prison, nomis_staff_id: 111)
+        create(:pom_detail, :deleted, prison: prison, nomis_staff_id: 222)
+        create(:pom_detail, :inactive, prison: prison, nomis_staff_id: 333)
+
+        results, total = described_class.search_staff(prison, filter)
+
+        # 111 excluded (active), 222 included (deleted), 333 excluded (inactive)
+        expect(results).to contain_exactly({ 'staffId' => 222 })
+        expect(total).to eq(1)
       end
     end
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2042

There are scenarios where POMs marked as deleted in our service still return the NOMIS role, and the onboarding search was filtering this out, thus making it impossible to re-onboard the POM.

The search filter has been updated to only filter existing "non-deleted" POMs (active, unavailable or inactive) as these can be updated via the profile edit page (they show on the staff lists). Deleted POMs will be returned so they can be re-onboarded.