### PR TITLE
MO-2043 Hardening of LDU import, handle edge cases

### DIFF
--- a/lib/import_local_delivery_units.rb
+++ b/lib/import_local_delivery_units.rb
@@ -10,6 +10,11 @@ class ImportLocalDeliveryUnits
     OTHERLDU
   ].freeze
 
+  # Safety threshold: if the API returns fewer than this percentage of the
+  # existing LDU count, abort the import to avoid mass deletion caused by
+  # an upstream API issue (empty response, partial data, misconfiguration)
+  MINIMUM_RETENTION_PERCENTAGE = 90
+
   attr_reader :dry_run
 
   def initialize(dry_run: true)
@@ -23,6 +28,12 @@ class ImportLocalDeliveryUnits
     log("Number of LDUs in database: #{existing_ldu_codes.size}")
     log("Retrieved #{mailboxes.size} mailboxes from register. Processing...")
 
+    if Rails.env.production? && existing_ldu_codes.any? && below_safety_threshold?(mailboxes.size, existing_ldu_codes.size)
+      log("ABORTING: API returned #{mailboxes.size} mailboxes but we have #{existing_ldu_codes.size} LDUs locally. " \
+          "This looks like a partial or empty response (threshold: #{MINIMUM_RETENTION_PERCENTAGE}%).")
+      return
+    end
+
     destroys_count = 0
     creates_count = 0
     updates_count = 0
@@ -34,9 +45,13 @@ class ImportLocalDeliveryUnits
       name = mailbox['name']
       uuid = mailbox['id']
 
-      ldu = LocalDeliveryUnit
-              .where(mailbox_register_id: uuid)
-              .first_or_initialize.tap do |record|
+      # Look up by UUID first, then fall back to code. This handles the case
+      # where an LDU was deleted from Mailbox Register and re-added with the
+      # same code but a new UUID, as we want to update the existing record (and
+      # preserve its associations) rather than trying to delete-and-recreate.
+      ldu = (LocalDeliveryUnit.find_by(mailbox_register_id: uuid) ||
+             LocalDeliveryUnit.find_by(code: code) ||
+             LocalDeliveryUnit.new).tap do |record|
         record.code = code
         record.mailbox_register_id = uuid
         record.name = mailbox['name'].presence || mailbox['emailAddress']
@@ -103,6 +118,12 @@ class ImportLocalDeliveryUnits
   end
 
 private
+
+  def below_safety_threshold?(remote_count, local_count)
+    return false if local_count.zero?
+
+    (remote_count.to_f / local_count * 100) < MINIMUM_RETENTION_PERCENTAGE
+  end
 
   def log(msg)
     logger.info("[#{self.class}] #{log_prefix}#{msg}")

--- a/lib/import_local_delivery_units.rb
+++ b/lib/import_local_delivery_units.rb
@@ -134,6 +134,6 @@ private
   end
 
   def logger
-    @logger ||= Logger.new($stdout)
+    @logger ||= Rails.env.test? ? Rails.logger : Logger.new($stdout)
   end
 end

--- a/spec/lib/import_local_delivery_units_spec.rb
+++ b/spec/lib/import_local_delivery_units_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportLocalDeliveryUnits do
+  subject(:import) { described_class.new(dry_run:) }
+
+  let(:dry_run) { false }
+
+  def build_mailbox(code:, uuid: SecureRandom.uuid, name: Faker::Address.county, email: Faker::Internet.email)
+    {
+      'id' => uuid,
+      'unitCode' => code,
+      'name' => name,
+      'emailAddress' => email,
+      'country' => 'England',
+      'createdAt' => '2025-01-01T00:00:00Z',
+      'updatedAt' => '2025-06-01T00:00:00Z',
+    }
+  end
+
+  before do
+    allow(HmppsApi::MailboxRegisterApi).to receive(:get_local_delivery_units).and_return(mailboxes)
+  end
+
+  describe 'creating new LDUs' do
+    let(:mailboxes) { [build_mailbox(code: 'NEWLDU', name: 'New Unit', email: 'new@example.com')] }
+
+    it 'creates an LDU that does not exist locally' do
+      expect { import.call }.to change(LocalDeliveryUnit, :count).by(1)
+
+      ldu = LocalDeliveryUnit.find_by(code: 'NEWLDU')
+      expect(ldu).to have_attributes(name: 'New Unit', email_address: 'new@example.com')
+    end
+  end
+
+  describe 'updating existing LDUs' do
+    let!(:existing) { create(:local_delivery_unit, code: 'EXIST1', name: 'Old Name', email_address: 'old@example.com', mailbox_register_id: uuid) }
+    let(:uuid) { SecureRandom.uuid }
+    let(:mailboxes) { [build_mailbox(code: 'EXIST1', uuid: uuid, name: 'New Name', email: 'new@example.com')] }
+
+    it 'updates the existing LDU attributes' do
+      expect { import.call }.not_to change(LocalDeliveryUnit, :count)
+
+      existing.reload
+      expect(existing).to have_attributes(name: 'New Name', email_address: 'new@example.com')
+    end
+  end
+
+  describe 'LDU re-added with new UUID but same code' do
+    let!(:existing) { create(:local_delivery_unit, code: 'READD1', name: 'Original', email_address: 'orig@example.com', mailbox_register_id: 'old-uuid') }
+    let(:new_uuid) { SecureRandom.uuid }
+    let(:mailboxes) { [build_mailbox(code: 'READD1', uuid: new_uuid, name: 'Updated', email: 'updated@example.com')] }
+
+    it 'updates the existing record with the new UUID rather than creating a duplicate' do
+      expect { import.call }.not_to change(LocalDeliveryUnit, :count)
+
+      existing.reload
+      expect(existing).to have_attributes(
+        mailbox_register_id: new_uuid,
+        name: 'Updated',
+        email_address: 'updated@example.com'
+      )
+    end
+
+    it 'does not queue the existing record for deletion' do
+      import.call
+      expect(LocalDeliveryUnit.find_by(code: 'READD1')).to be_present
+    end
+  end
+
+  describe 'deleting LDUs no longer in Mailbox Register' do
+    let!(:orphan) { create(:local_delivery_unit, code: 'ORPHAN1', mailbox_register_id: 'orphan-uuid') }
+    let!(:kept_ldus) { create_list(:local_delivery_unit, 3) }
+    let(:mailboxes) do
+      kept_ldus.map { |ldu| build_mailbox(code: ldu.code, uuid: ldu.mailbox_register_id || SecureRandom.uuid) }
+    end
+
+    context 'when the LDU has no associated case_information' do
+      it 'destroys the orphaned LDU' do
+        expect { import.call }.to change(LocalDeliveryUnit, :count).by(-1)
+        expect(LocalDeliveryUnit.find_by(code: 'ORPHAN1')).to be_nil
+      end
+    end
+
+    context 'when the LDU has associated case_information' do
+      before do
+        create(:case_information, local_delivery_unit: orphan)
+      end
+
+      it 'does not destroy the LDU' do
+        expect { import.call }.not_to change(LocalDeliveryUnit, :count)
+        expect(LocalDeliveryUnit.find_by(code: 'ORPHAN1')).to be_present
+      end
+    end
+  end
+
+  describe 'safety threshold' do
+    let!(:existing_ldus) { create_list(:local_delivery_unit, 10) }
+
+    before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+    context 'when the API returns fewer than 90% of local LDUs' do
+      let(:mailboxes) { [build_mailbox(code: 'ONLY1')] }
+
+      it 'aborts without making any changes' do
+        expect { import.call }.not_to change(LocalDeliveryUnit, :count)
+      end
+    end
+
+    context 'when the API returns at least 90% of local LDUs' do
+      let(:mailboxes) do
+        existing_ldus.map { |ldu| build_mailbox(code: ldu.code, uuid: ldu.mailbox_register_id || SecureRandom.uuid) }
+      end
+
+      it 'proceeds with the import' do
+        import.call
+        expect(LocalDeliveryUnit.count).to eq(10)
+      end
+    end
+  end
+
+  describe 'dry run mode' do
+    let(:dry_run) { true }
+    let(:mailboxes) { [build_mailbox(code: 'DRYRUN1', name: 'Dry Run', email: 'dry@example.com')] }
+
+    it 'does not persist any changes' do
+      expect { import.call }.not_to change(LocalDeliveryUnit, :count)
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2043

A few changes to the import so an API failure or misconfiguration that potentially results in many LDUs missing, will abort, and also to be able to update existing LDUs that have been deleted and then recreated with the same code in mailbox register.