### PR TITLE
Parametrise cache in prisoner-search request

### DIFF
--- a/app/controllers/prisons_application_controller.rb
+++ b/app/controllers/prisons_application_controller.rb
@@ -26,8 +26,8 @@ protected
     params.fetch(:prison_id, default_prison_code)
   end
 
-  def get_offender_or_404(offender_no, *args)
-    offender = OffenderService.get_offender(offender_no, *args)
+  def get_offender_or_404(offender_no, **options)
+    offender = OffenderService.get_offender(offender_no, **options)
     return offender if offender.present?
 
     redirect_to '/404'

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -5,14 +5,22 @@ module HmppsApi
     class OffenderApi
       extend PrisonApiClient
 
+      DEFAULT_OPTIONS = {
+        ignore_legal_status: false,
+        fetch_complexities: true,
+        fetch_categories: true,
+        fetch_movements: true,
+        cache: true,
+      }.freeze
+
       # Only allow offenders into the service if their legal status is in this list
       # Used to filter out offenders who are on remand, civil prisoners, unsentenced, etc.
       ALLOWED_LEGAL_STATUSES = %w[SENTENCED INDETERMINATE_SENTENCE RECALL IMMIGRATION_DETAINEE].freeze
 
-      def self.get_offenders_in_prison(prison, *args)
+      def self.get_offenders_in_prison(prison, **options)
         offenders = get_search_api_offenders_in_prison(prison)
 
-        build_offenders(offenders, prison, *args)
+        build_offenders(offenders, prison, **options)
       end
 
       def self.get_offenders_out_of_prison(prison)
@@ -31,22 +39,20 @@ module HmppsApi
       # Warning: when you ignore the offender's legal status, you could potentially receive an offender who wouldn't
       # normally appear within the service. This should only be done under certain circumstances –
       # e.g. when deallocating an offender who has since left the service due to a change in legal status
-      def self.get_offender(offender_no, *args)
-        offender = get_search_api_offenders(offender_no).first
+      def self.get_offender(offender_no, **options)
+        options = options_with_defaults(options)
+
+        offender = get_search_api_offenders(offender_no, cache: options[:cache]).first
         return if offender.nil?
 
         # Restricted Patients use supportingPrisonId, since the offender is currently in hospital
         prison_id = offender.fetch(offender['restrictedPatient'] ? 'supportingPrisonId' : 'prisonId')
 
-        build_offenders([offender], prison_id, *args).first
+        build_offenders([offender], prison_id, **options).first
       end
 
-      def self.build_offenders(unfiltered_offenders, prison_id, *args)
-        default_options = {
-          ignore_legal_status: false, fetch_complexities: true, fetch_categories: true, fetch_movements: true
-        }.freeze
-
-        options = default_options.dup.merge(args.extract_options! || {}).assert_valid_keys(default_options.keys)
+      def self.build_offenders(unfiltered_offenders, prison_id, **options)
+        options = options_with_defaults(options)
 
         offenders = options[:ignore_legal_status] ? unfiltered_offenders : filtered_offenders(unfiltered_offenders)
         return [] if offenders.empty?
@@ -208,13 +214,18 @@ module HmppsApi
         results
       end
 
-      def self.get_search_api_offenders(offender_nos)
+      def self.get_search_api_offenders(offender_nos, cache: true)
         search_route = '/prisoner-search/prisoner-numbers'
-        search_client.post(search_route, { prisonerNumbers: Array(offender_nos) }, queryparams: { 'include-restricted-patients': true }, cache: true)
+        search_client.post(search_route, { prisonerNumbers: Array(offender_nos) }, queryparams: { 'include-restricted-patients': true }, cache:)
       end
 
       def self.default_image
         File.read(Rails.root.join('app/assets/images/default_profile_image.jpg'))
+      end
+
+      def self.options_with_defaults(options)
+        options.assert_valid_keys(DEFAULT_OPTIONS.keys)
+        DEFAULT_OPTIONS.merge(options)
       end
     end
   end

--- a/app/services/offender_service.rb
+++ b/app/services/offender_service.rb
@@ -2,8 +2,8 @@
 
 class OffenderService
   class << self
-    def get_offender(offender_no, *args)
-      prison_record = HmppsApi::PrisonApi::OffenderApi.get_offender(offender_no, *args)
+    def get_offender(offender_no, **options)
+      prison_record = HmppsApi::PrisonApi::OffenderApi.get_offender(offender_no, **options)
       return unless prison_record
 
       prison = Prison.find_by(code: prison_record.prison_id)
@@ -13,9 +13,9 @@ class OffenderService
       MpcOffender.new(prison:, offender:, prison_record:)
     end
 
-    def get_offenders_in_prison(prison, *args)
+    def get_offenders_in_prison(prison, **options)
       prison_records = HmppsApi::PrisonApi::OffenderApi
-                         .get_offenders_in_prison(prison.code, *args)
+                         .get_offenders_in_prison(prison.code, **options)
                          .index_by(&:offender_no)
 
       offenders = find_or_create_offenders(prison_records.keys)
@@ -28,9 +28,9 @@ class OffenderService
       end
     end
 
-    def get_offenders(offender_numbers, *args)
+    def get_offenders(offender_numbers, **options)
       Array(offender_numbers)
-        .map { |offender_number| get_offender(offender_number, *args) }
+        .map { |offender_number| get_offender(offender_number, **options) }
         .compact
     end
 

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -89,6 +89,22 @@ describe HmppsApi::PrisonApi::OffenderApi do
           stub_offender(offender)
         end
 
+        it 'uses cached prisoner search by default' do
+          expect(described_class).to receive(:get_search_api_offenders)
+            .with(offender_no, cache: true)
+            .and_call_original
+
+          described_class.get_offender(offender_no)
+        end
+
+        it 'allows callers to disable prisoner search cache' do
+          expect(described_class).to receive(:get_search_api_offenders)
+            .with(offender_no, cache: false)
+            .and_call_original
+
+          described_class.get_offender(offender_no, cache: false)
+        end
+
         it "can get a single offender's details including recall flag" do
           expect(subject).to be_instance_of(HmppsApi::Offender)
           expect(subject.recalled?).to eq(true)


### PR DESCRIPTION
This PR allows fresh offender lookups by making the caching configurable, and wire keyword options through offender lookup callers.

We had a hardcoded `cache: true` but we will need to sometimes disable the cache to ensure we read back fresh data in some operations as part of a follow-up PR. Kept the default as cache: true, so no change in behaviour.