### PR TITLE
MO-2044 Hardening of nightly movements job

### DIFF
--- a/app/jobs/movement_job.rb
+++ b/app/jobs/movement_job.rb
@@ -1,8 +1,15 @@
 class MovementJob < ApplicationJob
   queue_as :default
 
-  def perform(movement_json)
-    movement = HmppsApi::Movement.new(JSON.parse(movement_json))
-    MovementService.process_movement(movement)
+  # Date-specific job; retrying days later would process stale movement data
+  sidekiq_options retry: 10
+
+  def perform(movement_payload_or_payloads)
+    payloads = movement_payload_or_payloads.is_a?(Array) ? movement_payload_or_payloads : [movement_payload_or_payloads]
+
+    payloads.each do |movement_payload|
+      movement = HmppsApi::Movement.from_job_payload(movement_payload)
+      MovementService.process_movement(movement)
+    end
   end
 end

--- a/app/jobs/movements_on_date_job.rb
+++ b/app/jobs/movements_on_date_job.rb
@@ -5,18 +5,24 @@ class MovementsOnDateJob < ApplicationJob
   sidekiq_options retry: 10
 
   def perform(date_string)
-    yesterday = Date.parse(date_string) - 1.day
+    target_date = Date.parse(date_string)
 
-    Rails.logger.info("[MOVEMENT] Getting movements for #{yesterday}")
+    Rails.logger.info("[MOVEMENT] Getting movements for #{target_date}")
 
-    movements = MovementService.movements_on(yesterday)
+    movements = MovementService.movements_on(target_date, cache: false)
+    movements_by_offender = movements.group_by(&:offender_no)
 
-    Rails.logger.info("[MOVEMENT] Found #{movements.count} movements for #{yesterday}")
+    Rails.logger.info(
+      "[MOVEMENT] Found #{movements.count} movements for #{target_date} across #{movements_by_offender.size} offenders"
+    )
 
-    # Ensure that 1 movement failure doesn't prevent all the others from running
-    # If we were to catch the exception here, then Sentry wouldn't report it :-(
-    movements.each do |movement|
-      MovementJob.perform_later(movement.to_json)
+    # Ensure that one offender's movement sequence failing does not prevent the
+    # others from running, while still processing all ordered movements belonging
+    # to the same offender
+    movements_by_offender.each_value do |offender_movements|
+      MovementJob.perform_later(
+        offender_movements.sort_by(&:happened_at).map(&:job_payload)
+      )
     end
   end
 end

--- a/app/models/hmpps_api/movement.rb
+++ b/app/models/hmpps_api/movement.rb
@@ -64,6 +64,22 @@ module HmppsApi
       Time.zone.parse "#{@movement_date} #{@movement_time}"
     end
 
+    def job_payload
+      {
+        offender_no: @offender_no,
+        from_agency: @from_agency,
+        to_agency: @to_agency,
+        movement_type: @movement_type,
+        direction_code: @direction_code,
+        movement_time: @movement_time,
+        movement_date: @movement_date,
+      }
+    end
+
+    def self.from_job_payload(payload)
+      Movement.new(payload.symbolize_keys)
+    end
+
     def self.from_json(payload)
       Movement.new.tap do |obj|
         obj.load_from_json(payload)

--- a/app/services/hmpps_api/prison_api/movement_api.rb
+++ b/app/services/hmpps_api/prison_api/movement_api.rb
@@ -8,7 +8,7 @@ module HmppsApi
       ADMISSION_TYPES = [HmppsApi::MovementType::ADMISSION,
                          HmppsApi::MovementType::TRANSFER].freeze
 
-      def self.movements_on_date(date)
+      def self.movements_on_date(date, cache: true)
         route = '/movements'
 
         # the 'fromDateTime' field in the API is the 'earliest creation date' of a movement
@@ -17,7 +17,7 @@ module HmppsApi
         data = client.get(route, queryparams: {
           movementDate: date.strftime('%F'),
           fromDateTime: (date - 1.year).strftime('%FT%R')
-        })
+        }, cache:)
         data.map do |movement|
           api_deserialiser.deserialise(HmppsApi::Movement, movement)
         end

--- a/app/services/movement_service.rb
+++ b/app/services/movement_service.rb
@@ -4,8 +4,8 @@ class MovementService
   ADMISSION_MOVEMENT_CODE = 'IN'
   RELEASE_MOVEMENT_CODE = 'OUT'
 
-  def self.movements_on(date)
-    HmppsApi::PrisonApi::MovementApi.movements_on_date(date)
+  def self.movements_on(date, cache: true)
+    HmppsApi::PrisonApi::MovementApi.movements_on_date(date, cache:)
   end
 
   # Fetches the last recorded movement for an offender and processes it via
@@ -104,22 +104,7 @@ private
   end
 
   def self.release_offender(nomis_offender_id, from_agency)
-    Rails.logger.info("[MOVEMENT] Processing release for #{nomis_offender_id}")
-
-    alloc = AllocationHistory.active.find_by(nomis_offender_id:)
-    alloc.deallocate_offender_after_release if alloc
-
-    destroy_offender_stint_data(nomis_offender_id)
-
-    HmppsApi::ComplexityApi.inactivate(nomis_offender_id) if PrisonService.womens_prison?(from_agency)
-  end
-
-  def self.destroy_offender_stint_data(nomis_offender_id)
-    [CaseInformation, CalculatedHandoverDate, HandoverProgressChecklist, Responsibility, OmicEligibility].each do |model|
-      model.find_by(nomis_offender_id:)&.destroy!
-    rescue StandardError => e
-      Rails.logger.error("[MOVEMENT] Failed to destroy #{model} for #{nomis_offender_id}: #{e.class} - #{e.message}")
-    end
+    OffenderReleasedService.release_offender(nomis_offender_id, prison_code: from_agency)
   end
 
   def self.hospital_agencies

--- a/app/services/offender_released_service.rb
+++ b/app/services/offender_released_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Centralises the cleanup performed when an offender leaves the service,
+# whether that is a release, immigration transfer, or reconciliation.
+#
+# This was extracted from MovementService so the same logic can be reused
+# by ReconcileReleasedOffendersService (and any future callers).
+#
+class OffenderReleasedService
+  STINT_DATA_MODELS = [
+    CaseInformation,
+    CalculatedHandoverDate,
+    HandoverProgressChecklist,
+    Responsibility,
+    OmicEligibility,
+  ].freeze
+
+  def self.release_offender(nomis_offender_id, prison_code: nil)
+    unless local_release_state_present?(nomis_offender_id)
+      Rails.logger.info("[RELEASE] Skipping #{nomis_offender_id}; no local release state remains")
+      return
+    end
+
+    Rails.logger.info("[RELEASE] Processing release for #{nomis_offender_id}")
+
+    deallocate(nomis_offender_id)
+    destroy_stint_data(nomis_offender_id)
+    inactivate_complexity(nomis_offender_id, prison_code) if prison_code.present?
+  end
+
+  def self.deallocate(nomis_offender_id)
+    alloc = AllocationHistory.active.find_by(nomis_offender_id:)
+    alloc.deallocate_offender_after_release if alloc
+  end
+
+  def self.destroy_stint_data(nomis_offender_id)
+    STINT_DATA_MODELS.each do |model|
+      model.find_by(nomis_offender_id:)&.destroy!
+    rescue StandardError => e
+      Rails.logger.error("[RELEASE] Failed to destroy #{model} for #{nomis_offender_id}: #{e.class} - #{e.message}")
+    end
+  end
+
+  def self.inactivate_complexity(nomis_offender_id, prison_code)
+    HmppsApi::ComplexityApi.inactivate(nomis_offender_id) if PrisonService.womens_prison?(prison_code)
+  end
+
+  def self.local_release_state_present?(nomis_offender_id)
+    AllocationHistory.active.exists?(nomis_offender_id:) ||
+      STINT_DATA_MODELS.any? { it.exists?(nomis_offender_id:) }
+  end
+
+  private_class_method :deallocate, :inactivate_complexity, :local_release_state_present?
+end

--- a/lib/tasks/movements.rake
+++ b/lib/tasks/movements.rake
@@ -4,8 +4,13 @@ require 'rake'
 require_relative '../../app/models/hmpps_api/movement'
 
 namespace :movements do
-  desc 'Process the movement events in the previous 24 hours'
+  desc 'Process recent movement events. Optionally set MOVEMENTS_LOOKBACK_DAYS=3 and/or MOVEMENTS_END_DATE=2026-08-18.'
   task process: :environment do
-    MovementsOnDateJob.perform_later(Time.zone.today.to_s)
+    lookback_days = Integer(ENV.fetch('MOVEMENTS_LOOKBACK_DAYS', 1))
+    end_date = Date.parse(ENV.fetch('MOVEMENTS_END_DATE', Time.zone.yesterday.to_s))
+
+    lookback_days.times do |offset|
+      MovementsOnDateJob.perform_later((end_date - offset.days).to_s)
+    end
   end
 end

--- a/spec/jobs/movement_job_spec.rb
+++ b/spec/jobs/movement_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe MovementJob, type: :job do
+  let(:first_movement) { build(:movement, offenderNo: 'A1234BC', movementTime: '08:00:00') }
+  let(:second_movement) { build(:movement, offenderNo: 'A1234BC', movementTime: '12:00:00') }
+
+  before do
+    allow(MovementService).to receive(:process_movement)
+  end
+
+  it 'processes a single movement payload' do
+    described_class.perform_now(first_movement.job_payload)
+
+    expect(MovementService).to have_received(:process_movement).with(
+      have_attributes(offender_no: 'A1234BC', movement_type: first_movement.movement_type)
+    )
+  end
+
+  it 'processes an ordered sequence of movement payloads' do
+    described_class.perform_now([first_movement.job_payload, second_movement.job_payload])
+
+    expect(MovementService).to have_received(:process_movement).ordered.with(
+      have_attributes(offender_no: 'A1234BC', happened_at: first_movement.happened_at)
+    )
+    expect(MovementService).to have_received(:process_movement).ordered.with(
+      have_attributes(offender_no: 'A1234BC', happened_at: second_movement.happened_at)
+    )
+  end
+
+  it 'rebuilds movement objects from explicit job payloads' do
+    described_class.perform_now(first_movement.job_payload)
+
+    expect(MovementService).to have_received(:process_movement).with(
+      have_attributes(
+        offender_no: first_movement.offender_no,
+        from_agency: first_movement.from_agency,
+        to_agency: first_movement.to_agency,
+        movement_type: first_movement.movement_type,
+        happened_at: first_movement.happened_at,
+      )
+    )
+  end
+end

--- a/spec/jobs/movements_on_date_job_spec.rb
+++ b/spec/jobs/movements_on_date_job_spec.rb
@@ -1,18 +1,39 @@
 RSpec.describe MovementsOnDateJob, type: :job do
-  it 'invokes MovementJob#perform_later for every movement from yesterday' do
-    today_str = '2020-06-12'
-    yesterday = Date.new(2020, 6, 11)
-    movements = [double(:movement1), double(:movement2)]
+  let(:target_date) { Date.parse('2020-06-11') }
+  let(:target_date_str) { target_date.to_s }
+
+  it 'invokes MovementJob once per offender with ordered job payloads and cache disabled' do
+    earlier_movement = build(:movement, offenderNo: 'A1234BC', movementDate: target_date_str, movementTime: '08:00:00')
+    later_movement = build(:movement, offenderNo: 'A1234BC', movementDate: target_date_str, movementTime: '12:00:00')
+    other_offender_movement = build(:movement, offenderNo: 'B1234CD', movementDate: target_date_str, movementTime: '09:00:00')
+    movements = [later_movement, other_offender_movement, earlier_movement]
+
     allow(MovementJob).to receive(:perform_later)
-
     allow(MovementService).to receive(:movements_on)
-    allow(MovementService).to receive(:movements_on).with(yesterday).and_return(movements)
+      .with(target_date, cache: false)
+      .and_return(movements)
 
-    described_class.perform_now(today_str)
+    described_class.perform_now(target_date_str)
 
     aggregate_failures do
-      expect(MovementJob).to have_received(:perform_later).with(movements[0].to_json)
-      expect(MovementJob).to have_received(:perform_later).with(movements[1].to_json)
+      expect(MovementJob).to have_received(:perform_later).with([
+        earlier_movement.job_payload,
+        later_movement.job_payload,
+      ])
+      expect(MovementJob).to have_received(:perform_later).with([
+        other_offender_movement.job_payload,
+      ])
     end
+  end
+
+  it 'does not enqueue movement jobs when no movements are returned' do
+    allow(MovementJob).to receive(:perform_later)
+    allow(MovementService).to receive(:movements_on)
+      .with(target_date, cache: false)
+      .and_return([])
+
+    described_class.perform_now(target_date_str)
+
+    expect(MovementJob).not_to have_received(:perform_later)
   end
 end

--- a/spec/jobs/process_prisoner_release_job_spec.rb
+++ b/spec/jobs/process_prisoner_release_job_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe ProcessPrisonerReleaseJob, type: :job do
   let(:nomis_offender_id) { 'A1234BC' }
+  let!(:prison) { Prison.find_by(code: 'LEI') || create(:prison, code: 'LEI') }
 
   before do
     allow(MovementService).to receive(:process_offender_last_movement)
@@ -20,6 +21,56 @@ RSpec.describe ProcessPrisonerReleaseJob, type: :job do
     it 'still routes processing through MovementService without raising' do
       expect(MovementService).to receive(:process_offender_last_movement).with(nomis_offender_id)
       described_class.perform_now(nomis_offender_id)
+    end
+  end
+
+  context 'when performing a release' do
+    let(:last_movement) do
+      build(:movement,
+            offenderNo: nomis_offender_id,
+            directionCode: 'OUT',
+            movementType: 'REL',
+            toAgency: 'OUT',
+            fromAgency: from_agency)
+    end
+    let(:timeline) { instance_double(HmppsApi::PrisonTimeline, last_movement:) }
+    let(:from_agency) { 'LEI' }
+
+    before do
+      allow(MovementService).to receive(:process_offender_last_movement).and_call_original
+      allow(HmppsApi::PrisonApi::MovementApi).to receive(:movements_for)
+        .with(nomis_offender_id, movement_types: [], cache: false)
+        .and_return(timeline)
+
+      stub_pom(
+        build(:pom, staffId: 485_926, firstName: 'MOIC', lastName: 'POM', primaryEmail: 'test@example.com')
+      )
+      stub_offender(
+        build(:nomis_offender, prisonerNumber: nomis_offender_id, prisonId: 'OUT', firstName: 'John', lastName: 'Doe')
+      )
+    end
+
+    it 'cleans up local state via MovementService and OffenderReleasedService' do
+      offender = create(:offender, nomis_offender_id:)
+      allocation = create(:allocation_history, prison: 'LEI', nomis_offender_id: offender.nomis_offender_id)
+      create(:case_information, offender:)
+      create(:omic_eligibility, nomis_offender_id: offender.nomis_offender_id)
+
+      described_class.perform_now(nomis_offender_id)
+
+      expect(allocation.reload.active?).to be false
+      expect(CaseInformation.find_by(nomis_offender_id:)).to be_nil
+      expect(OmicEligibility.find_by(nomis_offender_id:)).to be_nil
+    end
+
+    context 'when the offender has already been cleaned up by another path' do
+      let(:from_agency) { 'AGI' }
+
+      it 'does not fail and skips duplicate release side effects' do
+        expect(HmppsApi::ComplexityApi).not_to receive(:inactivate)
+
+        expect { described_class.perform_now(nomis_offender_id) }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/services/hmpps_api/prison_api/movement_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/movement_api_spec.rb
@@ -21,6 +21,34 @@ describe HmppsApi::PrisonApi::MovementApi do
       expect(movements.length).to eq(2)
       expect(movements).to all be_a(HmppsApi::Movement)
     end
+
+    it 'uses cache for date-based movement lookups by default' do
+      expect_any_instance_of(HmppsApi::Client).to receive(:get)
+        .with(
+          '/movements',
+          queryparams: {
+            movementDate: '2019-02-20',
+            fromDateTime: '2018-02-20T00:00'
+          },
+          cache: true
+        ).and_return(JSON.parse(movements.to_json))
+
+      described_class.movements_on_date(Date.iso8601('2019-02-20'))
+    end
+
+    it 'allows disabling cache for date-based movement lookups' do
+      expect_any_instance_of(HmppsApi::Client).to receive(:get)
+        .with(
+          '/movements',
+          queryparams: {
+            movementDate: '2019-02-20',
+            fromDateTime: '2018-02-20T00:00'
+          },
+          cache: false
+        ).and_return(JSON.parse(movements.to_json))
+
+      described_class.movements_on_date(Date.iso8601('2019-02-20'), cache: false)
+    end
   end
 
   describe 'Movements for single offenders' do

--- a/spec/services/movement_service_spec.rb
+++ b/spec/services/movement_service_spec.rb
@@ -35,6 +35,16 @@ describe MovementService, type: :feature do
     expect(movements.first).to be_a(HmppsApi::Movement)
   end
 
+  it 'passes cache through when getting recent movements' do
+    date = Date.iso8601('2019-02-20')
+
+    expect(HmppsApi::PrisonApi::MovementApi).to receive(:movements_on_date)
+      .with(date, cache: false)
+      .and_return([])
+
+    described_class.movements_on(date, cache: false)
+  end
+
   it "can ignore movements OUT" do
     processed = described_class.process_movement(transfer_out)
     expect(processed).to be false
@@ -167,92 +177,27 @@ describe MovementService, type: :feature do
   end
 
   describe "processing an offender release" do
-    let!(:case_info) { create(:case_information, offender: build(:offender, nomis_offender_id: 'G7266VD')) }
-    let!(:allocation) { create(:allocation_history, prison: 'LEI', nomis_offender_id: 'G7266VD') }
-    let!(:calculated_handover_date) { create(:calculated_handover_date, offender: case_info.offender) }
-    let!(:handover_progress_checklist) { create(:handover_progress_checklist, offender: case_info.offender) }
-    let!(:responsibility) { create(:responsibility, offender: case_info.offender) }
-    let!(:omic_eligibility) { create(:omic_eligibility, nomis_offender_id: case_info.nomis_offender_id) }
-
-    def pom_tester(valid_release)
-      mailer = double(:mailer)
-      expect(PomMailer).to receive(:with)
-              .with(email: "test@example.com",
-                    pom_name: "Moic",
-                    offender_name: "Doe, John",
-                    nomis_offender_id: valid_release.offender_no,
-                    prison_name: 'Leeds (HMP)',
-                    url: "http://localhost:3000/prisons/LEI/staff/485926/caseload")
-              .and_return(double(:pom_mailer_with, offender_deallocated: mailer))
-      expect(mailer).to receive(:deliver_later)
-    end
-
     context 'with a valid release movement' do
-      let(:updated_allocation) { AllocationHistory.find_by(nomis_offender_id: valid_release.offender_no) }
-      let(:processed) { described_class.process_movement(valid_release) }
-
-      let(:valid_release) do
+      def valid_release(from_agency)
         build(:movement, offenderNo: 'G7266VD', directionCode: 'OUT', movementType: 'REL', toAgency: 'OUT', fromAgency: from_agency)
       end
 
-      before { pom_tester(valid_release) }
+      it 'delegates male-prison release cleanup to OffenderReleasedService' do
+        expect(OffenderReleasedService).to receive(:release_offender).with('G7266VD', prison_code: 'BAI')
 
-      context 'and from a male prison' do
-        let(:from_agency) { 'BAI' }
-
-        it "can process movements" do
-          expect(HmppsApi::ComplexityApi).not_to receive(:inactivate).with(valid_release.offender_no)
-          expect(processed).to be true
-          expect(CaseInformation.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(CalculatedHandoverDate.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(HandoverProgressChecklist.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(Responsibility.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(OmicEligibility.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(updated_allocation.event_trigger).to eq 'offender_released'
-          expect(updated_allocation.prison).to eq 'LEI'
-        end
-
-        it 'continues processing even if a destroy fails' do
-          allow_any_instance_of(CaseInformation).to receive(:destroy!).and_raise(ActiveRecord::StatementInvalid, 'boom')
-
-          expect { processed }.not_to raise_error
-          expect(updated_allocation.reload.event_trigger).to eq 'offender_released'
-          expect(CaseInformation.where(nomis_offender_id: valid_release.offender_no)).not_to be_empty
-          expect(CalculatedHandoverDate.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-        end
+        expect(described_class.process_movement(valid_release('BAI'))).to be true
       end
 
-      context 'and from a female prison' do
-        let(:from_agency) { 'AGI' }
+      it 'delegates female-prison release cleanup to OffenderReleasedService' do
+        expect(OffenderReleasedService).to receive(:release_offender).with('G7266VD', prison_code: 'AGI')
 
-        it "can process movements" do
-          expect(HmppsApi::ComplexityApi).to receive(:inactivate).with(valid_release.offender_no)
-          expect(processed).to be true
-          expect(CaseInformation.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(updated_allocation.event_trigger).to eq 'offender_released'
-          expect(updated_allocation.prison).to eq 'LEI'
-        end
+        expect(described_class.process_movement(valid_release('AGI'))).to be true
       end
 
-      context 'and for hospital restricted patient' do
-        let(:from_agency) { 'HOS1' }
+      it 'delegates hospital release cleanup to OffenderReleasedService', flaky: true do
+        expect(OffenderReleasedService).to receive(:release_offender).with('G7266VD', prison_code: 'HOS1')
 
-        it "can process movements", flaky: true do
-          expect(processed).to be true
-          expect(CaseInformation.where(nomis_offender_id: valid_release.offender_no)).to be_empty
-          expect(updated_allocation.event_trigger).to eq 'offender_released'
-          expect(updated_allocation.prison).to eq 'LEI'
-        end
-      end
-
-      context 'and from open prison with inactive allocation' do
-        let(:from_agency) { 'BAI' }
-
-        before { allocation.deallocate_offender_after_release }
-
-        it "can process movements" do
-          expect(processed).to be true
-        end
+        expect(described_class.process_movement(valid_release('HOS1'))).to be true
       end
     end
 
@@ -262,6 +207,8 @@ describe MovementService, type: :feature do
       let(:invalid_release3) { build(:movement, offenderNo: 'G7266VD', directionCode: 'OUT', movementType: 'REL', fromAgency: 'BASDON')   }
 
       it "can ignore invalid release movements" do
+        expect(OffenderReleasedService).not_to receive(:release_offender)
+
         processed = described_class.process_movement(invalid_release1)
         expect(processed).to be false
 
@@ -309,10 +256,11 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'can process release movement for offender' do
+            expect(OffenderReleasedService).to receive(:release_offender)
+              .with(immigration_movement.offender_no, prison_code: immigration_movement.from_agency)
+
             processed = described_class.process_movement(immigration_movement)
 
-            expect(CaseInformation.where(nomis_offender_id: immigration_movement.offender_no)).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end
@@ -324,10 +272,11 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'IN' }
 
           it 'can process release movement for offender' do
+            expect(OffenderReleasedService).not_to receive(:release_offender)
+
             processed = described_class.process_movement(immigration_movement)
 
-            expect(CaseInformation.where(nomis_offender_id: immigration_movement.offender_no)).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_transferred'
+            expect(allocation.reload.event_trigger).to eq 'offender_transferred'
             expect(processed).to be true
           end
         end
@@ -357,10 +306,11 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'OUT' }
 
           it 'can release movement' do
+            expect(OffenderReleasedService).to receive(:release_offender)
+              .with(immigration_movement.offender_no, prison_code: immigration_movement.from_agency)
+
             processed = described_class.process_movement(immigration_movement)
 
-            expect(CaseInformation.where(nomis_offender_id: immigration_movement.offender_no)).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end
@@ -372,10 +322,11 @@ describe MovementService, type: :feature do
           let(:direction_code) { 'OUT' }
 
           it 'can release movement' do
+            expect(OffenderReleasedService).to receive(:release_offender)
+              .with(immigration_movement.offender_no, prison_code: immigration_movement.from_agency)
+
             processed = described_class.process_movement(immigration_movement)
 
-            expect(CaseInformation.where(nomis_offender_id: immigration_movement.offender_no)).to be_empty
-            expect(allocation.event_trigger).to eq 'offender_released'
             expect(processed).to be true
           end
         end

--- a/spec/services/offender_released_service_spec.rb
+++ b/spec/services/offender_released_service_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OffenderReleasedService do
+  before do
+    stub_pom(
+      build(:pom, staffId: 485_926, firstName: 'MOIC', lastName: 'POM', primaryEmail: 'test@example.com')
+    )
+    stub_offender(
+      build(:nomis_offender, prisonerNumber: offender.nomis_offender_id, prisonId: 'OUT', firstName: 'John', lastName: 'Doe')
+    )
+  end
+
+  let!(:prison) { Prison.find_by(code: 'LEI') || create(:prison, code: 'LEI') }
+  let(:offender) { create(:offender, nomis_offender_id: 'G7266VD') }
+
+  describe '.release_offender' do
+    context 'with full stint data and an active allocation' do
+      let!(:case_info) { create(:case_information, offender:) }
+      let!(:allocation) { create(:allocation_history, prison: 'LEI', nomis_offender_id: offender.nomis_offender_id) }
+      let!(:calculated_handover_date) { create(:calculated_handover_date, offender:) }
+      let!(:handover_progress_checklist) { create(:handover_progress_checklist, offender:) }
+      let!(:responsibility) { create(:responsibility, offender:) }
+      let!(:omic_eligibility) { create(:omic_eligibility, nomis_offender_id: offender.nomis_offender_id) }
+
+      it 'deallocates the offender and destroys all stint data' do
+        described_class.release_offender(offender.nomis_offender_id, prison_code: 'LEI')
+
+        expect(allocation.reload.active?).to be false
+        expect(allocation.event_trigger).to eq 'offender_released'
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(CalculatedHandoverDate.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(Responsibility.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(OmicEligibility.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+
+      it 'inactivates complexity for womens prisons' do
+        expect(HmppsApi::ComplexityApi).to receive(:inactivate).with(offender.nomis_offender_id)
+        described_class.release_offender(offender.nomis_offender_id, prison_code: 'AGI')
+      end
+
+      it 'does not inactivate complexity for mens prisons' do
+        expect(HmppsApi::ComplexityApi).not_to receive(:inactivate)
+        described_class.release_offender(offender.nomis_offender_id, prison_code: 'LEI')
+      end
+    end
+
+    context 'when there is no active allocation' do
+      let!(:case_info) { create(:case_information, offender:) }
+
+      it 'still destroys stint data without error' do
+        described_class.release_offender(offender.nomis_offender_id)
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when called without prison_code (reconciliation scenario)' do
+      let!(:case_info) { create(:case_information, offender:) }
+      let!(:allocation) { create(:allocation_history, prison: 'LEI', nomis_offender_id: offender.nomis_offender_id) }
+
+      it 'deallocates and destroys stint data without inactivating complexity' do
+        expect(HmppsApi::ComplexityApi).not_to receive(:inactivate)
+
+        described_class.release_offender(offender.nomis_offender_id)
+
+        expect(allocation.reload.active?).to be false
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when all local release state has already been removed' do
+      it 'skips duplicate processing, including complexity inactivation' do
+        expect(HmppsApi::ComplexityApi).not_to receive(:inactivate)
+
+        expect { described_class.release_offender(offender.nomis_offender_id, prison_code: 'AGI') }
+          .not_to raise_error
+      end
+    end
+
+    context 'when only some local release state remains' do
+      let!(:omic_eligibility) { create(:omic_eligibility, nomis_offender_id: offender.nomis_offender_id, prison: 'AGI') }
+
+      it 'continues cleanup and inactivates complexity for womens prisons' do
+        expect(HmppsApi::ComplexityApi).to receive(:inactivate).with(offender.nomis_offender_id)
+
+        described_class.release_offender(offender.nomis_offender_id, prison_code: 'AGI')
+
+        expect(OmicEligibility.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when a destroy fails' do
+      let!(:case_info) { create(:case_information, offender:) }
+      let!(:calculated_handover_date) { create(:calculated_handover_date, offender:) }
+
+      it 'continues processing remaining models' do
+        allow_any_instance_of(CaseInformation).to receive(:destroy!).and_raise(ActiveRecord::StatementInvalid, 'boom')
+
+        expect { described_class.release_offender(offender.nomis_offender_id) }.not_to raise_error
+
+        # CaseInformation destroy failed, but it should still be attempted
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+        # CalculatedHandoverDate should still be destroyed
+        expect(CalculatedHandoverDate.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+  end
+
+  describe '.destroy_stint_data' do
+    let!(:case_info) { create(:case_information, offender:) }
+
+    it 'is publicly accessible for targeted cleanup' do
+      described_class.destroy_stint_data(offender.nomis_offender_id)
+
+      expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2044

PR part of a series of improvements to better handle released or unsentenced offenders.

Hardens the scheduled movement processing flow. Allows to configure the number of days and date to process in the rake task and batch it per-offender, with retries.

Disable cache in the API call to avoid using stale data.