### PR TITLE
Add missing indexes to optimise queries

### DIFF
--- a/db/migrate/20260818120000_add_missing_indexes.rb
+++ b/db/migrate/20260818120000_add_missing_indexes.rb
@@ -1,0 +1,29 @@
+class AddMissingIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :case_information, :updated_at,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :case_information, :crn,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :allocation_history, :event_trigger,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :responsibilities, :nomis_offender_id,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :early_allocations, :nomis_offender_id,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :parole_reviews, :nomis_offender_id,
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1086,6 +1086,13 @@ ALTER TABLE ONLY public.victim_liaison_officers
 
 
 --
+-- Name: index_allocation_history_on_event_trigger; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_allocation_history_on_event_trigger ON public.allocation_history USING btree (event_trigger);
+
+
+--
 -- Name: index_allocation_history_on_nomis_offender_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1205,6 +1212,13 @@ CREATE UNIQUE INDEX index_calculated_handover_dates_on_nomis_offender_id ON publ
 
 
 --
+-- Name: index_case_information_on_crn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_case_information_on_crn ON public.case_information USING btree (crn);
+
+
+--
 -- Name: index_case_information_on_local_delivery_unit_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1216,6 +1230,20 @@ CREATE INDEX index_case_information_on_local_delivery_unit_id ON public.case_inf
 --
 
 CREATE UNIQUE INDEX index_case_information_on_nomis_offender_id ON public.case_information USING btree (nomis_offender_id);
+
+
+--
+-- Name: index_case_information_on_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_case_information_on_updated_at ON public.case_information USING btree (updated_at);
+
+
+--
+-- Name: index_early_allocations_on_nomis_offender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_early_allocations_on_nomis_offender_id ON public.early_allocations USING btree (nomis_offender_id);
 
 
 --
@@ -1289,6 +1317,13 @@ CREATE UNIQUE INDEX index_parole_review_imports_on_snapshot_date_row_number ON p
 
 
 --
+-- Name: index_parole_reviews_on_nomis_offender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_parole_reviews_on_nomis_offender_id ON public.parole_reviews USING btree (nomis_offender_id);
+
+
+--
 -- Name: index_parole_reviews_on_review_id_nomis_offender_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1307,6 +1342,13 @@ CREATE UNIQUE INDEX index_pom_details_on_nomis_staff_id_and_prison_code ON publi
 --
 
 CREATE UNIQUE INDEX index_prisons_on_name ON public.prisons USING btree (name);
+
+
+--
+-- Name: index_responsibilities_on_nomis_offender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_responsibilities_on_nomis_offender_id ON public.responsibilities USING btree (nomis_offender_id);
 
 
 --
@@ -1353,6 +1395,7 @@ ALTER TABLE ONLY public.offender_email_sent
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260818120000'),
 ('20260813173000'),
 ('20260811114112'),
 ('20260714160140'),

--- a/spec/services/subject_access_request_template_service_spec.rb
+++ b/spec/services/subject_access_request_template_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SubjectAccessRequestTemplateService do
 
   describe 'DB schema change guard' do
     # Keep this updated once any potential SAR drifting is asserted
-    let(:reviewed_version) { '20260813_173000' }
+    let(:reviewed_version) { '20260818_120000' }
 
     let(:current_version) { ActiveRecord::Base.connection_pool.migration_context.current_version }
     let(:message) do


### PR DESCRIPTION
Some of the reports and jobs we have rely on certain fields from table that didn't have indexes so it was very slow.

These will not block DB connections while the index is added.