### PR TITLE
MO-2048 Improve async handling of tier events

### DIFF
--- a/app/jobs/bulk_fetch_tier_job.rb
+++ b/app/jobs/bulk_fetch_tier_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Bulk variant of FetchTierJob used when refreshing tiers across all cases at
+# once. Runs on the deferred queue so it never blocks time-sensitive work.
+class BulkFetchTierJob < FetchTierJob
+  queue_as :deferred
+end

--- a/app/jobs/fetch_tier_job.rb
+++ b/app/jobs/fetch_tier_job.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 # Fetches the authoritative tier from the Tier API for a CaseInformation
-# record. Used on first nDelius import (where the probation-record tier
-# may be stale) and can also be enqueued in bulk to refresh all cases.
+# record. Used on first nDelius import where the probation-record tier may be
+# stale. For bulk refresh of all cases use BulkFetchTierJob instead.
 class FetchTierJob < ApplicationJob
   queue_as :default
 
+  # Transient errors bubble up from `TieringApi` and are retried by Sidekiq
   # 5 retries (~10 min with exp backoff) is sufficient for transient issues
   sidekiq_options retry: 5
 
@@ -19,6 +20,8 @@ class FetchTierJob < ApplicationJob
     case result.status
     when :updated
       logger.info "#{prefix},event=tier_updated,old_tier=#{result.old_tier},new_tier=#{result.new_tier}"
+    when :invalid_tier
+      logger.error "#{prefix},event=tier_invalid,old_tier=#{result.old_tier},new_tier=#{result.new_tier}|#{result.errors}"
     when :update_failed
       logger.error "#{prefix},event=tier_update_failed,old_tier=#{result.old_tier},new_tier=#{result.new_tier}|#{result.errors}"
     when :tier_api_failed

--- a/app/jobs/process_tier_change_job.rb
+++ b/app/jobs/process_tier_change_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ProcessTierChangeJob < ApplicationJob
+  queue_as :deferred
+
+  # Transient errors bubble up from `TieringApi` and are retried by Sidekiq
+  # 5 retries (~10 min with exp backoff) is sufficient for transient issues
+  sidekiq_options retry: 5
+
+  def perform(crn, event_type:)
+    result = TierUpdateService.call(crn:, audit_tags: ['handler'])
+
+    case result.status
+    when :updated
+      logger.info "event=process_tier_change_job_success,event_type=#{event_type}," \
+                  "version=#{result.version},crn=#{crn},old_tier=#{result.old_tier},new_tier=#{result.new_tier}"
+    when :invalid_tier
+      logger.error "event=process_tier_change_job_invalid_tier,event_type=#{event_type}," \
+                   "version=#{result.version},crn=#{crn},old_tier=#{result.old_tier},new_tier=#{result.new_tier}|#{result.errors}"
+    when :update_failed
+      logger.error "event=process_tier_change_job_failure,event_type=#{event_type}," \
+                   "version=#{result.version},crn=#{crn},old_tier=#{result.old_tier},new_tier=#{result.new_tier}|#{result.errors}"
+    when :tier_api_failed
+      logger.warn "event=process_tier_change_job_tier_api_failed,event_type=#{event_type}," \
+                  "version=#{result.version},crn=#{crn}"
+    end
+  end
+end

--- a/app/lib/domain_events/handlers/tier_change_handler.rb
+++ b/app/lib/domain_events/handlers/tier_change_handler.rb
@@ -5,21 +5,15 @@ module DomainEvents
         logger.info "event=domain_event_handle_start,domain_event_type=#{event.event_type}," \
                       "event_version=#{event.version},crn=#{event.crn_number}"
 
-        result = TierUpdateService.call(
-          crn: event.crn_number, audit_tags: ['handler']
-        )
-
-        case result.status
-        when :updated
-          logger.info "event=domain_event_handle_success,domain_event_type=#{event.event_type}," \
-                        "version=#{result.version},crn=#{event.crn_number},old_tier=#{result.old_tier},new_tier=#{result.new_tier}"
-        when :update_failed
-          logger.error "event=domain_event_handle_failure,domain_event_type=#{event.event_type}," \
-                         "version=#{result.version},crn=#{event.crn_number},old_tier=#{result.old_tier},new_tier=#{result.new_tier}|#{result.errors}"
-        when :tier_api_failed
-          logger.warn "event=domain_event_handle_tier_api_failed,domain_event_type=#{event.event_type}," \
-                        "version=#{result.version},crn=#{event.crn_number}"
+        if CaseInformation.exists?(crn: event.crn_number)
+          ProcessTierChangeJob.perform_later(
+            event.crn_number,
+            event_type: event.event_type,
+          )
         end
+
+        logger.info "event=domain_event_handle_success,domain_event_type=#{event.event_type}," \
+                      "event_version=#{event.version},crn=#{event.crn_number}"
       end
     end
   end

--- a/app/services/hmpps_api/tiering_api.rb
+++ b/app/services/hmpps_api/tiering_api.rb
@@ -14,7 +14,7 @@ module HmppsApi
         tier: response.fetch('tierScore'),
         calculation_date: response.fetch('calculationDate').to_date
       }
-    rescue Faraday::Error => e
+    rescue Faraday::ClientError => e
       Rails.logger.error("event=tiering_get_tier,route=#{route}|#{e.message}")
       nil
     end

--- a/app/services/tier_update_service.rb
+++ b/app/services/tier_update_service.rb
@@ -14,6 +14,16 @@ class TierUpdateService
     old_tier = case_information.tier
     return Result.new(status: :unchanged, old_tier:, new_tier:, version:) if new_tier == old_tier
 
+    unless CaseInformation.tier_levels.include?(new_tier)
+      return Result.new(
+        status: :invalid_tier,
+        errors: "Unsupported tier '#{new_tier}'. Accepted tiers: #{CaseInformation.tier_levels.join(',')}",
+        old_tier:,
+        new_tier:,
+        version:,
+      )
+    end
+
     case_information.tier = new_tier
     case_information.manual_entry = false
     attrs_before = case_information.changed_attributes

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,3 +5,4 @@
   - debounce
   - default
   - mailers
+  - deferred

--- a/lib/tasks/refresh_tiers.rake
+++ b/lib/tasks/refresh_tiers.rake
@@ -9,13 +9,13 @@ task refresh_tiers: :environment do
   total = cases.count
   queued = 0
 
-  puts "Queueing FetchTierJob for #{total} case information records"
+  puts "Queueing BulkFetchTierJob for #{total} case information records"
 
   cases.in_batches(of: 1000) do |batch|
     crns = batch.pluck(:crn)
 
     ActiveJob.perform_all_later(
-      crns.map { FetchTierJob.new(it, trigger_method: :bulk_refresh) }
+      crns.map { BulkFetchTierJob.new(it, trigger_method: :bulk_refresh) }
     )
 
     queued += crns.size

--- a/spec/jobs/bulk_fetch_tier_job_spec.rb
+++ b/spec/jobs/bulk_fetch_tier_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkFetchTierJob, type: :job do
+  it 'runs on the deferred queue' do
+    expect(described_class.new.queue_name).to eq('deferred')
+  end
+
+  it 'inherits perform behaviour from FetchTierJob' do
+    expect(described_class.superclass).to eq(FetchTierJob)
+  end
+
+  it 'calls TierUpdateService with bulk_refresh audit tag' do
+    crn = 'X362207'
+    result = TierUpdateService::Result.new(status: :unchanged, version: 3)
+    allow(TierUpdateService).to receive(:call).and_return(result)
+
+    described_class.new.perform(crn, trigger_method: :bulk_refresh)
+
+    expect(TierUpdateService).to have_received(:call).with(crn:, audit_tags: %w[job bulk_refresh])
+  end
+end

--- a/spec/jobs/fetch_tier_job_spec.rb
+++ b/spec/jobs/fetch_tier_job_spec.rb
@@ -63,14 +63,14 @@ RSpec.describe FetchTierJob, type: :job do
       end
     end
 
-    context 'when tier update fails validation' do
+    context 'when tier update fails during persistence' do
       let(:service_result) do
         TierUpdateService::Result.new(
           status: :update_failed,
           old_tier: 'A',
-          new_tier: 'Z',
+          new_tier: 'D',
           version: 3,
-          errors: 'Invalid tier'
+          errors: 'Could not save case information'
         )
       end
 
@@ -79,7 +79,27 @@ RSpec.describe FetchTierJob, type: :job do
 
         job.perform(crn)
 
-        expect(job.logger).to have_received(:error).with(/event=tier_update_failed/)
+        expect(job.logger).to have_received(:error).with(/event=tier_update_failed.*old_tier=A,new_tier=D/)
+      end
+    end
+
+    context 'when tier returned by API is unsupported' do
+      let(:service_result) do
+        TierUpdateService::Result.new(
+          status: :invalid_tier,
+          old_tier: 'A',
+          new_tier: 'Z',
+          version: 2,
+          errors: "Unsupported tier 'Z'. Accepted tiers: A,B,C,D"
+        )
+      end
+
+      it 'logs an invalid tier error' do
+        allow(job.logger).to receive(:error)
+
+        job.perform(crn)
+
+        expect(job.logger).to have_received(:error).with(/event=tier_invalid.*old_tier=A,new_tier=Z/)
       end
     end
   end

--- a/spec/jobs/process_tier_change_job_spec.rb
+++ b/spec/jobs/process_tier_change_job_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe ProcessTierChangeJob, type: :job do
+  let(:crn) { 'X408769' }
+  let(:event_type) { 'tier.calculation.changed' }
+
+  it 'is enqueued on the deferred queue' do
+    expect(described_class.new.queue_name).to eq('deferred')
+  end
+
+  context 'when the tier is updated successfully' do
+    let(:service_result) do
+      TierUpdateService::Result.new(status: :updated, old_tier: 'A', new_tier: 'D', version: 3)
+    end
+
+    before { allow(TierUpdateService).to receive(:call).and_return(service_result) }
+
+    it 'calls TierUpdateService with the correct CRN and audit tags' do
+      described_class.perform_now(crn, event_type:)
+
+      expect(TierUpdateService).to have_received(:call).with(crn:, audit_tags: ['handler'])
+    end
+
+    it 'logs a success message' do
+      allow(Rails.logger).to receive(:info)
+      described_class.perform_now(crn, event_type:)
+      expect(Rails.logger).to have_received(:info).with(/event=process_tier_change_job_success.*old_tier=A,new_tier=D/)
+    end
+  end
+
+  context 'when tier update fails during persistence' do
+    let(:service_result) do
+      TierUpdateService::Result.new(
+        status: :update_failed,
+        old_tier: 'A',
+        new_tier: 'D',
+        version: 3,
+        errors: 'Could not save case information'
+      )
+    end
+
+    before { allow(TierUpdateService).to receive(:call).and_return(service_result) }
+
+    it 'logs a failure message' do
+      allow(Rails.logger).to receive(:error)
+      described_class.perform_now(crn, event_type:)
+      expect(Rails.logger).to have_received(:error).with(/event=process_tier_change_job_failure.*old_tier=A,new_tier=D/)
+    end
+  end
+
+  context 'when the tier API fetch fails' do
+    let(:service_result) do
+      TierUpdateService::Result.new(status: :tier_api_failed, version: 3)
+    end
+
+    before { allow(TierUpdateService).to receive(:call).and_return(service_result) }
+
+    it 'logs a warning message' do
+      allow(Rails.logger).to receive(:warn)
+      described_class.perform_now(crn, event_type:)
+      expect(Rails.logger).to have_received(:warn).with(/event=process_tier_change_job_tier_api_failed.*crn=#{crn}/)
+    end
+  end
+
+  context 'when tier returned by API is unsupported' do
+    let(:service_result) do
+      TierUpdateService::Result.new(
+        status: :invalid_tier,
+        old_tier: 'A',
+        new_tier: 'Z',
+        version: 2,
+        errors: "Unsupported tier 'Z'. Accepted tiers: A,B,C,D"
+      )
+    end
+
+    before { allow(TierUpdateService).to receive(:call).and_return(service_result) }
+
+    it 'logs an invalid tier error' do
+      allow(Rails.logger).to receive(:error)
+      described_class.perform_now(crn, event_type:)
+      expect(Rails.logger).to have_received(:error).with(/event=process_tier_change_job_invalid_tier.*old_tier=A,new_tier=Z/)
+    end
+  end
+end

--- a/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
+++ b/spec/lib/domain_events/handlers/tier_change_handler_spec.rb
@@ -15,77 +15,64 @@ RSpec.describe DomainEvents::Handlers::TierChangeHandler do
     )
   end
   let(:event_version) { 3 }
-  let(:service_result) do
-    TierUpdateService::Result.new(status: :updated, old_tier: 'A', new_tier: 'D', version: 3)
-  end
 
   before do
     allow(Shoryuken::Logging.logger).to receive(:info).and_return(nil)
-    allow(Shoryuken::Logging.logger).to receive(:error).and_return(nil)
-    allow(Shoryuken::Logging.logger).to receive(:warn).and_return(nil)
-    allow(TierUpdateService).to receive(:call).and_return(service_result)
+    # Prevent the job running inline during handler-focused examples
+    allow(ProcessTierChangeJob).to receive(:perform_later)
   end
 
-  context 'when handling tier change event' do
-    before { handler.handle(event) }
-
-    it 'delegates to the shared tier service' do
-      expect(TierUpdateService).to have_received(:call).with(
-        crn:, audit_tags: %w[handler]
-      )
+  context 'when handling a tracked tier change event' do
+    before do
+      allow(CaseInformation).to receive(:exists?).with(crn: crn).and_return(true)
     end
 
-    it 'emits a start log message with event version' do
-      expect(Shoryuken::Logging.logger).to have_received(:info).with(/event=domain_event_handle_start.*version=3.*crn=#{crn}/)
+    it 'enqueues a ProcessTierChangeJob on the deferred queue', :queueing do
+      allow(ProcessTierChangeJob).to receive(:perform_later).and_call_original
+
+      expect { handler.handle(event) }
+        .to have_enqueued_job(ProcessTierChangeJob)
+        .with(crn, event_type: 'tier.calculation.changed')
+        .on_queue(:deferred)
     end
 
-    context 'when service reports unchanged' do
-      let(:service_result) do
-        TierUpdateService::Result.new(status: :unchanged, old_tier: 'D', new_tier: 'D', version: 3)
-      end
+    it 'checks if the CRN is tracked locally before enqueuing' do
+      handler.handle(event)
 
-      it 'does not emit success or failure logs' do
-        expect(Shoryuken::Logging.logger).not_to have_received(:info).with(/event=domain_event_handle_success/)
-        expect(Shoryuken::Logging.logger).not_to have_received(:error).with(/event=domain_event_handle_failure/)
-      end
+      expect(CaseInformation).to have_received(:exists?).with(crn: crn)
     end
 
-    context 'when service updates the tier' do
-      it 'emits success log with event version' do
-        expect(Shoryuken::Logging.logger).to have_received(:info).with(
-          /event=domain_event_handle_success.*version=3,crn=#{crn},old_tier=A,new_tier=D/
-        )
-      end
+    it 'emits a start log message with event version and CRN' do
+      handler.handle(event)
+
+      expect(Shoryuken::Logging.logger).to have_received(:info)
+        .with(/event=domain_event_handle_start.*event_version=3.*crn=#{crn}/)
     end
 
-    context 'when service reports an update failure' do
-      let(:service_result) do
-        TierUpdateService::Result.new(
-          status: :update_failed,
-          old_tier: 'A',
-          new_tier: 'Z',
-          version: 3,
-          errors: 'Tier is not included in the list'
-        )
-      end
+    it 'emits a success log message after enqueuing' do
+      handler.handle(event)
 
-      it 'emits failure log' do
-        expect(Shoryuken::Logging.logger).to have_received(:error).with(
-          /event=domain_event_handle_failure.*version=3,crn=#{crn},old_tier=A,new_tier=Z/
-        )
-      end
+      expect(Shoryuken::Logging.logger).to have_received(:info)
+        .with(/event=domain_event_handle_success.*event_version=3.*crn=#{crn}/)
+    end
+  end
+
+  context 'when CRN is not tracked locally' do
+    before do
+      allow(CaseInformation).to receive(:exists?).with(crn: crn).and_return(false)
     end
 
-    context 'when tier API fetch fails' do
-      let(:service_result) do
-        TierUpdateService::Result.new(status: :tier_api_failed, version: 3)
-      end
+    it 'does not enqueue a job' do
+      handler.handle(event)
 
-      it 'emits a warning log' do
-        expect(Shoryuken::Logging.logger).to have_received(:warn).with(
-          /event=domain_event_handle_tier_api_failed.*version=3,crn=#{crn}/
-        )
-      end
+      expect(ProcessTierChangeJob).not_to have_received(:perform_later)
+    end
+
+    it 'still emits a success log' do
+      handler.handle(event)
+
+      expect(Shoryuken::Logging.logger).to have_received(:info)
+        .with(/event=domain_event_handle_success.*event_version=3.*crn=#{crn}/)
     end
   end
 end

--- a/spec/services/hmpps_api/tiering_api_spec.rb
+++ b/spec/services/hmpps_api/tiering_api_spec.rb
@@ -51,6 +51,23 @@ describe HmppsApi::TieringApi do
       it 'returns nil' do
         expect(described_class.get_tier(crn, version:)).to be_nil
       end
+
+      it 'logs the error' do
+        allow(Rails.logger).to receive(:error)
+        described_class.get_tier(crn, version:)
+        expect(Rails.logger).to have_received(:error).with(/event=tiering_get_tier,route=#{route}/)
+      end
+    end
+
+    context 'when the endpoint returns another 4xx error' do
+      before do
+        allow(client).to receive(:get).with(route, cache: false)
+          .and_raise(Faraday::BadRequestError.new(nil))
+      end
+
+      it 'returns nil' do
+        expect(described_class.get_tier(crn, version:)).to be_nil
+      end
     end
 
     context 'when the endpoint returns a server error' do
@@ -59,14 +76,30 @@ describe HmppsApi::TieringApi do
           .and_raise(Faraday::ServerError.new(nil))
       end
 
-      it 'returns nil' do
-        expect(described_class.get_tier(crn, version:)).to be_nil
+      it 'raises so the calling job can be retried by Sidekiq' do
+        expect { described_class.get_tier(crn, version:) }.to raise_error(Faraday::ServerError)
+      end
+    end
+
+    context 'when the request times out' do
+      before do
+        allow(client).to receive(:get).with(route, cache: false)
+          .and_raise(Faraday::TimeoutError.new(nil))
       end
 
-      it 'logs the error' do
-        allow(Rails.logger).to receive(:error)
-        described_class.get_tier(crn, version:)
-        expect(Rails.logger).to have_received(:error).with(/event=tiering_get_tier,route=#{route}/)
+      it 'raises so the calling job can be retried by Sidekiq' do
+        expect { described_class.get_tier(crn, version:) }.to raise_error(Faraday::TimeoutError)
+      end
+    end
+
+    context 'when the connection fails' do
+      before do
+        allow(client).to receive(:get).with(route, cache: false)
+          .and_raise(Faraday::ConnectionFailed.new(nil))
+      end
+
+      it 'raises so the calling job can be retried by Sidekiq' do
+        expect { described_class.get_tier(crn, version:) }.to raise_error(Faraday::ConnectionFailed)
       end
     end
   end

--- a/spec/services/tier_update_service_spec.rb
+++ b/spec/services/tier_update_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe TierUpdateService do
       end
     end
 
-    context 'when update is invalid' do
+    context 'when tier API returns an unsupported tier' do
       let(:current_tier) { 'A' }
 
       before do
@@ -87,8 +87,15 @@ RSpec.describe TierUpdateService do
           .and_return({ tier: 'Z1', calculation_date: Date.current })
       end
 
-      it 'returns update_failed' do
-        expect(result.status).to eq(:update_failed)
+      it 'returns invalid_tier and does not persist changes' do
+        expect(result.status).to eq(:invalid_tier)
+        expect(result.errors).to include("Unsupported tier 'Z'")
+        expect(case_information.reload.tier).to eq('A')
+        expect(case_information.reload.manual_entry).to be(true)
+      end
+
+      it 'does not publish an audit event' do
+        expect { result }.not_to change(AuditEvent.tags('test'), :count)
       end
     end
   end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2048

We’ve had a few instances of an influx of thousands (60k+) `tier.calculation.changed` events, usually in non-prod envs but yesterday also in production.

The events processor was not enqueuing these as jobs, and instead run these inline, which takes a trip to the DB and API and blocks the thread. It took a long time to all clear the events.

This PR makes it so we enqueue these events processing as we do with the rest of events, so it is consistent, and handles transient API errors retries.

Also improved validation of tier ahead of attempting to save it.