### PR TITLE
MO-2046 Reconcile task for released/non-omic cases

### DIFF
--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -18,7 +18,15 @@ module HmppsApi
       ALLOWED_LEGAL_STATUSES = %w[SENTENCED INDETERMINATE_SENTENCE RECALL IMMIGRATION_DETAINEE].freeze
 
       # Used in `offender_summaries_for` for a brief payload of found offenders
-      OFFENDER_SUMMARY_RESPONSE_FIELDS = %w[prisonerNumber prisonId lastPrisonId restrictedPatient legalStatus].freeze
+      OFFENDER_SUMMARY_RESPONSE_FIELDS = %w[
+        prisonerNumber
+        prisonId
+        lastPrisonId
+        restrictedPatient
+        legalStatus
+        inOutStatus
+        lastMovementTypeCode
+      ].freeze
 
       def self.get_offenders_in_prison(prison, **options)
         offenders = get_search_api_offenders_in_prison(prison)

--- a/app/services/hmpps_api/prison_api/offender_api.rb
+++ b/app/services/hmpps_api/prison_api/offender_api.rb
@@ -17,19 +17,13 @@ module HmppsApi
       # Used to filter out offenders who are on remand, civil prisoners, unsentenced, etc.
       ALLOWED_LEGAL_STATUSES = %w[SENTENCED INDETERMINATE_SENTENCE RECALL IMMIGRATION_DETAINEE].freeze
 
+      # Used in `offender_summaries_for` for a brief payload of found offenders
+      OFFENDER_SUMMARY_RESPONSE_FIELDS = %w[prisonerNumber prisonId lastPrisonId restrictedPatient legalStatus].freeze
+
       def self.get_offenders_in_prison(prison, **options)
         offenders = get_search_api_offenders_in_prison(prison)
 
         build_offenders(offenders, prison, **options)
-      end
-
-      def self.get_offenders_out_of_prison(prison)
-        offenders = get_search_api_offenders_out_in_last_prison(prison)
-
-        build_offenders(
-          offenders, prison,
-          ignore_legal_status: true, fetch_complexities: false, fetch_categories: false, fetch_movements: false
-        )
       end
 
       # Get a single offender
@@ -121,6 +115,14 @@ module HmppsApi
         client.get(path)
       end
 
+      # Fetch offenders by prisoner numbers, but only return a small subset of
+      # fields from Prisoner Search to reduce payload size
+      def self.offender_summaries_for(offender_nos, cache: true)
+        get_search_api_offenders(
+          offender_nos, response_fields: OFFENDER_SUMMARY_RESPONSE_FIELDS, cache:
+        ).to_h { [it.fetch('prisonerNumber'), it.except('prisonerNumber', 'alerts')] }
+      end
+
       # Despite filtering out civil cases (legal status `CIVIL_PRISONER`) some civil cases
       # will show up as `SENTENCED` legal status, and we need to filter by their sentence type code.
       def self.filtered_offenders(offenders)
@@ -182,41 +184,13 @@ module HmppsApi
         results
       end
 
-      # NOTE: this API endpoint has a total hardcoded limit of 10_000 offenders returned
-      # in total, even if using a lower page size and looping. `BZI` will go over this limit.
-      def self.get_search_api_offenders_out_in_last_prison(prison_code)
-        route = '/attribute-search'
-        page_num = 0
-        last_page = false
-        results = []
-
-        body = {
-          "joinType": 'AND',
-          "queries": [
-            {
-              "joinType": 'AND',
-              "matchers": [
-                { "type": 'String', "attribute": 'prisonId', "condition": 'IS', "searchTerm": 'OUT' },
-                { "type": 'String', "attribute": 'lastPrisonId', "condition": 'IS', "searchTerm": prison_code },
-              ]
-            }
-          ]
-        }.freeze
-
-        until last_page
-          r = search_client.post(route, body, queryparams: { page: page_num, size: 2_000 })
-          # last should always indicate the last page of results, do perform manual check just to be safe
-          last_page = r.fetch('last') || page_num > r.fetch('totalPages')
-          page_num += 1
-          results.concat r.fetch('content')
-        end
-
-        results
-      end
-
-      def self.get_search_api_offenders(offender_nos, cache: true)
+      def self.get_search_api_offenders(offender_nos, response_fields: nil, cache: true)
         search_route = '/prisoner-search/prisoner-numbers'
-        search_client.post(search_route, { prisonerNumbers: Array(offender_nos) }, queryparams: { 'include-restricted-patients': true }, cache:)
+
+        queryparams = { 'include-restricted-patients': true }
+        queryparams['responseFields'] = response_fields if response_fields.present?
+
+        search_client.post(search_route, { prisonerNumbers: Array(offender_nos) }, queryparams:, cache:)
       end
 
       def self.default_image

--- a/app/services/reconcile_released_offenders_service.rb
+++ b/app/services/reconcile_released_offenders_service.rb
@@ -316,9 +316,15 @@ private
     restricted_patient = summary_attributes['restrictedPatient']
 
     return false if prison_id == HmppsApi::MovementDirection::OUT && restricted_patient
+    return false if temp_out_of_prison_from_summary?(summary_attributes)
     return true if prison_id == HmppsApi::MovementDirection::OUT
 
     false
+  end
+
+  def temp_out_of_prison_from_summary?(summary_attributes)
+    summary_attributes['inOutStatus'] == HmppsApi::MovementDirection::OUT &&
+      summary_attributes['lastMovementTypeCode'] == HmppsApi::MovementType::TEMPORARY
   end
 
   def legal_status_requires_status_job?(summary_attributes)

--- a/app/services/reconcile_released_offenders_service.rb
+++ b/app/services/reconcile_released_offenders_service.rb
@@ -1,0 +1,400 @@
+# frozen_string_literal: true
+
+# Manual backlog cleanup for offenders who still have local stale data
+# (CaseInformation, CalculatedHandoverDate, etc.) or active allocations,
+# but are no longer present in a managed prison.
+#
+# Relies on the `OmicEligibility` table, which is populated daily by the
+# `persist_omic_eligibility` cron job. Run this task manually only after that
+# snapshot is fresh.
+#
+class ReconcileReleasedOffendersService
+  DEFAULT_BATCH_SIZE = 500
+
+  Result = Struct.new(
+    :dry_run,
+    :candidate_count,
+    :unresolved_ids,
+    :released_ids,
+    :skipped_counts_by_prison,
+    :api_found_in_search_count,
+    :api_resolved_to_target_prisons_count,
+    :api_resolved_to_other_prisons_count,
+    :api_not_found_in_search_count,
+    keyword_init: true
+  ) do
+    delegate :to_a, to: :released_ids
+
+    def released_count = released_ids.size
+    def skipped_count  = skipped_counts_by_prison.values.sum
+    def unresolved_count = unresolved_ids.size
+    def api_resolution_candidates_count = api_found_in_search_count + api_not_found_in_search_count
+  end
+
+  attr_reader :dry_run, :batch_size
+
+  def initialize(
+    dry_run: true,
+    prison_codes: nil,
+    batch_size: DEFAULT_BATCH_SIZE
+  )
+    @dry_run = dry_run
+    @prison_codes = Array(prison_codes).presence || PrisonService.prison_codes
+    @batch_size = batch_size
+  end
+
+  def call
+    orphaned_ids_by_prison, unresolved_ids, attribution_stats = find_orphaned_offender_ids_by_prison
+    candidate_count = orphaned_ids_by_prison.values.sum(&:size)
+
+    log(
+      "event=reconcile_start,candidate_count=#{candidate_count},unresolved_count=#{unresolved_ids.size}," \
+        "prisons=#{@prison_codes.size},batch_size=#{batch_size},dry_run=#{dry_run}"
+    )
+
+    log(
+      "event=reconcile_attribution_summary,api_candidates=#{attribution_stats.fetch(:api_candidates)}," \
+        "api_found_in_search=#{attribution_stats.fetch(:api_found_in_search)}," \
+        "api_resolved_to_target_prisons=#{attribution_stats.fetch(:api_resolved_to_target_prisons)}," \
+        "api_resolved_to_other_prisons=#{attribution_stats.fetch(:api_resolved_to_other_prisons)}," \
+        "api_not_found_in_search=#{attribution_stats.fetch(:api_not_found_in_search)}," \
+        "still_unresolved=#{attribution_stats.fetch(:still_unresolved)}"
+    )
+
+    if unresolved_ids.any?
+      log(
+        "event=reconcile_unresolved_orphans,count=#{unresolved_ids.size},sample_nomis_ids=#{unresolved_ids.first(10).join(',')}"
+      )
+    end
+
+    released_ids = Set.new
+    skipped_counts_by_prison = Hash.new(0)
+
+    @prison_codes.each do |prison_code|
+      prison_result = process_prison(prison_code, orphaned_ids_by_prison[prison_code])
+      released_ids.merge(prison_result.fetch(:released_ids))
+      skipped_counts_by_prison[prison_code] += prison_result.fetch(:skipped_count)
+    rescue StandardError => e
+      skipped_counts_by_prison[prison_code] += orphaned_ids_by_prison[prison_code].size
+      log("event=reconcile_prison_error,prison=#{prison_code},error=#{e.class},message=#{e.message}")
+    end
+
+    build_result(
+      candidate_count:,
+      unresolved_ids:,
+      released_ids:,
+      skipped_counts_by_prison:,
+      api_found_in_search_count: attribution_stats.fetch(:api_found_in_search),
+      api_resolved_to_target_prisons_count: attribution_stats.fetch(:api_resolved_to_target_prisons),
+      api_resolved_to_other_prisons_count: attribution_stats.fetch(:api_resolved_to_other_prisons),
+      api_not_found_in_search_count: attribution_stats.fetch(:api_not_found_in_search)
+    ).tap do |result|
+      log(
+        "event=reconcile_complete,candidate_count=#{result.candidate_count},confirmed_released_count=#{result.released_count}," \
+          "not_confirmed_count=#{result.skipped_count},unresolved_count=#{result.unresolved_count}," \
+          "api_resolved_to_other_prisons=#{result.api_resolved_to_other_prisons_count}," \
+          "api_not_found_in_search=#{result.api_not_found_in_search_count},dry_run=#{dry_run}"
+      )
+    end
+  end
+
+  def self.logger
+    @logger ||= Rails.env.test? ? Rails.logger : Logger.new($stdout)
+  end
+
+private
+
+  def empty_result
+    build_result(
+      candidate_count: 0,
+      unresolved_ids: Set.new,
+      released_ids: Set.new,
+      skipped_counts_by_prison: {},
+      api_found_in_search_count: 0,
+      api_resolved_to_target_prisons_count: 0,
+      api_resolved_to_other_prisons_count: 0,
+      api_not_found_in_search_count: 0
+    )
+  end
+
+  def build_result(
+    candidate_count:,
+    unresolved_ids:,
+    released_ids:,
+    skipped_counts_by_prison:,
+    api_found_in_search_count:,
+    api_resolved_to_target_prisons_count:,
+    api_resolved_to_other_prisons_count:,
+    api_not_found_in_search_count:
+  )
+    Result.new(
+      dry_run:,
+      candidate_count:,
+      unresolved_ids:,
+      released_ids:,
+      skipped_counts_by_prison:,
+      api_found_in_search_count:,
+      api_resolved_to_target_prisons_count:,
+      api_resolved_to_other_prisons_count:,
+      api_not_found_in_search_count:
+    )
+  end
+
+  # Returns:
+  # - a Hash keyed by prison code with orphaned offender IDs as Sets
+  # - a Set of orphaned offender IDs we could not safely attribute to a prison
+  #
+  # Active allocations already carry local prison context (`AllocationHistory.prison`)
+  #
+  # For other stint rows where prison context is ambiguous, we use batched
+  # prisoner-search lookup and derive prison from prisonId (or lastPrisonId if OUT)
+  #
+  def find_orphaned_offender_ids_by_prison
+    orphaned_ids_by_prison = Hash.new { |hash, prison_code| hash[prison_code] = Set.new }
+    unresolved_ids = Set.new
+
+    merge_rows_by_prison!(
+      orphaned_ids_by_prison,
+      unresolved_ids,
+      orphaned_allocation_rows
+    )
+
+    orphaned_stint_ids.each { unresolved_ids << it }
+    orphaned_ids_by_prison.each_value { unresolved_ids.subtract(it) }
+
+    attribution_stats = resolve_prisons_from_prisoner_search!(orphaned_ids_by_prison, unresolved_ids)
+
+    [orphaned_ids_by_prison, unresolved_ids, attribution_stats]
+  end
+
+  # For one prison: bulk-fetch confirmed releases from prisoner-search,
+  # cross with the global orphaned set, then release the intersection
+  def process_prison(prison_code, orphaned_ids)
+    return { released_ids: Set.new, skipped_count: 0 } if orphaned_ids.blank?
+
+    confirmed = Set.new
+    legal_status_candidates = Set.new
+
+    orphaned_ids.each_slice(batch_size).with_index(1) do |batch_ids, index|
+      batch_set = batch_ids.to_set
+      summaries = offender_summaries_for(batch_set)
+      found_ids = summaries.keys.to_set
+      not_found_ids = batch_set - found_ids
+      legal_status_batch = found_ids.select { |nomis_offender_id|
+        legal_status_requires_status_job?(summaries.fetch(nomis_offender_id))
+      }.to_set
+      releasable_from_search = found_ids.select { |nomis_offender_id|
+        prune_candidate_for_prison?(summaries.fetch(nomis_offender_id))
+      }.to_set
+
+      confirmed_batch = releasable_from_search | not_found_ids
+      confirmed.merge(confirmed_batch)
+      legal_status_candidates.merge(legal_status_batch)
+
+      log(
+        "event=reconcile_prison_batch,prison=#{prison_code},batch=#{index},candidates=#{batch_set.size}," \
+          "confirmed_released=#{confirmed_batch.size},found_in_search=#{found_ids.size}," \
+          "not_found_in_search=#{not_found_ids.size},legal_status_candidates=#{legal_status_batch.size},dry_run=#{dry_run}"
+      )
+    end
+
+    to_release = orphaned_ids & confirmed
+    skipped_count = orphaned_ids.size - to_release.size
+
+    log("event=reconcile_prison,prison=#{prison_code},confirmed_released=#{confirmed.size}," \
+          "to_release=#{to_release.size},not_confirmed=#{skipped_count},dry_run=#{dry_run}")
+
+    status_only_candidates = legal_status_candidates - to_release
+
+    unless dry_run
+      to_release.each { release_offender(it, prison_code:) }
+      status_only_candidates.each { process_legal_status_change(it) }
+    end
+
+    log(
+      "event=reconcile_prison_status_actions,prison=#{prison_code}," \
+        "status_only_candidates=#{status_only_candidates.size},dry_run=#{dry_run}"
+    )
+
+    { released_ids: to_release, skipped_count: }
+  end
+
+  def orphaned_allocation_rows
+    AllocationHistory
+      .active
+      .where(prison: @prison_codes)
+      .where.not(nomis_offender_id: OmicEligibility.select(:nomis_offender_id))
+      .distinct
+      .pluck(:prison, :nomis_offender_id)
+  end
+
+  def orphaned_stint_ids
+    OffenderReleasedService::STINT_DATA_MODELS.each_with_object(Set.new) do |model, orphaned_ids|
+      orphaned_ids.merge(
+        model
+          .where.not(nomis_offender_id: OmicEligibility.select(:nomis_offender_id))
+          .distinct
+          .pluck(:nomis_offender_id)
+      )
+    end
+  end
+
+  def resolve_prisons_from_prisoner_search!(orphaned_ids_by_prison, unresolved_ids)
+    if unresolved_ids.empty?
+      return {
+        api_candidates: 0,
+        api_found_in_search: 0,
+        api_resolved_to_target_prisons: 0,
+        api_resolved_to_other_prisons: 0,
+        api_not_found_in_search: 0,
+        still_unresolved: 0
+      }
+    end
+
+    initial_unresolved_count = unresolved_ids.size
+    resolved_ids = Set.new
+    found_in_search_count = 0
+    resolved_to_target_prisons_count = 0
+    resolved_to_other_prisons_count = 0
+    not_found_in_search_total = 0
+
+    unresolved_ids.each_slice(batch_size).with_index(1) do |batch_ids, index|
+      batch_set = batch_ids.to_set
+      summaries = offender_summaries_for(batch_set)
+      resolved_in_batch = Set.new
+      outside_target_prisons_in_batch = Set.new
+
+      summaries.each do |nomis_offender_id, attributes|
+        prison_code = prison_code_from_summary(attributes)
+        next if prison_code.blank?
+
+        unless @prison_codes.include?(prison_code)
+          outside_target_prisons_in_batch << nomis_offender_id
+          next
+        end
+
+        orphaned_ids_by_prison[prison_code] << nomis_offender_id
+        resolved_ids << nomis_offender_id
+        resolved_in_batch << nomis_offender_id
+      end
+
+      found_in_search = summaries.keys.to_set
+      not_found_in_search_count = batch_set.size - found_in_search.size
+      found_in_search_count += found_in_search.size
+      resolved_to_target_prisons_count += resolved_in_batch.size
+      resolved_to_other_prisons_count += outside_target_prisons_in_batch.size
+      not_found_in_search_total += not_found_in_search_count
+
+      log(
+        "event=reconcile_prison_resolution_batch,batch=#{index},unresolved_candidates=#{batch_set.size}," \
+          "found_in_search=#{found_in_search.size},resolved_to_target_prisons=#{resolved_in_batch.size}," \
+          "outside_target_prisons=#{outside_target_prisons_in_batch.size},not_found_in_search=#{not_found_in_search_count}," \
+          "still_unresolved=#{batch_set.size - resolved_in_batch.size}"
+      )
+    rescue StandardError => e
+      not_found_in_search_total += batch_set.size
+      log(
+        "event=reconcile_prison_resolution_batch_error,batch=#{index},unresolved_candidates=#{batch_set.size}," \
+          "error=#{e.class},message=#{e.message}"
+      )
+    end
+
+    unresolved_ids.subtract(resolved_ids)
+
+    {
+      api_candidates: initial_unresolved_count,
+      api_found_in_search: found_in_search_count,
+      api_resolved_to_target_prisons: resolved_to_target_prisons_count,
+      api_resolved_to_other_prisons: resolved_to_other_prisons_count,
+      api_not_found_in_search: not_found_in_search_total,
+      still_unresolved: unresolved_ids.size
+    }
+  end
+
+  def prune_candidate_for_prison?(summary_attributes)
+    prison_id = summary_attributes['prisonId']
+    restricted_patient = summary_attributes['restrictedPatient']
+
+    return false if prison_id == HmppsApi::MovementDirection::OUT && restricted_patient
+    return true if prison_id == HmppsApi::MovementDirection::OUT
+
+    false
+  end
+
+  def legal_status_requires_status_job?(summary_attributes)
+    prison_id = summary_attributes['prisonId']
+    legal_status = summary_attributes['legalStatus']
+
+    return false if prison_id == HmppsApi::MovementDirection::OUT
+
+    allowed_legal_statuses_for_status_job.exclude?(legal_status)
+  end
+
+  def allowed_legal_statuses_for_status_job
+    HmppsApi::PrisonApi::OffenderApi::ALLOWED_LEGAL_STATUSES
+  end
+
+  def prison_code_from_summary(summary_attributes)
+    prison_id = summary_attributes['prisonId']
+    return summary_attributes['lastPrisonId'] if prison_id == HmppsApi::MovementDirection::OUT
+
+    prison_id
+  end
+
+  # Cache Prisoner Search summaries during one service run so we do not query the
+  # same offender IDs twice across attribution and per-prison confirmation phases.
+  def offender_summaries_for(offender_ids)
+    ids = offender_ids.to_set
+    missing_ids = ids - summary_ids_queried
+
+    if missing_ids.any?
+      found_summaries = HmppsApi::PrisonApi::OffenderApi.offender_summaries_for(missing_ids, cache: false) || {}
+      summary_cache.merge!(found_summaries)
+      summary_ids_queried.merge(missing_ids)
+    end
+
+    ids.each_with_object({}) do |nomis_offender_id, result|
+      summary = summary_cache[nomis_offender_id]
+      result[nomis_offender_id] = summary if summary
+    end
+  end
+
+  def summary_cache
+    @summary_cache ||= {}
+  end
+
+  def summary_ids_queried
+    @summary_ids_queried ||= Set.new
+  end
+
+  def merge_rows_by_prison!(orphaned_ids_by_prison, unresolved_ids, rows)
+    rows.each do |prison_code, nomis_offender_id|
+      if prison_code.present?
+        orphaned_ids_by_prison[prison_code] << nomis_offender_id
+      else
+        unresolved_ids << nomis_offender_id
+      end
+    end
+  end
+
+  def release_offender(nomis_offender_id, prison_code:)
+    log("event=reconcile_release,nomis_offender_id=#{nomis_offender_id},prison=#{prison_code}")
+    OffenderReleasedService.release_offender(nomis_offender_id, prison_code:)
+  rescue StandardError => e
+    log("event=reconcile_release_error,nomis_offender_id=#{nomis_offender_id},error=#{e.class},message=#{e.message}")
+  end
+
+  def process_legal_status_change(nomis_offender_id)
+    log("event=reconcile_legal_status_change,nomis_offender_id=#{nomis_offender_id}")
+    ProcessPrisonerStatusJob.perform_now(nomis_offender_id, trigger_method: :reconcile)
+  rescue StandardError => e
+    log(
+      "event=reconcile_legal_status_change_error,nomis_offender_id=#{nomis_offender_id}," \
+      "error=#{e.class},message=#{e.message}"
+    )
+  end
+
+  def log(msg)
+    self.class.logger.info("[ReconcileReleasedOffendersService] #{msg}")
+  end
+end

--- a/lib/tasks/reconcile_released_offenders.rake
+++ b/lib/tasks/reconcile_released_offenders.rake
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+namespace :reconcile do
+  desc 'Manual backlog cleanup for confirmed released offenders: dry-run mode (report only, no changes). ' \
+       'Optionally set PRISON_CODE=LEI or PRISON_CODE=LEI,MDI and/or RECONCILE_BATCH_SIZE=500.'
+  task dry_run: :environment do
+    prison_codes = ENV['PRISON_CODE']&.split(',')&.map(&:strip)
+    batch_size = Integer(ENV.fetch('RECONCILE_BATCH_SIZE', ReconcileReleasedOffendersService::DEFAULT_BATCH_SIZE))
+
+    puts("[reconcile] starting dry_run=true prison_scope=#{prison_codes&.join(',') || 'ALL'} batch_size=#{batch_size}")
+
+    result = ReconcileReleasedOffendersService.new(dry_run: true, prison_codes:, batch_size:).call
+
+    puts(
+      "[reconcile] dry_run=#{result.dry_run} candidates=#{result.candidate_count} " \
+      "confirmed_released=#{result.released_count} not_confirmed=#{result.skipped_count} " \
+      "unresolved=#{result.unresolved_count}"
+    )
+    puts(
+      "[reconcile] api_resolution candidates=#{result.api_resolution_candidates_count} " \
+      "found_in_search=#{result.api_found_in_search_count} " \
+      "resolved_to_target_prisons=#{result.api_resolved_to_target_prisons_count} " \
+      "resolved_to_other_prisons=#{result.api_resolved_to_other_prisons_count} " \
+      "not_found_in_search=#{result.api_not_found_in_search_count}"
+    )
+    puts("[reconcile] released_nomis_ids=#{result.released_ids.to_a.sort.join(',')}") if result.released_ids.any?
+  end
+
+  desc 'Manual backlog cleanup for confirmed released offenders: process mode (clean up orphaned data). ' \
+       'Optionally set PRISON_CODE=LEI or PRISON_CODE=LEI,MDI and/or RECONCILE_BATCH_SIZE=500.'
+  task process: :environment do
+    prison_codes = ENV['PRISON_CODE']&.split(',')&.map(&:strip)
+    batch_size = Integer(ENV.fetch('RECONCILE_BATCH_SIZE', ReconcileReleasedOffendersService::DEFAULT_BATCH_SIZE))
+
+    puts("[reconcile] starting dry_run=false prison_scope=#{prison_codes&.join(',') || 'ALL'} batch_size=#{batch_size}")
+
+    result = ReconcileReleasedOffendersService.new(dry_run: false, prison_codes:, batch_size:).call
+
+    puts(
+      "[reconcile] dry_run=#{result.dry_run} candidates=#{result.candidate_count} " \
+      "confirmed_released=#{result.released_count} not_confirmed=#{result.skipped_count} " \
+      "unresolved=#{result.unresolved_count}"
+    )
+    puts(
+      "[reconcile] api_resolution candidates=#{result.api_resolution_candidates_count} " \
+      "found_in_search=#{result.api_found_in_search_count} " \
+      "resolved_to_target_prisons=#{result.api_resolved_to_target_prisons_count} " \
+      "resolved_to_other_prisons=#{result.api_resolved_to_other_prisons_count} " \
+      "not_found_in_search=#{result.api_not_found_in_search_count}"
+    )
+    puts("[reconcile] released_nomis_ids=#{result.released_ids.to_a.sort.join(',')}") if result.released_ids.any?
+  end
+end

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -81,12 +81,42 @@ describe HmppsApi::PrisonApi::OffenderApi do
     it 'requests only the configured response fields from prisoner search' do
       offender_nos = %w[A1234AA A1234AB]
       search_api_response = [
-        { 'prisonerNumber' => 'A1234AA', 'prisonId' => 'LEI', 'lastPrisonId' => nil, 'restrictedPatient' => false, 'legalStatus' => 'SENTENCED' },
-        { 'prisonerNumber' => 'A1234AB', 'prisonId' => 'OUT', 'lastPrisonId' => 'MDI', 'restrictedPatient' => true, 'legalStatus' => 'RECALL' }
+        {
+          'prisonerNumber' => 'A1234AA',
+          'prisonId' => 'LEI',
+          'lastPrisonId' => nil,
+          'restrictedPatient' => false,
+          'legalStatus' => 'SENTENCED',
+          'inOutStatus' => 'IN',
+          'lastMovementTypeCode' => 'ADM'
+        },
+        {
+          'prisonerNumber' => 'A1234AB',
+          'prisonId' => 'OUT',
+          'lastPrisonId' => 'MDI',
+          'restrictedPatient' => true,
+          'legalStatus' => 'RECALL',
+          'inOutStatus' => 'OUT',
+          'lastMovementTypeCode' => HmppsApi::MovementType::TEMPORARY
+        }
       ]
       expected_result = {
-        'A1234AA' => { 'prisonId' => 'LEI', 'lastPrisonId' => nil, 'restrictedPatient' => false, 'legalStatus' => 'SENTENCED' },
-        'A1234AB' => { 'prisonId' => 'OUT', 'lastPrisonId' => 'MDI', 'restrictedPatient' => true, 'legalStatus' => 'RECALL' }
+        'A1234AA' => {
+          'prisonId' => 'LEI',
+          'lastPrisonId' => nil,
+          'restrictedPatient' => false,
+          'legalStatus' => 'SENTENCED',
+          'inOutStatus' => 'IN',
+          'lastMovementTypeCode' => 'ADM'
+        },
+        'A1234AB' => {
+          'prisonId' => 'OUT',
+          'lastPrisonId' => 'MDI',
+          'restrictedPatient' => true,
+          'legalStatus' => 'RECALL',
+          'inOutStatus' => 'OUT',
+          'lastMovementTypeCode' => HmppsApi::MovementType::TEMPORARY
+        }
       }
       search_client = instance_double(HmppsApi::Client)
 

--- a/spec/services/hmpps_api/prison_api/offender_api_spec.rb
+++ b/spec/services/hmpps_api/prison_api/offender_api_spec.rb
@@ -77,6 +77,50 @@ describe HmppsApi::PrisonApi::OffenderApi do
     end
   end
 
+  describe '.offender_summaries_for' do
+    it 'requests only the configured response fields from prisoner search' do
+      offender_nos = %w[A1234AA A1234AB]
+      search_api_response = [
+        { 'prisonerNumber' => 'A1234AA', 'prisonId' => 'LEI', 'lastPrisonId' => nil, 'restrictedPatient' => false, 'legalStatus' => 'SENTENCED' },
+        { 'prisonerNumber' => 'A1234AB', 'prisonId' => 'OUT', 'lastPrisonId' => 'MDI', 'restrictedPatient' => true, 'legalStatus' => 'RECALL' }
+      ]
+      expected_result = {
+        'A1234AA' => { 'prisonId' => 'LEI', 'lastPrisonId' => nil, 'restrictedPatient' => false, 'legalStatus' => 'SENTENCED' },
+        'A1234AB' => { 'prisonId' => 'OUT', 'lastPrisonId' => 'MDI', 'restrictedPatient' => true, 'legalStatus' => 'RECALL' }
+      }
+      search_client = instance_double(HmppsApi::Client)
+
+      allow(described_class).to receive(:search_client).and_return(search_client)
+      expect(search_client).to receive(:post)
+        .with(
+          '/prisoner-search/prisoner-numbers',
+          { prisonerNumbers: offender_nos },
+          queryparams: {
+            'include-restricted-patients': true,
+            "responseFields" => described_class::OFFENDER_SUMMARY_RESPONSE_FIELDS
+          },
+          cache: true
+        )
+        .and_return(search_api_response)
+
+      result = described_class.offender_summaries_for(offender_nos)
+
+      expect(result).to eq(expected_result)
+    end
+
+    it 'allows callers to disable or enable cache explicitly' do
+      expect(described_class).to receive(:get_search_api_offenders)
+        .with(
+          ['A1234AA'],
+          cache: false,
+          response_fields: described_class::OFFENDER_SUMMARY_RESPONSE_FIELDS
+        )
+        .and_return([])
+
+      described_class.offender_summaries_for(['A1234AA'], cache: false)
+    end
+  end
+
   describe 'Single offender' do
     describe '#get_offender' do
       subject { described_class.get_offender(offender_no) }

--- a/spec/services/reconcile_released_offenders_service_spec.rb
+++ b/spec/services/reconcile_released_offenders_service_spec.rb
@@ -1,0 +1,423 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReconcileReleasedOffendersService do
+  let(:prison) { create(:prison, code: 'LEI') }
+  let!(:omic_eligibility_marker) { create_omic_eligibility('A0000AA') }
+
+  before do
+    allow(PrisonService).to receive(:prison_codes).and_return([prison.code])
+    allow(HmppsApi::PrisonApi::OffenderApi).to receive(:offender_summaries_for)
+      .and_return({})
+    allow(ProcessPrisonerStatusJob).to receive(:perform_now)
+    stub_pom(
+      build(:pom, staffId: 485_926, firstName: 'MOIC', lastName: 'POM', primaryEmail: 'test@example.com')
+    )
+  end
+
+  def create_omic_eligibility(nomis_offender_id, prison_code: prison.code)
+    OmicEligibility.create!(nomis_offender_id:, eligible: true, prison: prison_code)
+  end
+
+  def offender_summary(prison_id:, last_prison_id: nil, legal_status: 'SENTENCED', restricted_patient: false)
+    {
+      'prisonId' => prison_id,
+      'lastPrisonId' => last_prison_id,
+      'restrictedPatient' => restricted_patient,
+      'legalStatus' => legal_status
+    }
+  end
+
+  def stub_summaries_for(nomis_offender_ids, summaries_by_id)
+    allow(HmppsApi::PrisonApi::OffenderApi).to receive(:offender_summaries_for)
+      .with(nomis_offender_ids.to_set, cache: false)
+      .and_return(summaries_by_id)
+  end
+
+  def stub_released_from(prison_code, *nomis_offender_ids)
+    summaries = nomis_offender_ids.index_with do
+      offender_summary(prison_id: 'OUT', last_prison_id: prison_code)
+    end
+    stub_summaries_for(nomis_offender_ids, summaries)
+  end
+
+  def create_prison_context(offender, prison_code: prison.code, active: false)
+    create(
+      :allocation_history,
+      *(active ? [:primary] : [:release]),
+      nomis_offender_id: offender.nomis_offender_id,
+      prison: prison_code
+    )
+  end
+
+  describe '#call' do
+    context 'when an offender is in OmicEligibility (still in a managed prison)' do
+      it 'does not flag them for cleanup' do
+        offender = create(:offender)
+        create(:case_information, offender:)
+        create_omic_eligibility(offender.nomis_offender_id)
+
+        result = described_class.new(prison_codes: [prison.code]).call
+
+        expect(result.released_ids).to be_empty
+        expect(result.candidate_count).to eq(0)
+      end
+    end
+
+    context 'when an offender is still present in OmicEligibility but marked ineligible' do
+      it 'does not treat them as a release-cleanup candidate' do
+        offender = create(:offender)
+        create(:case_information, offender:)
+        OmicEligibility.create!(nomis_offender_id: offender.nomis_offender_id, eligible: false, prison: prison.code)
+
+        result = described_class.new(prison_codes: [prison.code]).call
+
+        expect(result.released_ids).to be_empty
+        expect(result.candidate_count).to eq(0)
+      end
+    end
+
+    context 'when an offender has stint data, is absent from OmicEligibility, and prisoner-search confirms release' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        stub_released_from(prison.code, offender.nomis_offender_id)
+      end
+
+      it 'identifies them as orphaned' do
+        result = described_class.new(prison_codes: [prison.code]).call
+
+        expect(result.released_ids).to include(offender.nomis_offender_id)
+        expect(result.candidate_count).to eq(1)
+        expect(result.released_count).to eq(1)
+        expect(result.skipped_count).to eq(0)
+      end
+
+      it 'does not destroy data in dry-run mode' do
+        described_class.new(dry_run: true, prison_codes: [prison.code]).call
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+
+      it 'destroys stint data when not in dry-run mode' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when an offender has stint data, is absent from OmicEligibility, but prisoner-search does NOT confirm release (e.g. ROTL)' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(prison_id: prison.code, legal_status: 'SENTENCED')
+          }
+        )
+      end
+
+      it 'does not release them' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when offender has disallowed legal status but is not OUT' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(prison_id: prison.code, legal_status: 'REMAND')
+          }
+        )
+      end
+
+      it 'delegates to ProcessPrisonerStatusJob and does not prune stint data' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(ProcessPrisonerStatusJob).to have_received(:perform_now)
+          .with(offender.nomis_offender_id, trigger_method: :reconcile)
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when offender is OUT but marked as restricted patient' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(
+              prison_id: 'OUT',
+              last_prison_id: prison.code,
+              restricted_patient: true
+            )
+          }
+        )
+      end
+
+      it 'does not prune and does not run legal-status processing' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(ProcessPrisonerStatusJob).not_to have_received(:perform_now)
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when offender legal status is UNKNOWN and they are not OUT' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(prison_id: prison.code, legal_status: 'UNKNOWN')
+          }
+        )
+      end
+
+      it 'delegates to ProcessPrisonerStatusJob and does not prune stint data' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(ProcessPrisonerStatusJob).to have_received(:perform_now)
+          .with(offender.nomis_offender_id, trigger_method: :reconcile)
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when an offender has an active allocation and prisoner-search confirms release' do
+      let(:offender) { create(:offender) }
+      let!(:case_info) { create(:case_information, offender:) }
+      let!(:allocation) do
+        create(:allocation_history, :primary,
+               nomis_offender_id: offender.nomis_offender_id,
+               prison: prison.code)
+      end
+
+      before do
+        stub_pom(build(:pom, staffId: 123_456, firstName: 'MOIC', lastName: 'POM', primaryEmail: 'test@example.com'))
+        stub_offender(build(:nomis_offender, prisonerNumber: offender.nomis_offender_id, prisonId: 'OUT'))
+        stub_released_from(prison.code, offender.nomis_offender_id)
+      end
+
+      it 'does not deallocate in dry-run mode' do
+        described_class.new(dry_run: true, prison_codes: [prison.code]).call
+
+        expect(allocation.reload.active?).to be true
+      end
+
+      it 'deallocates and destroys stint data when not in dry-run mode' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        allocation.reload
+        expect(allocation.active?).to be false
+        expect(allocation.event_trigger).to eq('offender_released')
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when multiple stint data types exist for an orphaned offender' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create(:calculated_handover_date, offender:)
+        create(:responsibility, offender:)
+        create(:handover_progress_checklist, offender:)
+        create_prison_context(offender)
+        stub_released_from(prison.code, offender.nomis_offender_id)
+      end
+
+      it 'destroys all stint data when not in dry-run mode' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(CalculatedHandoverDate.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(Responsibility.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+        expect(HandoverProgressChecklist.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when processing only a specific prison' do
+      let(:other_prison) { create(:prison, code: 'MDI') }
+      let(:offender_in_target_prison) { create(:offender) }
+      let(:offender_in_other_prison) { create(:offender) }
+
+      before do
+        create(:case_information, offender: offender_in_target_prison)
+        create(:case_information, offender: offender_in_other_prison)
+        create_prison_context(offender_in_target_prison, prison_code: prison.code)
+        create_prison_context(offender_in_other_prison, prison_code: other_prison.code)
+
+        stub_summaries_for(
+          [offender_in_target_prison.nomis_offender_id, offender_in_other_prison.nomis_offender_id],
+          {
+            offender_in_target_prison.nomis_offender_id => offender_summary(prison_id: 'OUT', last_prison_id: prison.code),
+            offender_in_other_prison.nomis_offender_id => offender_summary(prison_id: other_prison.code, legal_status: 'SENTENCED')
+          }
+        )
+      end
+
+      it 'only processes releases confirmed from the target prison' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender_in_target_prison.nomis_offender_id)).to be_nil
+        expect(CaseInformation.find_by(nomis_offender_id: offender_in_other_prison.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when one prison has more candidates than the configured batch size' do
+      let(:offender1) { create(:offender) }
+      let(:offender2) { create(:offender) }
+
+      before do
+        create(:case_information, offender: offender1)
+        create(:case_information, offender: offender2)
+        create_prison_context(offender1)
+        create_prison_context(offender2)
+
+        stub_summaries_for(
+          [offender1.nomis_offender_id],
+          { offender1.nomis_offender_id => offender_summary(prison_id: 'OUT', last_prison_id: prison.code) }
+        )
+        stub_summaries_for(
+          [offender2.nomis_offender_id],
+          { offender2.nomis_offender_id => offender_summary(prison_id: prison.code, legal_status: 'SENTENCED') }
+        )
+      end
+
+      it 'verifies release candidates in batches' do
+        result = described_class.new(prison_codes: [prison.code], batch_size: 1).call
+
+        expect(result.released_ids).to contain_exactly(offender1.nomis_offender_id)
+        expect(result.skipped_count).to eq(1)
+        expect(HmppsApi::PrisonApi::OffenderApi).to have_received(:offender_summaries_for)
+          .with([offender1.nomis_offender_id].to_set, cache: false).at_least(:once)
+        expect(HmppsApi::PrisonApi::OffenderApi).to have_received(:offender_summaries_for)
+          .with([offender2.nomis_offender_id].to_set, cache: false).at_least(:once)
+      end
+    end
+
+    context 'when prisoner-search call fails for one prison' do
+      let(:other_prison) { create(:prison, code: 'MDI') }
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        allow(HmppsApi::PrisonApi::OffenderApi).to receive(:offender_summaries_for)
+          .with([offender.nomis_offender_id].to_set, cache: false).and_raise(StandardError, 'API unavailable')
+        allow(PrisonService).to receive(:prison_codes).and_return([prison.code, other_prison.code])
+      end
+
+      it 'continues processing remaining prisons without raising' do
+        expect { described_class.new(dry_run: false).call }.not_to raise_error
+      end
+    end
+
+    context 'when OffenderReleasedService raises for one offender' do
+      let(:offender1) { create(:offender) }
+      let(:offender2) { create(:offender) }
+
+      before do
+        create(:case_information, offender: offender1)
+        create(:case_information, offender: offender2)
+        create_prison_context(offender1)
+        create_prison_context(offender2)
+        stub_released_from(prison.code, offender1.nomis_offender_id, offender2.nomis_offender_id)
+
+        allow(OffenderReleasedService).to receive(:release_offender)
+          .with(offender1.nomis_offender_id, prison_code: prison.code).and_raise(StandardError, 'boom')
+        allow(OffenderReleasedService).to receive(:release_offender)
+          .with(offender2.nomis_offender_id, prison_code: prison.code).and_call_original
+      end
+
+      it 'continues processing remaining offenders' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(CaseInformation.find_by(nomis_offender_id: offender1.nomis_offender_id)).to be_present
+        expect(CaseInformation.find_by(nomis_offender_id: offender2.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when an offender has stint data but no local prison context' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+      end
+
+      it 'queries prisoner-search summaries but leaves data untouched if unresolved' do
+        expect(HmppsApi::PrisonApi::OffenderApi).to receive(:offender_summaries_for)
+          .with([offender.nomis_offender_id].to_set, cache: false)
+          .and_return({})
+
+        result = described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(result.released_ids).to be_empty
+        expect(result.unresolved_ids).to contain_exactly(offender.nomis_offender_id)
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when an offender has stint data, no local prison context, and prisoner-search resolves their prison' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(prison_id: 'OUT', last_prison_id: prison.code)
+          }
+        )
+      end
+
+      it 'uses the resolved prison to verify release and clean up' do
+        described_class.new(dry_run: false, prison_codes: [prison.code], batch_size: 1).call
+
+        expect(HmppsApi::PrisonApi::OffenderApi).to have_received(:offender_summaries_for)
+          .with([offender.nomis_offender_id].to_set, cache: false).at_least(:once)
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
+    end
+
+    context 'when an offender has stint data and prisoner-search resolves them to a non-target prison' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(prison_id: 'MDI', legal_status: 'SENTENCED')
+          }
+        )
+      end
+
+      it 'keeps them unresolved for this targeted run and does not attempt release checks' do
+        result = described_class.new(dry_run: false, prison_codes: [prison.code], batch_size: 1).call
+
+        expect(result.released_ids).to be_empty
+        expect(result.unresolved_ids).to contain_exactly(offender.nomis_offender_id)
+      end
+    end
+  end
+end

--- a/spec/services/reconcile_released_offenders_service_spec.rb
+++ b/spec/services/reconcile_released_offenders_service_spec.rb
@@ -20,12 +20,21 @@ RSpec.describe ReconcileReleasedOffendersService do
     OmicEligibility.create!(nomis_offender_id:, eligible: true, prison: prison_code)
   end
 
-  def offender_summary(prison_id:, last_prison_id: nil, legal_status: 'SENTENCED', restricted_patient: false)
+  def offender_summary(
+    prison_id:,
+    last_prison_id: nil,
+    legal_status: 'SENTENCED',
+    restricted_patient: false,
+    in_out_status: 'IN',
+    last_movement_type_code: 'ADM'
+  )
     {
       'prisonId' => prison_id,
       'lastPrisonId' => last_prison_id,
       'restrictedPatient' => restricted_patient,
-      'legalStatus' => legal_status
+      'legalStatus' => legal_status,
+      'inOutStatus' => in_out_status,
+      'lastMovementTypeCode' => last_movement_type_code
     }
   end
 
@@ -37,7 +46,7 @@ RSpec.describe ReconcileReleasedOffendersService do
 
   def stub_released_from(prison_code, *nomis_offender_ids)
     summaries = nomis_offender_ids.index_with do
-      offender_summary(prison_id: 'OUT', last_prison_id: prison_code)
+      offender_summary(prison_id: 'OUT', last_prison_id: prison_code, in_out_status: 'OUT', last_movement_type_code: 'REL')
     end
     stub_summaries_for(nomis_offender_ids, summaries)
   end
@@ -166,6 +175,33 @@ RSpec.describe ReconcileReleasedOffendersService do
               prison_id: 'OUT',
               last_prison_id: prison.code,
               restricted_patient: true
+            )
+          }
+        )
+      end
+
+      it 'does not prune and does not run legal-status processing' do
+        described_class.new(dry_run: false, prison_codes: [prison.code]).call
+
+        expect(ProcessPrisonerStatusJob).not_to have_received(:perform_now)
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_present
+      end
+    end
+
+    context 'when offender is temporarily OUT on ROTL' do
+      let(:offender) { create(:offender) }
+
+      before do
+        create(:case_information, offender:)
+        create_prison_context(offender)
+        stub_summaries_for(
+          [offender.nomis_offender_id],
+          {
+            offender.nomis_offender_id => offender_summary(
+              prison_id: 'OUT',
+              last_prison_id: prison.code,
+              in_out_status: 'OUT',
+              last_movement_type_code: HmppsApi::MovementType::TEMPORARY
             )
           }
         )


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2046

A manual, ad-hoc cleanup task to remove stale local data for offenders who have left the prison service but whose records weren't cleaned up automatically (for example, because a domain event was missed, or we didn't have event handling back then).

It uses OmicEligibility. Anyone absent from this table is considered a potential cleanup candidate but then we narrow down by checking with prisoner-search the orphaned IDs.

Based on the API response, we do the following:

* Not found: treat as released and call release mechanism and prune
* prisonId is OUT and not a restricted patient: same as above
* prisonId is OUT and is a restricted patient: do nothing
* Found on ROTL: do nothing
* Found with an allowed legal status: do nothing
* Found with a disallowed legal status: queue status change job (can deallocate but will not prune)