### PR TITLE
MO-2046 Skip emails when pruning old records

### DIFF
--- a/app/models/allocation_history.rb
+++ b/app/models/allocation_history.rb
@@ -159,17 +159,19 @@ class AllocationHistory < ApplicationRecord
     deallocate_secondary_pom(nomis_staff_id, prison, event_trigger:)
   end
 
-  def deallocate_offender_after_release
+  def deallocate_offender_after_release(send_email: true)
     deallocate_offender(
       event: AllocationHistory::DEALLOCATE_RELEASED_OFFENDER,
-      event_trigger: AllocationHistory::OFFENDER_RELEASED
+      event_trigger: AllocationHistory::OFFENDER_RELEASED,
+      send_email:
     )
   end
 
-  def deallocate_offender_after_transfer
+  def deallocate_offender_after_transfer(send_email: true)
     deallocate_offender(
       event: AllocationHistory::DEALLOCATE_PRIMARY_POM,
-      event_trigger: AllocationHistory::OFFENDER_TRANSFERRED
+      event_trigger: AllocationHistory::OFFENDER_TRANSFERRED,
+      send_email:
     )
   end
 
@@ -191,23 +193,11 @@ class AllocationHistory < ApplicationRecord
 
 private
 
-  def deallocate_offender(event:, event_trigger:)
+  def deallocate_offender(event:, event_trigger:, send_email:)
     return unless active?
 
-    primary_pom = HmppsApi::NomisUserRolesApi.staff_details(primary_pom_nomis_id)
-
-    # We intentionally bypass legal-status filtering because this can run after
-    # release/legalStatus changes, and we just need the offender's name
-    offender = HmppsApi::PrisonApi::OffenderApi.get_offender(nomis_offender_id, ignore_legal_status: true)
-
-    mail_params = {
-      email: primary_pom.email_address,
-      pom_name: primary_pom.first_name.titleize,
-      offender_name: offender.full_name,
-      nomis_offender_id: nomis_offender_id,
-      prison_name: Prison.find(prison).name,
-      url: Rails.application.routes.url_helpers.prison_staff_caseload_url(prison, primary_pom.staff_id)
-    }
+    # Needed before we do the update to nil
+    primary_pom_id = primary_pom_nomis_id
 
     update!(
       event: event,
@@ -220,15 +210,37 @@ private
       recommended_pom_type: nil,
     )
 
-    if mail_params[:email].present?
-      PomMailer.with(**mail_params).offender_deallocated.deliver_later
-    else
-      Rails.logger.error 'event=deallocate_offender_blank_email,' \
-                         "nomis_offender_id=#{nomis_offender_id}," \
-                         "primary_pom_nomis_id=#{primary_pom.staff_id}," \
-                         "event_trigger=#{event_trigger}|" \
-                         'Attempted to schedule an email send but the primary POM email address is blank'
+    send_deallocation_email(primary_pom_id) if send_email
+  end
+
+  def send_deallocation_email(primary_pom_nomis_id)
+    primary_pom = HmppsApi::NomisUserRolesApi.staff_details(primary_pom_nomis_id)
+
+    if primary_pom&.email_address.blank?
+      Rails.logger.info(
+        'event=deallocate_offender_blank_email,' \
+        "nomis_offender_id=#{nomis_offender_id}," \
+        "primary_pom_nomis_id=#{primary_pom_nomis_id}," \
+        "event_trigger=#{event_trigger}|" \
+        'Attempted to schedule an email send but the primary POM email address is blank'
+      )
+      return
     end
+
+    # We intentionally bypass legal-status filtering because this can run after
+    # release/legalStatus changes, and we just need the offender's name
+    offender = HmppsApi::PrisonApi::OffenderApi.get_offender(nomis_offender_id, ignore_legal_status: true)
+
+    mail_params = {
+      email: primary_pom&.email_address,
+      pom_name: primary_pom&.first_name&.titleize,
+      offender_name: offender&.full_name || 'N/A',
+      nomis_offender_id: nomis_offender_id,
+      prison_name: Prison.find(prison).name,
+      url: Rails.application.routes.url_helpers.prison_staff_caseload_url(prison, primary_pom_nomis_id)
+    }
+
+    PomMailer.with(**mail_params).offender_deallocated.deliver_later
   end
 
   def audit_event_tags

--- a/app/services/offender_released_service.rb
+++ b/app/services/offender_released_service.rb
@@ -15,7 +15,7 @@ class OffenderReleasedService
     OmicEligibility,
   ].freeze
 
-  def self.release_offender(nomis_offender_id, prison_code: nil)
+  def self.release_offender(nomis_offender_id, prison_code: nil, send_email: true)
     unless local_release_state_present?(nomis_offender_id)
       Rails.logger.info("[RELEASE] Skipping #{nomis_offender_id}; no local release state remains")
       return
@@ -23,14 +23,10 @@ class OffenderReleasedService
 
     Rails.logger.info("[RELEASE] Processing release for #{nomis_offender_id}")
 
-    deallocate(nomis_offender_id)
+    AllocationHistory.active.find_by(nomis_offender_id:)&.deallocate_offender_after_release(send_email:)
+
     destroy_stint_data(nomis_offender_id)
     inactivate_complexity(nomis_offender_id, prison_code) if prison_code.present?
-  end
-
-  def self.deallocate(nomis_offender_id)
-    alloc = AllocationHistory.active.find_by(nomis_offender_id:)
-    alloc.deallocate_offender_after_release if alloc
   end
 
   def self.destroy_stint_data(nomis_offender_id)
@@ -50,5 +46,5 @@ class OffenderReleasedService
       STINT_DATA_MODELS.any? { it.exists?(nomis_offender_id:) }
   end
 
-  private_class_method :deallocate, :inactivate_complexity, :local_release_state_present?
+  private_class_method :inactivate_complexity, :local_release_state_present?
 end

--- a/app/services/reconcile_released_offenders_service.rb
+++ b/app/services/reconcile_released_offenders_service.rb
@@ -385,7 +385,7 @@ private
 
   def release_offender(nomis_offender_id, prison_code:)
     log("event=reconcile_release,nomis_offender_id=#{nomis_offender_id},prison=#{prison_code}")
-    OffenderReleasedService.release_offender(nomis_offender_id, prison_code:)
+    OffenderReleasedService.release_offender(nomis_offender_id, prison_code:, send_email: false)
   rescue StandardError => e
     log("event=reconcile_release_error,nomis_offender_id=#{nomis_offender_id},error=#{e.class},message=#{e.message}")
   end

--- a/spec/models/allocation_history_spec.rb
+++ b/spec/models/allocation_history_spec.rb
@@ -348,6 +348,22 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
           expect(fake_mailer).to have_received(:offender_deallocated)
         end
 
+        it 'passes the expected payload to PomMailer' do
+          expect(PomMailer).to have_received(:with) do |payload|
+            expect(payload).to include(
+              :email,
+              :pom_name,
+              :offender_name,
+              :nomis_offender_id,
+              :prison_name,
+              :url
+            )
+            expect(payload[:email]).to eq(pom_email)
+            expect(payload[:nomis_offender_id]).to eq(nomis_offender_id)
+            expect(payload[:url]).to include("/prisons/#{prison_code}/staff/")
+          end
+        end
+
         it 'logs no error' do
           expect(fake_logger).not_to have_received(:error)
         end
@@ -359,8 +375,8 @@ RSpec.describe AllocationHistory, :enable_domain_event_publish, type: :model do
             expect(fake_mailer).not_to have_received(:offender_deallocated)
           end
 
-          it 'logs an error' do
-            expect(fake_logger).to have_received(:error)
+          it 'logs that email was skipped' do
+            expect(fake_logger).to have_received(:info).with(include('event=deallocate_offender_blank_email'))
           end
         end
       end

--- a/spec/services/offender_released_service_spec.rb
+++ b/spec/services/offender_released_service_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe OffenderReleasedService do
         expect(allocation.reload.active?).to be false
         expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
       end
+
+      it 'can skip deallocation email and still complete cleanup when offender lookup is missing' do
+        allow(HmppsApi::PrisonApi::OffenderApi).to receive(:get_offender).and_return(nil)
+        expect(PomMailer).not_to receive(:with)
+
+        described_class.release_offender(offender.nomis_offender_id, send_email: false)
+
+        expect(allocation.reload.active?).to be false
+        expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
+      end
     end
 
     context 'when all local release state has already been removed' do

--- a/spec/services/reconcile_released_offenders_service_spec.rb
+++ b/spec/services/reconcile_released_offenders_service_spec.rb
@@ -112,6 +112,8 @@ RSpec.describe ReconcileReleasedOffendersService do
       end
 
       it 'destroys stint data when not in dry-run mode' do
+        expect(PomMailer).not_to receive(:with)
+
         described_class.new(dry_run: false, prison_codes: [prison.code]).call
 
         expect(CaseInformation.find_by(nomis_offender_id: offender.nomis_offender_id)).to be_nil
@@ -380,9 +382,9 @@ RSpec.describe ReconcileReleasedOffendersService do
         stub_released_from(prison.code, offender1.nomis_offender_id, offender2.nomis_offender_id)
 
         allow(OffenderReleasedService).to receive(:release_offender)
-          .with(offender1.nomis_offender_id, prison_code: prison.code).and_raise(StandardError, 'boom')
+          .with(offender1.nomis_offender_id, prison_code: prison.code, send_email: false).and_raise(StandardError, 'boom')
         allow(OffenderReleasedService).to receive(:release_offender)
-          .with(offender2.nomis_offender_id, prison_code: prison.code).and_call_original
+          .with(offender2.nomis_offender_id, prison_code: prison.code, send_email: false).and_call_original
       end
 
       it 'continues processing remaining offenders' do


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-2046

Follow-up to previous PR #2921.

On the reconcile job, when marking old cases detected as released, skip deallocation emails as these belongs to offender not visible anymore on the UI and stale records.

Added additional nil protections around this operation for other scenarios outside the reconcile, because for very old cases, the POM and/or Offender will no longer be retrievable via the API so we might not have email address, or names, etc.