### PR TITLE
Configure sensible http timeout defaults

### DIFF
--- a/app/services/hmpps_api/client.rb
+++ b/app/services/hmpps_api/client.rb
@@ -8,6 +8,9 @@ module HmppsApi
     def initialize(root, extra_retry_methods: [])
       @root = root
       @connection = Faraday.new do |faraday|
+        faraday.options.open_timeout = Rails.configuration.hmpps_api_open_timeout_seconds
+        faraday.options.timeout = Rails.configuration.hmpps_api_timeout_seconds
+
         faraday.request(
           :retry,
           max: 3, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2,
@@ -18,7 +21,7 @@ module HmppsApi
           # update the retried request's Authorization header there
           exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed, Faraday::UnauthorizedError],
           retry_block: lambda { |env, _options, retries_remaining, exception|
-            refresh_token_on_retry(env, retries_remaining, exception)
+            handle_retry_event(env, retries_remaining, exception)
           },
         )
 
@@ -126,6 +129,13 @@ module HmppsApi
         req.params.update(queryparams)
         req.body = body.to_json unless body.nil?
       end
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+      Rails.logger.warn(
+        "event=hmpps_api_request_failed,reason=#{e.class},method=#{method.to_s.upcase},route=#{route}," \
+        "open_timeout_seconds=#{Rails.configuration.hmpps_api_open_timeout_seconds}," \
+        "timeout_seconds=#{Rails.configuration.hmpps_api_timeout_seconds},message=#{e.message}"
+      )
+      raise
     rescue Faraday::UnauthorizedError => e
       Rails.logger.error("[#{self.class}] #{url} -- #{e.message}")
 
@@ -154,16 +164,25 @@ module HmppsApi
       HmppsApi::Oauth::TokenService.valid_token
     end
 
-    def refresh_token_on_retry(env, retries_remaining, exception)
-      return unless exception.is_a?(Faraday::UnauthorizedError)
+    def handle_retry_event(env, retries_remaining, exception)
+      if exception.is_a?(Faraday::UnauthorizedError)
+        Rails.logger.warn(
+          "event=hmpps_api_retry_refresh_token,method=#{env.method.to_s.upcase},route=#{env.url.path}," \
+          "retries_remaining=#{retries_remaining}"
+        )
+
+        refreshed_token = HmppsApi::Oauth::TokenService.refresh_token!
+        env.request_headers['Authorization'] = "Bearer #{refreshed_token.access_token}"
+        return
+      end
+
+      return unless exception.is_a?(Faraday::TimeoutError) || exception.is_a?(Faraday::ConnectionFailed)
 
       Rails.logger.warn(
-        "event=hmpps_api_retry_refresh_token,method=#{env.method.to_s.upcase},route=#{env.url.path}," \
-        "retries_remaining=#{retries_remaining}"
+        "event=hmpps_api_retry,reason=#{exception.class},method=#{env.method.to_s.upcase},route=#{env.url.path}," \
+        "retries_remaining=#{retries_remaining},open_timeout_seconds=#{Rails.configuration.hmpps_api_open_timeout_seconds}," \
+        "timeout_seconds=#{Rails.configuration.hmpps_api_timeout_seconds}"
       )
-
-      refreshed_token = HmppsApi::Oauth::TokenService.refresh_token!
-      env.request_headers['Authorization'] = "Bearer #{refreshed_token.access_token}"
     end
 
     def response_cache

--- a/app/services/hmpps_api/oauth/client.rb
+++ b/app/services/hmpps_api/oauth/client.rb
@@ -8,6 +8,9 @@ module HmppsApi
       def initialize(host)
         @host = host
         @connection = Faraday.new do |faraday|
+          faraday.options.open_timeout = Rails.configuration.hmpps_api_open_timeout_seconds
+          faraday.options.timeout = Rails.configuration.hmpps_api_timeout_seconds
+
           faraday.request :retry, max: 3, interval: 0.05,
                                   interval_randomness: 0.5, backoff_factor: 2,
                                   # We appear to get occasional transient 5xx errors, so retry them

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,10 @@ module OffenderManagementAllocationClient
     config.collect_prometheus_metrics = ENV['PROMETHEUS_METRICS']&.strip == 'on'
     config.redis_url = ENV['REDIS_URL']&.strip
 
+    # Shared outbound HTTP timeout defaults for HMPPS API integrations
+    config.hmpps_api_open_timeout_seconds = ENV.fetch('HMPPS_API_OPEN_TIMEOUT_SECONDS', 5).to_i
+    config.hmpps_api_timeout_seconds = ENV.fetch('HMPPS_API_TIMEOUT_SECONDS', 30).to_i
+
     config.cache_expiry = (ENV['CACHE_TIMEOUT']&.strip || 60.minutes).to_i
 
     config.x.simplified_handover_cutoff_date = Date.parse(

--- a/spec/services/hmpps_api/client_spec.rb
+++ b/spec/services/hmpps_api/client_spec.rb
@@ -116,6 +116,45 @@ describe HmppsApi::Client do
       expect { client.get(route) }
         .to raise_error(Faraday::TimeoutError, 'request timed out')
     end
+
+    it 'logs the failed request details after retries are exhausted' do
+      allow(Rails.logger).to receive(:warn)
+
+      expect { client.get(route) }.to raise_error(Faraday::TimeoutError, 'request timed out')
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(include('event=hmpps_api_request_failed,reason=Faraday::TimeoutError,method=GET,route=/api/endpoint'))
+        .once
+    end
+  end
+
+  describe 'when a timeout is transient' do
+    let(:route) { '/api/endpoint' }
+
+    before do
+      WebMock.stub_request(:get, api_host + route)
+        .to_raise(Faraday::TimeoutError.new('request timed out')).then
+        .to_return(status: 200, body: '{}')
+    end
+
+    it 'retries and logs the retry event' do
+      allow(Rails.logger).to receive(:warn)
+
+      expect(client.get(route)).to eq({})
+      expect(WebMock).to have_requested(:get, api_host + route).twice
+      expect(Rails.logger).to have_received(:warn)
+        .with(include('event=hmpps_api_retry,reason=Faraday::TimeoutError,method=GET,route=/api/endpoint'))
+        .once
+    end
+  end
+
+  describe 'timeout configuration' do
+    it 'uses the shared HMPPS API timeout settings' do
+      connection = client.instance_variable_get(:@connection)
+
+      expect(connection.options.open_timeout).to eq(Rails.configuration.hmpps_api_open_timeout_seconds)
+      expect(connection.options.timeout).to eq(Rails.configuration.hmpps_api_timeout_seconds)
+    end
   end
 
   describe 'instance method' do

--- a/spec/services/hmpps_api/oauth/client_spec.rb
+++ b/spec/services/hmpps_api/oauth/client_spec.rb
@@ -6,6 +6,15 @@ describe HmppsApi::Oauth::Client do
   let(:client) { described_class.new(api_host) }
   let(:route) { '/auth/oauth/token?grant_type=client_credentials' }
 
+  describe 'timeout configuration' do
+    it 'uses the shared HMPPS API timeout settings' do
+      connection = client.instance_variable_get(:@connection)
+
+      expect(connection.options.open_timeout).to eq(Rails.configuration.hmpps_api_open_timeout_seconds)
+      expect(connection.options.timeout).to eq(Rails.configuration.hmpps_api_timeout_seconds)
+    end
+  end
+
   context 'with a valid request' do
     it 'sets the Authorization header' do
       client.post(route)


### PR DESCRIPTION
We didn't have any way to set the timeout defaults for http API calls.

Introduce some configuration and sensible defaults. Added additional logging. Timeouts are transient errors and will be retry (as part of our existing retry mechanism).